### PR TITLE
Fix varlib names

### DIFF
--- a/Lib/fontTools/misc/loggingTools.py
+++ b/Lib/fontTools/misc/loggingTools.py
@@ -429,6 +429,41 @@ class ChannelsFilter(logging.Filter):
 		return False
 
 
+class CapturingLogHandler(logging.Handler):
+	def __init__(self, logger, level):
+		self.records = []
+		self.level = logging._checkLevel(level)
+		if isinstance(logger, basestring):
+			self.logger = logging.getLogger(logger)
+		else:
+			self.logger = logger
+
+	def __enter__(self):
+		self.original_disabled = self.logger.disabled
+		self.original_level = self.logger.level
+
+		self.logger.addHandler(self)
+		self.logger.level = self.level
+		self.logger.disabled = False
+
+		return self
+
+	def __exit__(self, type, value, traceback):
+		self.logger.removeHandler(self)
+		self.logger.level = self.original_level
+		self.logger.disabled = self.logger.disabled
+		return self
+
+	def handle(self, record):
+		self.records.append(record)
+
+	def emit(self, record):
+		pass
+
+	def createLock(self):
+		self.lock = None
+
+
 def deprecateArgument(name, msg, category=UserWarning):
 	""" Raise a warning about deprecated function argument 'name'. """
 	warnings.warn(

--- a/Lib/fontTools/subset/subset_test.py
+++ b/Lib/fontTools/subset/subset_test.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools import subset
 from fontTools.ttLib import TTFont, newTable
-import contextlib
+from fontTools.misc.loggingTools import CapturingLogHandler
 import difflib
 import logging
 import os
@@ -10,38 +10,6 @@ import shutil
 import sys
 import tempfile
 import unittest
-
-
-class CapturingLogHandler(logging.Handler):
-  def __init__(self, log_path, level):
-    self.records = []
-    self.level = level
-    self.logger = logging.getLogger(log_path)
-
-  def __enter__(self):
-    self.original_disabled = self.logger.disabled
-    self.original_level = self.logger.level
-
-    self.logger.addHandler(self)
-    self.logger.level = self.level
-    self.logger.disabled = False
-
-    return self
-
-  def __exit__(self, type, value, traceback):
-    self.logger.removeHandler(self)
-    self.logger.level = self.original_level
-    self.logger.disabled = self.logger.disabled
-    return self
-
-  def handle(self, record):
-    self.records.append(record)
-
-  def emit(self, record):
-    pass
-
-  def createLock(self):
-    self.lock = None
 
 
 class SubsetTest(unittest.TestCase):


### PR DESCRIPTION
This should fix https://github.com/fonttools/fonttools/issues/683

varLib now adds both Macintosh (platformID=1) and Windows (platformID=3) name records for axes names and instance styles, to work around an issue when loading OpenType Variable fonts on macOS.

I also fixed another str/bytes issue related to the `NameRecord.setName` method. This now accepts as input string both unicode or bytes, with the latter assumed to be already encoded with the specified (platformID, platEncID, langID) triplet.

Note that this is how the `string` attribute of `NameRecord` worked already: it takes either a unicode string (in which case, it attempts to encode it with the correct platform encoding upon compiling), or it takes a pre-encoded bytes string which is treated literally. It's the client's responsibility to either pass unicodes (and let the library encode them), or to take care of passing in the correct bytes.