### PR TITLE
[py23] further optimizie round3 function

### DIFF
--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -259,7 +259,48 @@ def xrange(*args, **kwargs):
 	raise Py23Error("'xrange' is not defined. Use 'range' instead.")
 
 
-import decimal as _decimal
+import math as _math
+
+try:
+	isclose = _math.isclose
+except AttributeError:
+	# math.isclose() was only added in Python 3.5
+
+	_isinf = _math.isinf
+	_fabs = _math.fabs
+
+	def isclose(a, b, rel_tol=1e-09, abs_tol=0):
+		"""
+		Python 2 implementation of Python 3.5 math.isclose()
+		https://hg.python.org/cpython/file/v3.5.2/Modules/mathmodule.c#l1993
+		"""
+		# sanity check on the inputs
+		if rel_tol < 0 or abs_tol < 0:
+			raise ValueError("tolerances must be non-negative")
+		# short circuit exact equality -- needed to catch two infinities of
+		# the same sign. And perhaps speeds things up a bit sometimes.
+		if a == b:
+			return True
+		# This catches the case of two infinities of opposite sign, or
+		# one infinity and one finite number. Two infinities of opposite
+		# sign would otherwise have an infinite relative tolerance.
+		# Two infinities of the same sign are caught by the equality check
+		# above.
+		if _isinf(a) or _isinf(b):
+			return False
+		# Cast to float to allow decimal.Decimal arguments
+		if not isinstance(a, float):
+			a = float(a)
+		if not isinstance(b, float):
+			b = float(b)
+		# now do the regular computation
+		# this is essentially the "weak" test from the Boost library
+		diff = _fabs(b - a)
+		result = ((diff <= _fabs(rel_tol * a)) or
+				  (diff <= _fabs(rel_tol * b)) or
+				  (diff <= abs_tol))
+		return result
+
 
 if PY3:
 	def round2(number, ndigits=None):
@@ -297,6 +338,12 @@ if PY3:
 	round = round3 = round
 
 else:
+	import decimal as _decimal
+
+	# in Python 2, 'round2' is an alias to the built-in 'round' and
+	# 'round' is shadowed by 'round3'
+	round2 = round
+
 	def round3(number, ndigits=None):
 		"""
 		Implementation of Python 3 built-in round() function.
@@ -330,24 +377,28 @@ else:
 			# return the same type as the number, when called with two arguments
 			totype = type(number)
 
-		if ndigits < 0:
-			exponent = 10 ** (-ndigits)
-			quotient, remainder = divmod(number, exponent)
-			half = exponent//2
-			if remainder > half or (remainder == half and quotient % 2 != 0):
-				quotient += 1
-			d = quotient * exponent
-		else:
-			exponent = _decimal.Decimal('10') ** (-ndigits) if ndigits != 0 else 1
+		m = number * (10 ** ndigits)
+		# if number is half-way between two multiples, and the mutliple that is
+		# closer to zero is even, we use the (slow) pure-Python implementation
+		if isclose(m % 1, .5) and int(m) % 2 == 0:
+			if ndigits < 0:
+				exponent = 10 ** (-ndigits)
+				quotient, remainder = divmod(number, exponent)
+				half = exponent//2
+				if remainder > half or (remainder == half and quotient % 2 != 0):
+					quotient += 1
+				d = quotient * exponent
+			else:
+				exponent = _decimal.Decimal('10') ** (-ndigits) if ndigits != 0 else 1
 
-			d = _decimal.Decimal.from_float(number).quantize(
-				exponent, rounding=_decimal.ROUND_HALF_EVEN)
+				d = _decimal.Decimal.from_float(number).quantize(
+					exponent, rounding=_decimal.ROUND_HALF_EVEN)
+		else:
+			# else we use the built-in round() as it produces the same results
+			d = round2(number, ndigits)
 
 		return totype(d)
 
-	# in Python 2, 'round2' is an alias to the built-in 'round' and
-	# 'round' is shadowed by 'round3'
-	round2 = round
 	round = round3
 
 

--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -302,6 +302,8 @@ except AttributeError:
 		return result
 
 
+import decimal as _decimal
+
 if PY3:
 	def round2(number, ndigits=None):
 		"""
@@ -338,8 +340,6 @@ if PY3:
 	round = round3 = round
 
 else:
-	import decimal as _decimal
-
 	# in Python 2, 'round2' is an alias to the built-in 'round' and
 	# 'round' is shadowed by 'round3'
 	round2 = round

