### PR TITLE
[_h_m_t_x] Read advanceWidth as unsigned short (uint16)

### DIFF
--- a/Lib/fontTools/ttLib/tables/_h_m_t_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x.py
@@ -53,11 +53,11 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
 					"Glyph %r has a huge advance %s (%d); is it intentional or "
 					"an (invalid) negative value?", glyphName, self.advanceName,
 					advanceWidth)
-			self.metrics[glyphName] = [advanceWidth, lsb]
+			self.metrics[glyphName] = (advanceWidth, lsb)
 		lastAdvance = metrics[-2]
 		for i in range(numberOfSideBearings):
 			glyphName = glyphOrder[i + numberOfMetrics]
-			self.metrics[glyphName] = [lastAdvance, sideBearings[i]]
+			self.metrics[glyphName] = (lastAdvance, sideBearings[i])
 
 	def compile(self, ttFont):
 		metrics = []
@@ -117,8 +117,8 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
 		if not hasattr(self, "metrics"):
 			self.metrics = {}
 		if name == "mtx":
-			self.metrics[attrs["name"]] = [safeEval(attrs[self.advanceName]),
-					safeEval(attrs[self.sideBearingName])]
+			self.metrics[attrs["name"]] = (safeEval(attrs[self.advanceName]),
+					safeEval(attrs[self.sideBearingName]))
 
 	def __delitem__(self, glyphName):
 		del self.metrics[glyphName]
@@ -127,4 +127,4 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
 		return self.metrics[glyphName]
 
 	def __setitem__(self, glyphName, advance_sb_pair):
-		self.metrics[glyphName] = list(advance_sb_pair)
+		self.metrics[glyphName] = tuple(advance_sb_pair)

--- a/Lib/fontTools/ttLib/tables/_h_m_t_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x.py
@@ -18,6 +18,7 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
 	advanceName = 'width'
 	sideBearingName = 'lsb'
 	numberOfMetricsName = 'numberOfHMetrics'
+	longMetricFormat = 'Hh'
 
 	def decompile(self, data, ttFont):
 		numGlyphs = ttFont['maxp'].numGlyphs
@@ -29,8 +30,8 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
 		# Note: advanceWidth is unsigned, but some font editors might
 		# read/write as signed. We can't be sure whether it was a mistake
 		# or not, so we read as unsigned but also issue a warning...
-		longHorMetricFormat = ">" + "Hh"*numberOfMetrics
-		metrics = struct.unpack(longHorMetricFormat, data[:4 * numberOfMetrics])
+		metricsFmt = ">" + self.longMetricFormat * numberOfMetrics
+		metrics = struct.unpack(metricsFmt, data[:4 * numberOfMetrics])
 		data = data[4 * numberOfMetrics:]
 		numberOfSideBearings = numGlyphs - numberOfMetrics
 		sideBearings = array.array("h", data[:2 * numberOfSideBearings])
@@ -77,8 +78,8 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
 		allMetrics = []
 		for item in metrics:
 			allMetrics.extend(item)
-		longHorMetricFormat = ">" + "Hh"*numberOfMetrics
-		data = struct.pack(longHorMetricFormat, *allMetrics)
+		metricsFmt = ">" + self.longMetricFormat * numberOfMetrics
+		data = struct.pack(metricsFmt, *allMetrics)
 
 		additionalMetrics = array.array("h", additionalMetrics)
 		if sys.byteorder != "big":

--- a/Lib/fontTools/ttLib/tables/_h_m_t_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x.py
@@ -127,4 +127,4 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
 		return self.metrics[glyphName]
 
 	def __setitem__(self, glyphName, advance_sb_pair):
-		self.metrics[glyphName] = tuple(advance_sb_pair)
+		self.metrics[glyphName] = list(advance_sb_pair)

--- a/Lib/fontTools/ttLib/tables/_h_m_t_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x.py
@@ -24,7 +24,9 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
 		numGlyphs = ttFont['maxp'].numGlyphs
 		numberOfMetrics = int(getattr(ttFont[self.headerTag], self.numberOfMetricsName))
 		if numberOfMetrics > numGlyphs:
