### PR TITLE
[subset] default to ttx-style output filename, keep original extension or use '.woff'

### DIFF
--- a/Lib/fontTools/subset.py
+++ b/Lib/fontTools/subset.py
@@ -8,6 +8,7 @@ from fontTools import ttLib
 from fontTools.ttLib.tables import otTables
 from fontTools.misc import psCharStrings
 from fontTools.misc.textTools import binary2num
+from fontTools.ttx import makeOutputFileName
 from fontTools.pens import basePen
 import sys
 import struct
@@ -2593,10 +2594,18 @@ def main(args):
     sys.exit(1)
 
   fontfile = args[0]
+  if options.flavor:
+    ext = "."+options.flavor.lower()
+  else:
+    i = fontfile.rfind('.')
+    if i != -1:
+      ext = fontfile[i:]
+    else:
+      ext = '.subset'
   args = args[1:]
 
   subsetter = Subsetter(options=options, log=log)
-  outfile = fontfile + '.subset'
+  outfile = makeOutputFileName(fontfile, outputDir=None, extension=ext)
   glyphs = []
   gids = []
   unicodes = []


### PR DESCRIPTION
I know there are some, like @schriftgestalt in another pull request (https://github.com/behdad/fonttools/pull/112), who don't like like the way that ttx handles output file names. 

However, I think most users are by now used to that, and may like if other tools such as pyftsybset behave the same as ttx does. The function makeOutputFileName is already in there to use.

So, my suggestion would be, when no output filename is explicitly specified in the options, then try to save it in the input file's folder with the same name+extension; if it clashes with an existing filename, then append an incremental #<number> until the output filename is unique.

Also, it'd be nice to have the extension 'woff' when that flavor is specified in the options, while keeping the original '.ttf' or '.otf' from the input filename. I'd use the current ".subset" only if the input file bear no extension at all. 

But maybe these are just my personal preferences.
