### PR TITLE
[varLib] Do not emit null axes in fvar (default==min==max)

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -382,6 +382,8 @@ def build(designspace_filename, master_finder=lambda s:s, axisMap=None, build_HV
 		default = master_locs[base_idx][tag]
 		lower = min(m[tag] for m in master_locs)
 		upper = max(m[tag] for m in master_locs)
+		if default == lower == upper:
+			continue
 		axes[tag] = (lower, default, upper)
 	print("Axes:")
 	pprint(axes)


### PR DESCRIPTION
With this change, varLib will not export unused axes (i.e. axes with default==min==max). 

Currently, FontMake exports all 3 axes from Glyphs files, even if they aren't used (https://github.com/googlei18n/fontmake/issues/144).  Then, varLib would propagate these to the fvar table. While these don't do any harm per-se, it's inconvenient when trying to maintain hand-coded tables for which fontTools doesn't support (e.g. cvar, MVAR, STAT) with production values (i.e. their axisCount fields only reference the axes that are actually used, thus not being in synch with the value in fvar, gvar, HVAR and other tables that fontTools does build). 

It probably needs to be fixed upstream in fontmake, but this is a quick, tidy addition to varLib.