### PR TITLE
update Makefile; use pytest-runner; etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,22 @@
 all:
-	./setup.py bdist
+	./setup.py build
 
 dist:
-	./setup.py sdist
+	./setup.py sdist bdist_wheel
 
 install:
-	./setup.py install
+	pip install --ignore-installed .
 
 install-user:
-	./setup.py install --user
+	pip install --ignore-installed --user .
+
+uninstall:
+	pip uninstall --yes fonttools
 
 check: all
 	./run-tests.sh
+
+clean:
+	./setup.py clean --all
+
+.PHONY: all dist install install-user uninstall check clean

--- a/README.md
+++ b/README.md
@@ -124,12 +124,13 @@ A selection of sample python programs is in the [Snippets](https://github.com/fo
 
 ### Testing
 
-You can use [pytest](http://docs.pytest.org/en/latest/) to run the test suite:
+To run the test suite, you can do:
 
 ```sh
-pip install pytest
-py.test
+python setup.py test
 ```
+
+Or if you have [pytest](http://docs.pytest.org/en/latest/), you can run the `pytest` command directly.
 
 We also use [tox](https://testrun.org/tox/latest/) to automatically test on different Python versions in isolated virtual environments.
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -22,7 +22,7 @@ done
 
 # Run tests
 if [ -z "$FILTERS" ]; then
-	$PYTHON -m pytest
+	$PYTHON setup.py test
 else
-	$PYTHON -m pytest -k "$FILTERS"
+	$PYTHON setup.py test --addopts="-k \"$FILTERS\""
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,25 @@ universal = 1
 
 [sdist]
 formats = zip
+
+[aliases]
+test = pytest
+
+[tool:pytest]
+minversion = 2.8
+testpaths =
+    Lib/fontTools
+python_files =
+    *_test.py
+python_classes =
+    *Test
+addopts =
+    # run py.test in verbose mode
+    -v
+    # show extra test summary info
+    -r a
+    # run doctests in all .py modules
+    --doctest-modules
+    # py.test raises ImportError with inspect.py (requires pygtk) and with
+    # reportLabPen.py (reportlab). They don't have doctests, it's OK to skip.
+    --doctest-ignore-import-errors

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,10 @@ def doraise_py_compile(file, cfile=None, dfile=None, doraise=False):
 
 py_compile.compile = doraise_py_compile
 
+needs_pytest = {'pytest', 'test'}.intersection(sys.argv)
+pytest_runner = ['pytest_runner'] if needs_pytest else []
+needs_wheel = {'bdist_wheel'}.intersection(sys.argv)
+wheel = ['wheel'] if needs_wheel else []
 
 # Trove classifiers for PyPI
 classifiers = {"classifiers": [
@@ -59,7 +63,10 @@ setup(
 		('share/man/man1', ["Doc/ttx.1"])
 	] if sys.platform.startswith('linux') else [],
 	setup_requires=[
-		"setuptools_scm>=1.11.1",
+			"setuptools_scm>=1.11.1",
+		] + pytest_runner + wheel,
+	tests_require=[
+		'pytest>=2.8',
 	],
 	entry_points={
 		'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -32,22 +32,3 @@ commands=
     # measure test coverage and upload report to coveralls
     py.test --cov
     coveralls
-
-[pytest]
-minversion = 2.8
-testpaths =
-    Lib/fontTools
-python_files =
-    *_test.py
-python_classes = 
-    *Test
-addopts =
-    # run py.test in verbose mode
-    -v
-    # show extra test summary info
-    -r a
-    # run doctests in all .py modules
-    --doctest-modules
-    # py.test raises ImportError with inspect.py (requires pygtk) and with
-    # reportLabPen.py (reportlab). They don't have doctests, it's OK to skip.
-    --doctest-ignore-import-errors


### PR DESCRIPTION
Follow up from https://github.com/fonttools/fonttools/commit/064932e2e6557852d311f901e3c798cca8e34174

Tests can now be run from a local checkout with the canonical `python setup.py test`. You can also use the `run-tests.sh` script or `make check`, so everyone is happy. :)

We use the pytest-runner plugin to bootstrap pytest when running `setup.py test`, without having to pip install it beforehand.