### PR TITLE
subset: must 'draw' charstrings to set 'width' attribute before calling 'drop_hints'

### DIFF
--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -110,7 +110,7 @@ class BuilderTest(unittest.TestCase):
         expected = self.read_ttx(expected_ttx)
         if actual != expected:
             for line in difflib.unified_diff(
-                    expected, actual, fromfile=path, tofile=expected_ttx):
+                    expected, actual, fromfile=expected_ttx, tofile=path):
                 sys.stdout.write(line)
             self.fail("TTX output is different from expected")
 

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -7,7 +7,7 @@ from fontTools.misc.py23 import *
 from fontTools import ttLib
 from fontTools.ttLib.tables import otTables
 from fontTools.misc import psCharStrings
-from fontTools.pens.boundsPen import BoundsPen
+from fontTools.pens.basePen import NullPen
 from fontTools.misc.loggingTools import Timer
 import sys
 import struct
@@ -1847,8 +1847,8 @@ def prune_pre_subset(self, font, options):
                 private = font.Private
             dfltWdX = private.defaultWidthX
             nmnlWdX = private.nominalWidthX
-            pen = BoundsPen(None)
-            c.draw(pen) # this will set the charstring's width
+            pen = NullPen()
+            c.draw(pen)  # this will set the charstring's width
             if c.width != dfltWdX:
                 c.program = [c.width - nmnlWdX, 'endchar']
             else:
@@ -2207,7 +2207,9 @@ def prune_post_subset(self, options):
                 subrs = getattr(c.private, "Subrs", [])
                 decompiler = _DehintingT2Decompiler(css, subrs, c.globalSubrs)
                 decompiler.execute(c)
+            pen = NullPen()
             for charstring in css:
+                charstring.draw(pen)  # this will set the charstring's width
                 charstring.drop_hints()
             del css
 

--- a/Lib/fontTools/subset/subset_test.py
+++ b/Lib/fontTools/subset/subset_test.py
@@ -59,7 +59,7 @@ class SubsetTest(unittest.TestCase):
         expected = self.read_ttx(expected_ttx)
         if actual != expected:
             for line in difflib.unified_diff(
-                    expected, actual, fromfile=path, tofile=expected_ttx):
+                    expected, actual, fromfile=expected_ttx, tofile=path):
                 sys.stdout.write(line)
             self.fail("TTX output is different from expected")
 

--- a/Lib/fontTools/subset/subset_test.py
+++ b/Lib/fontTools/subset/subset_test.py
@@ -194,6 +194,44 @@ class SubsetTest(unittest.TestCase):
         # unknown tables are kept if --passthrough-tables option is passed
         self.assertTrue(unknown_tag in subsetfont)
 
+    def test_drop_hints_CFF(self):
+        _, fontpath = self.compile_font(self.getpath("TestOTF-Regular.ttx"), ".otf")
+        subsetpath = self.temp_path(".otf")
+        subset.main([fontpath, "--no-hinting", "--notdef-outline",
+                     "--output-file=%s" % subsetpath, "*"])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath(
+            "expect_drop_hints_CFF.ttx"), ["CFF "])
+
+    def test_desubroutinize_CFF(self):
+        _, fontpath = self.compile_font(self.getpath("TestOTF-Regular.ttx"), ".otf")
+        subsetpath = self.temp_path(".otf")
+        subset.main([fontpath, "--desubroutinize", "--notdef-outline",
+                     "--output-file=%s" % subsetpath, "*"])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath(
+            "expect_desubroutinize_CFF.ttx"), ["CFF "])
+
+    def test_drop_hints_desubroutinize_CFF(self):
+        _, fontpath = self.compile_font(self.getpath("TestOTF-Regular.ttx"), ".otf")
+        subsetpath = self.temp_path(".otf")
+        subset.main([fontpath, "--no-hinting", "--desubroutinize", "--notdef-outline",
+                     "--output-file=%s" % subsetpath, "*"])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath(
+            "expect_drop_hints_desubroutinize_CFF.ttx"), ["CFF "])
+
+    def test_drop_hints_TTF(self):
+        _, fontpath = self.compile_font(self.getpath("TestTTF-Regular.ttx"), ".ttf")
+        subsetpath = self.temp_path(".ttf")
+        subset.main([fontpath, "--no-hinting", "--notdef-outline",
+                     "--output-file=%s" % subsetpath, "*"])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath(
+            "expect_drop_hints_TTF.ttx"), ["glyf", "maxp"])
+        for tag in subset.Options().hinting_tables:
+            self.assertTrue(tag not in subsetfont)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/fontTools/subset/subset_test.py
+++ b/Lib/fontTools/subset/subset_test.py
@@ -152,7 +152,6 @@ class SubsetTest(unittest.TestCase):
 
     def test_timing_publishes_parts(self):
         _, fontpath = self.compile_font(self.getpath("TestTTF-Regular.ttx"), ".ttf")
