### PR TITLE
[subset] drop nameIDs 16, 17 and 18 if obfuscate_name

### DIFF
--- a/Lib/fontTools/subset.py
+++ b/Lib/fontTools/subset.py
@@ -2069,12 +2069,14 @@ def prune_pre_subset(self, options):
   if options.obfuscate_names:
     namerecs = []
     for n in self.names:
-      if n.nameID in [1, 4, 16, 18]:
+      if n.nameID in [1, 4]:
         n.string = ".\x7f".encode('utf-16be') if n.isUnicode() else ".\x7f"
-      elif n.nameID in [2, 6, 17]:
+      elif n.nameID in [2, 6]:
         n.string = "\x7f".encode('utf-16be') if n.isUnicode() else "\x7f"
       elif n.nameID == 3:
         n.string = ""
+      elif n.nameID in [16, 17, 18]:
+        continue
       namerecs.append(n)
     self.names = namerecs
   return True  # Required table


### PR DESCRIPTION
If --obufscate-name, and name IDs 16, 17 and 18 are present, these will be dropped.
I believe it makes more sense, instead of having them as duplicate.

C.
