### PR TITLE
[subset] [WIP] second attempt at fixing --no-hinting with CFF

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -7,7 +7,7 @@ from fontTools.misc.py23 import *
 from fontTools import ttLib
 from fontTools.ttLib.tables import otTables
 from fontTools.misc import psCharStrings
-from fontTools.pens.boundsPen import BoundsPen
+from fontTools.pens.basePen import NullPen
 from fontTools.misc.loggingTools import Timer
 import sys
 import struct
@@ -1851,8 +1851,8 @@ def prune_pre_subset(self, font, options):
                 private = font.Private
             dfltWdX = private.defaultWidthX
             nmnlWdX = private.nominalWidthX
-            pen = BoundsPen(None)
-            c.draw(pen) # this will set the charstring's width
+            pen = NullPen()
+            c.draw(pen)  # this will set the charstring's width
             if c.width != dfltWdX:
                 c.program = [c.width - nmnlWdX, 'endchar']
             else:
@@ -2211,7 +2211,9 @@ def prune_post_subset(self, options):
                 subrs = getattr(c.private, "Subrs", [])
                 decompiler = _DehintingT2Decompiler(css, subrs, c.globalSubrs)
                 decompiler.execute(c)
+            pen = NullPen()
             for charstring in css:
+                charstring.draw(pen)  # this will set the charstring's width
                 charstring.drop_hints()
             del css
 

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2047,7 +2047,7 @@ class _DehintingT2Decompiler(psCharStrings.T2WidthExtractor):
         cs = self.callingStack[-1]
         hints = cs._hints
         hints.has_hintmask = True
-        if hints.status != 2 and hints.has_hint:
+        if hints.status != 2:
             # Check from last_check, see if we may be an implicit vstem
             for i in range(hints.last_checked, index - 1):
                 if isinstance(cs.program[i], str):
@@ -2055,6 +2055,7 @@ class _DehintingT2Decompiler(psCharStrings.T2WidthExtractor):
                     break
             if hints.status != 2:
                 # We are an implicit vstem
+                hints.has_hint = True
                 hints.last_hint = index + 1
                 hints.status = 0
         hints.last_checked = index + 1

