### PR TITLE
Fix compiling back Times New Roman font

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -960,12 +960,11 @@ class GlyphCoordinates(object):
 		self._a = array.array("f", self._a)
 
 	def _checkFloat(self, p):
-		if not any(isinstance(v, float) for v in p):
-			return
-		p = [int(v) if int(v) == v else v for v in p]
-		if not any(isinstance(v, float) for v in p):
-			return
-		self._ensureFloat()
+		if any(isinstance(v, float) for v in p):
+			p = [int(v) if int(v) == v else v for v in p]
+			if any(isinstance(v, float) for v in p):
+				self._ensureFloat()
+		return p
 
 	@staticmethod
 	def zeros(count):
@@ -991,19 +990,19 @@ class GlyphCoordinates(object):
 			for j,i in enumerate(indices):
 				self[i] = v[j]
 			return
-		self._checkFloat(v)
+		v = self._checkFloat(v)
 		self._a[2*k],self._a[2*k+1] = v
 
 	def __repr__(self):
 		return 'GlyphCoordinates(['+','.join(str(c) for c in self)+'])'
 
 	def append(self, p):
-		self._checkFloat(p)
+		p = self._checkFloat(p)
 		self._a.extend(tuple(p))
 
 	def extend(self, iterable):
 		for p in iterable:
-			self._checkFloat(p)
+			p = self._checkFloat(p)
 			self._a.extend(p)
 
 	def relativeToAbsolute(self):


### PR DESCRIPTION
This has been broken since f2c2b4d38bd7bba23db71936262db984e4b7aebb,
assigning a new object to a function argument will not change the
original one, so we need to return the modified list.
