### PR TITLE
[ttx/xmlWriter] allow to override OS-specific line endings 

### DIFF
--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -61,9 +61,8 @@ class TestXMLReader_(object):
 
 
 def makeXMLWriter():
-    writer = XMLWriter(BytesIO())
     # don't write OS-specific new lines
-    writer.newlinestr = writer.totype('')
+    writer = XMLWriter(BytesIO(), newlinestr='')
     # erase XML declaration
     writer.file.seek(0)
     writer.file.truncate()

--- a/Lib/fontTools/misc/xmlWriter.py
+++ b/Lib/fontTools/misc/xmlWriter.py
@@ -11,7 +11,8 @@ INDENT = "  "
 
 class XMLWriter(object):
 
-	def __init__(self, fileOrPath, indentwhite=INDENT, idlefunc=None, encoding="utf_8"):
+	def __init__(self, fileOrPath, indentwhite=INDENT, idlefunc=None, encoding="utf_8",
+			newlinestr=None):
 		if encoding.lower().replace('-','').replace('_','') != 'utf8':
 			raise Exception('Only UTF-8 encoding is supported.')
 		if fileOrPath == '-':
@@ -33,7 +34,10 @@ class XMLWriter(object):
 			self.file.write(tounicode(''))
 			self.totype = tounicode
 		self.indentwhite = self.totype(indentwhite)
-		self.newlinestr = self.totype(os.linesep)
+		if newlinestr is None:
+			self.newlinestr = self.totype(os.linesep)
+		else:
+			self.newlinestr = self.totype(newlinestr)
 		self.indentlevel = 0
 		self.stack = []
 		self.needindent = 1

--- a/Lib/fontTools/misc/xmlWriter_test.py
+++ b/Lib/fontTools/misc/xmlWriter_test.py
@@ -106,6 +106,22 @@ class TestXMLWriter(unittest.TestCase):
 			HEADER + b'two lines&#13;\nseparated by Windows line endings',
 			writer.file.getvalue())
 
+	def test_newlinestr(self):
+		header = b'<?xml version="1.0" encoding="UTF-8"?>'
+
+		for nls in (None, '\n', '\r\n', '\r', ''):
+			writer = XMLWriter(BytesIO(), newlinestr=nls)
+			writer.write("hello")
+			writer.newline()
+			writer.write("world")
+			writer.newline()
+
+			linesep = tobytes(os.linesep) if nls is None else tobytes(nls)
+
+			self.assertEqual(
+				header + linesep + b"hello" + linesep + b"world" + linesep,
+				writer.file.getvalue())
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/Lib/fontTools/ttLib/__init__.py
+++ b/Lib/fontTools/ttLib/__init__.py
@@ -242,7 +242,7 @@ class TTFont(object):
 
 	def saveXML(self, fileOrPath, progress=None, quiet=None,
 			tables=None, skipTables=None, splitTables=False, disassembleInstructions=True,
-			bitmapGlyphDataFormat='raw'):
+			bitmapGlyphDataFormat='raw', newlinestr=None):
 		"""Export the font as TTX (an XML-based text file), or as a series of text
 		files when splitTables is true. In the latter case, the 'fileOrPath'
 		argument should be a path to a directory.
@@ -277,7 +277,8 @@ class TTFont(object):
 		else:
 			idlefunc = None
 
-		writer = xmlWriter.XMLWriter(fileOrPath, idlefunc=idlefunc)
+		writer = xmlWriter.XMLWriter(fileOrPath, idlefunc=idlefunc,
+				newlinestr=newlinestr)
 		writer.begintag("ttFont", sfntVersion=repr(tostr(self.sfntVersion))[1:-1],
 				ttLibVersion=version)
 		writer.newline()
@@ -295,7 +296,8 @@ class TTFont(object):
 			tag = tables[i]
 			if splitTables:
 				tablePath = fileNameTemplate % tagToIdentifier(tag)
-				tableWriter = xmlWriter.XMLWriter(tablePath, idlefunc=idlefunc)
+				tableWriter = xmlWriter.XMLWriter(tablePath, idlefunc=idlefunc,
+						newlinestr=newlinestr)
 				tableWriter.begintag("ttFont", ttLibVersion=version)
 				tableWriter.newline()
 				tableWriter.newline()

--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -61,6 +61,9 @@ usage: ttx [options] inputfile1 [... inputfileN]
        starting from 0.
     --unicodedata <UnicodeData.txt> Use custom database file to write
        character names in the comments of the cmap TTX output.
+    --newline <value> Control how line endings are written in the XML
+       file. It can be 'LF', 'CR', or 'CRLF'. If not specified, the
+       default platform-specific line endings are used.
 
     Compile options:
     -m Merge with TrueType-input-file: specify a TrueType or OpenType
@@ -128,6 +131,7 @@ class Options(object):
 	ignoreDecompileErrors = True
 	bitmapGlyphDataFormat = 'raw'
 	unicodedata = None
+	newlinestr = None
 	recalcTimestamp = False
 	flavor = None
 	useZopfli = False
@@ -189,6 +193,18 @@ class Options(object):
 				self.ignoreDecompileErrors = False
 			elif option == "--unicodedata":
 				self.unicodedata = value
+			elif option == "--newline":
+				validOptions = ('LF', 'CR', 'CRLF')
+				if value == "LF":
+					self.newlinestr = "\n"
+				elif value == "CR":
+					self.newlinestr = "\r"
+				elif value == "CRLF":
+					self.newlinestr = "\r\n"
+				else:
+					raise getopt.GetoptError(
+						"Invalid choice for --newline: %r (choose from %s)"
+						% (value, ", ".join(map(repr, validOptions))))
 			elif option == "--recalc-timestamp":
 				self.recalcTimestamp = True
 			elif option == "--flavor":
@@ -252,7 +268,8 @@ def ttDump(input, output, options):
 			skipTables=options.skipTables,
 			splitTables=options.splitTables,
 			disassembleInstructions=options.disassembleInstructions,
-			bitmapGlyphDataFormat=options.bitmapGlyphDataFormat)
+			bitmapGlyphDataFormat=options.bitmapGlyphDataFormat,
+			newlinestr=options.newlinestr)
 	ttf.close()
 
 
@@ -312,7 +329,7 @@ def guessFileType(fileName):
 def parseOptions(args):
 	rawOptions, files = getopt.getopt(args, "ld:o:fvqht:x:sim:z:baey:",
 			['unicodedata=', "recalc-timestamp", 'flavor=', 'version',
-			 'with-zopfli'])
+			 'with-zopfli', 'newline='])
 
 	options = Options(rawOptions, len(files))
 	jobs = []


### PR DESCRIPTION
When TTX files are under version control and are being modified across multiple platforms, it's good to be able to _not_ use the default `os.linesep`, currently used by `XMLWriter`, but instead specify one particular line ending for all different platforms (e.g. most likely, LF).

This PR adds a `newlinestr` keyword argument to `XMLWriter` constructor, as well as to `TTFont.saveXML` method.
It also adds a `--newline` option to `ttx` console script.

The default does not change (ie. we keep using the native line endings).

However, we may wish to revise this in the future and always write Unix-style line feeds, since the XML specification says XML processor have to normalize them as such anyway. See https://www.w3.org/TR/REC-xml/#sec-line-ends

BTW, lxml always writes `"\n"` as line endings when `pretty_print`-ing XML, even on Windows.