-			numberOfMetrics = numGlyphs  # We warn later.
+			log.warning("The %s.%s exceeds the maxp.numGlyphs" % (
+				self.headerTag, self.numberOfMetricsName))
+			numberOfMetrics = numGlyphs
 		if len(data) < 4 * numberOfMetrics:
 			raise ttLib.TTLibError("not enough '%s' table data" % self.tableTag)
 		# Note: advanceWidth is unsigned, but some font editors might

--- a/Lib/fontTools/ttLib/tables/_h_m_t_x_test.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x_test.py
@@ -1,0 +1,205 @@
+from __future__ import print_function, division, absolute_import
+from __future__ import unicode_literals
+from fontTools.misc.py23 import *
+from fontTools.misc.testTools import parseXML, getXML
+from fontTools.misc.textTools import deHexStr
+from fontTools.ttLib import TTFont, newTable, TTLibError
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.ttLib.tables._h_m_t_x import table__h_m_t_x, log
+import struct
+import unittest
+
+
+class HmtxTableTest(unittest.TestCase):
+
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+        # Python 3 renamed assertRaisesRegexp to assertRaisesRegex,
+        # and fires deprecation warnings if a program uses the old name.
+        if not hasattr(self, "assertRaisesRegex"):
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tableClass = table__h_m_t_x
+        cls.tag = "hmtx"
+
+    def makeFont(self, numGlyphs, numberOfMetrics):
+        font = TTFont()
+        maxp = font['maxp'] = newTable('maxp')
+        maxp.numGlyphs = numGlyphs
+        # from A to ...
+        font.glyphOrder = [chr(i) for i in range(65, 65+numGlyphs)]
+        headerTag = self.tableClass.headerTag
+        font[headerTag] = newTable(headerTag)
+        numberOfMetricsName = self.tableClass.numberOfMetricsName
+        setattr(font[headerTag], numberOfMetricsName, numberOfMetrics)
+        return font
+
+    def test_decompile(self):
+        font = self.makeFont(numGlyphs=3, numberOfMetrics=3)
+        data = deHexStr("02A2 FFF5 0278 004F 02C6 0036")
+
+        mtxTable = newTable(self.tag)
+        mtxTable.decompile(data, font)
+
+        self.assertEqual(mtxTable['A'], [674, -11])
+        self.assertEqual(mtxTable['B'], [632, 79])
+        self.assertEqual(mtxTable['C'], [710, 54])
+
+    def test_decompile_additional_SB(self):
+        font = self.makeFont(numGlyphs=4, numberOfMetrics=2)
+        metrics = deHexStr("02A2 FFF5 0278 004F")
+        extraSideBearings = deHexStr("0036 FFFC")
+        data = metrics + extraSideBearings
+
+        mtxTable = newTable(self.tag)
+        mtxTable.decompile(data, font)
+
+        self.assertEqual(mtxTable['A'], [674, -11])
+        self.assertEqual(mtxTable['B'], [632, 79])
+        # all following have same width as the previous
+        self.assertEqual(mtxTable['C'], [632, 54])
+        self.assertEqual(mtxTable['D'], [632, -4])
+
+    def test_decompile_not_enough_data(self):
+        font = self.makeFont(numGlyphs=1, numberOfMetrics=1)
+        mtxTable = newTable(self.tag)
+        msg = "not enough '%s' table data" % self.tag
+
+        with self.assertRaisesRegex(TTLibError, msg):
+            mtxTable.decompile(b"\0\0\0", font)
+
+    def test_decompile_too_much_data(self):
+        font = self.makeFont(numGlyphs=1, numberOfMetrics=1)
+        mtxTable = newTable(self.tag)
+        msg = "too much '%s' table data" % self.tag
+
+        with CapturingLogHandler(log, "WARNING") as captor:
+            mtxTable.decompile(b"\0\0\0\0\0", font)
+
+        self.assertTrue(
+            len([r for r in captor.records if msg == r.msg]) == 1)
+
+    def test_decompile_num_metrics_greater_than_glyphs(self):
+        font = self.makeFont(numGlyphs=1, numberOfMetrics=2)
+        mtxTable = newTable(self.tag)
+        msg = "The %s.%s exceeds the maxp.numGlyphs" % (
+            self.tableClass.headerTag, self.tableClass.numberOfMetricsName)
+
+        with CapturingLogHandler(log, "WARNING") as captor:
+            mtxTable.decompile(b"\0\0\0\0", font)
+
+        self.assertTrue(
+            len([r for r in captor.records if msg == r.msg]) == 1)
+
+    def test_decompile_possibly_negative_advance(self):
+        font = self.makeFont(numGlyphs=1, numberOfMetrics=1)
+        # we warn if advance is > 0x7FFF as it might be interpreted as signed
+        # by some authoring tools
+        data = deHexStr("8000 0000")
+        mtxTable = newTable(self.tag)
+
+        with CapturingLogHandler(log, "WARNING") as captor:
+            mtxTable.decompile(data, font)
+
+        self.assertTrue(
+            len([r for r in captor.records
+                if "has a huge advance" in r.msg]) == 1)
+
+    def test_compile(self):
+        # we set the wrong 'numberOfMetrics' to check it gets adjusted
+        font = self.makeFont(numGlyphs=3, numberOfMetrics=4)
+        mtxTable = font[self.tag] = newTable(self.tag)
+        mtxTable.metrics = {
+            'A': [674, -11],
+            'B': [632, 79],
+            'C': [710, 54],
+        }
+
+        data = mtxTable.compile(font)
+
+        self.assertEqual(data, deHexStr("02A2 FFF5 0278 004F 02C6 0036"))
+
+        headerTable = font[self.tableClass.headerTag]
+        self.assertEqual(
+            getattr(headerTable, self.tableClass.numberOfMetricsName), 3)
+
+    def test_compile_additional_SB(self):
+        font = self.makeFont(numGlyphs=4, numberOfMetrics=1)
+        mtxTable = font[self.tag] = newTable(self.tag)
+        mtxTable.metrics = {
+            'A': [632, -11],
+            'B': [632, 79],
+            'C': [632, 54],
+            'D': [632, -4],
+        }
+
+        data = mtxTable.compile(font)
+
+        self.assertEqual(data, deHexStr("0278 FFF5 004F 0036 FFFC"))
+
+    def test_compile_negative_advance(self):
+        font = self.makeFont(numGlyphs=1, numberOfMetrics=1)
+        mtxTable = font[self.tag] = newTable(self.tag)
+        mtxTable.metrics = {'A': [-1, 0]}
+
+        with CapturingLogHandler(log, "ERROR") as captor:
+            with self.assertRaisesRegex(TTLibError, "negative advance"):
+                mtxTable.compile(font)
+
+        self.assertTrue(
+            len([r for r in captor.records
+                if "Glyph 'A' has negative advance" in r.msg]) == 1)
+
+    def test_compile_struct_out_of_range(self):
+        font = self.makeFont(numGlyphs=1, numberOfMetrics=1)
+        mtxTable = font[self.tag] = newTable(self.tag)
+        mtxTable.metrics = {'A': [0xFFFF+1, -0x8001]}
+
+        with self.assertRaises(struct.error):
+            mtxTable.compile(font)
+
+    def test_toXML(self):
+        font = self.makeFont(numGlyphs=2, numberOfMetrics=2)
+        mtxTable = font[self.tag] = newTable(self.tag)
+        mtxTable.metrics = {'B': [632, 79], 'A': [674, -11]}
+
+        self.assertEqual(
+            getXML(mtxTable.toXML),
+            '<mtx name="A" %s="674" %s="-11"/>'
+            '<mtx name="B" %s="632" %s="79"/>' % (
+                (self.tableClass.advanceName,
+                 self.tableClass.sideBearingName) * 2))
+
+    def test_fromXML(self):
+        mtxTable = newTable(self.tag)
+
+        for name, attrs, content in parseXML(
+                '<mtx name="A" %s="674" %s="-11"/>'
+                '<mtx name="B" %s="632" %s="79"/>' % (
+                    (self.tableClass.advanceName,
+                     self.tableClass.sideBearingName) * 2)):
+            mtxTable.fromXML(name, attrs, content, ttFont=None)
+
+        self.assertEqual(
+            mtxTable.metrics, {'A': [674, -11], 'B': [632, 79]})
+
+    def test_delitem(self):
+        mtxTable = newTable(self.tag)
+        mtxTable.metrics = {'A': [0, 0]}
+
+        del mtxTable['A']
+
+        self.assertTrue('A' not in mtxTable.metrics)
+
+    def test_setitem(self):
+        mtxTable = newTable(self.tag)
+        mtxTable.metrics = {'A': [674, -11], 'B': [632, 79]}
+        mtxTable['B'] = (0, 0)  # tuple is converted to list
+
+        self.assertEqual(mtxTable.metrics, {'A': [674, -11], 'B': [0, 0]})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/fontTools/ttLib/tables/_h_m_t_x_test.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x_test.py
@@ -43,9 +43,9 @@ class HmtxTableTest(unittest.TestCase):
         mtxTable = newTable(self.tag)
         mtxTable.decompile(data, font)
 