--- a/Tests/subset/data/Lobster.subset.ttx
+++ b/Tests/subset/data/Lobster.subset.ttx
@@ -1,0 +1,649 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="3.5">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="A"/>
+    <GlyphID id="2" name="A.salt"/>
+    <GlyphID id="3" name="B"/>
+    <GlyphID id="4" name="B.salt"/>
+    <GlyphID id="5" name="I"/>
+    <GlyphID id="6" name="IJ"/>
+    <GlyphID id="7" name="J"/>
+    <GlyphID id="8" name="one"/>
+    <GlyphID id="9" name="three"/>
+    <GlyphID id="10" name="two"/>
+    <GlyphID id="11" name="zero"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.004"/>
+    <checkSumAdjustment value="0x10139fda"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Jul  2 22:09:08 2010"/>
+    <modified value="Fri Jan 13 19:25:20 2017"/>
+    <xMin value="-209"/>
+    <yMin value="-250"/>
+    <xMax value="1186"/>
+    <yMax value="1000"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-250"/>
+    <lineGap value="28"/>
+    <advanceWidthMax value="1158"/>
+    <minLeftSideBearing value="-209"/>
+    <minRightSideBearing value="-284"/>
+    <xMaxExtent value="1186"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="12"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="12"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="2"/>
+    <xAvgCharWidth value="542"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="700"/>
+    <ySubscriptYSize value="650"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="140"/>
+    <ySuperscriptXSize value="700"/>
+    <ySuperscriptYSize value="650"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="477"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="250"/>
+    <sFamilyClass value="2562"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="5"/>
+      <bProportion value="6"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="2"/>
+      <bMidline value="0"/>
+      <bXHeight value="3"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="\x00\x00\x00\x00"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="48"/>
+    <usLastCharIndex value="74"/>
+    <sTypoAscender value="700"/>
+    <sTypoDescender value="-250"/>
+    <sTypoLineGap value="56"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="250"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="750"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="3"/>
+  </OS_2>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright (c) 2010 by Pablo Impallari. www.impallari.com. All rights reserved.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Lobster 1.4
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      PabloImpallari.www.impallari.com: Lobster 1.4: 2010
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Lobster1.4
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.4
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      Lobster1.4
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Lobster 1.4 is a trademark of Pablo Impallari. www.impallari.com.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Pablo Impallari. www.impallari.com
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Pablo Impallari
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Copyright (c) 2010 by Pablo Impallari. All rights reserved.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      www.impallari.com
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      www.impallari.com
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      Copyright (c) 2010, Pablo Impallari (www.impallari.com|impallari@gmail.com),&#13;
+with Reserved Font Name Lobster.&#13;
+This Font Software is licensed under the SIL Open Font License, Version 1.1.&#13;
+This license is available with a FAQ at: http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+  </name>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+      <map code="0x31" name="one"/><!-- DIGIT ONE -->
+      <map code="0x32" name="two"/><!-- DIGIT TWO -->
+      <map code="0x33" name="three"/><!-- DIGIT THREE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x49" name="I"/><!-- LATIN CAPITAL LETTER I -->
+      <map code="0x4a" name="J"/><!-- LATIN CAPITAL LETTER J -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+      <map code="0x31" name="one"/><!-- DIGIT ONE -->
+      <map code="0x32" name="two"/><!-- DIGIT TWO -->
+      <map code="0x33" name="three"/><!-- DIGIT THREE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x49" name="I"/><!-- LATIN CAPITAL LETTER I -->
+      <map code="0x4a" name="J"/><!-- LATIN CAPITAL LETTER J -->
+    </cmap_format_4>
+  </cmap>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="Lobster1.4">
+      <version value="001.001"/>
+      <Notice value="Copyright (c) 2010 by Pablo Impallari. www.impallari.com. All rights reserved."/>
+      <Copyright value="Copyright (c) 2010 by Pablo Impallari. All rights reserved."/>
+      <FullName value="Lobster 1.4"/>
+      <FamilyName value="Lobster 1.4"/>
+      <Weight value="Regular"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="-209 -250 1186 1000"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueValues value="0 0"/>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="267"/>
+        <nominalWidthX value="448"/>
+        <Subrs>
+          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+          <CharString index="0">
+            397 748 rmoveto
+            1 -13 -13 1 -14 hhcurveto
+            -106 callsubr
+            53 75 87 36 vhcurveto
+            -145 -679 rlineto
+            return
+          </CharString>
+          <CharString index="1">
+            -167 -184 -127 -133 -72 38 -25 69 hvcurveto
+            -1 9 -13 8 51 vvcurveto
+            107 return
+          </CharString>
+          <CharString index="2">
+            119 hintmask 01111100
+            230 636 rmoveto
+            -136 -636 rlineto
+            144 hlineto
+            return
+          </CharString>
+          <CharString index="3">
+            -67 41 -25 66 vhcurveto
+            -1 9 -13 8 51 vvcurveto
+            return
+          </CharString>
+        </Subrs>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          -63 endchar
+        </CharString>
+        <CharString name="A">
+          220 -93 -21 114 -20 297 181 -59 59 292 -20 hstemhm
+          9 118 -43 120 hintmask 11101100
+          535 hmoveto
+          157 736 rlineto
+          10 -24 -32 4 -23 hhcurveto
+          -117 -130 -135 -160 -101 hvcurveto
+          2 -21 -17 1 -14 hhcurveto
+          -118 -86 -55 -68 -39 28 -19 34 31 25 15 24 14 -8 17 -5 hvcurveto
+          hintmask 11011010
+          13 34 42 14 62 4 rrcurveto
+          -87 -153 -60 -164 -90 vvcurveto
+          -104 80 -2 54 vhcurveto
+          -6 9 -8 15 32 vvcurveto
+          104 55 190 75 163 vhcurveto
+          44 -4 39 -9 51 -23 -77 -363 rcurveline
+          86 407 rmoveto
+          -39 16 -43 11 -40 8 56 112 64 93 60 32 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="A.salt">
+          142 -92 -21 113 -20 386 52 333 -20 hstem
+          8 120 vstem
+          459 hmoveto
+          157 736 rlineto
+          12 -30 -26 3 -24 hhcurveto
+          -238 -290 -563 -189 -106 65 -2 69 -4 hvcurveto
+          -1 9 -13 -4 51 vvcurveto
+          97 42 172 64 154 vhcurveto
+          158 hlineto
+          -77 -366 rlineto
+          -59 418 rmoveto
+          58 126 72 106 73 32 -56 -264 rcurveline
+          endchar
+        </CharString>
+        <CharString name="B">
+          187 -17 96 -79 -20 406 48 270 46 hstemhm
+          6 93 362 139 -119 101 -101 -105 callsubr
+          82 383 rlineto
+          2 18 20 1 8 hhcurveto
+          73 22 -57 -70 hvcurveto
+          hintmask 10111001
+          -76 -26 -104 -73 -23 -19 10 26 -25 vhcurveto
+          -9 -23 -4 -19 -16 vvcurveto
+          -61 56 -13 43 167 52 192 96 75 -33 69 -85 17 vhcurveto
+          hintmask 10111010
+          65 37 35 63 59 vvcurveto
+          82 -66 77 -147 -189 -174 -127 -138 -104 callsubr
+          165 133 78 117 95 37 -51 -57 -75 -64 -87 -80 vhcurveto
+          -6 hlineto
+          47 222 rlineto
+          endchar
+        </CharString>
+        <CharString name="B.salt">
+          185 -28 92 -64 -20 413 41 270 46 hstemhm
+          6 93 350 149 -119 105 -105 -105 callsubr
+          6 30 rlineto
+          hintmask 10111001
+          -41 39 41 -17 39 hhcurveto
+          125 110 175 136 72 -32 62 -82 15 hvcurveto
+          hintmask 10111010
+          64 38 36 61 58 vvcurveto
+          83 -74 78 -144 -183 -177 -126 -139 -104 callsubr
+          152 116 91 138 101 25 -49 -53 -81 -59 -87 -83 vhcurveto
+          -6 hlineto
+          47 222 rlineto
+          -59 -592 rmoveto
+          -20 -21 8 21 -20 hvcurveto
+          62 290 rlineto
+          2 18 20 1 7 hhcurveto
+          hintmask 10111100
+          63 21 -49 -57 -96 -58 -120 -72 hvcurveto
+          endchar
+        </CharString>
+        <CharString name="I">
+          -73 21 -21 750 -20 hstem
+          6 93 vstem
+          -107 callsubr
+          144 hlineto
+          endchar
+        </CharString>
+        <CharString name="IJ">
+          215 -207 50 157 -20 770 -20 hstemhm
+          6 93 13 84 -84 205 hintmask 11111000
+          -107 callsubr
+          34 hlineto
+          -11 -20 -5 -23 -27 vvcurveto
+          -79 48 -58 113 155 66 109 138 29 vhcurveto
+          150 710 -150 -33 -164 -751 rlineto
+          -100 -22 -30 -23 -40 hhcurveto
+          -44 -27 29 39 40 29 33 36 16 17 -7 -16 16 hvcurveto
+          hintmask 11110100
+          4 11 3 11 11 vvcurveto
+          34 -26 24 -41 6 vhcurveto
+          endchar
+        </CharString>
+        <CharString name="J">
+          88 -207 50 144 81 682 -20 hstemhm
+          17 84 -84 220 -50 93 hintmask 11110100
+          538 750 rmoveto
+          -106 callsubr
+          54 76 87 36 vhcurveto
+          -157 -714 rlineto
+          -103 -23 -27 -20 -45 hhcurveto
+          -29 -39 18 52 37 24 37 46 20 15 -5 -21 25 hvcurveto
+          hintmask 11101000
+          4 15 2 14 11 vvcurveto
+          64 -58 3 -40 -79 -43 -66 -68 -83 53 -58 95 164 67 94 153 32 vhcurveto
+          150 710 rlineto
+          endchar
+        </CharString>
+        <CharString name="one">
+          -131 21 -21 624 46 78 -20 hstem
+          324 748 rmoveto
+          -72 -121 -78 -6 -55 hhcurveto
+          -12 -46 rlineto
+          95 hlineto
+          -132 -624 rlineto
+          144 hlineto
+          endchar
+        </CharString>
+        <CharString name="three">
+          66 -5 65 197 51 204 237 -54 54 hstemhm
+          6 111 -12 110 117 155 -117 117 hintmask 11101001
+          205 257 rmoveto
+          38 -8 -33 13 -37 hhcurveto
+          -80 -41 -60 -83 -154 141 -16 58 171 111 136 121 71 -38 65 -88 29 hvcurveto
+          92 46 45 74 66 vvcurveto
+          78 -63 68 -123 vhcurveto
+          hintmask 11100110
+          -116 -91 -61 -91 -54 32 -31 40 24 27 11 23 25 hvcurveto
+          -28 8 -10 36 27 vvcurveto
+          hintmask 11011001
+          47 31 31 48 51 25 -36 -46 -70 -58 -94 -113 -31 vhcurveto
+          hintmask 11101010
+          93 -33 40 -80 -76 vvcurveto
+          -87 -53 -82 -86 -37 -39 13 76 40 10 62 78 6 vhcurveto
+          endchar
+        </CharString>
+        <CharString name="two">
+          44 -11 125 -89 89 -89 107 380 237 -54 54 hstemhm
+          66 110 142 119 -119 144 hintmask 00110101
+          111 132 rmoveto
+          -5 hlineto
+          83 135 273 98 223 vvcurveto
+          97 -53 64 -137 -151 -55 -79 -68 -58 31 -32 41 24 26 11 23 26 vhcurveto
+          -28 8 -10 37 23 vvcurveto
+          hintmask 01001110
+          50 14 31 67 29 32 -33 -49 vhcurveto
+          -266 -329 -98 -219 vvcurveto
+          -11 0 -11 2 -11 vhcurveto
+          7 20 36 21 23 hhcurveto
+          hintmask 10010110
+          102 37 -36 109 hhcurveto
+          99 20 52 98 14 0 14 -1 16 hvcurveto
+          -44 -47 -17 -25 -70 hhcurveto
+          hintmask 00110110
+          -75 -57 18 -59 hhcurveto
+          endchar
+        </CharString>
+        <CharString name="zero">
+          98 -9 84 623 52 hstem
+          30 158 236 131 vstem
+          377 750 rmoveto
+          -215 -132 -223 -273 -166 35 -97 172 205 113 299 199 168 -53 93 -125 hvcurveto
+          -189 -425 rmoveto
+          225 17 105 148 60 hhcurveto
+          47 7 -63 -82 -232 -68 -246 -114 -48 -11 77 74 37 3 35 2 27 hvcurveto
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage Format="2">
+            <Glyph value="one"/>
+            <Glyph value="three"/>
+            <Glyph value="two"/>
+            <Glyph value="zero"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=4 -->
+          <PairSet index="0">
+            <!-- PairValueCount=3 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="one"/>
+              <Value1 XAdvance="20"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="two"/>
+              <Value1 XAdvance="20"/>
+            </PairValueRecord>
+            <PairValueRecord index="2">
+              <SecondGlyph value="zero"/>
+              <Value1 XAdvance="10"/>
+            </PairValueRecord>
+          </PairSet>
+          <PairSet index="1">
+            <!-- PairValueCount=4 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="one"/>
+              <Value1 XAdvance="10"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="three"/>
+              <Value1 XAdvance="15"/>
+            </PairValueRecord>
+            <PairValueRecord index="2">
+              <SecondGlyph value="two"/>
+              <Value1 XAdvance="20"/>
+            </PairValueRecord>
+            <PairValueRecord index="3">
+              <SecondGlyph value="zero"/>
+              <Value1 XAdvance="10"/>
+            </PairValueRecord>
+          </PairSet>
+          <PairSet index="2">
+            <!-- PairValueCount=3 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="one"/>
+              <Value1 XAdvance="30"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="three"/>
+              <Value1 XAdvance="10"/>
+            </PairValueRecord>
+            <PairValueRecord index="2">
+              <SecondGlyph value="two"/>
+              <Value1 XAdvance="20"/>
+            </PairValueRecord>
+          </PairSet>
+          <PairSet index="3">
+            <!-- PairValueCount=3 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="three"/>
+              <Value1 XAdvance="3"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="two"/>
+              <Value1 XAdvance="20"/>
+            </PairValueRecord>
+            <PairValueRecord index="2">
+              <SecondGlyph value="zero"/>
+              <Value1 XAdvance="20"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=3 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+            <FeatureIndex index="2" value="2"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=3 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="aalt"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="liga"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="salt"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="2"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=3 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="A" out="A.salt"/>
+          <Substitution in="B" out="B.salt"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0" Format="1">
+          <LigatureSet glyph="I">
+            <Ligature components="J" glyph="IJ"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="A" out="A.salt"/>
+          <Substitution in="B" out="B.salt"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+  <hmtx>
+    <mtx name=".notdef" width="385" lsb="0"/>
+    <mtx name="A" width="668" lsb="9"/>
+    <mtx name="A.salt" width="590" lsb="8"/>
+    <mtx name="B" width="635" lsb="6"/>
+    <mtx name="B.salt" width="633" lsb="6"/>
+    <mtx name="I" width="375" lsb="6"/>
+    <mtx name="IJ" width="663" lsb="6"/>
+    <mtx name="J" width="536" lsb="17"/>
+    <mtx name="one" width="317" lsb="21"/>
+    <mtx name="three" width="514" lsb="6"/>
+    <mtx name="two" width="492" lsb="-11"/>
+    <mtx name="zero" width="546" lsb="30"/>
+  </hmtx>
+
+</ttFont>

