### PR TITLE
[subset] added --fsType option to modify OS/2 embedding settings

### DIFF
--- a/Lib/fontTools/subset.py
+++ b/Lib/fontTools/subset.py
@@ -7,7 +7,7 @@ from fontTools.misc.py23 import *
 from fontTools import ttLib
 from fontTools.ttLib.tables import otTables
 from fontTools.misc import psCharStrings
-from fontTools.misc.textTools import num2binary, binary2num
+from fontTools.misc.textTools import binary2num
 from fontTools.pens import basePen
 import sys
 import struct


### PR DESCRIPTION
Sometimes, when making webfonts, you may need to tweak the font embedding settings.
An option similar to this may come in handy.
