### PR TITLE
Fix vhea, add vhea to feaLib, table version functions in fixedTools

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -656,3 +656,13 @@ class HheaField(Statement):
 
     def build(self, builder):
         builder.add_hhea_field(self.key, self.value)
+
+
+class VheaField(Statement):
+    def __init__(self, location, key, value):
+        Statement.__init__(self, location)
+        self.key = key
+        self.value = value
+
+    def build(self, builder):
+        builder.add_vhea_field(self.key, self.value)

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -198,7 +198,7 @@ class Builder(object):
         if not table:  # this only happens for unit tests
             table = self.font["hhea"] = newTable("hhea")
             table.decompile(b"\0" * 36, self.font)
-            table.tableVersion = 1.0
+            table.tableVersion = 0x00010000
         if "caretoffset" in self.hhea_:
             table.caretOffset = self.hhea_["caretoffset"]
         if "ascender" in self.hhea_:

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -71,6 +71,8 @@ class Builder(object):
         self.os2_ = {}
         # for table 'hhea'
         self.hhea_ = {}
+        # for table 'vhea'
+        self.vhea_ = {}
 
     def build(self):
         self.parseTree = Parser(self.file).parse()
@@ -78,6 +80,7 @@ class Builder(object):
         self.build_feature_aalt_()
         self.build_head()
         self.build_hhea()
+        self.build_vhea()
         self.build_name()
         self.build_OS_2()
         for tag in ('GPOS', 'GSUB'):
@@ -204,6 +207,21 @@ class Builder(object):
             table.descent = self.hhea_["descender"]
         if "linegap" in self.hhea_:
             table.lineGap = self.hhea_["linegap"]
+
+    def build_vhea(self):
+        if not self.vhea_:
+            return
+        table = self.font.get("vhea")
+        if not table:  # this only happens for unit tests
+            table = self.font["vhea"] = newTable("vhea")
+            table.decompile(b"\0" * 36, self.font)
+            table.tableVersion = 0x00011000
+        if "verttypoascender" in self.vhea_:
+            table.ascent = self.vhea_["verttypoascender"]
+        if "verttypodescender" in self.vhea_:
+            table.descent = self.vhea_["verttypodescender"]
+        if "verttypolinegap" in self.vhea_:
+            table.lineGap = self.vhea_["verttypolinegap"]
 
     def get_user_name_id(self, table):
         # Try to find first unused font-specific name id
@@ -967,6 +985,9 @@ class Builder(object):
 
     def add_hhea_field(self, key, value):
         self.hhea_[key] = value
+
+    def add_vhea_field(self, key, value):
+        self.vhea_[key] = value
 
 
 def makeOpenTypeAnchor(anchor):

--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -57,7 +57,7 @@ class BuilderTest(unittest.TestCase):
         spec5f_ii_1 spec5f_ii_2 spec5f_ii_3 spec5f_ii_4
         spec5h1 spec6b_ii spec6d2 spec6e spec6f
         spec6h_ii spec6h_iii_1 spec6h_iii_3d spec8a spec8b spec8c
-        spec9a spec9b spec9c1 spec9c2 spec9c3 spec9d spec9e spec9f
+        spec9a spec9b spec9c1 spec9c2 spec9c3 spec9d spec9e spec9f spec9g
         spec10
         bug453 bug463 bug501 bug502 bug504 bug505 bug506 bug509 bug512 bug568
         name size size2 multiple_feature_blocks
@@ -105,7 +105,7 @@ class BuilderTest(unittest.TestCase):
     def expect_ttx(self, font, expected_ttx):
         path = self.temp_path(suffix=".ttx")
         font.saveXML(path, tables=['head', 'name', 'BASE', 'GDEF', 'GSUB',
-                                   'GPOS', 'OS/2', 'hhea'])
+                                   'GPOS', 'OS/2', 'hhea', 'vhea'])
         actual = self.read_ttx(path)
         expected = self.read_ttx(expected_ttx)
         if actual != expected:

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -717,6 +717,7 @@ class Parser(object):
             "GDEF": self.parse_table_GDEF_,
             "head": self.parse_table_head_,
             "hhea": self.parse_table_hhea_,
+            "vhea": self.parse_table_vhea_,
             "name": self.parse_table_name_,
             "BASE": self.parse_table_BASE_,
             "OS/2": self.parse_table_OS_2_,
