### PR TITLE
Add otConverters.NameID

### DIFF
--- a/Lib/fontTools/feaLib/testdata/spec8b.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec8b.ttx
@@ -37,7 +37,7 @@
           <FeatureParamsSize>
             <DesignSize value="10.0"/>
             <SubfamilyID value="3"/>
-            <SubfamilyNameID value="256"/>
+            <SubfamilyNameID value="256"/>  <!-- Win MinionPro Size Name -->
             <RangeStart value="8.0"/>
             <RangeEnd value="13.9"/>
           </FeatureParamsSize>

--- a/Lib/fontTools/feaLib/testdata/spec8c.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec8c.ttx
@@ -39,7 +39,7 @@
         <Feature>
           <FeatureParamsStylisticSet>
             <Version value="0"/>
-            <UINameID value="256"/>
+            <UINameID value="256"/>  <!-- Feature description for MS Platform, script Unicode, language English -->
           </FeatureParamsStylisticSet>
           <!-- LookupCount=1 -->
           <LookupListIndex index="0" value="0"/>

--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -60,16 +60,21 @@ class TestXMLReader_(object):
         self.stack[-1][2].append(data)
 
 
-def getXML(func, ttFont=None):
-    """Call the passed toXML function and return the written content as string.
-    Result is stripped of XML declaration and OS-specific newline characters.
-    """
+def makeXMLWriter():
     writer = XMLWriter(BytesIO())
     # don't write OS-specific new lines
     writer.newlinestr = writer.totype('')
     # erase XML declaration
     writer.file.seek(0)
     writer.file.truncate()
+    return writer
+
+
+def getXML(func, ttFont=None):
+    """Call the passed toXML function and return the written content as string.
+    Result is stripped of XML declaration and OS-specific newline characters.
+    """
+    writer = makeXMLWriter()
     func(writer, ttFont)
     xml = writer.file.getvalue().decode("utf-8")
     return xml

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -236,6 +236,22 @@ class GlyphID(SimpleValue):
 	def write(self, writer, font, tableDict, value, repeatIndex=None):
 		writer.writeUShort(font.getGlyphID(value))
 
+
+class NameID(UShort):
+	def xmlWrite(self, xmlWriter, font, value, name, attrs):
+		xmlWriter.simpletag(name, attrs + [("value", value)])
+		nameTable = font.get("name") if font else None
+		if nameTable:
+			name = nameTable.getDebugName(value)
+			xmlWriter.write("  ")
+			if name:
+				xmlWriter.comment(name)
+			else:
+				xmlWriter.comment("missing from name table")
+				log.warning("name id %d missing from name table" % value)
+		xmlWriter.newline()
+
+
 class FloatValue(SimpleValue):
 	def xmlRead(self, attrs, content, font):
 		return float(attrs["value"])