--- a/Tests/subset/data/expect_desubroutinize_CFF.ttx
+++ b/Tests/subset/data/expect_desubroutinize_CFF.ttx
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="3.5">
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="Lobster1.4">
+      <version value="001.001"/>
+      <Notice value="Copyright (c) 2010 by Pablo Impallari. www.impallari.com. All rights reserved."/>
+      <Copyright value="Copyright (c) 2010 by Pablo Impallari. All rights reserved."/>
+      <FullName value="Lobster 1.4"/>
+      <FamilyName value="Lobster 1.4"/>
+      <Weight value="Regular"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="-209 -250 1186 1000"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueValues value="0 0"/>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="267"/>
+        <nominalWidthX value="448"/>
+        <Subrs>
+          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+        </Subrs>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          -63 endchar
+        </CharString>
+        <CharString name="A">
+          220 -93 -21 114 -20 297 181 -59 59 292 -20 hstemhm
+          9 118 -43 120 hintmask 11101100
+          535 hmoveto
+          157 736 rlineto
+          10 -24 -32 4 -23 hhcurveto
+          -117 -130 -135 -160 -101 hvcurveto
+          2 -21 -17 1 -14 hhcurveto
+          -118 -86 -55 -68 -39 28 -19 34 31 25 15 24 14 -8 17 -5 hvcurveto
+          hintmask 11011010
+          13 34 42 14 62 4 rrcurveto
+          -87 -153 -60 -164 -90 vvcurveto
+          -104 80 -2 54 vhcurveto
+          -6 9 -8 15 32 vvcurveto
+          104 55 190 75 163 vhcurveto
+          44 -4 39 -9 51 -23 -77 -363 rcurveline
+          86 407 rmoveto
+          -39 16 -43 11 -40 8 56 112 64 93 60 32 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="A.salt">
+          142 -92 -21 113 -20 386 52 333 -20 hstem
+          8 120 vstem
+          459 hmoveto
+          157 736 rlineto
+          12 -30 -26 3 -24 hhcurveto
+          -238 -290 -563 -189 -106 65 -2 69 -4 hvcurveto
+          -1 9 -13 -4 51 vvcurveto
+          97 42 172 64 154 vhcurveto
+          158 hlineto
+          -77 -366 rlineto
+          -59 418 rmoveto
+          58 126 72 106 73 32 -56 -264 rcurveline
+          endchar
+        </CharString>
+        <CharString name="B">
+          187 -17 96 -79 -20 406 48 270 46 hstemhm
+          6 93 362 139 -119 101 -101 119 hintmask 01111100
+          230 636 rmoveto
+          -136 -636 rlineto
+          144 hlineto
+          82 383 rlineto
+          2 18 20 1 8 hhcurveto
+          73 22 -57 -70 hvcurveto
+          hintmask 10111001
+          -76 -26 -104 -73 -23 -19 10 26 -25 vhcurveto
+          -9 -23 -4 -19 -16 vvcurveto
+          -61 56 -13 43 167 52 192 96 75 -33 69 -85 17 vhcurveto
+          hintmask 10111010
+          65 37 35 63 59 vvcurveto
+          82 -66 77 -147 -189 -174 -127 -138 -67 41 -25 66 vhcurveto
+          -1 9 -13 8 51 vvcurveto
+          165 133 78 117 95 37 -51 -57 -75 -64 -87 -80 vhcurveto
+          -6 hlineto
+          47 222 rlineto
+          endchar
+        </CharString>
+        <CharString name="B.salt">
+          185 -28 92 -64 -20 413 41 270 46 hstemhm
+          6 93 350 149 -119 105 -105 119 hintmask 01111100
+          230 636 rmoveto
+          -136 -636 rlineto
+          144 hlineto
+          6 30 rlineto
+          hintmask 10111001
+          -41 39 41 -17 39 hhcurveto
+          125 110 175 136 72 -32 62 -82 15 hvcurveto
+          hintmask 10111010
+          64 38 36 61 58 vvcurveto
+          83 -74 78 -144 -183 -177 -126 -139 -67 41 -25 66 vhcurveto
+          -1 9 -13 8 51 vvcurveto
+          152 116 91 138 101 25 -49 -53 -81 -59 -87 -83 vhcurveto
+          -6 hlineto
+          47 222 rlineto
+          -59 -592 rmoveto
+          -20 -21 8 21 -20 hvcurveto
+          62 290 rlineto
+          2 18 20 1 7 hhcurveto
+          hintmask 10111100
+          63 21 -49 -57 -96 -58 -120 -72 hvcurveto
+          endchar
+        </CharString>
+        <CharString name="I">
+          -73 21 -21 750 -20 hstem
+          6 93 vstem
+          397 748 rmoveto
+          1 -13 -13 1 -14 hhcurveto
+          -167 -184 -127 -133 -72 38 -25 69 hvcurveto
+          -1 9 -13 8 51 vvcurveto
+          107 53 75 87 36 vhcurveto
+          -145 -679 rlineto
+          144 hlineto
+          endchar
+        </CharString>
+        <CharString name="IJ">
+          215 -207 50 157 -20 770 -20 hstemhm
+          6 93 13 84 -84 205 hintmask 11111000
+          397 748 rmoveto
+          1 -13 -13 1 -14 hhcurveto
+          -167 -184 -127 -133 -72 38 -25 69 hvcurveto
+          -1 9 -13 8 51 vvcurveto
+          107 53 75 87 36 vhcurveto
+          -145 -679 rlineto
+          34 hlineto
+          -11 -20 -5 -23 -27 vvcurveto
+          -79 48 -58 113 155 66 109 138 29 vhcurveto
+          150 710 -150 -33 -164 -751 rlineto
+          -100 -22 -30 -23 -40 hhcurveto
+          -44 -27 29 39 40 29 33 36 16 17 -7 -16 16 hvcurveto
+          hintmask 11110100
+          4 11 3 11 11 vvcurveto
+          34 -26 24 -41 6 vhcurveto
+          endchar
+        </CharString>
+        <CharString name="J">
+          88 -207 50 144 81 682 -20 hstemhm
+          17 84 -84 220 -50 93 hintmask 11110100
+          538 750 rmoveto
+          -167 -184 -127 -133 -72 38 -25 69 hvcurveto
+          -1 9 -13 8 51 vvcurveto
+          107 54 76 87 36 vhcurveto
+          -157 -714 rlineto
+          -103 -23 -27 -20 -45 hhcurveto
+          -29 -39 18 52 37 24 37 46 20 15 -5 -21 25 hvcurveto
+          hintmask 11101000
+          4 15 2 14 11 vvcurveto
+          64 -58 3 -40 -79 -43 -66 -68 -83 53 -58 95 164 67 94 153 32 vhcurveto
+          150 710 rlineto
+          endchar
+        </CharString>
+        <CharString name="one">
+          -131 21 -21 624 46 78 -20 hstem
+          324 748 rmoveto
+          -72 -121 -78 -6 -55 hhcurveto
+          -12 -46 rlineto
+          95 hlineto
+          -132 -624 rlineto
+          144 hlineto
+          endchar
+        </CharString>
+        <CharString name="three">
+          66 -5 65 197 51 204 237 -54 54 hstemhm
+          6 111 -12 110 117 155 -117 117 hintmask 11101001
+          205 257 rmoveto
+          38 -8 -33 13 -37 hhcurveto
+          -80 -41 -60 -83 -154 141 -16 58 171 111 136 121 71 -38 65 -88 29 hvcurveto
+          92 46 45 74 66 vvcurveto
+          78 -63 68 -123 vhcurveto
+          hintmask 11100110
+          -116 -91 -61 -91 -54 32 -31 40 24 27 11 23 25 hvcurveto
+          -28 8 -10 36 27 vvcurveto
+          hintmask 11011001
+          47 31 31 48 51 25 -36 -46 -70 -58 -94 -113 -31 vhcurveto
+          hintmask 11101010
+          93 -33 40 -80 -76 vvcurveto
+          -87 -53 -82 -86 -37 -39 13 76 40 10 62 78 6 vhcurveto
+          endchar
+        </CharString>
+        <CharString name="two">
+          44 -11 125 -89 89 -89 107 380 237 -54 54 hstemhm
+          66 110 142 119 -119 144 hintmask 00110101
+          111 132 rmoveto
+          -5 hlineto
+          83 135 273 98 223 vvcurveto
+          97 -53 64 -137 -151 -55 -79 -68 -58 31 -32 41 24 26 11 23 26 vhcurveto
+          -28 8 -10 37 23 vvcurveto
+          hintmask 01001110
+          50 14 31 67 29 32 -33 -49 vhcurveto
+          -266 -329 -98 -219 vvcurveto
+          -11 0 -11 2 -11 vhcurveto
+          7 20 36 21 23 hhcurveto
+          hintmask 10010110
+          102 37 -36 109 hhcurveto
+          99 20 52 98 14 0 14 -1 16 hvcurveto
+          -44 -47 -17 -25 -70 hhcurveto
+          hintmask 00110110
+          -75 -57 18 -59 hhcurveto
+          endchar
+        </CharString>
+        <CharString name="zero">
+          98 -9 84 623 52 hstem
+          30 158 236 131 vstem
+          377 750 rmoveto
+          -215 -132 -223 -273 -166 35 -97 172 205 113 299 199 168 -53 93 -125 hvcurveto
+          -189 -425 rmoveto
+          225 17 105 148 60 hhcurveto
+          47 7 -63 -82 -232 -68 -246 -114 -48 -11 77 74 37 3 35 2 27 hvcurveto
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+</ttFont>

