### PR TITLE
Remove py_modules sstruct and xmlWriter from setup.py for issue#696

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
 	long_description=long_description,
 	package_dir={'': 'Lib'},
 	packages=find_packages("Lib"),
-	py_modules=['sstruct', 'xmlWriter'],
 	include_package_data=True,
 	data_files=[
 		('share/man/man1', ["Doc/ttx.1"])


### PR DESCRIPTION
With the new 3.3.0 release, I found that when you do "python setup.py build", you will see 

```
$ python2 setup.py build 
running build
running build_py
file Lib/sstruct.py (for module sstruct) not found
file Lib/xmlWriter.py (for module xmlWriter) not found
.....
```

This can be fixed by removing following line from setup.py
``` 
 py_modules=['sstruct', 'xmlWriter'],
```

I think this is also related with #696 