@@ -601,6 +617,7 @@ converterMapping = {
 	"Version":	Version,
 	"Tag":		Tag,
 	"GlyphID":	GlyphID,
+	"NameID":	NameID,
 	"DeciPoints":	DeciPoints,
 	"Fixed":	Fixed,
 	"F2Dot14":	F2Dot14,

--- a/Lib/fontTools/ttLib/tables/otConverters_test.py
+++ b/Lib/fontTools/ttLib/tables/otConverters_test.py
@@ -1,8 +1,10 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
-from fontTools.misc.testTools import FakeFont
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.misc.testTools import FakeFont, makeXMLWriter
 from fontTools.misc.textTools import deHexStr
 import fontTools.ttLib.tables.otConverters as otConverters
+from fontTools.ttLib import newTable
 from fontTools.ttLib.tables.otBase import OTTableReader, OTTableWriter
 import unittest
 
@@ -26,6 +28,47 @@ class GlyphIDTest(unittest.TestCase):
         writer = OTTableWriter(globalState={})
         self.converter.write(writer, self.font, {}, "B")
         self.assertEqual(writer.getData(), deHexStr("0002"))
+
+
+class NameIDTest(unittest.TestCase):
+    converter = otConverters.NameID('NameID', 0, None, None)
+
+    def makeFont(self):
+        nameTable = newTable('name')
+        nameTable.setName(u"Demibold Condensed", 0x123, 3, 0, 0x409)
+        return {"name": nameTable}
+
+    def test_read(self):
+        font = self.makeFont()
+        reader = OTTableReader(deHexStr("0123"))
+        self.assertEqual(self.converter.read(reader, font, {}), 0x123)
+
+    def test_write(self):
+        writer = OTTableWriter(globalState={})
+        self.converter.write(writer, self.makeFont(), {}, 0x123)
+        self.assertEqual(writer.getData(), deHexStr("0123"))
+
+    def test_xmlWrite(self):
+        writer = makeXMLWriter()
+        self.converter.xmlWrite(writer, self.makeFont(), 291,
+                                "FooNameID", [("attr", "val")])
+        xml = writer.file.getvalue().decode("utf-8")
+        self.assertEqual(
+            xml,
+            '<FooNameID attr="val" value="291"/>  <!-- Demibold Condensed -->')
+
+    def test_xmlWrite_missingID(self):
+        writer = makeXMLWriter()
+        with CapturingLogHandler(otConverters.log, "WARNING") as captor:
+            self.converter.xmlWrite(writer, self.makeFont(), 666,
+                                    "Entity", [("attrib", "val")])
+        self.assertIn("name id 666 missing from name table",
+                      [r.msg for r in captor.records])
+        xml = writer.file.getvalue().decode("utf-8")
+        self.assertEqual(
+            xml,
+            '<Entity attrib="val"'
+            ' value="666"/>  <!-- missing from name table -->')
 
 
 if __name__ == "__main__":

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -59,23 +59,23 @@ otData = [
 	('FeatureParamsSize', [
 		('DeciPoints', 'DesignSize', None, None, 'The design size in 720/inch units (decipoints).'),
 		('uint16', 'SubfamilyID', None, None, 'Serves as an identifier that associates fonts in a subfamily.'),
-		('uint16', 'SubfamilyNameID', None, None, 'Subfamily NameID.'),
+		('NameID', 'SubfamilyNameID', None, None, 'Subfamily NameID.'),
 		('DeciPoints', 'RangeStart', None, None, 'Small end of recommended usage range (exclusive) in 720/inch units.'),
 		('DeciPoints', 'RangeEnd', None, None, 'Large end of recommended usage range (inclusive) in 720/inch units.'),
 	]),
 
 	('FeatureParamsStylisticSet', [
 		('uint16', 'Version', None, None, 'Set to 0.'),
-		('uint16', 'UINameID', None, None, 'UI NameID.'),
+		('NameID', 'UINameID', None, None, 'UI NameID.'),
 	]),
 
 	('FeatureParamsCharacterVariants', [
 		('uint16', 'Format', None, None, 'Set to 0.'),
-		('uint16', 'FeatUILabelNameID', None, None, 'Feature UI label NameID.'),
-		('uint16', 'FeatUITooltipTextNameID', None, None, 'Feature UI tooltip text NameID.'),
-		('uint16', 'SampleTextNameID', None, None, 'Sample text NameID.'),
+		('NameID', 'FeatUILabelNameID', None, None, 'Feature UI label NameID.'),
+		('NameID', 'FeatUITooltipTextNameID', None, None, 'Feature UI tooltip text NameID.'),
+		('NameID', 'SampleTextNameID', None, None, 'Sample text NameID.'),
 		('uint16', 'NumNamedParameters', None, None, 'Number of named parameters.'),
-		('uint16', 'FirstParamUILabelNameID', None, None, 'First NameID of UI feature parameters.'),
+		('NameID', 'FirstParamUILabelNameID', None, None, 'First NameID of UI feature parameters.'),
 		('uint16', 'CharCount', None, None, 'Count of characters this feature provides glyph variants for.'),
 		('uint24', 'Character', 'CharCount', 0, 'Unicode characters for which this feature provides glyph variants.'),
 	]),
@@ -1114,7 +1114,7 @@ otData = [
 		('uint16', 'SettingsCount', None, None, 'The number of records in the setting name array.'),
 		('LOffset', 'Settings', None, None, 'Offset to setting table for this feature.'),
 		('uint16', 'FeatureFlags', None, None, 'Single-bit flags associated with the feature type.'),
-		('uint16', 'FeatureNameID', None, None, 'The name table index for the feature name.'),
+		('NameID', 'FeatureNameID', None, None, 'The name table index for the feature name.'),
 	]),
 
 	('Settings', [
@@ -1123,7 +1123,7 @@ otData = [
 
 	('Setting', [
 		('uint16', 'SettingValue', None, None, 'The setting.'),
-		('uint16', 'SettingNameID', None, None, 'The name table index for the setting name.'),
+		('NameID', 'SettingNameID', None, None, 'The name table index for the setting name.'),
 	]),
 
 ]


### PR DESCRIPTION
When writing XML, this produces a comment with the English name.
If the name ID is missing from the name table, it logs a warning.