--- a/Lib/fontTools/misc/py23_test.py
+++ b/Lib/fontTools/misc/py23_test.py
@@ -257,12 +257,14 @@ class IsCloseTests(unittest.TestCase):
 	isclose = staticmethod(isclose)
 
 	def assertIsClose(self, a, b, *args, **kwargs):
-		self.assertTrue(self.isclose(a, b, *args, **kwargs),
-						msg="%s and %s should be close!" % (a, b))
+		self.assertTrue(
+			self.isclose(a, b, *args, **kwargs),
+			msg="%s and %s should be close!" % (a, b))
 
 	def assertIsNotClose(self, a, b, *args, **kwargs):
-		self.assertFalse(self.isclose(a, b, *args, **kwargs),
-						 msg="%s and %s should not be close!" % (a, b))
+		self.assertFalse(
+			self.isclose(a, b, *args, **kwargs),
+			msg="%s and %s should not be close!" % (a, b))
 
 	def assertAllClose(self, examples, *args, **kwargs):
 		for a, b in examples:
@@ -281,27 +283,30 @@ class IsCloseTests(unittest.TestCase):
 
 	def test_identical(self):
 		# identical values must test as close
-		identical_examples = [(2.0, 2.0),
-							  (0.1e200, 0.1e200),
-							  (1.123e-300, 1.123e-300),
-							  (12345, 12345.0),
-							  (0.0, -0.0),
-							  (345678, 345678)]
+		identical_examples = [
+			(2.0, 2.0),
+			(0.1e200, 0.1e200),
+			(1.123e-300, 1.123e-300),
+			(12345, 12345.0),
+			(0.0, -0.0),
+			(345678, 345678)]
 		self.assertAllClose(identical_examples, rel_tol=0.0, abs_tol=0.0)
 
 	def test_eight_decimal_places(self):
 		# examples that are close to 1e-8, but not 1e-9
-		eight_decimal_places_examples = [(1e8, 1e8 + 1),
-										 (-1e-8, -1.000000009e-8),
-										 (1.12345678, 1.12345679)]
+		eight_decimal_places_examples = [
+			(1e8, 1e8 + 1),
+			(-1e-8, -1.000000009e-8),
+			(1.12345678, 1.12345679)]
 		self.assertAllClose(eight_decimal_places_examples, rel_tol=1e-8)
 		self.assertAllNotClose(eight_decimal_places_examples, rel_tol=1e-9)
 
 	def test_near_zero(self):
 		# values close to zero
-		near_zero_examples = [(1e-9, 0.0),
-							  (-1e-9, 0.0),
-							  (-1e-150, 0.0)]
+		near_zero_examples = [
+			(1e-9, 0.0),
+			(-1e-9, 0.0),
+			(-1e-150, 0.0)]
 		# these should not be close to any rel_tol
 		self.assertAllNotClose(near_zero_examples, rel_tol=0.9)
 		# these should be close to abs_tol=1e-8
@@ -316,29 +321,32 @@ class IsCloseTests(unittest.TestCase):
 
 	def test_inf_ninf_nan(self):
 		# these should never be close (following IEEE 754 rules for equality)
-		not_close_examples = [(NAN, NAN),
-							  (NAN, 1e-100),
-							  (1e-100, NAN),
-							  (INF, NAN),
-							  (NAN, INF),
-							  (INF, NINF),
-							  (INF, 1.0),
-							  (1.0, INF),
-							  (INF, 1e308),
-							  (1e308, INF)]
+		not_close_examples = [
+			(NAN, NAN),
+			(NAN, 1e-100),
+			(1e-100, NAN),
+			(INF, NAN),
+			(NAN, INF),
+			(INF, NINF),
+			(INF, 1.0),
+			(1.0, INF),
+			(INF, 1e308),
+			(1e308, INF)]
 		# use largest reasonable tolerance
 		self.assertAllNotClose(not_close_examples, abs_tol=0.999999999999999)
 
 	def test_zero_tolerance(self):
 		# test with zero tolerance
-		zero_tolerance_close_examples = [(1.0, 1.0),
-										 (-3.4, -3.4),
-										 (-1e-300, -1e-300)]
+		zero_tolerance_close_examples = [
+			(1.0, 1.0),
+			(-3.4, -3.4),
+			(-1e-300, -1e-300)]
 		self.assertAllClose(zero_tolerance_close_examples, rel_tol=0.0)
 