--- a/Tests/subset/data/expect_no_hinting_CFF.ttx
+++ b/Tests/subset/data/expect_no_hinting_CFF.ttx
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="3.5">
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="Lobster1.4">
+      <version value="001.001"/>
+      <Notice value="Copyright (c) 2010 by Pablo Impallari. www.impallari.com. All rights reserved."/>
+      <Copyright value="Copyright (c) 2010 by Pablo Impallari. All rights reserved."/>
+      <FullName value="Lobster 1.4"/>
+      <FamilyName value="Lobster 1.4"/>
+      <Weight value="Regular"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="-209 -250 1186 1000"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="267"/>
+        <nominalWidthX value="448"/>
+        <Subrs>
+          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+          <CharString index="0">
+            397 748 rmoveto
+            1 -13 -13 1 -14 hhcurveto
+            -106 callsubr
+            53 75 87 36 vhcurveto
+            -145 -679 rlineto
+            return
+          </CharString>
+          <CharString index="1">
+            -167 -184 -127 -133 -72 38 -25 69 hvcurveto
+            -1 9 -13 8 51 vvcurveto
+            107 return
+          </CharString>
+          <CharString index="2">
+            230 636 rmoveto
+            -136 -636 rlineto
+            144 hlineto
+            return
+          </CharString>
+          <CharString index="3">
+            -67 41 -25 66 vhcurveto
+            -1 9 -13 8 51 vvcurveto
+            return
+          </CharString>
+        </Subrs>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          -63 endchar
+        </CharString>
+        <CharString name="A">
+          220 535 hmoveto
+          157 736 rlineto
+          10 -24 -32 4 -23 hhcurveto
+          -117 -130 -135 -160 -101 hvcurveto
+          2 -21 -17 1 -14 hhcurveto
+          -118 -86 -55 -68 -39 28 -19 34 31 25 15 24 14 -8 17 -5 hvcurveto
+          13 34 42 14 62 4 rrcurveto
+          -87 -153 -60 -164 -90 vvcurveto
+          -104 80 -2 54 vhcurveto
+          -6 9 -8 15 32 vvcurveto
+          104 55 190 75 163 vhcurveto
+          44 -4 39 -9 51 -23 -77 -363 rcurveline
+          86 407 rmoveto
+          -39 16 -43 11 -40 8 56 112 64 93 60 32 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="A.salt">
+          142 459 hmoveto
+          157 736 rlineto
+          12 -30 -26 3 -24 hhcurveto
+          -238 -290 -563 -189 -106 65 -2 69 -4 hvcurveto
+          -1 9 -13 -4 51 vvcurveto
+          97 42 172 64 154 vhcurveto
+          158 hlineto
+          -77 -366 rlineto
+          -59 418 rmoveto
+          58 126 72 106 73 32 -56 -264 rcurveline
+          endchar
+        </CharString>
+        <CharString name="B">
+          187 -105 callsubr
+          82 383 rlineto
+          2 18 20 1 8 hhcurveto
+          73 22 -57 -70 hvcurveto
+          -76 -26 -104 -73 -23 -19 10 26 -25 vhcurveto
+          -9 -23 -4 -19 -16 vvcurveto
+          -61 56 -13 43 167 52 192 96 75 -33 69 -85 17 vhcurveto
+          65 37 35 63 59 vvcurveto
+          82 -66 77 -147 -189 -174 -127 -138 -104 callsubr
+          165 133 78 117 95 37 -51 -57 -75 -64 -87 -80 vhcurveto
+          -6 hlineto
+          47 222 rlineto
+          endchar
+        </CharString>
+        <CharString name="B.salt">
+          185 -105 callsubr
+          6 30 rlineto
+          -41 39 41 -17 39 hhcurveto
+          125 110 175 136 72 -32 62 -82 15 hvcurveto
+          64 38 36 61 58 vvcurveto
+          83 -74 78 -144 -183 -177 -126 -139 -104 callsubr
+          152 116 91 138 101 25 -49 -53 -81 -59 -87 -83 vhcurveto
+          -6 hlineto
+          47 222 rlineto
+          -59 -592 rmoveto
+          -20 -21 8 21 -20 hvcurveto
+          62 290 rlineto
+          2 18 20 1 7 hhcurveto
+          63 21 -49 -57 -96 -58 -120 -72 hvcurveto
+          endchar
+        </CharString>
+        <CharString name="I">
+          -73 -107 callsubr
+          144 hlineto
+          endchar
+        </CharString>
+        <CharString name="IJ">
+          215 -107 callsubr
+          34 hlineto
+          -11 -20 -5 -23 -27 vvcurveto
+          -79 48 -58 113 155 66 109 138 29 vhcurveto
+          150 710 -150 -33 -164 -751 rlineto
+          -100 -22 -30 -23 -40 hhcurveto
+          -44 -27 29 39 40 29 33 36 16 17 -7 -16 16 hvcurveto
+          4 11 3 11 11 vvcurveto
+          34 -26 24 -41 6 vhcurveto
+          endchar
+        </CharString>
+        <CharString name="J">
+          88 538 750 rmoveto
+          -106 callsubr
+          54 76 87 36 vhcurveto
+          -157 -714 rlineto
+          -103 -23 -27 -20 -45 hhcurveto
+          -29 -39 18 52 37 24 37 46 20 15 -5 -21 25 hvcurveto
+          4 15 2 14 11 vvcurveto
+          64 -58 3 -40 -79 -43 -66 -68 -83 53 -58 95 164 67 94 153 32 vhcurveto
+          150 710 rlineto
+          endchar
+        </CharString>
+        <CharString name="one">
+          -131 324 748 rmoveto
+          -72 -121 -78 -6 -55 hhcurveto
+          -12 -46 rlineto
+          95 hlineto
+          -132 -624 rlineto
+          144 hlineto
+          endchar
+        </CharString>
+        <CharString name="three">
+          66 205 257 rmoveto
+          38 -8 -33 13 -37 hhcurveto
+          -80 -41 -60 -83 -154 141 -16 58 171 111 136 121 71 -38 65 -88 29 hvcurveto
+          92 46 45 74 66 vvcurveto
+          78 -63 68 -123 vhcurveto
+          -116 -91 -61 -91 -54 32 -31 40 24 27 11 23 25 hvcurveto
+          -28 8 -10 36 27 vvcurveto
+          47 31 31 48 51 25 -36 -46 -70 -58 -94 -113 -31 vhcurveto
+          93 -33 40 -80 -76 vvcurveto
+          -87 -53 -82 -86 -37 -39 13 76 40 10 62 78 6 vhcurveto
+          endchar
+        </CharString>
+        <CharString name="two">
+          44 111 132 rmoveto
+          -5 hlineto
+          83 135 273 98 223 vvcurveto
+          97 -53 64 -137 -151 -55 -79 -68 -58 31 -32 41 24 26 11 23 26 vhcurveto
+          -28 8 -10 37 23 vvcurveto
+          50 14 31 67 29 32 -33 -49 vhcurveto
+          -266 -329 -98 -219 vvcurveto
+          -11 0 -11 2 -11 vhcurveto
+          7 20 36 21 23 hhcurveto
+          102 37 -36 109 hhcurveto
+          99 20 52 98 14 0 14 -1 16 hvcurveto
+          -44 -47 -17 -25 -70 hhcurveto
+          -75 -57 18 -59 hhcurveto
+          endchar
+        </CharString>
+        <CharString name="zero">
+          98 377 750 rmoveto
+          -215 -132 -223 -273 -166 35 -97 172 205 113 299 199 168 -53 93 -125 hvcurveto
+          -189 -425 rmoveto
+          225 17 105 148 60 hhcurveto
+          47 7 -63 -82 -232 -68 -246 -114 -48 -11 77 74 37 3 35 2 27 hvcurveto
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+</ttFont>

