### PR TITLE
feaLib: fix code to use hex version instead of float

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -452,7 +452,7 @@ class Builder(object):
 
     def makeTable(self, tag):
         table = getattr(otTables, tag, None)()
-        table.Version = 1.0
+        table.Version = 0x00010000
         table.ScriptList = otTables.ScriptList()
         table.ScriptList.ScriptRecord = []
         table.FeatureList = otTables.FeatureList()


### PR DESCRIPTION
This avoids the new warning `Table version value is a float: 1; fix code to use hex instead: 00010000`.
See https://github.com/googlei18n/fontmake/issues/149.