-		zero_tolerance_not_close_examples = [(1.0, 1.000000000000001),
-											 (0.99999999999999, 1.0),
-											 (1.0e200, .999999999999999e200)]
+		zero_tolerance_not_close_examples = [
+			(1.0, 1.000000000000001),
+			(0.99999999999999, 1.0),
+			(1.0e200, .999999999999999e200)]
 		self.assertAllNotClose(zero_tolerance_not_close_examples, rel_tol=0.0)
 
 	def test_assymetry(self):
@@ -347,8 +355,9 @@ class IsCloseTests(unittest.TestCase):
 
 	def test_integers(self):
 		# test with integer values
-		integer_examples = [(100000001, 100000000),
-							(123456789, 123456788)]
+		integer_examples = [
+			(100000001, 100000000),
+			(123456789, 123456788)]
 
 		self.assertAllClose(integer_examples, rel_tol=1e-8)
 		self.assertAllNotClose(integer_examples, rel_tol=1e-9)
@@ -357,9 +366,10 @@ class IsCloseTests(unittest.TestCase):
 		# test with Decimal values
 		from decimal import Decimal
 
-		decimal_examples = [(Decimal('1.00000001'), Decimal('1.0')),
-							(Decimal('1.00000001e-20'), Decimal('1.0e-20')),
-							(Decimal('1.00000001e-100'), Decimal('1.0e-100'))]
+		decimal_examples = [
+			(Decimal('1.00000001'), Decimal('1.0')),
+			(Decimal('1.00000001e-20'), Decimal('1.0e-20')),
+			(Decimal('1.00000001e-100'), Decimal('1.0e-100'))]
 		self.assertAllClose(decimal_examples, rel_tol=1e-8)
 		self.assertAllNotClose(decimal_examples, rel_tol=1e-9)
 

--- a/Lib/fontTools/misc/py23_test.py
+++ b/Lib/fontTools/misc/py23_test.py
@@ -8,7 +8,7 @@ import sys
 import os
 import unittest
 
