### PR TITLE
Allow single-point open contours in area pen

### DIFF
--- a/Lib/fontTools/pens/areaPen.py
+++ b/Lib/fontTools/pens/areaPen.py
@@ -63,5 +63,9 @@ class AreaPen(BasePen):
 		del self._p0, self._startPoint
 
 	def _endPath(self):
-		"""Area is not defined for open contours."""
-		raise NotImplementedError
+		"""Area is not defined for open contours.
+		Single-point open contours, which often represent anchors, are allowed.
+		"""
+		if self._p0 != self.startPoint:
+			raise NotImplementedError
+		del self._p0, self._startPoint

--- a/Lib/fontTools/pens/areaPen.py
+++ b/Lib/fontTools/pens/areaPen.py
@@ -66,6 +66,6 @@ class AreaPen(BasePen):
 		"""Area is not defined for open contours.
 		Single-point open contours, which often represent anchors, are allowed.
 		"""
-		if self._p0 != self.startPoint:
+		if self._p0 != self._startPoint:
 			raise NotImplementedError
 		del self._p0, self._startPoint

--- a/Lib/fontTools/pens/areaPen_test.py
+++ b/Lib/fontTools/pens/areaPen_test.py
@@ -163,6 +163,17 @@ class AreaPenTest(unittest.TestCase):
         draw8_(pen)
         self.assertEqual(104602.791667, round(pen.value, precision))
 
+    def test_openPaths(self):
+        pen = AreaPen()
+        pen.moveTo((0, 0))
+        pen.endPath()
+        self.assertEqual(0, pen.value)
+
+        pen.moveTo((0, 0))
+        pen.lineTo((1, 0))
+        with self.assertRaises(NotImplementedError):
+            pen.endPath()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Sometimes an anchor is drawn as a moveTo followed by an endPath, for
that case it makes sense just to ignore and count the area as zero.

r? @anthrotype