### PR TITLE
Letovers from pyftfontview → pyftinspect rename

### DIFF
--- a/Lib/fontTools/inspect.py
+++ b/Lib/fontTools/inspect.py
@@ -266,7 +266,7 @@ class Inspect:
 
 def main(args):
 	if len(args) < 1:
-		print >>sys.stderr, "usage: pyftfontview font..."
+		print >>sys.stderr, "usage: pyftinspect font..."
 		sys.exit(1)
 	for arg in args:
 		Inspect(arg)

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
 				libraries=[],
 			)
 		],
-		scripts = ["Tools/ttx", "Tools/pyftsubset", "Tools/pyftfontview"],
+		scripts = ["Tools/ttx", "Tools/pyftsubset", "Tools/pyftinspect"],
 		console = ["Tools/ttx", "Tools/pyftsubset"],
 		cmdclass = {"build_ext": build_ext_optional},
 		data_files = [('share/man/man1', ["Doc/ttx.1"])],


### PR DESCRIPTION
Fixes “setup.py install”.