-        subsetpath = self.temp_path(".ttf")
 
         options = subset.Options()
         options.timing = True

--- a/Lib/fontTools/subset/testdata/expect_desubroutinize_CFF.ttx
+++ b/Lib/fontTools/subset/testdata/expect_desubroutinize_CFF.ttx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="3.1">
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="TestOTF-Regular">
+      <version value="1.0"/>
+      <FamilyName value="Test OTF"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="0 0 486 660"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueValues value="-10 0 500 510"/>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <StdHW value="20"/>
+        <StdVW value="20"/>
+        <StemSnapH value="20"/>
+        <StemSnapV value="20"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="500"/>
+        <nominalWidthX value="300"/>
+        <Subrs>
+          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+        </Subrs>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          196 10 hmoveto
+          476 660 -476 hlineto
+          108 -602 rmoveto
+          74 132 54 103 rlineto
+          4 hlineto
+          52 -103 73 -132 rlineto
+          -129 329 rmoveto
+          -50 94 -66 119 rlineto
+          235 hlineto
+          -66 -119 -49 -94 rlineto
+          -175 -277 rmoveto
+          462 vlineto
+          127 -232 rlineto
+          217 -230 rmoveto
+          -126 230 126 232 rlineto
+          endchar
+        </CharString>
+        <CharString name="A">
+          132 304 rmoveto
+          233 263 -233 hlineto
+          endchar
+        </CharString>
+        <CharString name="B">
+          100 304 263 hstem
+          132 233 vstem
+          132 304 rmoveto
+          233 263 -233 hlineto
+          endchar
+        </CharString>
+        <CharString name="C">
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+</ttFont>

--- a/Lib/fontTools/subset/testdata/expect_drop_hints_CFF.ttx
+++ b/Lib/fontTools/subset/testdata/expect_drop_hints_CFF.ttx
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="3.1">
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="TestOTF-Regular">
+      <version value="1.0"/>
+      <FamilyName value="Test OTF"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="0 0 486 660"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="500"/>
+        <nominalWidthX value="300"/>
+        <Subrs>
+          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+          <CharString index="0">
+            132 304 rmoveto
+            233 263 -233 hlineto
+            endchar
+          </CharString>
+        </Subrs>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          196 10 hmoveto
+          476 660 -476 hlineto
+          108 -602 rmoveto
+          74 132 54 103 rlineto
+          4 hlineto
+          52 -103 73 -132 rlineto
+          -129 329 rmoveto
+          -50 94 -66 119 rlineto
+          235 hlineto
+          -66 -119 -49 -94 rlineto
+          -175 -277 rmoveto
+          462 vlineto
+          127 -232 rlineto
+          217 -230 rmoveto
+          -126 230 126 232 rlineto
+          endchar
+        </CharString>
+        <CharString name="A">
+          -107 callsubr
+        </CharString>
+        <CharString name="B">
+          100 -107 callsubr
+        </CharString>
+        <CharString name="C">
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+</ttFont>

