### PR TITLE
[Travis] try to speed up osx builds a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,6 @@ matrix:
       env: TOXENV=pypy
     - language: generic
       os: osx
-      # the default 'osx' on Travis is 10.9 Mavericks, with Python 2.7.5
-      env: TOXENV=py27
-    - language: generic
-      os: osx
-      # this is to test on 10.11 El Capitan which comes with Python 2.7.10
-      osx_image: xcode7.3
       env: TOXENV=py27
     - language: generic
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ matrix:
     - language: generic
       os: osx
       env: TOXENV=py35
-    - language: generic
-      os: osx
-      env: TOXENV=pypy
     # coveralls is not listed in tox's envlist, but should run in travis
     - python: 3.5
       env: TOXENV=coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ matrix:
       env: TOXENV=py27
     - language: generic
       os: osx
-      env: TOXENV=py34
-    - language: generic
-      os: osx
       env: TOXENV=py35
     # coveralls is not listed in tox's envlist, but should run in travis
     - python: 3.5

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -25,8 +25,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             pyenv global 3.5.2
             ;;
         pypy)
-            pyenv install pypy-5.3.1
-            pyenv global pypy-5.3.1
+            pyenv install pypy-5.4.1
+            pyenv global pypy-5.4.1
             ;;
     esac
     pyenv rehash
@@ -40,8 +40,8 @@ else
         eval "$(pyenv init -)"
 
         if [[ "${TOXENV}" == "pypy" ]]; then
-            pyenv install pypy-5.3.1
-            pyenv global pypy-5.3.1
+            pyenv install pypy-5.4.1
+            pyenv global pypy-5.4.1
         else
             pyenv install jython-2.7.1b3
             pyenv global jython-2.7.1b3


### PR DESCRIPTION
Travis CI has become too slow, especially for the osx environment.

It's not just for the recent outage -- https://www.traviscistatus.com/ --, but I think it's also because of its increasing popularity, and the fact that it's the only one free providing OS X environments.
Even Appveyor, which does one build at the time, is now faster than Travis!

So I think we need to clean up our Travis configuration and only run the most essential ones.

We don't need to test two Python 2.7 bugfix releases on OSX; one (whatever is the current Travis default) is enough.

Also, PyPy is quite niche and we can get away with only testing it on the Linux platform.