-        self.assertEqual(mtxTable['A'], [674, -11])
-        self.assertEqual(mtxTable['B'], [632, 79])
-        self.assertEqual(mtxTable['C'], [710, 54])
+        self.assertEqual(mtxTable['A'], (674, -11))
+        self.assertEqual(mtxTable['B'], (632, 79))
+        self.assertEqual(mtxTable['C'], (710, 54))
 
     def test_decompile_additional_SB(self):
         font = self.makeFont(numGlyphs=4, numberOfMetrics=2)
@@ -56,11 +56,11 @@ class HmtxTableTest(unittest.TestCase):
         mtxTable = newTable(self.tag)
         mtxTable.decompile(data, font)
 
-        self.assertEqual(mtxTable['A'], [674, -11])
-        self.assertEqual(mtxTable['B'], [632, 79])
+        self.assertEqual(mtxTable['A'], (674, -11))
+        self.assertEqual(mtxTable['B'], (632, 79))
         # all following have same width as the previous
-        self.assertEqual(mtxTable['C'], [632, 54])
-        self.assertEqual(mtxTable['D'], [632, -4])
+        self.assertEqual(mtxTable['C'], (632, 54))
+        self.assertEqual(mtxTable['D'], (632, -4))
 
     def test_decompile_not_enough_data(self):
         font = self.makeFont(numGlyphs=1, numberOfMetrics=1)