--- a/Tests/subset/data/expect_no_hinting_TTF.ttx
+++ b/Tests/subset/data/expect_no_hinting_TTF.ttx
@@ -39,8 +39,7 @@
         <pt x="293" y="340" on="1"/>
         <pt x="419" y="110" on="1"/>
       </contour>
-      <instructions><assembly>
-        </assembly></instructions>
+      <instructions/>
     </TTGlyph>
 
     <TTGlyph name="A" xMin="132" yMin="304" xMax="365" yMax="567">
@@ -50,8 +49,7 @@
         <pt x="365" y="304" on="1"/>
         <pt x="132" y="304" on="1"/>
       </contour>
-      <instructions><assembly>
-        </assembly></instructions>
+      <instructions/>
     </TTGlyph>
 
     <TTGlyph name="B" xMin="132" yMin="304" xMax="365" yMax="567">
@@ -61,8 +59,7 @@
         <pt x="365" y="304" on="1"/>
         <pt x="132" y="304" on="1"/>
       </contour>
-      <instructions><assembly>
-        </assembly></instructions>
+      <instructions/>
     </TTGlyph>
 
     <TTGlyph name="C"/><!-- contains no outline data -->

--- a/Tests/subset/data/expect_no_hinting_TTF.ttx
+++ b/Tests/subset/data/expect_no_hinting_TTF.ttx
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.0">
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="10" yMin="0" xMax="486" yMax="660">
+      <contour>
+        <pt x="10" y="660" on="1"/>
+        <pt x="486" y="660" on="1"/>
+        <pt x="486" y="0" on="1"/>
+        <pt x="10" y="0" on="1"/>
+      </contour>
+      <contour>
+        <pt x="375" y="58" on="1"/>
+        <pt x="302" y="190" on="1"/>
+        <pt x="250" y="293" on="1"/>
+        <pt x="246" y="293" on="1"/>
+        <pt x="192" y="190" on="1"/>
+        <pt x="118" y="58" on="1"/>
+      </contour>
+      <contour>
+        <pt x="250" y="387" on="1"/>
+        <pt x="299" y="481" on="1"/>
+        <pt x="365" y="600" on="1"/>
+        <pt x="130" y="600" on="1"/>
+        <pt x="196" y="481" on="1"/>
+        <pt x="246" y="387" on="1"/>
+      </contour>
+      <contour>
+        <pt x="202" y="340" on="1"/>
+        <pt x="75" y="572" on="1"/>
+        <pt x="75" y="110" on="1"/>
+      </contour>
+      <contour>
+        <pt x="419" y="572" on="1"/>
+        <pt x="293" y="340" on="1"/>
+        <pt x="419" y="110" on="1"/>
+      </contour>
+      <instructions><assembly>
+        </assembly></instructions>
+    </TTGlyph>
+
+    <TTGlyph name="A" xMin="132" yMin="304" xMax="365" yMax="567">
+      <contour>
+        <pt x="132" y="567" on="1"/>
+        <pt x="365" y="567" on="1"/>
+        <pt x="365" y="304" on="1"/>
+        <pt x="132" y="304" on="1"/>
+      </contour>
+      <instructions><assembly>
+        </assembly></instructions>
+    </TTGlyph>
+
+    <TTGlyph name="B" xMin="132" yMin="304" xMax="365" yMax="567">
+      <contour>
+        <pt x="132" y="567" on="1"/>
+        <pt x="365" y="567" on="1"/>
+        <pt x="365" y="304" on="1"/>
+        <pt x="132" y="304" on="1"/>
+      </contour>
+      <instructions><assembly>
+        </assembly></instructions>
+    </TTGlyph>
+
+    <TTGlyph name="C"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="4"/>
+    <maxPoints value="22"/>
+    <maxContours value="5"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+</ttFont>