-from fontTools.misc.py23 import round2, round3
+from fontTools.misc.py23 import round2, round3, isclose
 
 
 PIPE_SCRIPT = """\
@@ -242,6 +242,135 @@ class Round3Test(unittest.TestCase):
 		self.assertAlmostEqual(round3(-0.5e22, -22), 0.0)
 		self.assertAlmostEqual(round3(0.5e22, -22), 0.0)
 		self.assertAlmostEqual(round3(1.5e22, -22), 2e22)
+
+
+NAN = float('nan')
+INF = float('inf')
+NINF = float('-inf')
+
+
+class IsCloseTests(unittest.TestCase):
+	"""
+	Tests taken from Python 3.5 test_math.py:
+	https://hg.python.org/cpython/file/v3.5.2/Lib/test/test_math.py
+	"""
+	isclose = staticmethod(isclose)
+
+	def assertIsClose(self, a, b, *args, **kwargs):
+		self.assertTrue(self.isclose(a, b, *args, **kwargs),
+						msg="%s and %s should be close!" % (a, b))
+
+	def assertIsNotClose(self, a, b, *args, **kwargs):
+		self.assertFalse(self.isclose(a, b, *args, **kwargs),
+						 msg="%s and %s should not be close!" % (a, b))
+
+	def assertAllClose(self, examples, *args, **kwargs):
+		for a, b in examples:
+			self.assertIsClose(a, b, *args, **kwargs)
+
+	def assertAllNotClose(self, examples, *args, **kwargs):
+		for a, b in examples:
+			self.assertIsNotClose(a, b, *args, **kwargs)
+
+	def test_negative_tolerances(self):
+		# ValueError should be raised if either tolerance is less than zero
+		with self.assertRaises(ValueError):
+			self.assertIsClose(1, 1, rel_tol=-1e-100)
+		with self.assertRaises(ValueError):
+			self.assertIsClose(1, 1, rel_tol=1e-100, abs_tol=-1e10)
+
+	def test_identical(self):
+		# identical values must test as close
+		identical_examples = [(2.0, 2.0),
+							  (0.1e200, 0.1e200),
+							  (1.123e-300, 1.123e-300),
+							  (12345, 12345.0),
+							  (0.0, -0.0),
+							  (345678, 345678)]
+		self.assertAllClose(identical_examples, rel_tol=0.0, abs_tol=0.0)
+
+	def test_eight_decimal_places(self):
+		# examples that are close to 1e-8, but not 1e-9
+		eight_decimal_places_examples = [(1e8, 1e8 + 1),
+										 (-1e-8, -1.000000009e-8),
+										 (1.12345678, 1.12345679)]
+		self.assertAllClose(eight_decimal_places_examples, rel_tol=1e-8)
+		self.assertAllNotClose(eight_decimal_places_examples, rel_tol=1e-9)
+
+	def test_near_zero(self):
+		# values close to zero
+		near_zero_examples = [(1e-9, 0.0),
+							  (-1e-9, 0.0),
+							  (-1e-150, 0.0)]
+		# these should not be close to any rel_tol
+		self.assertAllNotClose(near_zero_examples, rel_tol=0.9)
+		# these should be close to abs_tol=1e-8
+		self.assertAllClose(near_zero_examples, abs_tol=1e-8)
+
+	def test_identical_infinite(self):
+		# these are close regardless of tolerance -- i.e. they are equal
+		self.assertIsClose(INF, INF)
+		self.assertIsClose(INF, INF, abs_tol=0.0)
+		self.assertIsClose(NINF, NINF)
+		self.assertIsClose(NINF, NINF, abs_tol=0.0)
+
+	def test_inf_ninf_nan(self):
+		# these should never be close (following IEEE 754 rules for equality)
+		not_close_examples = [(NAN, NAN),
+							  (NAN, 1e-100),
+							  (1e-100, NAN),
+							  (INF, NAN),
+							  (NAN, INF),
+							  (INF, NINF),
+							  (INF, 1.0),
+							  (1.0, INF),
+							  (INF, 1e308),
+							  (1e308, INF)]
+		# use largest reasonable tolerance
+		self.assertAllNotClose(not_close_examples, abs_tol=0.999999999999999)
+
+	def test_zero_tolerance(self):
+		# test with zero tolerance
+		zero_tolerance_close_examples = [(1.0, 1.0),
+										 (-3.4, -3.4),
+										 (-1e-300, -1e-300)]
+		self.assertAllClose(zero_tolerance_close_examples, rel_tol=0.0)
+
+		zero_tolerance_not_close_examples = [(1.0, 1.000000000000001),
+											 (0.99999999999999, 1.0),
+											 (1.0e200, .999999999999999e200)]
+		self.assertAllNotClose(zero_tolerance_not_close_examples, rel_tol=0.0)
+
+	def test_assymetry(self):
+		# test the assymetry example from PEP 485
+		self.assertAllClose([(9, 10), (10, 9)], rel_tol=0.1)
+
+	def test_integers(self):
+		# test with integer values
+		integer_examples = [(100000001, 100000000),
+							(123456789, 123456788)]
+
+		self.assertAllClose(integer_examples, rel_tol=1e-8)
+		self.assertAllNotClose(integer_examples, rel_tol=1e-9)
+
+	def test_decimals(self):
+		# test with Decimal values
+		from decimal import Decimal
+
+		decimal_examples = [(Decimal('1.00000001'), Decimal('1.0')),
+							(Decimal('1.00000001e-20'), Decimal('1.0e-20')),
+							(Decimal('1.00000001e-100'), Decimal('1.0e-100'))]
+		self.assertAllClose(decimal_examples, rel_tol=1e-8)
+		self.assertAllNotClose(decimal_examples, rel_tol=1e-9)
+
+	def test_fractions(self):
+		# test with Fraction values
+		from fractions import Fraction
+
+		# could use some more examples here!
+		fraction_examples = [(Fraction(1, 100000000) + 1, Fraction(1))]
+		self.assertAllClose(fraction_examples, rel_tol=1e-8)
+		self.assertAllNotClose(fraction_examples, rel_tol=1e-9)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
in normal circumstances, we get a huge speed improvement if we use the built-in Python 2 `round()` function for those values which we know will produce the same results as our slow implementation of Python 3 rounding (that uses the pure-python `decimal` module).

The latter will only be used when a number is half-way between the two multiples of 10 to the power `ndigits`, and the multiple towards zero is even.

When I check if the float number is "half-way" I can't simply take the `% 1 == .5`, because floating point math is funny. For that I use `math.isclose()` function (added in Python 3.5), for which I add a pure-python backport.

Checking that a float `isclose` is still faster than rounding it using the slow `Decimal` method.

@jamesgk @behdad 