### PR TITLE
Fix: 'list' object has no attribute 'tolist'

### DIFF
--- a/Lib/fontTools/ttLib/__init__.py
+++ b/Lib/fontTools/ttLib/__init__.py
@@ -730,8 +730,8 @@ class _TTGlyph(object):
 			start = 0
 			for end in endPts:
 				end = end + 1
-				contour = coordinates[start:end].tolist()
-				cFlags = flags[start:end].tolist()
+				contour = coordinates[start:end]
+				cFlags = flags[start:end]
 				start = end
 				if 1 not in cFlags:
 					# There is not a single on-curve point on the curve,


### PR DESCRIPTION
I was testing the reportLabPen, and it seems that drawing TrueType glyphs to pens is broken (no idea since when, this code is from 2003!). I tested with something like:

```
python Lib/fontTools/pens/reportLabPen.py amiri-regular.ttf A a.png
```