--- a/Tests/subset/data/expect_no_hinting_desubroutinize_CFF.ttx
+++ b/Tests/subset/data/expect_no_hinting_desubroutinize_CFF.ttx
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="3.5">
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="Lobster1.4">
+      <version value="001.001"/>
+      <Notice value="Copyright (c) 2010 by Pablo Impallari. www.impallari.com. All rights reserved."/>
+      <Copyright value="Copyright (c) 2010 by Pablo Impallari. All rights reserved."/>
+      <FullName value="Lobster 1.4"/>
+      <FamilyName value="Lobster 1.4"/>
+      <Weight value="Regular"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="-209 -250 1186 1000"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="267"/>
+        <nominalWidthX value="448"/>
+        <Subrs>
+          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+        </Subrs>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          -63 endchar
+        </CharString>
+        <CharString name="A">
+          220 535 hmoveto
+          157 736 rlineto
+          10 -24 -32 4 -23 hhcurveto
+          -117 -130 -135 -160 -101 hvcurveto
+          2 -21 -17 1 -14 hhcurveto
+          -118 -86 -55 -68 -39 28 -19 34 31 25 15 24 14 -8 17 -5 hvcurveto
+          13 34 42 14 62 4 rrcurveto
+          -87 -153 -60 -164 -90 vvcurveto
+          -104 80 -2 54 vhcurveto
+          -6 9 -8 15 32 vvcurveto
+          104 55 190 75 163 vhcurveto
+          44 -4 39 -9 51 -23 -77 -363 rcurveline
+          86 407 rmoveto
+          -39 16 -43 11 -40 8 56 112 64 93 60 32 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="A.salt">
+          142 459 hmoveto
+          157 736 rlineto
+          12 -30 -26 3 -24 hhcurveto
+          -238 -290 -563 -189 -106 65 -2 69 -4 hvcurveto
+          -1 9 -13 -4 51 vvcurveto
+          97 42 172 64 154 vhcurveto
+          158 hlineto
+          -77 -366 rlineto
+          -59 418 rmoveto
+          58 126 72 106 73 32 -56 -264 rcurveline
+          endchar
+        </CharString>
+        <CharString name="B">
+          187 230 636 rmoveto
+          -136 -636 rlineto
+          144 hlineto
+          82 383 rlineto
+          2 18 20 1 8 hhcurveto
+          73 22 -57 -70 hvcurveto
+          -76 -26 -104 -73 -23 -19 10 26 -25 vhcurveto
+          -9 -23 -4 -19 -16 vvcurveto
+          -61 56 -13 43 167 52 192 96 75 -33 69 -85 17 vhcurveto
+          65 37 35 63 59 vvcurveto
+          82 -66 77 -147 -189 -174 -127 -138 -67 41 -25 66 vhcurveto
+          -1 9 -13 8 51 vvcurveto
+          165 133 78 117 95 37 -51 -57 -75 -64 -87 -80 vhcurveto
+          -6 hlineto
+          47 222 rlineto
+          endchar
+        </CharString>
+        <CharString name="B.salt">
+          185 230 636 rmoveto
+          -136 -636 rlineto
+          144 hlineto
+          6 30 rlineto
+          -41 39 41 -17 39 hhcurveto
+          125 110 175 136 72 -32 62 -82 15 hvcurveto
+          64 38 36 61 58 vvcurveto
+          83 -74 78 -144 -183 -177 -126 -139 -67 41 -25 66 vhcurveto
+          -1 9 -13 8 51 vvcurveto
+          152 116 91 138 101 25 -49 -53 -81 -59 -87 -83 vhcurveto
+          -6 hlineto
+          47 222 rlineto
+          -59 -592 rmoveto
+          -20 -21 8 21 -20 hvcurveto
+          62 290 rlineto
+          2 18 20 1 7 hhcurveto
+          63 21 -49 -57 -96 -58 -120 -72 hvcurveto
+          endchar
+        </CharString>
+        <CharString name="I">
+          -73 397 748 rmoveto
+          1 -13 -13 1 -14 hhcurveto
+          -167 -184 -127 -133 -72 38 -25 69 hvcurveto
+          -1 9 -13 8 51 vvcurveto
+          107 53 75 87 36 vhcurveto
+          -145 -679 rlineto
+          144 hlineto
+          endchar
+        </CharString>
+        <CharString name="IJ">
+          215 397 748 rmoveto
+          1 -13 -13 1 -14 hhcurveto
+          -167 -184 -127 -133 -72 38 -25 69 hvcurveto
+          -1 9 -13 8 51 vvcurveto
+          107 53 75 87 36 vhcurveto
+          -145 -679 rlineto
+          34 hlineto
+          -11 -20 -5 -23 -27 vvcurveto
+          -79 48 -58 113 155 66 109 138 29 vhcurveto
+          150 710 -150 -33 -164 -751 rlineto
+          -100 -22 -30 -23 -40 hhcurveto
+          -44 -27 29 39 40 29 33 36 16 17 -7 -16 16 hvcurveto
+          4 11 3 11 11 vvcurveto
+          34 -26 24 -41 6 vhcurveto
+          endchar
+        </CharString>
+        <CharString name="J">
+          88 538 750 rmoveto
+          -167 -184 -127 -133 -72 38 -25 69 hvcurveto
+          -1 9 -13 8 51 vvcurveto
+          107 54 76 87 36 vhcurveto
+          -157 -714 rlineto
+          -103 -23 -27 -20 -45 hhcurveto
+          -29 -39 18 52 37 24 37 46 20 15 -5 -21 25 hvcurveto
+          4 15 2 14 11 vvcurveto
+          64 -58 3 -40 -79 -43 -66 -68 -83 53 -58 95 164 67 94 153 32 vhcurveto
+          150 710 rlineto
+          endchar
+        </CharString>
+        <CharString name="one">
+          -131 324 748 rmoveto
+          -72 -121 -78 -6 -55 hhcurveto
+          -12 -46 rlineto
+          95 hlineto
+          -132 -624 rlineto
+          144 hlineto
+          endchar
+        </CharString>
+        <CharString name="three">
+          66 205 257 rmoveto
+          38 -8 -33 13 -37 hhcurveto
+          -80 -41 -60 -83 -154 141 -16 58 171 111 136 121 71 -38 65 -88 29 hvcurveto
+          92 46 45 74 66 vvcurveto
+          78 -63 68 -123 vhcurveto
+          -116 -91 -61 -91 -54 32 -31 40 24 27 11 23 25 hvcurveto
+          -28 8 -10 36 27 vvcurveto
+          47 31 31 48 51 25 -36 -46 -70 -58 -94 -113 -31 vhcurveto
+          93 -33 40 -80 -76 vvcurveto
+          -87 -53 -82 -86 -37 -39 13 76 40 10 62 78 6 vhcurveto
+          endchar
+        </CharString>
+        <CharString name="two">
+          44 111 132 rmoveto
+          -5 hlineto
+          83 135 273 98 223 vvcurveto
+          97 -53 64 -137 -151 -55 -79 -68 -58 31 -32 41 24 26 11 23 26 vhcurveto
+          -28 8 -10 37 23 vvcurveto
+          50 14 31 67 29 32 -33 -49 vhcurveto
+          -266 -329 -98 -219 vvcurveto
+          -11 0 -11 2 -11 vhcurveto
+          7 20 36 21 23 hhcurveto
+          102 37 -36 109 hhcurveto
+          99 20 52 98 14 0 14 -1 16 hvcurveto
+          -44 -47 -17 -25 -70 hhcurveto
+          -75 -57 18 -59 hhcurveto
+          endchar
+        </CharString>
+        <CharString name="zero">
+          98 377 750 rmoveto
+          -215 -132 -223 -273 -166 35 -97 172 205 113 299 199 168 -53 93 -125 hvcurveto
+          -189 -425 rmoveto
+          225 17 105 148 60 hhcurveto
+          47 7 -63 -82 -232 -68 -246 -114 -48 -11 77 74 37 3 35 2 27 hvcurveto
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+</ttFont>

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -224,6 +224,47 @@ class SubsetTest(unittest.TestCase):
         self.assertEqual(subsetfont['maxp'].numGlyphs, 3)
         self.assertEqual(subsetfont.getGlyphOrder(), ['.notdef', 'A', 'u1F6D2'])
 
