### PR TITLE
[py23] fix inconsistency of built-in round on Python 3.5 if second argument is None

### DIFF
--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -360,7 +360,7 @@ else:
 		Implementation of Python 3 built-in round() function.
 
 		Rounds a number to a given precision in decimal digits (default
-		0 digits). This returns an int when called with one argument,
+		0 digits). This returns an int when ndigits is omitted or is None,
 		otherwise the same type as the number.
 
 		Values are rounded to the closest multiple of 10 to the power minus

--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -336,8 +336,19 @@ if PY3:
 
 			return float(d)
 
-	# in Python 3, 'round3' is an alias to the built-in 'round'
-	round = round3 = round
+	if sys.version_info[:2] >= (3, 6):
+		# in Python 3.6, 'round3' is an alias to the built-in 'round'
+		round = round3 = round
+	else:
+		# in Python3 < 3.6 we need work around the inconsistent behavior of
+		# built-in round(), whereby floats accept a second None argument,
+		# while integers raise TypeError. See https://bugs.python.org/issue27936
+		_round = round
+
+		def round3(number, ndigits=None):
+			return _round(number) if ndigits is None else _round(number, ndigits)
+
+		round = round3
 
 else:
 	# in Python 2, 'round2' is an alias to the built-in 'round' and

--- a/Lib/fontTools/misc/py23_test.py
+++ b/Lib/fontTools/misc/py23_test.py
@@ -164,6 +164,12 @@ class Round3Test(unittest.TestCase):
 		# floats should be illegal
 		self.assertRaises(TypeError, round3, 3.14159, 2.0)
 
+		# None should be allowed
+		self.assertEqual(round3(1.0, None), 1)
+		# the following would raise an error with the built-in Python3.5 round:
+		# TypeError: 'NoneType' object cannot be interpreted as an integer
+		self.assertEqual(round3(1, None), 1)
+
 	def test_halfway_cases(self):
 		self.assertAlmostEqual(round3(0.125, 2), 0.12)
 		self.assertAlmostEqual(round3(0.375, 2), 0.38)


### PR DESCRIPTION
This round thing is killing me..

There's a problem with the built-in `round()` function on Python 3.5.

If one passes `None` as a second argument, and the first argument is a float, everything is ok 

```python
>>> round(1.0, None)
1
```

But if the first argument is an integer and you pass None as second argument, it raises:

```python
>>> round(1, None)
TypeError: 'NoneType' object cannot be interpreted as an integer
```

Now, this happens to be a known issue (https://bugs.python.org/issue27936) which has been fixed in Python 3.6.

Here, on Python3 below 3.6, I have to wrap the built-in round() so that when it gets None as second argument, it behaves as if one did not provide the second argument at all.

See also https://github.com/typesupply/fontMath/pull/37#issuecomment-264435328
