### PR TITLE
[subset] also obfuscate nameIDs 16, 17 and 18, if present

### DIFF
--- a/Lib/fontTools/subset.py
+++ b/Lib/fontTools/subset.py
@@ -2069,9 +2069,9 @@ def prune_pre_subset(self, options):
   if options.obfuscate_names:
     namerecs = []
     for n in self.names:
-      if n.nameID in [1, 4]:
+      if n.nameID in [1, 4, 16, 18]:
         n.string = ".\x7f".encode('utf-16be') if n.isUnicode() else ".\x7f"
-      elif n.nameID in [2, 6]:
+      elif n.nameID in [2, 6, 17]:
         n.string = "\x7f".encode('utf-16be') if n.isUnicode() else "\x7f"
       elif n.nameID == 3:
         n.string = ""


### PR DESCRIPTION
The current name obfuscation method does not change the Preferred Family (16), Preferred Subfamily (17) and Compatible Full Name (18).
FontBook on OSX can still read these name IDs, even when the basic names 1–6 are obfuscated.
Of course, one can always drop names using --name-IDs= option, but then you have to specify all the other names you want to preserve. 
I suggest to add name IDs 16, 17 and 18 to the list of obfuscated names.