+    def test_no_hinting_CFF(self):
+        ttxpath = self.getpath("Lobster.subset.ttx")
+        _, fontpath = self.compile_font(ttxpath, ".otf")
+        subsetpath = self.temp_path(".otf")
+        subset.main([fontpath, "--no-hinting", "--notdef-outline",
+                     "--output-file=%s" % subsetpath, "*"])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath(
+            "expect_no_hinting_CFF.ttx"), ["CFF "])
+
+    def test_desubroutinize_CFF(self):
+        ttxpath = self.getpath("Lobster.subset.ttx")
+        _, fontpath = self.compile_font(ttxpath, ".otf")
+        subsetpath = self.temp_path(".otf")
+        subset.main([fontpath, "--desubroutinize", "--notdef-outline",
+                     "--output-file=%s" % subsetpath, "*"])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath(
+            "expect_desubroutinize_CFF.ttx"), ["CFF "])
+
+    def test_no_hinting_desubroutinize_CFF(self):
+        ttxpath = self.getpath("Lobster.subset.ttx")
+        _, fontpath = self.compile_font(ttxpath, ".otf")
+        subsetpath = self.temp_path(".otf")
+        subset.main([fontpath, "--no-hinting", "--desubroutinize", "--notdef-outline",
+                     "--output-file=%s" % subsetpath, "*"])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath(
+            "expect_no_hinting_desubroutinize_CFF.ttx"), ["CFF "])
+
+    def test_no_hinting_TTF(self):
+        _, fontpath = self.compile_font(self.getpath("TestTTF-Regular.ttx"), ".ttf")
+        subsetpath = self.temp_path(".ttf")
+        subset.main([fontpath, "--no-hinting", "--notdef-outline",
+                     "--output-file=%s" % subsetpath, "*"])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath(
+            "expect_no_hinting_TTF.ttx"), ["glyf", "maxp"])
+        for tag in subset.Options().hinting_tables:
+            self.assertTrue(tag not in subsetfont)
+
 
 if __name__ == "__main__":
     sys.exit(unittest.main())


