### PR TITLE
Revert "[subset] also obfuscate nameIDs 16, 17 and 18, if present"

### DIFF
--- a/Lib/fontTools/subset.py
+++ b/Lib/fontTools/subset.py
@@ -2069,9 +2069,9 @@ def prune_pre_subset(self, options):
   if options.obfuscate_names:
     namerecs = []
     for n in self.names:
-      if n.nameID in [1, 4, 16, 18]:
+      if n.nameID in [1, 4]:
         n.string = ".\x7f".encode('utf-16be') if n.isUnicode() else ".\x7f"
-      elif n.nameID in [2, 6, 17]:
+      elif n.nameID in [2, 6]:
         n.string = "\x7f".encode('utf-16be') if n.isUnicode() else "\x7f"
       elif n.nameID == 3:
         n.string = ""


### PR DESCRIPTION
Actually, I have changed my mind. I think there is no point in keeping name IDs 16, 17 and 18 as duplicate of the (obfuscated) name IDs 1, 2 and 4.
I'll file a new PR and will simply drop those name IDs 16–18.
Sorry,

C.