@@ -112,9 +112,9 @@ class HmtxTableTest(unittest.TestCase):
         font = self.makeFont(numGlyphs=3, numberOfMetrics=4)
         mtxTable = font[self.tag] = newTable(self.tag)
         mtxTable.metrics = {
-            'A': [674, -11],
-            'B': [632, 79],
-            'C': [710, 54],
+            'A': (674, -11),
+            'B': (632, 79),
+            'C': (710, 54),
         }
 
         data = mtxTable.compile(font)
@@ -129,10 +129,10 @@ class HmtxTableTest(unittest.TestCase):
         font = self.makeFont(numGlyphs=4, numberOfMetrics=1)
         mtxTable = font[self.tag] = newTable(self.tag)
         mtxTable.metrics = {
-            'A': [632, -11],
-            'B': [632, 79],
-            'C': [632, 54],
-            'D': [632, -4],
+            'A': (632, -11),
+            'B': (632, 79),
+            'C': (632, 54),
+            'D': (632, -4),
         }
 
         data = mtxTable.compile(font)
@@ -155,7 +155,7 @@ class HmtxTableTest(unittest.TestCase):
     def test_compile_struct_out_of_range(self):
         font = self.makeFont(numGlyphs=1, numberOfMetrics=1)
         mtxTable = font[self.tag] = newTable(self.tag)
-        mtxTable.metrics = {'A': [0xFFFF+1, -0x8001]}
+        mtxTable.metrics = {'A': (0xFFFF+1, -0x8001)}
 
         with self.assertRaises(struct.error):
             mtxTable.compile(font)
@@ -163,7 +163,7 @@ class HmtxTableTest(unittest.TestCase):
     def test_toXML(self):
         font = self.makeFont(numGlyphs=2, numberOfMetrics=2)
         mtxTable = font[self.tag] = newTable(self.tag)
-        mtxTable.metrics = {'B': [632, 79], 'A': [674, -11]}
+        mtxTable.metrics = {'B': (632, 79), 'A': (674, -11)}
 
         self.assertEqual(
             getXML(mtxTable.toXML),
@@ -183,11 +183,11 @@ class HmtxTableTest(unittest.TestCase):
             mtxTable.fromXML(name, attrs, content, ttFont=None)
 
         self.assertEqual(
-            mtxTable.metrics, {'A': [674, -11], 'B': [632, 79]})
+            mtxTable.metrics, {'A': (674, -11), 'B': (632, 79)})
 
     def test_delitem(self):
         mtxTable = newTable(self.tag)
