### PR TITLE
Feaplus

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -75,6 +75,9 @@ class AnonymousBlock(Statement):
         Statement.__init__(self, location)
         self.tag, self.content = tag, content
 
+    def build(self, builder):
+        builder.process_anon_block(self.content, self.tag)
+
 
 class Block(Statement):
     def __init__(self, location):

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -77,7 +77,8 @@ class Builder(object):
         self.python = {}
 
     def build(self):
-        self.parseTree = Parser(self.file).parse()
+        self.parser = Parser(self.file)
+        self.parseTree = self.parser.parse()
         self.parseTree.build(self)
         self.build_feature_aalt_()
         self.build_head()
@@ -1000,6 +1001,11 @@ class Builder(object):
                     'builder' : self
                 }
             exec content in self.python
+
+# Methods to provide capabilities to anon py blocks on builder
+    def parse_string(self, data) :
+        doc = self.parser.parse_string(data)
+        doc.build(self)
 
 
 def makeOpenTypeAnchor(anchor):

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1000,7 +1000,7 @@ class Builder(object):
                     # 'parser' : self.parser,
                     'builder' : self
                 }
-            exec content in self.python
+            exec (content, self.python)
 
 # Methods to provide capabilities to anon py blocks on builder
     def parse_string(self, data) :

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -73,6 +73,8 @@ class Builder(object):
         self.hhea_ = {}
         # for table 'vhea'
         self.vhea_ = {}
+        # for anon py blocks
+        self.python = {}
 
     def build(self):
         self.parseTree = Parser(self.file).parse()
@@ -988,6 +990,16 @@ class Builder(object):
 
     def add_vhea_field(self, key, value):
         self.vhea_[key] = value
+
+    def process_anon_block(self, content, tag) :
+        if tag == 'py  ' :
+            if '__builtins__' not in self.python :
+                self.python = {
+                    '__builtins__' : __builtins__,
+                    # 'parser' : self.parser,
+                    'builder' : self
+                }
+            exec content in self.python
 
 
 def makeOpenTypeAnchor(anchor):

--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -61,6 +61,7 @@ class BuilderTest(unittest.TestCase):
         spec10
         bug453 bug463 bug501 bug502 bug504 bug505 bug506 bug509 bug512 bug568
         name size size2 multiple_feature_blocks
+        anon_python
     """.split()
 
     def __init__(self, methodName):

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -237,5 +237,9 @@ class IncludingLexer(object):
             fileobj.close()
         return Lexer(data, filename)
 
+    def push_lexer(self, lexer) :
+        self.lexers_.append(lexer)
+
     def scan_anonymous_block(self, tag):
         return self.lexers_[-1].scan_anonymous_block(tag)
+

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -60,6 +60,15 @@ class Parser(object):
                     self.cur_token_location_)
         return self.doc_
 
+    def parse_string(self, data) :
+        olddoc = self.doc_
+        self.doc_ = ast.FeatureFile()
+        self.lexer_.push_lexer(Lexer(data, "<anon>"))
+        self.advance_lexer_()
+        res = self.parse()
+        self.doc_ = olddoc
+        return res
+
     def parse_anchor_(self):
         self.expect_symbol_("<")
         self.expect_keyword_("anchor")

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1155,9 +1155,10 @@ class Parser(object):
         for symtab in self.symbol_tables_:
             symtab.exit_scope()
 
-        name = self.expect_name_()
-        if name != block.name.strip():
-            raise FeatureLibError("Expected \"%s\"" % block.name.strip(),
+        if self.next_token_ != ";" :
+            name = self.expect_name_()
+            if name != block.name.strip():
+                raise FeatureLibError("Expected \"%s\"" % block.name.strip(),
                                   self.cur_token_location_)
         self.expect_symbol_(";")
 

--- a/Lib/fontTools/feaLib/testdata/anon_python.fea
+++ b/Lib/fontTools/feaLib/testdata/anon_python.fea
@@ -1,0 +1,9 @@
+anon py {
+
+builder.parse_string('''
+    feature size {
+        parameters 10.0 0;
+    } size;
+''')
+
+} py;

--- a/Lib/fontTools/feaLib/testdata/anon_python.ttx
+++ b/Lib/fontTools/feaLib/testdata/anon_python.ttx
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="size"/>
+        <Feature>
+          <FeatureParamsSize>
+            <DesignSize value="10.0"/>
+            <SubfamilyID value="0"/>
+            <SubfamilyNameID value="0"/>
+            <RangeStart value="0"/>
+            <RangeEnd value="0"/>
+          </FeatureParamsSize>
+          <!-- LookupCount=0 -->
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Lib/fontTools/feaLib/testdata/lookup.fea
+++ b/Lib/fontTools/feaLib/testdata/lookup.fea
@@ -11,12 +11,12 @@ feature tst1 {
 
 feature tst2 {
     lookup SomeLookup;
-} tst2;
+} ;
 
 feature tst3 {
     lookup EmbeddedLookup {
         sub A by A.sc;
-    } EmbeddedLookup;
+    } ;
 } tst3;
 
 feature tst4 {


### PR DESCRIPTION
This adds two capabilities to feaLib
- Ignore a missing tagname after a block, except for anonymous blocks
- Add support for anon py { } py; type blocks with limited reparsing capability.
