### PR TITLE
[feaLib] support backslash-escaped glyphs in FEA

### DIFF
--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -39,7 +39,7 @@ def makeTTFont():
         a_n_d T_h T_h.swash germandbls ydieresis yacute breve
         grave acute dieresis macron circumflex cedilla umlaut ogonek caron
         damma hamza sukun kasratan lam_meem_jeem noon.final noon.initial
-        \\glyphNameWithBackslash1 \\glyphNameWithBackslash2
+        by feature lookup sub table
     """.split()
     font = TTFont()
     font.setGlyphOrder(glyphs)

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1184,6 +1184,7 @@ class Parser(object):
     def expect_glyph_(self):
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.NAME:
+            self.cur_token_ = self.cur_token_.lstrip("\\")
             if len(self.cur_token_) > 63:
                 raise FeatureLibError(
                     "Glyph names must not be longer than 63 characters",

--- a/Lib/fontTools/feaLib/testdata/bug457.fea
+++ b/Lib/fontTools/feaLib/testdata/bug457.fea
@@ -1,4 +1,4 @@
-@group = [\glyphNameWithBackslash1 \glyphNameWithBackslash2];
+@group = [\A \sub \lookup \feature \by \table];
 
 feature liga {
     sub @group by G;

--- a/Lib/fontTools/feaLib/testdata/bug457.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug457.ttx
@@ -34,8 +34,12 @@
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
-          <Substitution in="\glyphNameWithBackslash1" out="G"/>
-          <Substitution in="\glyphNameWithBackslash2" out="G"/>
+          <Substitution in="A" out="G"/>
+          <Substitution in="by" out="G"/>
+          <Substitution in="feature" out="G"/>
+          <Substitution in="lookup" out="G"/>
+          <Substitution in="sub" out="G"/>
+          <Substitution in="table" out="G"/>
         </SingleSubst>
       </Lookup>
     </LookupList>

--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,7 @@
 - [hmtx/vmts] Read advance width/heights as unsigned short (uint16); automatically round float values to integers.
 - [ttLib/xmlWriter] add 'newlinestr=None' keyword argument to `TTFont.saveXML` for overriding os-specific line endings (passed on to `XMLWriter` instances).
 - [versioning] Use versioneer instead of setuptools_scm to dynamically load version info from a git checkout at import time.
+- [feaLib] Support backslash-prefixed glyph names.
 
 ## TTX/FontTools Version 3.1.2
 


### PR DESCRIPTION
Backslash-prefixed glyph name can be used in a Feature file to distinguish them from identically-named keywords.

From section "2.f.i. Glyph name" of Adobe's Feature File Specification:

> An initial backslash serves to differentiate a glyph name from an identical keyword in the feature file language. For example, a glyph named "table" must be specified in the feature file as: \table

Thus, when we parse a glyph name that begins with a backslash, we need to ignore the first character.

Note that makeotf rejects feature files with glyph names that start with or contain backslashes escaped with another backslash.

```
feature liga {
    sub \\glyphWithBackslash by A;
} liga;
```

This yields:

    makeotfexe [FATAL] <Backslash-Regular> invalid token (text was "\") [features 2]


Fixes https://github.com/fonttools/fonttools/issues/457

/cc @brawer @adrientetar 