@@ -777,6 +778,23 @@ class Parser(object):
             else:
                 raise FeatureLibError("Expected CaretOffset, Ascender, "
                                       "Descender or LineGap",
+                                      self.cur_token_location_)
+
+    def parse_table_vhea_(self, table):
+        statements = table.statements
+        fields = ("VertTypoAscender", "VertTypoDescender", "VertTypoLineGap")
+        while self.next_token_ != "}":
+            self.advance_lexer_()
+            if self.cur_token_type_ is Lexer.NAME and self.cur_token_ in fields:
+                key = self.cur_token_.lower()
+                value = self.expect_number_()
+                statements.append(
+                    ast.VheaField(self.cur_token_location_, key, value))
+            elif self.cur_token_ == ";":
+                continue
+            else:
+                raise FeatureLibError("Expected VertTypoAscender, "
+                                      "VertTypoDescender or VertTypoLineGap",
                                       self.cur_token_location_)
 
     def parse_table_name_(self, table):

--- a/Lib/fontTools/feaLib/testdata/spec9d.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec9d.ttx
@@ -2,7 +2,7 @@
 <ttFont>
 
   <hhea>
-    <tableVersion value="1.0"/>
+    <tableVersion value="0x00010000"/>
     <ascent value="800"/>
     <descent value="200"/>
     <lineGap value="200"/>

--- a/Lib/fontTools/feaLib/testdata/spec9g.fea
+++ b/Lib/fontTools/feaLib/testdata/spec9g.fea
@@ -1,0 +1,5 @@
+table vhea {
+   VertTypoAscender 500;
+   VertTypoDescender -500;
+   VertTypoLineGap 1000;
+} vhea;

--- a/Lib/fontTools/feaLib/testdata/spec9g.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec9g.ttx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="500"/>
+    <descent value="-500"/>
+    <lineGap value="1000"/>
+    <advanceHeightMax value="0"/>
+    <minTopSideBearing value="0"/>
+    <minBottomSideBearing value="0"/>
+    <yMaxExtent value="0"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="0"/>
+  </vhea>
+
+</ttFont>

--- a/Lib/fontTools/misc/fixedTools.py
+++ b/Lib/fontTools/misc/fixedTools.py
@@ -3,10 +3,15 @@
 
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+import logging
+
+log = logging.getLogger(__name__)
 
 __all__ = [
 	"fixedToFloat",
 	"floatToFixed",
+	"fixedToVersion",
+	"versionToFixed",
 ]
 
 def fixedToFloat(value, precisionBits):
