### PR TITLE
Remove extra_path distribution kwarg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
 	package_dir={'': 'Lib'},
 	packages=find_packages("Lib"),
 	py_modules=['sstruct', 'xmlWriter'],
-	extra_path='FontTools',
 	include_package_data=True,
 	data_files=[
 		('share/man/man1', ["Doc/ttx.1"])


### PR DESCRIPTION
This is of no use, it is undocumented and bound to be removed.

See https://bugs.python.org/issue901727 and https://bugs.python.org/issue27919.