### PR TITLE
Make inspect.py file compatible to run with python2 and python3

### DIFF
--- a/Lib/fontTools/inspect.py
+++ b/Lib/fontTools/inspect.py
@@ -8,8 +8,14 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools import misc, ttLib, cffLib
-import pygtk
-pygtk.require('2.0')
+try:
+    from gi import pygtkcompat
+except ImportError:
+    pygtkcompat = None
+
+if pygtkcompat is not None:
+    pygtkcompat.enable()
+    pygtkcompat.enable_gtk(version='3.0')
 import gtk
 import sys
 


### PR DESCRIPTION
pyftinspect when run in python3 environment, it failed on Fedora 24 as pygtk is not python3 compatible. We need to port inspect.py file to use gobject-introspection but easy way I found is to use [pygtkcompat](https://wiki.gnome.org/Projects/PyGObject/PyGTKCompat) module. With this change we can run pyftinspect in both the python 2 and python 3 environment.

Please review this pull request and ask if needed any more changes.

Thanks.