--- a/Lib/fontTools/subset/testdata/expect_drop_hints_TTF.ttx
+++ b/Lib/fontTools/subset/testdata/expect_drop_hints_TTF.ttx
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.0">
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="10" yMin="0" xMax="486" yMax="660">
+      <contour>
+        <pt x="10" y="660" on="1"/>
+        <pt x="486" y="660" on="1"/>
+        <pt x="486" y="0" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="375" y="58" on="1"/>
+        <pt x="302" y="190" on="1"/>
+        <pt x="250" y="293" on="1"/>
+        <pt x="246" y="293" on="1"/>
+        <pt x="192" y="190" on="1"/>
+        <pt x="118" y="58" on="1"/>
+      </contour>
+      <contour>
+        <pt x="250" y="387" on="1"/>
+        <pt x="299" y="481" on="1"/>
+        <pt x="365" y="600" on="1"/>
+        <pt x="130" y="600" on="1"/>
+        <pt x="196" y="481" on="1"/>
+        <pt x="246" y="387" on="1"/>
+      </contour>
+      <contour>
+        <pt x="202" y="340" on="1"/>
+        <pt x="75" y="572" on="1"/>
+        <pt x="75" y="110" on="1"/>
+      </contour>
+      <contour>
+        <pt x="419" y="572" on="1"/>
+        <pt x="293" y="340" on="1"/>
+        <pt x="419" y="110" on="1"/>
+      </contour>
+      <instructions><assembly>
+        </assembly></instructions>
+    </TTGlyph>
+
+    <TTGlyph name="A" xMin="132" yMin="304" xMax="365" yMax="567">
+      <contour>
+        <pt x="132" y="567" on="1"/>
+        <pt x="365" y="567" on="1"/>
+        <pt x="365" y="304" on="1"/>
+        <pt x="132" y="304" on="1"/>
+      </contour>
+      <instructions><assembly>
+        </assembly></instructions>
+    </TTGlyph>
+
+    <TTGlyph name="B" xMin="132" yMin="304" xMax="365" yMax="567">
+      <contour>
+        <pt x="132" y="567" on="1"/>
+        <pt x="365" y="567" on="1"/>
+        <pt x="365" y="304" on="1"/>
+        <pt x="132" y="304" on="1"/>
+      </contour>
+      <instructions><assembly>
+        </assembly></instructions>
+    </TTGlyph>
+
+    <TTGlyph name="C"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="4"/>
+    <maxPoints value="22"/>
+    <maxContours value="5"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+</ttFont>

--- a/Lib/fontTools/subset/testdata/expect_drop_hints_desubroutinize_CFF.ttx
+++ b/Lib/fontTools/subset/testdata/expect_drop_hints_desubroutinize_CFF.ttx
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="3.1">
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="TestOTF-Regular">
+      <version value="1.0"/>
+      <FamilyName value="Test OTF"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="0 0 486 660"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="500"/>
+        <nominalWidthX value="300"/>
+        <Subrs>
+          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+        </Subrs>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          196 10 hmoveto
+          476 660 -476 hlineto
+          108 -602 rmoveto
+          74 132 54 103 rlineto
+          4 hlineto
+          52 -103 73 -132 rlineto
+          -129 329 rmoveto
+          -50 94 -66 119 rlineto
+          235 hlineto
+          -66 -119 -49 -94 rlineto
+          -175 -277 rmoveto
+          462 vlineto
+          127 -232 rlineto
+          217 -230 rmoveto
+          -126 230 126 232 rlineto
+          endchar
+        </CharString>
+        <CharString name="A">
+          132 304 rmoveto
+          233 263 -233 hlineto
+          endchar
+        </CharString>
+        <CharString name="B">
+          100 132 304 rmoveto
+          233 263 -233 hlineto
+          endchar
+        </CharString>
+        <CharString name="C">
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+</ttFont>


### PR DESCRIPTION
It seems that the horizontal advance of hinted charstrings gets lost when the CFF hinting is stripped with '--no-hinting' option, as it was noted by @miguelsousa in this comment:

https://github.com/behdad/fonttools/issues/343#issuecomment-156234918

The reason is `T2CharString` objects only get assigned a 'witdh' attribute after their 'draw' method is called.

The subsetter's `drop_hints` function attempts to insert the width back at the beginning of the de-hinted charstring's program, but can do that only if the charstring does have a 'width' attribute:

https://github.com/behdad/fonttools/blob/master/Lib/fontTools/subset/__init__.py#L1908

Hence, we must 'draw' the charstring (with a `NullPen`) before stripping the hints.

(I will add a quick test tomorrow.)