### PR DESCRIPTION
After merging PR #606, we spotted an issue so we decided to revert while investigating.

PR #606 was meant to fix an issue with the subsetter's `--no-hinting` option, which makes it strip all the advance widths from CFF charstrings.
I tried to fix this by 'drawing' the charstring with a NullPen, which would force setting its `width` attribute.

However I discovered that, with the above mentioned patch, the `--no-hinting` option would now throw an error with some fonts -- but not with the (admittedly too simple) 'TestOTF-Regular.otf' which is why I didn't catch this while running the automated tests.

Basically some charstrings have their `private` attribute set to None, hence have no `nominalWidthX` or `defaultWidthX` and the `draw()` method can't compute their width.

Now, if _both_ `--no-hinting` and `--desubroutinize` options are passed, the subsetter completes without error.
I suspect it might be related to https://github.com/fonttools/fonttools/issues/144
But I am not sure how to solve this, so I defer to someone more experienced wih CFF and T2CharStrings.

Here's the traceback

```
$ python -m fontTools.subset "/Users/cosimolupo/Library/Fonts/AGaramondPro-Regular.otf" --no-hinting --notdef-outline '*'
Traceback (most recent call last):
  [...]
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/subset/__init__.py", line 2967, in main
    subsetter.subset(font)
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/subset/__init__.py", line 2783, in subset
    self._prune_post_subset(font)
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/subset/__init__.py", line 2766, in _prune_post_subset
    retain = table.prune_post_subset(self.options)
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/subset/__init__.py", line 2212, in prune_post_subset
    charstring.draw(pen)  # this will set the charstring's width
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/misc/psCharStrings.py", line 282, in draw
    self.private.nominalWidthX, self.private.defaultWidthX)
AttributeError: 'NoneType' object has no attribute 'nominalWidthX'
```

Again, apologies for the revert commit.