-        mtxTable.metrics = {'A': [0, 0]}
+        mtxTable.metrics = {'A': (0, 0)}
 
         del mtxTable['A']
 
@@ -195,10 +195,10 @@ class HmtxTableTest(unittest.TestCase):
 
     def test_setitem(self):
         mtxTable = newTable(self.tag)
-        mtxTable.metrics = {'A': [674, -11], 'B': [632, 79]}
-        mtxTable['B'] = (0, 0)  # tuple is converted to list
+        mtxTable.metrics = {'A': (674, -11), 'B': (632, 79)}
+        mtxTable['B'] = [0, 0]  # list is converted to tuple
 
-        self.assertEqual(mtxTable.metrics, {'A': [674, -11], 'B': [0, 0]})
+        self.assertEqual(mtxTable.metrics, {'A': (674, -11), 'B': (0, 0)})
 
 
 if __name__ == "__main__":

--- a/Lib/fontTools/ttLib/tables/_v_m_t_x_test.py
+++ b/Lib/fontTools/ttLib/tables/_v_m_t_x_test.py
@@ -1,0 +1,18 @@
+from __future__ import print_function, division, absolute_import
+from __future__ import unicode_literals
+from fontTools.misc.py23 import *
+from fontTools.ttLib.tables._v_m_t_x import table__v_m_t_x
+from fontTools.ttLib.tables import _h_m_t_x_test
+import unittest
+
+
+class VmtxTableTest(_h_m_t_x_test.HmtxTableTest):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tableClass = table__v_m_t_x
+        cls.tag = "vmtx"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,7 +13,7 @@ include run-tests.sh
 
 recursive-include Lib/fontTools testdata/*.ttx testdata/*.otx testdata/*.fea
 recursive-include Lib/fontTools testdata/*.lwfn testdata/*.pfa testdata/*.pfb
-recursive-include Lib/fontTools testdata/*.xml testdata/*.designspace
+recursive-include Lib/fontTools testdata/*.xml testdata/*.designspace testdata/*.bin
 
 include versioneer.py
 include Lib/fontTools/_version.py

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,6 @@ deps =
 install_command =
     {envpython} -m pip install -v {opts} {packages}
 commands =
-    # check that we have the expected Python version and architecture
-    {envpython} -c "import sys; print(sys.version)"
-    {envpython} -c "import struct; print(struct.calcsize('P') * 8)"
     # run the test suite against the package installed inside tox env
     py.test {posargs:--pyargs fontTools}
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,21 @@ commands =
     # run the test suite against the package installed inside tox env
     py.test {posargs:--pyargs fontTools}
 
+[testenv:coverage]
+basepython = {env:TOXPYTHON:python3.5}
+deps =
+    {[testenv]deps}
+    pytest-cov
+skip_install = true
+commands=
+    # measure test coverage and create html report
+    py.test --cov --cov-report html {posargs}
+
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 basepython=python3.5
 deps =
-    {[testenv]deps}
-    pytest-cov
+    {[testenv:coverage]deps}
     coveralls
 skip_install = true
 ignore_outcome = true

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ commands =
     # check that we have the expected Python version and architecture
     {envpython} -c "import sys; print(sys.version)"
     {envpython} -c "import struct; print(struct.calcsize('P') * 8)"
-    # run the test suite
-    py.test {posargs}
+    # run the test suite against the package installed inside tox env
+    py.test {posargs:--pyargs fontTools}
 
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
Print a warning on decompile if advance width (or height for vmtx) exceeds 0x7FFF (32767).

Upon compile, `struct.pack` will raise if the value is negative as it is out of range for the unsigned "H" format.

Fixes #645 

---

Apparently both FontLab Studio (both 5 and VI) and Robofont allow these negative advances to occur in a font. UFO spec either does not enforce the value to be positive. I wonder why this is the case. Glyphs like that are definitely broken, as you can see from the mega-huge width they take when loaded in FreeType, MS and Apple rasterizers.

/cc @twardoch @typemytype @typesupply