@@ -45,3 +50,22 @@ def floatToFixed(value, precisionBits):
 	precisionBits.  Ie. int(round(value * (1<<precisionBits))).
 	"""
 	return int(round(value * (1<<precisionBits)))
+
+
+def ensureVersionIsLong(value):
+	"""Ensure a table version is an unsigned long (unsigned short major,
+	unsigned short minor) instead of a float."""
+	if value < 0x10000:
+		newValue = floatToFixed(value, 16)
+		log.warning(
+			"Table version value is a float: %.4f; "
+			"fix to use hex instead: 0x%08x", value, newValue)
+		value = newValue
+	return value
+
+
+def versionToFixed(value):
+	"""Converts a table version to a fixed"""
+	value = int(value, 0) if value.startswith("0") else float(value)
+	value = ensureVersionIsLong(value)
+	return value

--- a/Lib/fontTools/ttLib/tables/_h_h_e_a_test.py
+++ b/Lib/fontTools/ttLib/tables/_h_h_e_a_test.py
@@ -1,0 +1,160 @@
+from __future__ import absolute_import, unicode_literals
+from fontTools.misc.py23 import *
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.misc.testTools import parseXML, getXML
+from fontTools.misc.textTools import deHexStr
+from fontTools.ttLib import TTFont, newTable
+from fontTools.misc.fixedTools import log
+import unittest
+
+HHEA_DATA = deHexStr(
+    '0001 0000 '  # 1.0   version
+    '02EE '       # 750   ascent
+    'FF06 '       # -250  descent
+    '00C8 '       # 200   lineGap
+    '03E8 '       # 1000  advanceWidthMax
+    'FFE7 '       # -25   minLeftSideBearing
+    'FFEC '       # -20   minRightSideBearing
+    '03D1 '       # 977   xMaxExtent
+    '0000 '       # 0     caretSlopeRise
+    '0001 '       # 1     caretSlopeRun
+    '0010 '       # 16    caretOffset
+    '0000 '       # 0     reserved0
+    '0000 '       # 0     reserved1
+    '0000 '       # 0     reserved2
+    '0000 '       # 0     reserved3
+    '0000 '       # 0     metricDataFormat
+    '002A '       # 42    numberOfHMetrics
+)
+
+HHEA_AS_DICT = {
+    'tableTag': 'hhea',
+    'tableVersion': 0x00010000,
+    'ascent': 750,
+    'descent': -250,
+    'lineGap': 200,
+    'advanceWidthMax': 1000,
+    'minLeftSideBearing': -25,
+    'minRightSideBearing': -20,
+    'xMaxExtent': 977,
+    'caretSlopeRise': 0,
+    'caretSlopeRun': 1,
+    'caretOffset': 16,
+    'reserved0': 0,
+    'reserved1': 0,
+    'reserved2': 0,
+    'reserved3': 0,
+    'metricDataFormat': 0,
+    'numberOfHMetrics': 42,
+}
+
+HHEA_XML = (
+    '<tableVersion value="0x00010000"/>'
+    '<ascent value="750"/>'
+    '<descent value="-250"/>'
+    '<lineGap value="200"/>'
+    '<advanceWidthMax value="1000"/>'
+    '<minLeftSideBearing value="-25"/>'
+    '<minRightSideBearing value="-20"/>'
+    '<xMaxExtent value="977"/>'
+    '<caretSlopeRise value="0"/>'
+    '<caretSlopeRun value="1"/>'
+    '<caretOffset value="16"/>'
+    '<reserved0 value="0"/>'
+    '<reserved1 value="0"/>'
+    '<reserved2 value="0"/>'
+    '<reserved3 value="0"/>'
+    '<metricDataFormat value="0"/>'
+    '<numberOfHMetrics value="42"/>'
+)
+
+HHEA_XML_VERSION_AS_FLOAT = HHEA_XML.replace(
+    '<tableVersion value="0x00010000"/>',
+    '<tableVersion value="1.0"/>'
+)
+
+
+class HheaCompileOrToXMLTest(unittest.TestCase):
+
+    def setUp(self):
+        hhea = newTable('hhea')
+        hhea.tableVersion = 0x00010000
+        hhea.ascent = 750
+        hhea.descent = -250
+        hhea.lineGap = 200
+        hhea.advanceWidthMax = 1000
+        hhea.minLeftSideBearing = -25
+        hhea.minRightSideBearing = -20
+        hhea.xMaxExtent = 977
+        hhea.caretSlopeRise = 0
+        hhea.caretSlopeRun = 1
+        hhea.caretOffset = 16
+        hhea.metricDataFormat = 0
+        hhea.numberOfHMetrics = 42
+        hhea.reserved0 = hhea.reserved1 = hhea.reserved2 = hhea.reserved3 = 0
+        self.font = TTFont(sfntVersion='OTTO')
+        self.font['hhea'] = hhea
+
+    def test_compile(self):
+        hhea = self.font['hhea']
+        hhea.tableVersion = 0x00010000
+        self.assertEqual(HHEA_DATA, hhea.compile(self.font))
+
+    def test_compile_version_10_as_float(self):
+        hhea = self.font['hhea']
+        hhea.tableVersion = 1.0
+        with CapturingLogHandler(log, "WARNING") as captor:
+            self.assertEqual(HHEA_DATA, hhea.compile(self.font))
+        self.assertTrue(
+            len([r for r in captor.records
+                 if "Table version value is a float" in r.msg]) == 1)
+
+    def test_toXML(self):
+        hhea = self.font['hhea']
+        self.font['hhea'].tableVersion = 0x00010000
+        self.assertEqual(getXML(hhea.toXML), HHEA_XML)
+
+    def test_toXML_version_as_float(self):
+        hhea = self.font['hhea']
+        hhea.tableVersion = 1.0
+        with CapturingLogHandler(log, "WARNING") as captor:
+            self.assertEqual(getXML(hhea.toXML), HHEA_XML)
+        self.assertTrue(
+            len([r for r in captor.records
+                 if "Table version value is a float" in r.msg]) == 1)
+
+
+class HheaDecompileOrFromXMLTest(unittest.TestCase):
+
+    def setUp(self):
+        hhea = newTable('hhea')
+        self.font = TTFont(sfntVersion='OTTO')
+        self.font['hhea'] = hhea
+
+    def test_decompile(self):
+        hhea = self.font['hhea']
+        hhea.decompile(HHEA_DATA, self.font)
+        for key in hhea.__dict__:
+            self.assertEqual(getattr(hhea, key), HHEA_AS_DICT[key])
+
+    def test_fromXML(self):
+        hhea = self.font['hhea']
+        for name, attrs, content in parseXML(HHEA_XML):
+            hhea.fromXML(name, attrs, content, self.font)
+        for key in hhea.__dict__:
+            self.assertEqual(getattr(hhea, key), HHEA_AS_DICT[key])
+
+    def test_fromXML_version_as_float(self):
+        hhea = self.font['hhea']
+        with CapturingLogHandler(log, "WARNING") as captor:
+            for name, attrs, content in parseXML(HHEA_XML_VERSION_AS_FLOAT):
+                hhea.fromXML(name, attrs, content, self.font)
+        self.assertTrue(
+            len([r for r in captor.records
+                 if "Table version value is a float" in r.msg]) == 1)
+        for key in hhea.__dict__:
+            self.assertEqual(getattr(hhea, key), HHEA_AS_DICT[key])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/fontTools/ttLib/tables/_v_h_e_a.py
+++ b/Lib/fontTools/ttLib/tables/_v_h_e_a.py
@@ -2,11 +2,13 @@ from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval
+from fontTools.misc.fixedTools import (
+	ensureVersionIsLong as fi2ve, versionToFixed as ve2fi)
 from . import DefaultTable
 
 vheaFormat = """
 		>	# big endian
