### PR TITLE
[hmtx/vmtx] Round float values to int

### DIFF
--- a/Lib/fontTools/ttLib/tables/_h_m_t_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x.py
@@ -78,14 +78,14 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
 				lastIndex = 1
 				break
 		additionalMetrics = metrics[lastIndex:]
-		additionalMetrics = [sb for advance, sb in additionalMetrics]
+		additionalMetrics = [int(round(sb)) for _, sb in additionalMetrics]
 		metrics = metrics[:lastIndex]
 		numberOfMetrics = len(metrics)
 		setattr(ttFont[self.headerTag], self.numberOfMetricsName, numberOfMetrics)
 
 		allMetrics = []
-		for item in metrics:
-			allMetrics.extend(item)
+		for advance, sb in metrics:
+			allMetrics.extend([int(round(advance)), int(round(sb))])
 		metricsFmt = ">" + self.longMetricFormat * numberOfMetrics
 		try:
 			data = struct.pack(metricsFmt, *allMetrics)

--- a/Lib/fontTools/ttLib/tables/_h_m_t_x_test.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x_test.py
@@ -160,6 +160,19 @@ class HmtxTableTest(unittest.TestCase):
         with self.assertRaises(struct.error):
             mtxTable.compile(font)
 
+    def test_compile_round_float_values(self):
+        font = self.makeFont(numGlyphs=3, numberOfMetrics=2)
+        mtxTable = font[self.tag] = newTable(self.tag)
+        mtxTable.metrics = {
+            'A': (0.5, 0.5),  # round -> (0, 0)
+            'B': (0.1, 0.9),  # round -> (0, 1)
+            'C': (0.1, 0.1),  # round -> (0, 0)
+        }
+
+        data = mtxTable.compile(font)
+
+        self.assertEqual(data, deHexStr("0000 0000 0000 0001 0000"))
+
     def test_toXML(self):
         font = self.makeFont(numGlyphs=2, numberOfMetrics=2)
         mtxTable = font[self.tag] = newTable(self.tag)


### PR DESCRIPTION
I think we don't need to issue any warnings here, since we don't do that either when we round `glyf` coordinates.

Fixes #593