### PR TITLE
Fix for #740.

### DIFF
--- a/Lib/fontTools/cffLib.py
+++ b/Lib/fontTools/cffLib.py
@@ -1513,7 +1513,7 @@ class FontDictCompiler(TopDictCompiler):
 				if getattr(dictObj, name, None) != default:
 					ignoredNames.append(name)
 		if ignoredNames:
-			log.warning("Some CFF Dict keys were ignored upon compile: " +
+			log.warning("Some CFF FontDict keys were ignored upon compile: " +
 				" ".join(sorted(ignoredNames)))
 
 

--- a/Lib/fontTools/cffLib.py
+++ b/Lib/fontTools/cffLib.py
@@ -1513,7 +1513,7 @@ class FontDictCompiler(TopDictCompiler):
 				if getattr(dictObj, name, None) != default:
 					ignoredNames.append(name)
 		if ignoredNames:
-			log.warning("Some CFF FontDict keys were ignored upon compile: " +
+			log.warning("Some CFF FDArray/FontDict keys were ignored upon compile: " +
 				" ".join(sorted(ignoredNames)))
 
 

--- a/Lib/fontTools/cffLib.py
+++ b/Lib/fontTools/cffLib.py
@@ -1371,6 +1371,14 @@ class DictCompiler(object):
 				continue
 			rawDict[name] = value
 		self.rawDict = rawDict
+		ignoredNames = []
+		for name in sorted(set(dictObj.rawDict) - set(dictObj.order)):
+			value = getattr(dictObj, name, None)
+			if value is not None:
+				ignoredNames.append(name)
+		if ignoredNames:
+			log.log(logging.WARNING, "Some CFF Dict keys were ignored upon compile: " +
+				" ".join(sorted(ignoredNames)))
 
 	def setPos(self, pos, endPos):
 		pass

--- a/Lib/fontTools/cffLib.py
+++ b/Lib/fontTools/cffLib.py
@@ -1377,7 +1377,7 @@ class DictCompiler(object):
 			if value is not None:
 				ignoredNames.append(name)
 		if ignoredNames:
-			log.log(logging.WARNING, "Some CFF Dict keys were ignored upon compile: " +
+			log.warning("Some CFF Dict keys were ignored upon compile: " +
 				" ".join(sorted(ignoredNames)))
 
 	def setPos(self, pos, endPos):

--- a/Lib/fontTools/cffLib.py
+++ b/Lib/fontTools/cffLib.py
@@ -1544,6 +1544,10 @@ class BaseDict(object):
 				continue
 			conv = self.converters[name]
 			conv.xmlWrite(xmlWriter, name, value, progress)
+		ignoredNames = set(self.rawDict) - set(self.order)
+		if ignoredNames:
+			xmlWriter.comment("some keys were ignored: %s" % " ".join(sorted(ignoredNames)))
+			xmlWriter.newline()
 
 	def fromXML(self, name, attrs, content):
 		conv = self.converters[name]
@@ -1624,7 +1628,10 @@ class FontDict(TopDict):
 	# While this is not ideal -- we won't get to see "useless" key/value pairs that are
 	# actually in the font -- it's better than crashing on them.
 	#
-	# See https://github.com/fonttools/fonttools/issues/740
+	# See:
+	# - https://github.com/fonttools/fonttools/issues/740
+	# - https://github.com/fonttools/fonttools/issues/601
+	# - https://github.com/adobe-type-tools/afdko/issues/137
 	#
 	order = ['FontName', 'FontMatrix', 'Weight', 'Private']
 


### PR DESCRIPTION
This fixes #740.

Commits https://github.com/fonttools/fonttools/commit/3063def35b7ad733bf584b45452f9ef8f6efbab4 and https://github.com/fonttools/fonttools/commit/5b47971 introduced a separate fontDictOperators list for FontDict, only listing those TopDict key/value pairs that are actually used in the FontDict context. It provided a fallback that TTX files containing such "useless" key/value pairs would not be rejected.

However, the code still rejected binary fonts that contained such values, even though it didn't before, and yes, such fonts exist. Also: such fonts are not broken per spec, they just contain some fields that otherwise no one ever looks at, so it's a little harsh to reject them.

This patch removes most of the special FontDict code, and uses everything from TopDict, *except* the order attribute: it sets that to a list of the relevant keys for the FontDict. The effect of this is that "useless" key/value pairs are ignored, not just upon reading XML, but also upon decompilation and compilation of binary fonts. It improves on the previous XML reading behavior in that it no longer silently ignores key typos in the TTX input.

Ideally, we would *output* everything that is actually in the FontDict to TTX, and only ignore the values when compiling, but I didn't find a clean solution for that, so I decided to just fix the issue.