-		tableVersion:		16.16F
+		tableVersion:		L
 		ascent:			h
 		descent:		h
 		lineGap:		h
@@ -38,7 +40,6 @@ class table__v_h_e_a(DefaultTable.DefaultTable):
 		if ttFont.isLoaded('glyf') and ttFont.recalcBBoxes:
 			self.recalc(ttFont)
 		self.tableVersion = fi2ve(self.tableVersion)
-
 		return sstruct.pack(vheaFormat, self)
 
 	def recalc(self, ttFont):
@@ -85,10 +86,16 @@ class table__v_h_e_a(DefaultTable.DefaultTable):
 		formatstring, names, fixes = sstruct.getformat(vheaFormat)
 		for name in names:
 			value = getattr(self, name)
+			if name == "tableVersion":
+				value = fi2ve(value)
+				value = "0x%08x" % value
 			writer.simpletag(name, value=value)
 			writer.newline()
 
 	def fromXML(self, name, attrs, content, ttFont):
+		if name == "tableVersion":
+			setattr(self, name, ve2fi(attrs["value"]))
+			return
 		setattr(self, name, safeEval(attrs["value"]))
 
 	# reserved0 is caretOffset for legacy reasons

--- a/Lib/fontTools/ttLib/tables/_v_h_e_a.py
+++ b/Lib/fontTools/ttLib/tables/_v_h_e_a.py
@@ -16,7 +16,7 @@ vheaFormat = """
 		yMaxExtent:		h
 		caretSlopeRise:		h
 		caretSlopeRun:		h
-		reserved0:		h
+		caretOffset:		h
 		reserved1:		h
 		reserved2:		h
 		reserved3:		h
@@ -37,6 +37,8 @@ class table__v_h_e_a(DefaultTable.DefaultTable):
 	def compile(self, ttFont):
 		if ttFont.isLoaded('glyf') and ttFont.recalcBBoxes:
 			self.recalc(ttFont)
+		self.tableVersion = fi2ve(self.tableVersion)
+
 		return sstruct.pack(vheaFormat, self)
 
 	def recalc(self, ttFont):
@@ -88,3 +90,12 @@ class table__v_h_e_a(DefaultTable.DefaultTable):
 
 	def fromXML(self, name, attrs, content, ttFont):
 		setattr(self, name, safeEval(attrs["value"]))
+
+	# reserved0 is caretOffset for legacy reasons
+	@property
+	def reserved0(self):
+		return self.caretOffset
+
+	@reserved0.setter
+	def reserved0(self, value):
+		self.caretOffset = value

--- a/Lib/fontTools/ttLib/tables/_v_h_e_a_test.py
+++ b/Lib/fontTools/ttLib/tables/_v_h_e_a_test.py
@@ -1,0 +1,239 @@
+from __future__ import absolute_import, unicode_literals
+from fontTools.misc.py23 import *
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.misc.testTools import parseXML, getXML
+from fontTools.misc.textTools import deHexStr
+from fontTools.ttLib import TTFont, newTable
+from fontTools.misc.fixedTools import log
+import unittest
+
+VHEA_DATA_VERSION_11 = deHexStr(
+    '0001 1000 '  # 1.1   version
+    '01F4 '       # 500   ascent
+    'FE0C '       # -500  descent
+    '0000 '       # 0     lineGap
+    '0BB8 '       # 3000  advanceHeightMax
+    'FC16 '       # -1002 minTopSideBearing
+    'FD5B '       # -677  minBottomSideBearing
+    '0B70 '       # 2928  yMaxExtent
+    '0000 '       # 0     caretSlopeRise
+    '0001 '       # 1     caretSlopeRun
+    '0000 '       # 0     caretOffset
+    '0000 '       # 0     reserved1
+    '0000 '       # 0     reserved2
+    '0000 '       # 0     reserved3
+    '0000 '       # 0     reserved4
+    '0000 '       # 0     metricDataFormat
+    '000C '       # 12    numberOfVMetrics
+)
+
+VHEA_DATA_VERSION_10 = deHexStr('00010000') + VHEA_DATA_VERSION_11[4:]
+
+VHEA_VERSION_11_AS_DICT = {
+    'tableTag': 'vhea',
+    'tableVersion': 0x00011000,
+    'ascent': 500,
+    'descent': -500,
+    'lineGap': 0,
+    'advanceHeightMax': 3000,
+    'minTopSideBearing': -1002,
+    'minBottomSideBearing': -677,
+    'yMaxExtent': 2928,
+    'caretSlopeRise': 0,
+    'caretSlopeRun': 1,
+    'caretOffset': 0,
+    'reserved1': 0,
+    'reserved2': 0,
+    'reserved3': 0,
+    'reserved4': 0,
+    'metricDataFormat': 0,
+    'numberOfVMetrics': 12,
+}
+
+VHEA_VERSION_10_AS_DICT = dict(VHEA_VERSION_11_AS_DICT)
+VHEA_VERSION_10_AS_DICT['tableVersion'] = 0x00010000
+
+VHEA_XML_VERSION_11 = (
+    '<tableVersion value="0x00011000"/>'
+    '<ascent value="500"/>'
+    '<descent value="-500"/>'
+    '<lineGap value="0"/>'
+    '<advanceHeightMax value="3000"/>'
+    '<minTopSideBearing value="-1002"/>'
+    '<minBottomSideBearing value="-677"/>'
+    '<yMaxExtent value="2928"/>'
+    '<caretSlopeRise value="0"/>'
+    '<caretSlopeRun value="1"/>'
+    '<caretOffset value="0"/>'
+    '<reserved1 value="0"/>'
+    '<reserved2 value="0"/>'
+    '<reserved3 value="0"/>'
+    '<reserved4 value="0"/>'
+    '<metricDataFormat value="0"/>'
+    '<numberOfVMetrics value="12"/>'
+)
+
+VHEA_XML_VERSION_11_AS_FLOAT = VHEA_XML_VERSION_11.replace(
+    '<tableVersion value="0x00011000"/>',
+    '<tableVersion value="1.0625"/>'
+)
+
+VHEA_XML_VERSION_10 = VHEA_XML_VERSION_11.replace(
+    '<tableVersion value="0x00011000"/>',
+    '<tableVersion value="0x00010000"/>'
+)
+
+VHEA_XML_VERSION_10_AS_FLOAT = VHEA_XML_VERSION_11.replace(
+    '<tableVersion value="0x00011000"/>',
+    '<tableVersion value="1.0"/>'
+)
+
+
+class VheaCompileOrToXMLTest(unittest.TestCase):
+
+    def setUp(self):
+        vhea = newTable('vhea')
+        vhea.tableVersion = 0x00010000
+        vhea.ascent = 500
+        vhea.descent = -500
+        vhea.lineGap = 0
+        vhea.advanceHeightMax = 3000
+        vhea.minTopSideBearing = -1002
+        vhea.minBottomSideBearing = -677
+        vhea.yMaxExtent = 2928
+        vhea.caretSlopeRise = 0
+        vhea.caretSlopeRun = 1
+        vhea.caretOffset = 0
+        vhea.metricDataFormat = 0
+        vhea.numberOfVMetrics = 12
+        vhea.reserved1 = vhea.reserved2 = vhea.reserved3 = vhea.reserved4 = 0
+        self.font = TTFont(sfntVersion='OTTO')
+        self.font['vhea'] = vhea
+
+    def test_compile_caretOffset_as_reserved0(self):
+        vhea = self.font['vhea']
+        del vhea.caretOffset
+        vhea.reserved0 = 0
+        self.assertEqual(VHEA_DATA_VERSION_10, vhea.compile(self.font))
+
+    def test_compile_version_10(self):
+        vhea = self.font['vhea']
+        vhea.tableVersion = 0x00010000
+        self.assertEqual(VHEA_DATA_VERSION_10, vhea.compile(self.font))
+
+    def test_compile_version_10_as_float(self):
+        vhea = self.font['vhea']
+        vhea.tableVersion = 1.0
+        with CapturingLogHandler(log, "WARNING") as captor:
+            self.assertEqual(VHEA_DATA_VERSION_10, vhea.compile(self.font))
+        self.assertTrue(
+            len([r for r in captor.records
+                 if "Table version value is a float" in r.msg]) == 1)
+
+    def test_compile_version_11(self):
+        vhea = self.font['vhea']
+        vhea.tableVersion = 0x00011000
+        self.assertEqual(VHEA_DATA_VERSION_11, vhea.compile(self.font))
+
+    def test_compile_version_11_as_float(self):
+        vhea = self.font['vhea']
+        vhea.tableVersion = 1.0625
+        with CapturingLogHandler(log, "WARNING") as captor:
+            self.assertEqual(VHEA_DATA_VERSION_11, vhea.compile(self.font))
+        self.assertTrue(
+            len([r for r in captor.records
+                 if "Table version value is a float" in r.msg]) == 1)
+
+    def test_toXML_caretOffset_as_reserved0(self):
+        vhea = self.font['vhea']
+        del vhea.caretOffset
+        vhea.reserved0 = 0
+        self.assertEqual(getXML(vhea.toXML), VHEA_XML_VERSION_10)
+
+    def test_toXML_version_10(self):
+        vhea = self.font['vhea']
+        self.font['vhea'].tableVersion = 0x00010000
+        self.assertEqual(getXML(vhea.toXML), VHEA_XML_VERSION_10)
+
+    def test_toXML_version_10_as_float(self):
+        vhea = self.font['vhea']
+        vhea.tableVersion = 1.0
+        with CapturingLogHandler(log, "WARNING") as captor:
+            self.assertEqual(getXML(vhea.toXML), VHEA_XML_VERSION_10)
+        self.assertTrue(
+            len([r for r in captor.records
+                 if "Table version value is a float" in r.msg]) == 1)
+
+    def test_toXML_version_11(self):
+        vhea = self.font['vhea']
+        self.font['vhea'].tableVersion = 0x00011000
+        self.assertEqual(getXML(vhea.toXML), VHEA_XML_VERSION_11)
+
+    def test_toXML_version_11_as_float(self):
+        vhea = self.font['vhea']
+        vhea.tableVersion = 1.0625
+        with CapturingLogHandler(log, "WARNING") as captor:
+            self.assertEqual(getXML(vhea.toXML), VHEA_XML_VERSION_11)
+        self.assertTrue(
+            len([r for r in captor.records
+                 if "Table version value is a float" in r.msg]) == 1)
+
+
+class VheaDecompileOrFromXMLTest(unittest.TestCase):
+
+    def setUp(self):
+        vhea = newTable('vhea')
+        self.font = TTFont(sfntVersion='OTTO')
+        self.font['vhea'] = vhea
+
+    def test_decompile_version_10(self):
+        vhea = self.font['vhea']
+        vhea.decompile(VHEA_DATA_VERSION_10, self.font)
+        for key in vhea.__dict__:
+            self.assertEqual(getattr(vhea, key), VHEA_VERSION_10_AS_DICT[key])
+
+    def test_decompile_version_11(self):
+        vhea = self.font['vhea']
+        vhea.decompile(VHEA_DATA_VERSION_11, self.font)
+        for key in vhea.__dict__:
+            self.assertEqual(getattr(vhea, key), VHEA_VERSION_11_AS_DICT[key])
+
+    def test_fromXML_version_10(self):
+        vhea = self.font['vhea']
+        for name, attrs, content in parseXML(VHEA_XML_VERSION_10):
+            vhea.fromXML(name, attrs, content, self.font)
+        for key in vhea.__dict__:
+            self.assertEqual(getattr(vhea, key), VHEA_VERSION_10_AS_DICT[key])
+
+    def test_fromXML_version_10_as_float(self):
+        vhea = self.font['vhea']
+        with CapturingLogHandler(log, "WARNING") as captor:
+            for name, attrs, content in parseXML(VHEA_XML_VERSION_10_AS_FLOAT):
+                vhea.fromXML(name, attrs, content, self.font)
+        self.assertTrue(
+            len([r for r in captor.records
+                 if "Table version value is a float" in r.msg]) == 1)
+        for key in vhea.__dict__:
+            self.assertEqual(getattr(vhea, key), VHEA_VERSION_10_AS_DICT[key])
+
+    def test_fromXML_version_11(self):
+        vhea = self.font['vhea']
+        for name, attrs, content in parseXML(VHEA_XML_VERSION_11):
+            vhea.fromXML(name, attrs, content, self.font)
+        for key in vhea.__dict__:
+            self.assertEqual(getattr(vhea, key), VHEA_VERSION_11_AS_DICT[key])
+
+    def test_fromXML_version_11_as_float(self):
+        vhea = self.font['vhea']
+        with CapturingLogHandler(log, "WARNING") as captor:
+            for name, attrs, content in parseXML(VHEA_XML_VERSION_11_AS_FLOAT):
+                vhea.fromXML(name, attrs, content, self.font)
+        self.assertTrue(
+            len([r for r in captor.records
+                 if "Table version value is a float" in r.msg]) == 1)
+        for key in vhea.__dict__:
+            self.assertEqual(getattr(vhea, key), VHEA_VERSION_11_AS_DICT[key])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1,7 +1,9 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools.misc.textTools import safeEval
-from fontTools.misc.fixedTools import fixedToFloat as fi2fl, floatToFixed as fl2fi
+from fontTools.misc.fixedTools import (
+	fixedToFloat as fi2fl, floatToFixed as fl2fi, ensureVersionIsLong as fi2ve,
+	versionToFixed as ve2fi)
 from .otBase import ValueRecordFactory
 from functools import partial
 import logging
@@ -285,25 +287,15 @@ class Version(BaseConverter):
 		assert (value >> 16) == 1, "Unsupported version 0x%08x" % value
 		return value
 	def write(self, writer, font, tableDict, value, repeatIndex=None):
-		if value < 0x10000:
-			newValue = self.fromFloat(value)
-			log.warning("Table version value is a float: %g; fix code to use hex instead: %08x", value, newValue)
-			value = newValue
+		value = fi2ve(value)
 		assert (value >> 16) == 1, "Unsupported version 0x%08x" % value
 		writer.writeLong(value)
 	def xmlRead(self, attrs, content, font):
 		value = attrs["value"]
-		value = int(value, 0) if value.startswith("0") else float(value)
-		if value < 0x10000:
-			newValue = self.fromFloat(value)
-			log.warning("Table version value is a float: %g; fix XML to use hex instead: %08x", value, newValue)
-			value = newValue
+		value = ve2fi(value)
 		return value
 	def xmlWrite(self, xmlWriter, font, value, name, attrs):
-		if value < 0x10000:
-			newValue = self.fromFloat(value)
-			log.warning("Table version value is a float: %g; fix code to use hex instead: %08x", value, newValue)
-			value = newValue
+		value = fi2ve(value)
 		value = "0x%08x" % value
 		xmlWriter.simpletag(name, attrs + [("value", value)])
 		xmlWriter.newline()


### PR DESCRIPTION
- Replace reserved0 by caretOffset in vhea, keep reserved1...reserved4 instead of reordering for legacy.
- Add vhea support to feaLib.
- Fix for *tableVersion in 'vhea' is confusing* #540 and keeps hhea in sync with vhea, tableVersion is now hex (with translation from float).
- Moved otConverters.Version logic to new fixedTools functions, use in vhea, hhea and otConverters.Version.
- Add tests for vhea and hhea, update feaLib tests to use hex table version.
