### PR TITLE
Add fea generation support

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -573,7 +573,7 @@ class LigatureCaretByPosStatement(Statement):
 
     def build(self, builder):
         glyphs = self.glyphs.glyphSet()
-        builder.add_ligatureCaretByPos_(self.location, glyphs, self.carets)
+        builder.add_ligatureCaretByPos_(self.location, glyphs, set(self.carets))
 
     def asFea(self, indent=""):
         return "LigatureCaretByPos {} {};".format(self.glyphs.asFea(), " ".join([str(x) for x in self.carets]))
@@ -781,9 +781,12 @@ class ReverseChainSingleSubstStatement(Statement):
     def build(self, builder):
         prefix = [p.glyphSet() for p in self.old_prefix]
         suffix = [s.glyphSet() for s in self.old_suffix]
-        builder.add_reverse_chain_single_subst(
-            self.location, prefix, suffix,
-            dict(zip(self.glyphs[0].glyphSet, self.replacements[0].glyphSet)))
+        originals = self.glyphs[0].glyphSet()
+        replaces = self.replacements[0].glyphSet()
+        if len(replaces) == 1 :
+            replaces = replaces * len(originals)
+        builder.add_reverse_chain_single_subst(self.location, prefix, suffix,
+                                dict(zip(replaces, originals)))
 
     def asFea(self, indent=""):
         res = "rsub "
@@ -810,8 +813,11 @@ class SingleSubstStatement(Statement):
     def build(self, builder):
         prefix = [p.glyphSet() for p in self.prefix]
         suffix = [s.glyphSet() for s in self.suffix]
+        replaces = self.replacements[0].glyphSet()
+        if len(replaces) == 1 :
+            replaces = replaces * len(originals)
         builder.add_single_subst(self.location, prefix, suffix,
-                                 OrderedDict(zip(self.glyphs[0].glyphSet(), self.replacements[0].glyphSet())),
+                                 OrderedDict(zip(originals, replaces)),
                                  self.forceChain)
 
     def asFea(self, indent=""):

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -793,11 +793,11 @@ class PairPosStatement(Statement):
     def asFea(self, indent=""):
         res = "enum " if self.enumerated else ""
         if self.valuerecord2 :
-            res += "pos {} {} {} {};".format(self.glyphs1.asFea(), self.valuerecord1.makeString(False),
-                        self.glyphs2.asFea(), self.valuerecord2.makeString(False))
+            res += "pos {} {} {} {};".format(self.glyphs1.asFea(), self.valuerecord1.makeString(),
+                        self.glyphs2.asFea(), self.valuerecord2.makeString())
         else :
             res += "pos {} {} {};".format(self.glyphs1.asFea(), self.glyphs2.asFea(), 
-                        self.valuerecord1.makeString(False))
+                        self.valuerecord1.makeString())
         return res
 
 
@@ -895,11 +895,11 @@ class SinglePosStatement(Statement):
         if len(self.prefix) or len(self.suffix) or self.forceChain :
             if len(self.prefix) :
                 res += " ".join(map(asFea, self.prefix)) + " "
-            res += " ".join([asFea(x[0]) + "'" + ((" " + x[1].makeString(False)) if x[1] else "") for x in self.pos])
+            res += " ".join([asFea(x[0]) + "'" + ((" " + x[1].makeString()) if x[1] else "") for x in self.pos])
             if len(self.suffix) :
                 res += " " + " ".join(map(asFea, self.suffix))
         else :
-            res += " ".join([asFea(x[0]) + " " + (x[1].makeString(False) if x[1] else "") for x in self.pos])
+            res += " ".join([asFea(x[0]) + " " + (x[1].makeString() if x[1] else "") for x in self.pos])
         res += ";"
         return res
 
@@ -910,13 +910,14 @@ class SubtableStatement(Statement):
 
 
 class ValueRecord(Expression):
-    def __init__(self, location, xPlacement, yPlacement, xAdvance, yAdvance,
+    def __init__(self, location, vertical, xPlacement, yPlacement, xAdvance, yAdvance,
                  xPlaDevice, yPlaDevice, xAdvDevice, yAdvDevice):
         Expression.__init__(self, location)
         self.xPlacement, self.yPlacement = (xPlacement, yPlacement)
         self.xAdvance, self.yAdvance = (xAdvance, yAdvance)
         self.xPlaDevice, self.yPlaDevice = (xPlaDevice, yPlaDevice)
         self.xAdvDevice, self.yAdvDevice = (xAdvDevice, yAdvDevice)
+        self.vertical = vertical
 
     def __eq__(self, other):
         return (self.xPlacement == other.xPlacement and
@@ -935,11 +936,12 @@ class ValueRecord(Expression):
                 hash(self.xPlaDevice) ^ hash(self.yPlaDevice) ^
                 hash(self.xAdvDevice) ^ hash(self.yAdvDevice))
 
-    def makeString(self, vertical):
+    def makeString(self, vertical = None):
         x, y = self.xPlacement, self.yPlacement
         xAdvance, yAdvance = self.xAdvance, self.yAdvance
         xPlaDevice, yPlaDevice = self.xPlaDevice, self.yPlaDevice
         xAdvDevice, yAdvDevice = self.xAdvDevice, self.yAdvDevice
+        if vertical is None : vertical = self.vertical
 
         # Try format A, if possible.
         if x == 0 and y == 0:

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -4,6 +4,7 @@ from fontTools.feaLib.error import FeatureLibError
 from collections import OrderedDict
 import itertools
 
+SHIFT = " " * 4
 
 def deviceToString(device):
     if device is None:
@@ -11,6 +12,31 @@ def deviceToString(device):
     else:
         return "<device %s>" % ", ".join(["%d %d" % t for t in device])
 
+fea_keywords = set([
+    "anchor", "anchordef", "anon", "anonymous",
+    "by",
+    "contour", "cursive",
+    "device",
+    "enum", "enumerate", "excludedflt", "exclude_dflt"
+    "feature", "from",
+    "ignore", "ignorebaseglyphs", "ignoreligatures", "ignoremarks", "include", "includedflt", "include_dflt",
+    "language", "languagesystem", "lookup", "lookupflag",
+    "mark", "markattachmenttype", "markclass",
+    "nameid", "null",
+    "parameters", "pos", "position",
+    "required", "righttoleft", "reversesub", "rsub",
+    "script", "sub", "substitute", "subtable",
+    "table",
+    "usemarkfilteringset", "useextension", "valuerecorddef"]
+)
+
+def asFea(g) :
+    if hasattr(g, 'asFea') :
+        return g.asFea()
+    elif g.lower() in fea_keywords :
+        return "\\" + g
+    else :
+        return g
 
 class Statement(object):
     def __init__(self, location):
@@ -19,12 +45,18 @@ class Statement(object):
     def build(self, builder):
         pass
 
+    def asFea(self, indent=""):
+        pass
+
 
 class Expression(object):
     def __init__(self, location):
         self.location = location
 
     def build(self, builder):
+        pass
+
+    def asFea(self, indent=""):
         pass
 
 
@@ -37,6 +69,9 @@ class GlyphName(Expression):
     def glyphSet(self):
         return (self.glyph,)
 
+    def asFea(self, indent=""):
+        return str(self.glyph)
+
 
 class GlyphClass(Expression):
     """A glyph class, such as [acute cedilla grave]."""
@@ -46,6 +81,9 @@ class GlyphClass(Expression):
 
     def glyphSet(self):
         return tuple(self.glyphs)
+
+    def asFea(self, indent=""):
+        return "[" + " ".join(map(asFea, self.glyphs)) + "]"
 
 
 class GlyphClassName(Expression):
@@ -58,6 +96,9 @@ class GlyphClassName(Expression):
     def glyphSet(self):
         return tuple(self.glyphclass.glyphs)
 
+    def asFea(self, indent=""):
+        return "@" + self.glyphclass.name
+
 
 class MarkClassName(Expression):
     """A mark class name, such as @FRENCH_MARKS defined with markClass."""
@@ -69,11 +110,20 @@ class MarkClassName(Expression):
     def glyphSet(self):
         return self.markClass.glyphSet()
 
+    def asFea(self, indent=""):
+        return "@" + self.markClass.name
+
 
 class AnonymousBlock(Statement):
     def __init__(self, tag, content, location):
         Statement.__init__(self, location)
         self.tag, self.content = tag, content
+
+    def asFea(self, indent=""):
+        res = "anon {} {{\n".format(self.tag)
+        res += self.content
+        res += "}} {};\n\n".format(self.tag)
+        return res
 
 
 class Block(Statement):
@@ -85,11 +135,18 @@ class Block(Statement):
         for s in self.statements:
             s.build(builder)
 
+    def asFea(self, indent="") :
+        indent += SHIFT
+        return indent + ("\n" + indent).join([s.asFea(indent=indent) for s in self.statements]) + "\n"; 
+
 
 class FeatureFile(Block):
     def __init__(self):
         Block.__init__(self, location=None)
         self.markClasses = {}  # name --> ast.MarkClass
+
+    def asFea(self, indent=""):
+        return "\n".join([s.asFea(indent=indent) for s in self.statements])
 
 
 class FeatureBlock(Block):
@@ -110,6 +167,26 @@ class FeatureBlock(Block):
         builder.features_ = features
         builder.end_feature()
 
+    def asFea(self, indent="") :
+        res = indent + "feature {} {{\n".format(self.name)
+        indent += SHIFT
+        if len(self.statements) and isinstance(self.statements[0], FeatureNameStatement) :
+            res += indent + "featureNames {\n";
+            res += indent + SHIFT
+            res += ("\n" + indent + SHIFT).join([s.asFea(indent=indent + SHIFT * 2)
+                                for s in self.statements if isinstance(s, FeatureNameStatement)])
+            res += "\n"
+            res += indent + "};\n" + indent
+            res += ("\n" + indent).join([s.asFea(indent=indent)
+                                for s in self.statements if not isinstance(s, FeatureNameStatement)])
+            res += "\n"
+        else :
+            res += indent
+            res += ("\n" + indent).join([s.asFea(indent=indent) for s in self.statements])
+            res += "\n"
+        res += "{}}} {};\n".format(indent[:-len(SHIFT)], self.name)
+        return res
+
 
 class LookupBlock(Block):
     def __init__(self, location, name, use_extension):
@@ -122,11 +199,23 @@ class LookupBlock(Block):
         Block.build(self, builder)
         builder.end_lookup_block()
 
+    def asFea(self, indent="") :
+        res = "lookup {} {{\n".format(self.name)
+        res += Block.asFea(self, indent = indent);
+        res += "{}}} {};\n".format(indent, self.name)
+        return res
+
 
 class TableBlock(Block):
     def __init__(self, location, name):
         Block.__init__(self, location)
         self.name = name
+
+    def asFea(self, indent=""):
+        res = "table {} {{\n".format(self.name)
+        res += super(TableBlock, self).asFea(indent=indent)
+        res += "}} {};\n".format(self.name)
+        return res
 
 
 class GlyphClassDefinition(Statement):
@@ -138,6 +227,9 @@ class GlyphClassDefinition(Statement):
 
     def glyphSet(self):
         return tuple(self.glyphs)
+
+    def asFea(self, indent=""):
+        return "@" + self.name + " = [" + " ".join(map(asFea, self.glyphs)) + "];"
 
 
 class GlyphClassDefStatement(Statement):
@@ -157,6 +249,11 @@ class GlyphClassDefStatement(Statement):
         comp = (self.componentGlyphs.glyphSet()
                 if self.componentGlyphs else tuple())
         builder.add_glyphClassDef(self.location, base, liga, mark, comp)
+
+    def asFea(self, indent=""):
+        return "GlyphClassDef {}, {}, {}, {};".format(self.baseGlyphs.asFea(),
+                    self.markGlyphs.asFea(), self.ligatureGlyphs.asFea(),
+                    self.componentGlyphs.asFea())
 
 
 # While glyph classes can be defined only once, the feature file format
@@ -186,6 +283,12 @@ class MarkClass(object):
     def glyphSet(self):
         return tuple(self.glyphs.keys())
 
+    def asFea(self, indent="") :
+        res = ""
+        for d in self.definitions :
+            res += "{}markClass {} @{};\n".format(indent, d.asFea(), self.name);
+        return res;
+
 
 class MarkClassDefinition(Statement):
     def __init__(self, location, markClass, anchor, glyphs):
@@ -196,6 +299,9 @@ class MarkClassDefinition(Statement):
 
     def glyphSet(self):
         return self.glyphs.glyphSet()
+
+    def asFea(self, indent=""):
+        return "markClass {} {} @{};".format(self.glyphs.asFea(), self.anchor.asFea(), self.markClass.name);
 
 
 class AlternateSubstStatement(Statement):
@@ -214,19 +320,54 @@ class AlternateSubstStatement(Statement):
         builder.add_alternate_subst(self.location, prefix, glyph, suffix,
                                     replacement)
 
+    def asFea(self, indent=""):
+        res = "sub "
+        if len(self.prefix) or len(self.suffix) :
+            if len(self.prefix) :
+                res += " ".join(map(asFea, self.prefix)) + " "
+            res += " " + asFea(self.glyph) + "'"    # even though we really only use 1
+            if len(self.suffix) :
+                res += " ".join(map(asFea, self.suffix))
+        else :
+            res += asFea(self.glyph)
+        res += " from "
+        res += asFea(self.replacement)
+        res += ";"
+        return res
 
 class Anchor(Expression):
-    def __init__(self, location, x, y, contourpoint,
+    def __init__(self, location, name, x, y, contourpoint,
                  xDeviceTable, yDeviceTable):
         Expression.__init__(self, location)
+        self.name = name
         self.x, self.y, self.contourpoint = x, y, contourpoint
         self.xDeviceTable, self.yDeviceTable = xDeviceTable, yDeviceTable
 
+    def asFea(self, indent=""):
+        if self.name is not None :
+            return "<anchor {}>".format(self.name)
+        res = "<anchor {} {}".format(self.x, self.y)
+        if self.contourpoint :
+            res += " contourpoint {}".format(self.contourpoint)
+        if self.xDeviceTable or self.yDeviceTable :
+            res += " "
+            res += deviceToString(self.xDeviceTable)
+            res += " "
+            res += deviceToString(self.yDeviceTable)
+        res += ">"
+        return res
 
 class AnchorDefinition(Statement):
     def __init__(self, location, name, x, y, contourpoint):
         Statement.__init__(self, location)
         self.name, self.x, self.y, self.contourpoint = name, x, y, contourpoint
+
+    def asFea(self, indent=""):
+        res = "anchorDef {} {}".format(self.x, self.y)
+        if self.contourpoint :
+            res += " contourpoint {}".format(self.contourpoint)
+        res += " {};".format(self.name)
+        return res
 
 
 class AttachStatement(Statement):
@@ -238,8 +379,11 @@ class AttachStatement(Statement):
         glyphs = self.glyphs.glyphSet()
         builder.add_attach_points(self.location, glyphs, self.contourPoints)
 
+    def asFea(self, indent=""):
+        return "Attach {} {};".format(self.glyphs.asFea(), " ".join([str(c) for c in self.contourPoints]));
 
-class ChainContextPosStatement(Statement):
+
+class ChainContextStatement(Statement) :
     def __init__(self, location, prefix, glyphs, suffix, lookups):
         Statement.__init__(self, location)
         self.prefix, self.glyphs, self.suffix = prefix, glyphs, suffix
@@ -252,19 +396,30 @@ class ChainContextPosStatement(Statement):
         builder.add_chain_context_pos(
             self.location, prefix, glyphs, suffix, self.lookups)
 
+    def asFea(self, indent=""):
+        res = ""
+        if len(self.prefix) or len(self.suffix) or any([x is not None for x in self.lookups]) :
+            res += " ".join([g.asFea() for g in self.prefix])
+            if len(self.prefix) : res += " "
+            for i, g in enumerate(self.glyphs) :
+                res += g.asFea() + "' "
+                if self.lookups[i] is not None :
+                    res += "lookup " + self.lookups[i].name + " "
+            res += " ".join(map(asFea, self.suffix))
+        else :
+            res += " ".join(map(asFea, self.glyph))
+        res += ";"
+        return res
 
-class ChainContextSubstStatement(Statement):
-    def __init__(self, location, prefix, glyphs, suffix, lookups):
-        Statement.__init__(self, location)
-        self.prefix, self.glyphs, self.suffix = prefix, glyphs, suffix
-        self.lookups = lookups
 
-    def build(self, builder):
-        prefix = [p.glyphSet() for p in self.prefix]
-        glyphs = [g.glyphSet() for g in self.glyphs]
-        suffix = [s.glyphSet() for s in self.suffix]
-        builder.add_chain_context_subst(
-            self.location, prefix, glyphs, suffix, self.lookups)
+class ChainContextPosStatement(ChainContextStatement):
+    def asFea(self, indent=""):
+        return "pos " + super(ChainContextPosStatement, self).asFea()
+
+
+class ChainContextSubstStatement(ChainContextStatement):
+    def asFea(self, indent=""):
+        return "sub " + super(ChainContextSubstStatement, self).asFea()
 
 
 class CursivePosStatement(Statement):
@@ -275,7 +430,12 @@ class CursivePosStatement(Statement):
 
     def build(self, builder):
         builder.add_cursive_pos(
-            self.location, self.glyphclass, self.entryAnchor, self.exitAnchor)
+            self.location, self.glyphclass.glyphSet(), self.entryAnchor, self.exitAnchor)
+
+    def asFea(self, indent=""):
+        entry = self.entryAnchor.asFea() if self.entryAnchor else "<anchor NULL>"
+        exit = self.exitAnchor.asFea() if self.exitAnchor else "<anchor NULL>"
+        return "pos cursive {} {} {};".format(self.glyphclass.asFea(), entry, exit)
 
 
 class FeatureReferenceStatement(Statement):
@@ -286,6 +446,9 @@ class FeatureReferenceStatement(Statement):
 
     def build(self, builder):
         builder.add_feature_reference(self.location, self.featureName)
+
+    def asFea(self, indent="") :
+        return "feature {};".format(self.featureName)
 
 
 class IgnorePosStatement(Statement):
@@ -301,6 +464,21 @@ class IgnorePosStatement(Statement):
             builder.add_chain_context_pos(
                 self.location, prefix, glyphs, suffix, [])
 
+    def asFea(self, indent=""):
+        contexts = []
+        for prefix, glyphs, suffix in self.chainContexts :
+            res = ""
+            if len(prefix) or len(suffix) :
+                if len(prefix) :
+                    res += " ".join(map(asFea, prefix)) + " "
+                res += " ".join([g.asFea() + "'" for g in glyphs])
+                if len(suffix) :
+                    res += " " + " ".join(map(asFea, suffix))
+            else :
+                res += " ".join(map(asFea, glyphs))
+            contexts.append(res)
+        return "ignore position " + ", ".join(contexts) + ";"
+
 
 class IgnoreSubstStatement(Statement):
     def __init__(self, location, chainContexts):
@@ -314,6 +492,21 @@ class IgnoreSubstStatement(Statement):
             suffix = [s.glyphSet() for s in suffix]
             builder.add_chain_context_subst(
                 self.location, prefix, glyphs, suffix, [])
+
+    def asFea(self, indent=""):
+        contexts = []
+        for prefix, glyphs, suffix in self.chainContexts :
+            res = ""
+            if len(prefix) or len(suffix) :
+                if len(prefix) :
+                    res += " ".join(map(asFea, prefix)) + " "
+                res += " ".join([g.asFea() + "'" for g in glyphs])
+                if len(suffix) :
+                    res += " " + " ".join(map(asFea, suffix))
+            else :
+                res += " ".join(map(asFea, glyphs))
+            contexts.append(res)
+        return "ignore sub " + ", ".join(contexts) + ";"
 
 
 class LanguageStatement(Statement):
@@ -329,6 +522,13 @@ class LanguageStatement(Statement):
                              include_default=self.include_default,
                              required=self.required)
 
+    def asFea(self, indent=""):
+        res = "language {}".format(self.language)
+        if not self.include_default : res += " exclude_dflt"
+        if self.required : res += " required"
+        res += ";"
+        return res
+
 
 class LanguageSystemStatement(Statement):
     def __init__(self, location, script, language):
@@ -337,6 +537,9 @@ class LanguageSystemStatement(Statement):
 
     def build(self, builder):
         builder.add_language_system(self.location, self.script, self.language)
+
+    def asFea(self, indent=""):
+        return "languagesystem {} {};".format(self.script, self.language);
 
 
 class FontRevisionStatement(Statement):
@@ -347,6 +550,8 @@ class FontRevisionStatement(Statement):
     def build(self, builder):
         builder.set_font_revision(self.location, self.revision)
 
+    def asFea(self, indent=""):
+        return "FontRevision {:.3f};".format(self.revision)
 
 class LigatureCaretByIndexStatement(Statement):
     def __init__(self, location, glyphs, carets):
@@ -355,7 +560,10 @@ class LigatureCaretByIndexStatement(Statement):
 
     def build(self, builder):
         glyphs = self.glyphs.glyphSet()
-        builder.add_ligatureCaretByIndex_(self.location, glyphs, self.carets)
+        builder.add_ligatureCaretByIndex_(self.location, glyphs, set(self.carets))
+
+    def asFea(self, indent=""):
+        return "LigatureCaretByIndex {} {};".format(self.glyphs.asFea(), " ".join([str(x) for x in self.carets]))
 
 
 class LigatureCaretByPosStatement(Statement):
@@ -366,6 +574,9 @@ class LigatureCaretByPosStatement(Statement):
     def build(self, builder):
         glyphs = self.glyphs.glyphSet()
         builder.add_ligatureCaretByPos_(self.location, glyphs, self.carets)
+
+    def asFea(self, indent=""):
+        return "LigatureCaretByPos {} {};".format(self.glyphs.asFea(), " ".join([str(x) for x in self.carets]))
 
 
 class LigatureSubstStatement(Statement):
@@ -382,6 +593,21 @@ class LigatureSubstStatement(Statement):
         builder.add_ligature_subst(
             self.location, prefix, glyphs, suffix, self.replacement,
             self.forceChain)
+
+    def asFea(self, indent=""):
+        res = "sub "
+        if len(self.prefix) or len(self.suffix) or self.forceChain :
+            if len(self.prefix) :
+                res += " ".join([g.asFea() for g in self.prefix]) + " "
+            res += " ".join([g.asFea() + "'" for g in self.glyphs])
+            if len(self.suffix) :
+                res += " " + " ".join([g.asFea() for g in self.suffix])
+        else :
+            res += " ".join([g.asFea() for g in self.glyphs])
+        res += " by "
+        res += asFea(self.replacement)
+        res += ";"
+        return res
 
 
 class LookupFlagStatement(Statement):
@@ -401,6 +627,21 @@ class LookupFlagStatement(Statement):
         builder.set_lookup_flag(self.location, self.value,
                                 markAttach, markFilter)
 
+    def asFea(self, indent=""):
+        res = "lookupflag"
+        flags = ["RightToLeft", "IgnoreBaseGlyphs", "IgnoreLigatures", "IgnoreMarks"]
+        curr = 1
+        for i in range(len(flags)):
+            if self.value & curr != 0 :
+                res += " " + flags[i]
+            curr = curr << 1
+        if self.markAttachment is not None :
+            res += " MarkAttachmentType {}".format(self.markAttachment.asFea())
+        if self.markFilteringSet is not None :
+            res += " UseMarkFilteringSet {}".format(self.markFilteringSet.asFea())
+        res += ";"
+        return res
+
 
 class LookupReferenceStatement(Statement):
     def __init__(self, location, lookup):
@@ -410,6 +651,9 @@ class LookupReferenceStatement(Statement):
     def build(self, builder):
         builder.add_lookup_call(self.lookup.name)
 
+    def asFea(self, indent=""):
+        return "lookup {};".format(self.lookup.name)
+
 
 class MarkBasePosStatement(Statement):
     def __init__(self, location, base, marks):
@@ -417,8 +661,14 @@ class MarkBasePosStatement(Statement):
         self.base, self.marks = base, marks
 
     def build(self, builder):
-        builder.add_mark_base_pos(self.location, self.base, self.marks)
+        builder.add_mark_base_pos(self.location, self.base.glyphSet(), self.marks)
 
+    def asFea(self, indent=""):
+        res = "pos base {}".format(self.base.asFea())
+        for a, m in self.marks:
+            res += " {} mark @{}".format(a.asFea(), m.name)
+        res += ";"
+        return res
 
 class MarkLigPosStatement(Statement):
     def __init__(self, location, ligatures, marks):
@@ -426,8 +676,22 @@ class MarkLigPosStatement(Statement):
         self.ligatures, self.marks = ligatures, marks
 
     def build(self, builder):
-        builder.add_mark_lig_pos(self.location, self.ligatures, self.marks)
+        builder.add_mark_lig_pos(self.location, self.ligatures.glyphSet(), self.marks)
 
+    def asFea(self, indent="") :
+        res = "pos ligature {}".format(self.ligatures.asFea())
+        ligs = []
+        for l in self.marks :
+            temp = ""
+            if l is None or not len(l) :
+                temp = " <anchor NULL>"
+            else :
+                for a, m in l :
+                    temp += " {} mark @{}".format(a.asFea(), m.name)
+            ligs.append(temp)
+        res += ("\n" + indent + SHIFT + "ligComponent").join(ligs)
+        res += ";"
+        return res
 
 class MarkMarkPosStatement(Statement):
     def __init__(self, location, baseMarks, marks):
@@ -435,7 +699,14 @@ class MarkMarkPosStatement(Statement):
         self.baseMarks, self.marks = baseMarks, marks
 
     def build(self, builder):
-        builder.add_mark_mark_pos(self.location, self.baseMarks, self.marks)
+        builder.add_mark_mark_pos(self.location, self.baseMarks.glyphSet(), self.marks)
+
+    def asFea(self, indent=""):
+        res = "pos mark {}".format(self.baseMarks.asFea())
+        for a, m in self.marks:
+            res += " {} mark @{}".format(a.asFea(), m.name)
+        res += ";"
+        return res
 
 
 class MultipleSubstStatement(Statement):
@@ -449,6 +720,17 @@ class MultipleSubstStatement(Statement):
         suffix = [s.glyphSet() for s in self.suffix]
         builder.add_multiple_subst(
             self.location, prefix, self.glyph, suffix, self.replacement)
+
+    def asFea(self, indent="") :
+        res = "subst ";
+        if len(self.prefix) or len(self.suffix) :
+            res += " ".join([g.asFea() for g in self.prefix]) + " "
+            res += self.glyph.asFea() + "' "
+            res += " ".join([g.asFea() for g in self.suffix])
+        else :
+            res += self.glyph.asFea()
+        res += ";"
+        return res
 
 
 class PairPosStatement(Statement):
@@ -479,31 +761,71 @@ class PairPosStatement(Statement):
                 self.location, self.glyphs1.glyphSet(), self.valuerecord1,
                 self.glyphs2.glyphSet(), self.valuerecord2)
 
+    def asFea(self, indent=""):
+        if self.valuerecord2 :
+            res = "pos {} {} {} {};".format(self.glyphs1.asFea(), self.valuerecord1.makeString(False),
+                        self.glyphs2.asFea(), self.valuerecord2.makeString(False))
+        else :
+            res = "pos {} {} {};".format(self.glyphs1.asFea(), self.glyphs2.asFea(), 
+                        self.valuerecord1.makeString(False))
+        return res
+
 
 class ReverseChainSingleSubstStatement(Statement):
-    def __init__(self, location, old_prefix, old_suffix, mapping):
+    def __init__(self, location, old_prefix, old_suffix, glyphs, replacements):
         Statement.__init__(self, location)
         self.old_prefix, self.old_suffix = old_prefix, old_suffix
-        self.mapping = mapping
+        self.glyphs = glyphs
+        self.replacements = replacements
 
     def build(self, builder):
         prefix = [p.glyphSet() for p in self.old_prefix]
         suffix = [s.glyphSet() for s in self.old_suffix]
         builder.add_reverse_chain_single_subst(
-            self.location, prefix, suffix, self.mapping)
+            self.location, prefix, suffix,
+            dict(zip(self.glyphs[0].glyphSet, self.replacements[0].glyphSet)))
+
+    def asFea(self, indent=""):
+        res = "rsub "
+        if len(self.old_prefix) or len(self.old_suffix) :
+            if len(self.old_prefix) :
+                res += " ".join([asFea(g) for g in self.old_prefix]) + " "
+            res += " ".join([asFea(g) + "'" for g in self.glyphs])
+            if len(self.old_suffix) :
+                res += " " + " ".join([asFea(g) for g in self.old_suffix])
+        else :
+            res += left
+        res += " by {};".format(" ".join([asFea(g) for g in self.replacements]))
+        return res
 
 
 class SingleSubstStatement(Statement):
-    def __init__(self, location, mapping, prefix, suffix, forceChain):
+    def __init__(self, location, glyphs, replace, prefix, suffix, forceChain):
         Statement.__init__(self, location)
-        self.mapping, self.prefix, self.suffix = mapping, prefix, suffix
+        self.prefix, self.suffix = prefix, suffix
         self.forceChain = forceChain
+        self.glyphs = glyphs
+        self.replacements = replace
 
     def build(self, builder):
         prefix = [p.glyphSet() for p in self.prefix]
         suffix = [s.glyphSet() for s in self.suffix]
-        builder.add_single_subst(self.location, prefix, suffix, self.mapping,
+        builder.add_single_subst(self.location, prefix, suffix,
+                                 OrderedDict(zip(self.glyphs[0].glyphSet(), self.replacements[0].glyphSet())),
                                  self.forceChain)
+
+    def asFea(self, indent=""):
+        res = "sub "
+        if len(self.prefix) or len(self.suffix) or self.forceChain :
+            if len(self.prefix) :
+                res += " ".join([asFea(g) for g in self.prefix]) + " "
+            res += " ".join([asFea(g) + "'" for g in self.glyphs])
+            if len(self.suffix) :
+                res += " " + " ".join([asFea(g) for g in self.suffix])
+        else :
+            res += " ".join([asFea(g) for g in self.glyphs])
+        res += " by {};".format(" ".join([asFea(g) for g in self.replacements]))
+        return res
 
 
 class ScriptStatement(Statement):
@@ -513,6 +835,9 @@ class ScriptStatement(Statement):
 
     def build(self, builder):
         builder.set_script(self.location, self.script)
+
+    def asFea(self, indent=""):
+        return "script {};".format(self.script)
 
 
 class SinglePosStatement(Statement):
@@ -527,6 +852,19 @@ class SinglePosStatement(Statement):
         pos = [(g.glyphSet(), value) for g, value in self.pos]
         builder.add_single_pos(self.location, prefix, suffix,
                                pos, self.forceChain)
+
+    def asFea(self, indent=""):
+        res = "pos "
+        if len(self.prefix) or len(self.suffix) or self.forceChain :
+            if len(self.prefix) :
+                res += " ".join(map(asFea, self.prefix)) + " "
+            res += " ".join([asFea(x[0]) + "' " + (x[1].makeString(False) if x[1] else "") for x in self.pos])
+            if len(self.suffix) :
+                res += " " + " ".join(map(asFea, self.suffix))
+        else :
+            res += " ".join([asFea(x[0]) + " " + (x[1].makeString(False) if x[1] else "") for x in self.pos])
+        res += ";"
+        return res
 
 
 class SubtableStatement(Statement):
@@ -591,6 +929,8 @@ class ValueRecordDefinition(Statement):
         self.name = name
         self.value = value
 
+    def asFea(self, indent=""):
+        return "valueRecordDef {} {};".format(self.value.asFea(), self.name)
 
 class NameRecord(Statement):
     def __init__(self, location, nameID, platformID,
@@ -607,11 +947,21 @@ class NameRecord(Statement):
             self.location, self.nameID, self.platformID,
             self.platEncID, self.langID, self.string)
 
+    def asFea(self, indent="") :
+        return "nameid {} {} {} {} \"{}\";".format(self.nameID, self.platformID, self.platEncID, self.langID, self.string)
+
+
 class FeatureNameStatement(NameRecord):
     def build(self, builder):
         NameRecord.build(self, builder)
         builder.add_featureName(self.location, self.nameID)
 
+    def asFea(self, indent="") :
+        if self.nameID == "size" :
+            tag = "sizemenuname"
+        else :
+            tag = "name"
+        return "{} {} {} {} \"{}\";".format(tag, self.platformID, self.platEncID, self.langID, self.string)
 
 class SizeParameters(Statement):
     def __init__(self, location, DesignSize, SubfamilyID, RangeStart,
@@ -626,6 +976,12 @@ class SizeParameters(Statement):
         builder.set_size_parameters(self.location, self.DesignSize,
                 self.SubfamilyID, self.RangeStart, self.RangeEnd)
 
+    def asFea(self, indent="") :
+        res = "parameters {} {}".format(int(self.DesignSize * 10), self.SubfamilyID)
+        if self.RangeStart != 0 or self.RangeEnd != 0 :
+            res += " {} {}".format(int(self.RangeStart * 10), int(self.RangeEnd * 10))
+        return res + ";"
+
 
 class BaseAxis(Statement):
     def __init__(self, location, bases, scripts, vertical):
@@ -637,6 +993,11 @@ class BaseAxis(Statement):
     def build(self, builder):
         builder.set_base_axis(self.bases, self.scripts, self.vertical)
 
+    def asFea(self, indent="") :
+        direction = "Vert" if self.vertical else "Horiz"
+        scripts = ["{} {} {}".format(a[0], a[1], " ".join(map(str, a[2]))) for a in self.scripts]
+        return "{}Axis.BaseTagList {}\n{}{}Axis.BaseScriptList {}".format(direction,
+                "; ".join(self.bases), indent, direction, ", ".join(scripts))
 
 class OS2Field(Statement):
     def __init__(self, location, key, value):
@@ -646,6 +1007,21 @@ class OS2Field(Statement):
 
     def build(self, builder):
         builder.add_os2_field(self.key, self.value)
+
+    def asFea(self, indent="") :
+        def intarr2str(x) :
+            return " ".join(map(str, x))
+        numbers = ("FSType", "TypoAscender", "TypoDescender", "TypoLineGap",
+                   "winAscent", "winDescent", "XHeight", "CapHeight",
+                   "WeightClass", "WidthClass", "LowerOpSize", "UpperOpSize")
+        ranges = ("UnicodeRange", "CodePageRange")
+        keywords = dict([(x.lower(), [x, str]) for x in numbers])
+        keywords.update([(x.lower(), [x, intarr2str]) for x in ranges])
+        keywords["panose"] = ["Panose", intarr2str]
+        keywords["vender"] = ["Vendor", lambda y: y]
+        if self.key in keywords :
+            return "{} {};".format(keywords[self.key][0], keywords[self.key][1](self.value))
+        return ""   # should raise exception
 
 
 class HheaField(Statement):
@@ -657,6 +1033,11 @@ class HheaField(Statement):
     def build(self, builder):
         builder.add_hhea_field(self.key, self.value)
 
+    def asFea(self, indent="") :
+        fields = ("CaretOffset", "Ascender", "Descender", "LineGap")
+        keywords = dict([(x.lower(), x) for x in fields])
+        return "{} {};".format(keywords[self.key], self.value)
+
 
 class VheaField(Statement):
     def __init__(self, location, key, value):
@@ -666,3 +1047,9 @@ class VheaField(Statement):
 
     def build(self, builder):
         builder.add_vhea_field(self.key, self.value)
+
+    def asFea(self, indent="") :
+        fields = ("VertTypoAscender", "VertTypoDescender", "VertTypoLineGap")
+        keywords = dict([(x.lower(), x) for x in fields])
+        return "{} {};".format(keywords[self.key], self.value)
+

--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -66,6 +66,23 @@ class BuilderTest(unittest.TestCase):
         name size size2 multiple_feature_blocks
     """.split()
 
+    TEST_FEA2FEA_FILES = """
+        Attach enum markClass language_required
+        GlyphClassDef LigatureCaretByIndex LigatureCaretByPos
+        lookup lookupflag feature_aalt ignore_pos
+        GPOS_1 GPOS_1_zero GPOS_2 GPOS_2b GPOS_3 GPOS_4 GPOS_5 GPOS_6 GPOS_8
+        GSUB_2 GSUB_3 GSUB_6 GSUB_8
+        spec4h1 spec4h2 spec5d1 spec5d2 spec5fi1 spec5fi2 spec5fi3 spec5fi4
+        spec5f_ii_1 spec5f_ii_2 spec5f_ii_3 spec5f_ii_4
+        spec5h1 spec6b_ii spec6d2 spec6e spec6f
+        spec6h_ii spec6h_iii_1 spec6h_iii_3d spec8a spec8b spec8c
+        spec9a spec9b spec9c1 spec9c2 spec9c3 spec9d spec9e spec9f spec9g
+        spec10
+        bug453 bug457 bug463 bug501 bug502 bug504 bug505 bug506 bug509
+        bug512 bug568
+        name size size2 multiple_feature_blocks
+    """.split()
+
     def __init__(self, methodName):
         unittest.TestCase.__init__(self, methodName)
         # Python 3 renamed assertRaisesRegexp to assertRaisesRegex,
@@ -130,6 +147,37 @@ class BuilderTest(unittest.TestCase):
         for tag in ('GDEF', 'GSUB', 'GPOS'):
             if tag in font:
                 font[tag].compile(font)
+
+    def check_fea2fea_file(self, name):
+        import pdb; pdb.set_trace()
+        f = self.getpath("{}.fea".format(name))
+        p = Parser(f)
+        doc = p.parse()
+        tlines = self.normal_fea(doc.asFea().split("\n"))
+        with open(f) as ofile :
+            olines = self.normal_fea(ofile.readlines())
+        if olines != tlines :
+            for line in difflib.unified_diff(tlines, olines) L
+                sys.stdout.write(line)
+            sys.fail("Fea2Fea output is different from expected")
+
+    def normal_fea(self, lines) :
+        output = []
+        skip = 0
+        for l in lines:
+            l = l.strip()
+            if l.startswith("#test-fea2fea: ") :
+                output.append(l[15:])
+                skip = 1
+            x = l.find("#")
+            if x >= 0 :
+                l = l[:x].strip()
+            if not len(l) : continue
+            if skip > 0 :
+                skip = skip - 1
+                continue
+            output.append(l)
+        return output
 
     def test_alternateSubst_multipleSubstitutionsForSameGlyph(self):
         self.assertRaisesRegex(
@@ -336,6 +384,13 @@ def generate_feature_file_test(name):
 for name in BuilderTest.TEST_FEATURE_FILES:
     setattr(BuilderTest, "test_FeatureFile_%s" % name,
             generate_feature_file_test(name))
+
+def generate_fea2fea_file_test(name):
+    return lambda self: self.check_fea2fea_file(name)
+
+#for name in BuilderTest.TEST_FEA2FEA_FILES:
+#    setattr(BuilderTest, "test_Fea2feaFile_{}".format(name),
+#            generate_fea2fea_file_test(name))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -69,18 +69,15 @@ class BuilderTest(unittest.TestCase):
 
     # The aim is to get this down to nothing
     TEST_FEA2FEA_SKIP_FILES = """
-        enum markClass language_required
-        GlyphClassDef
-        lookupflag feature_aalt ignore_pos
-        GPOS_1 GPOS_2 GPOS_3 GPOS_4 GPOS_5 GPOS_6 GPOS_8
-        GSUB_2 GSUB_3 GSUB_6 GSUB_8
-        spec4h1 spec4h2 spec5d1 spec5d2 spec5fi1 spec5fi2 spec5fi3 spec5fi4
-        spec5f_ii_1 spec5f_ii_2 spec5f_ii_3 spec5f_ii_4
-        spec5h1 spec6b_ii spec6d2 spec6e spec6f
-        spec6h_ii spec6h_iii_1 spec6h_iii_3d spec8a spec8b spec8c
-        spec9a spec9b spec9c1 spec9e spec9f
-        bug453 bug457 bug505
-        name size size2 multiple_feature_blocks
+        language_required
+        lookupflag ignore_pos
+        GPOS_1 GPOS_2
+        GSUB_6 GSUB_8
+        spec4h1 spec5fi2 spec5fi3
+        spec5f_ii_2 spec5f_ii_3 spec5f_ii_4
+        spec8a spec8b spec8c
+        spec9e
+        name
     """.split()
 
     def __init__(self, methodName):
@@ -156,7 +153,7 @@ class BuilderTest(unittest.TestCase):
         with open(f) as ofile :
             olines = self.normal_fea(ofile.readlines())
         if olines != tlines :
-            for line in difflib.unified_diff(tlines, olines) :
+            for line in difflib.unified_diff(olines, tlines) :
                 sys.stdout.write(line)
             self.fail("Fea2Fea output is different from expected")
 
@@ -166,7 +163,7 @@ class BuilderTest(unittest.TestCase):
         for l in lines:
             l = l.strip()
             if l.startswith("#test-fea2fea: ") :
-                output.append(l[15:])
+                output.append(l[15:].strip())
                 skip = 1
             x = l.find("#")
             if x >= 0 :

--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -70,8 +70,7 @@ class BuilderTest(unittest.TestCase):
     # The aim is to get this down to nothing
     TEST_FEA2FEA_SKIP_FILES = """
         language_required
-        lookupflag ignore_pos
-        GPOS_1 GPOS_2
+        lookupflag
         GSUB_6 GSUB_8
         spec4h1 spec5fi2 spec5fi3
         spec5f_ii_2 spec5f_ii_3 spec5f_ii_4

--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -71,7 +71,7 @@ class BuilderTest(unittest.TestCase):
     TEST_FEA2FEA_SKIP_FILES = """
         language_required
         GSUB_6 GSUB_8
-        spec4h1 spec5fi2 spec5fi3
+        spec4h1 spec5fi3
         spec5f_ii_2 spec5f_ii_3 spec5f_ii_4
         spec8a spec8b spec8c
         spec9e

--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -70,7 +70,6 @@ class BuilderTest(unittest.TestCase):
     # The aim is to get this down to nothing
     TEST_FEA2FEA_SKIP_FILES = """
         language_required
-        lookupflag
         GSUB_6 GSUB_8
         spec4h1 spec5fi2 spec5fi3
         spec5f_ii_2 spec5f_ii_3 spec5f_ii_4

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -370,9 +370,9 @@ class Parser(object):
         assert self.is_cur_keyword_("LigatureCaretByPos")
         location = self.cur_token_location_
         glyphs = self.parse_glyphclass_(accept_glyphname=True)
-        carets = {self.expect_number_()}
+        carets = [self.expect_number_()]
         while self.next_token_ != ";":
-            carets.add(self.expect_number_())
+            carets.append(self.expect_number_())
         self.expect_symbol_(";")
         return ast.LigatureCaretByPosStatement(location, glyphs, carets)
 

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -966,10 +966,10 @@ class Parser(object):
         if self.next_token_type_ is Lexer.NUMBER:
             number, location = self.expect_number_(), self.cur_token_location_
             if vertical:
-                val = ast.ValueRecord(location, 0, 0, 0, number,
+                val = ast.ValueRecord(location, vertical, 0, 0, 0, number,
                                       None, None, None, None)
             else:
-                val = ast.ValueRecord(location, 0, 0, number, 0,
+                val = ast.ValueRecord(location, vertical, 0, 0, number, 0,
                                       None, None, None, None)
             return val
         self.expect_symbol_("<")
@@ -1012,7 +1012,7 @@ class Parser(object):
 
         self.expect_symbol_(">")
         return ast.ValueRecord(
-            location, xPlacement, yPlacement, xAdvance, yAdvance,
+            location, vertical, xPlacement, yPlacement, xAdvance, yAdvance,
             xPlaDevice, yPlaDevice, xAdvDevice, yAdvDevice)
 
     def parse_valuerecord_definition_(self, vertical):

--- a/Lib/fontTools/feaLib/parser_test.py
+++ b/Lib/fontTools/feaLib/parser_test.py
@@ -17,8 +17,12 @@ def glyphstr(glyphs):
     return ' '.join([f(g.glyphSet()) for g in glyphs])
 
 def mapping(s) :
-    b = reduce(lambda a, x:a + list(x.glyphSet()), s.glyphs, [])
-    c = reduce(lambda a, x:a + list(x.glyphSet()), s.replacements, [])
+    b = []
+    for a in s.glyphs :
+        b.extend(a.glyphSet())
+    c = []
+    for a in s.replacements :
+        c.extend(a.glyphSet())
     if len(c) == 1 :
         c = c * len(b)
     return dict(zip(b, c))

--- a/Lib/fontTools/feaLib/parser_test.py
+++ b/Lib/fontTools/feaLib/parser_test.py
@@ -16,6 +16,12 @@ def glyphstr(glyphs):
             return '[%s]' % ' '.join(sorted(list(x)))
     return ' '.join([f(g.glyphSet()) for g in glyphs])
 
+def mapping(s) :
+    b = reduce(lambda a, x:a + list(x.glyphSet()), s.glyphs, [])
+    c = reduce(lambda a, x:a + list(x.glyphSet()), s.replacements, [])
+    if len(c) == 1 :
+        c = c * len(b)
+    return dict(zip(b, c))
 
 class ParserTest(unittest.TestCase):
     def __init__(self, methodName):
@@ -285,7 +291,7 @@ class ParserTest(unittest.TestCase):
             "feature F1 { lookup L { @GLYPHCLASS = [A B C];} L; } F1;"
             "feature F2 { sub @GLYPHCLASS by D; } F2;"
         ).statements
-        self.assertEqual(list(f2.statements[0].mapping.keys()),
+        self.assertEqual(list(f2.statements[0].glyphs[0].glyphSet()),
                          ["A", "B", "C"])
 
     def test_GlyphClassDef(self):
@@ -424,28 +430,28 @@ class ParserTest(unittest.TestCase):
         s = doc.statements[0].statements[0]
         self.assertIsInstance(s, ast.LigatureCaretByIndexStatement)
         self.assertEqual(glyphstr([s.glyphs]), "[c_t f_i]")
-        self.assertEqual(s.carets, {2})
+        self.assertEqual(s.carets, [2])
 
     def test_ligatureCaretByIndex_singleGlyph(self):
         doc = self.parse("table GDEF{LigatureCaretByIndex f_f_i 3 7;}GDEF;")
         s = doc.statements[0].statements[0]
         self.assertIsInstance(s, ast.LigatureCaretByIndexStatement)
         self.assertEqual(glyphstr([s.glyphs]), "f_f_i")
-        self.assertEqual(s.carets, {3, 7})
+        self.assertEqual(s.carets, [3, 7])
 
     def test_ligatureCaretByPos_glyphClass(self):
         doc = self.parse("table GDEF {LigatureCaretByPos [c_t f_i] 7;} GDEF;")
         s = doc.statements[0].statements[0]
         self.assertIsInstance(s, ast.LigatureCaretByPosStatement)
         self.assertEqual(glyphstr([s.glyphs]), "[c_t f_i]")
-        self.assertEqual(s.carets, {7})
+        self.assertEqual(s.carets, [7])
 
     def test_ligatureCaretByPos_singleGlyph(self):
         doc = self.parse("table GDEF {LigatureCaretByPos f_i 400 380;} GDEF;")
         s = doc.statements[0].statements[0]
         self.assertIsInstance(s, ast.LigatureCaretByPosStatement)
         self.assertEqual(glyphstr([s.glyphs]), "f_i")
-        self.assertEqual(s.carets, {380, 400})
+        self.assertEqual(s.carets, [400, 380])
 
     def test_lookup_block(self):
         [lookup] = self.parse("lookup Ligatures {} Ligatures;").statements
@@ -687,7 +693,7 @@ class ParserTest(unittest.TestCase):
                          "} kern;")
         pos = doc.statements[0].statements[0]
         self.assertEqual(type(pos), ast.CursivePosStatement)
-        self.assertEqual(pos.glyphclass, ("A",))
+        self.assertEqual(pos.glyphclass.glyphSet(), ("A",))
         self.assertEqual((pos.entryAnchor.x, pos.entryAnchor.y), (12, -2))
         self.assertEqual((pos.exitAnchor.x, pos.exitAnchor.y), (2, 3))
 
@@ -712,7 +718,7 @@ class ParserTest(unittest.TestCase):
             "} test;")
         pos = doc.statements[-1].statements[0]
         self.assertEqual(type(pos), ast.MarkBasePosStatement)
-        self.assertEqual(pos.base, ("a", "e", "o", "u"))
+        self.assertEqual(pos.base.glyphSet(), ("a", "e", "o", "u"))
         (a1, m1), (a2, m2) = pos.marks
         self.assertEqual((a1.x, a1.y, m1.name), (250, 450, "TOP_MARKS"))
         self.assertEqual((a2.x, a2.y, m2.name), (210, -10, "BOTTOM_MARKS"))
@@ -754,7 +760,7 @@ class ParserTest(unittest.TestCase):
             "} test;")
         pos = doc.statements[-1].statements[0]
         self.assertEqual(type(pos), ast.MarkLigPosStatement)
-        self.assertEqual(pos.ligatures, ("a_f_f_i", "o_f_f_i"))
+        self.assertEqual(pos.ligatures.glyphSet(), ("a_f_f_i", "o_f_f_i"))
         [(a11, m11), (a12, m12)], [(a2, m2)], [], [(a4, m4)] = pos.marks
         self.assertEqual((a11.x, a11.y, m11.name), (50, 600, "TOP_MARKS"))
         self.assertEqual((a12.x, a12.y, m12.name), (50, -10, "BOTTOM_MARKS"))
@@ -790,7 +796,7 @@ class ParserTest(unittest.TestCase):
             "} test;")
         pos = doc.statements[-1].statements[0]
         self.assertEqual(type(pos), ast.MarkMarkPosStatement)
-        self.assertEqual(pos.baseMarks, ("hamza",))
+        self.assertEqual(pos.baseMarks.glyphSet(), ("hamza",))
         [(a1, m1)] = pos.marks
         self.assertEqual((a1.x, a1.y, m1.name), (221, 301, "MARK_CLASS_1"))
 
@@ -850,7 +856,8 @@ class ParserTest(unittest.TestCase):
         rsub = doc.statements[0].statements[0]
         self.assertEqual(type(rsub), ast.ReverseChainSingleSubstStatement)
         self.assertEqual(glyphstr(rsub.old_prefix), "a [B b]")
-        self.assertEqual(rsub.mapping, {"c": "C"})
+        self.assertEqual(rsub.glyphs[0].glyphSet(), ("c",))
+        self.assertEqual(rsub.replacements[0].glyphSet(), ("C",))
         self.assertEqual(glyphstr(rsub.old_suffix), "d [E e]")
 
     def test_rsub_format_a_cid(self):
@@ -859,7 +866,8 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(type(rsub), ast.ReverseChainSingleSubstStatement)
         self.assertEqual(glyphstr(rsub.old_prefix),
                          "cid00001 [cid00002 cid00003]")
-        self.assertEqual(rsub.mapping, {"cid00004": "cid00006"})
+        self.assertEqual(rsub.glyphs[0].glyphSet(), ("cid00004",))
+        self.assertEqual(rsub.replacements[0].glyphSet(), ("cid00006",))
         self.assertEqual(glyphstr(rsub.old_suffix), "cid00005")
 
     def test_rsub_format_b(self):
@@ -871,7 +879,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(type(rsub), ast.ReverseChainSingleSubstStatement)
         self.assertEqual(glyphstr(rsub.old_prefix), "A B")
         self.assertEqual(glyphstr(rsub.old_suffix), "C [D d]")
-        self.assertEqual(rsub.mapping, {
+        self.assertEqual(mapping(rsub), {
             "one.fitted": "one",
             "one.oldstyle": "one"
         })
@@ -885,7 +893,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(type(rsub), ast.ReverseChainSingleSubstStatement)
         self.assertEqual(glyphstr(rsub.old_prefix), "BACK TRACK")
         self.assertEqual(glyphstr(rsub.old_suffix), "LOOK AHEAD")
-        self.assertEqual(rsub.mapping, {
+        self.assertEqual(mapping(rsub), {
             "a": "A.sc",
             "b": "B.sc",
             "c": "C.sc",
@@ -929,14 +937,14 @@ class ParserTest(unittest.TestCase):
         sub = doc.statements[0].statements[0]
         self.assertIsInstance(sub, ast.SingleSubstStatement)
         self.assertEqual(glyphstr(sub.prefix), "")
-        self.assertEqual(sub.mapping, {"a": "a.sc"})
+        self.assertEqual(mapping(sub), {"a": "a.sc"})
         self.assertEqual(glyphstr(sub.suffix), "")
 
     def test_sub_single_format_a_chained(self):  # chain to GSUB LookupType 1
         doc = self.parse("feature test {sub [A a] d' [C] by d.alt;} test;")
         sub = doc.statements[0].statements[0]
         self.assertIsInstance(sub, ast.SingleSubstStatement)
-        self.assertEqual(sub.mapping, {"d": "d.alt"})
+        self.assertEqual(mapping(sub), {"d": "d.alt"})
         self.assertEqual(glyphstr(sub.prefix), "[A a]")
         self.assertEqual(glyphstr(sub.suffix), "C")
 
@@ -945,7 +953,7 @@ class ParserTest(unittest.TestCase):
         sub = doc.statements[0].statements[0]
         self.assertIsInstance(sub, ast.SingleSubstStatement)
         self.assertEqual(glyphstr(sub.prefix), "")
-        self.assertEqual(sub.mapping, {"cid12345": "cid78987"})
+        self.assertEqual(mapping(sub), {"cid12345": "cid78987"})
         self.assertEqual(glyphstr(sub.suffix), "")
 
     def test_sub_single_format_b(self):  # GSUB LookupType 1
@@ -955,7 +963,7 @@ class ParserTest(unittest.TestCase):
             "} smcp;")
         sub = doc.statements[0].statements[0]
         self.assertIsInstance(sub, ast.SingleSubstStatement)
-        self.assertEqual(sub.mapping, {
+        self.assertEqual(mapping(sub), {
             "one.fitted": "one",
             "one.oldstyle": "one"
         })
@@ -969,7 +977,7 @@ class ParserTest(unittest.TestCase):
             "} smcp;")
         sub = doc.statements[0].statements[0]
         self.assertIsInstance(sub, ast.SingleSubstStatement)
-        self.assertEqual(sub.mapping, {
+        self.assertEqual(mapping(sub), {
             "one.fitted": "one",
             "one.oldstyle": "one"
         })
@@ -983,7 +991,7 @@ class ParserTest(unittest.TestCase):
             "} smcp;")
         sub = doc.statements[0].statements[0]
         self.assertIsInstance(sub, ast.SingleSubstStatement)
-        self.assertEqual(sub.mapping, {
+        self.assertEqual(mapping(sub), {
             "a": "A.sc",
             "b": "B.sc",
             "c": "C.sc",
@@ -999,7 +1007,7 @@ class ParserTest(unittest.TestCase):
             "} smcp;")
         sub = doc.statements[0].statements[0]
         self.assertIsInstance(sub, ast.SingleSubstStatement)
-        self.assertEqual(sub.mapping, {
+        self.assertEqual(mapping(sub), {
             "a": "A.sc",
             "b": "B.sc",
             "c": "C.sc",

--- a/Lib/fontTools/feaLib/testdata/GPOS_1.fea
+++ b/Lib/fontTools/feaLib/testdata/GPOS_1.fea
@@ -3,29 +3,17 @@ languagesystem DFLT dflt;
 @sevenEightNine = [seven eight nine];
 
 feature kern {
-    position zero 0;
+    pos zero 0;
 
-    position [one two three] <-80 0 -160 0>;
-    position A <
-        1 2 3 4
-        <device 11 111, 12 112> <device 13 113, 14 114>
-        <device 16 116>	<device NULL>
-    >;
-    position B <
-        1 2 3 4
-        <device 11 111, 12 112> <device 13 113, 14 114>
-        <device 16 116>	<device NULL>
-    >;
-    position C <
-        1 2 3 4
-        <device 11 -2, 14 1> <device 13 -3, 15 1>
-        <device 11 -8, 14 7> <device 13 8, 15 1>
-    >;
-    position four 400;
-    position four.oldstyle 401;
-    position five <-80 0 -160 0>;
-    position six -200;
-    position @sevenEightNine -100;
+    pos [one two three] <-80 0 -160 0>;
+    pos A <1 2 3 4 <device 11 111, 12 112> <device 13 113, 14 114> <device 16 116> <device NULL>>;
+    pos B <1 2 3 4 <device 11 111, 12 112> <device 13 113, 14 114> <device 16 116> <device NULL>>;
+    pos C <1 2 3 4 <device 11 -2, 14 1> <device 13 -3, 15 1> <device 11 -8, 14 7> <device 13 8, 15 1>>;
+    pos four 400;
+    pos four.oldstyle 401;
+    pos five <-80 0 -160 0>;
+    pos six -200;
+    pos @sevenEightNine -100;
 
     pos P <1 0 800 0>;
     pos Q <1 0 801 0>;
@@ -35,11 +23,12 @@ feature kern {
     pos U <1 1 805 0>;
 
     # The AFDKO makeotf tool accepts re-definitions of previously defined
-    # single adjustment positionings, provided the re-definition is using
+    # single adjustment posings, provided the re-definition is using
     # the same value.  We replicate this behavior.
-    position four 400;
-    position four <0 0 400 0>;
-    position nine -100;
+    pos four 400;
+#test-fea2fea: pos four 400;
+    pos four <0 0 400 0>;
+    pos nine -100;
 } kern;
 
 # According to the OpenType Feature File specification section 2.e.iv,
@@ -50,5 +39,5 @@ feature kern {
 # we follow the specification, so we produce different output than makeotf.
 # https://github.com/adobe-type-tools/afdko/issues/85
 feature vkrn {
-    position A -100;
+    pos A -100;
 } vkrn;

--- a/Lib/fontTools/feaLib/testdata/GPOS_3.fea
+++ b/Lib/fontTools/feaLib/testdata/GPOS_3.fea
@@ -8,7 +8,5 @@ feature kern {
     pos cursive two <anchor 122 -2> <anchor 3 4>;
     pos cursive three <anchor 123 -3> <anchor NULL>;
     pos cursive four <anchor 124 -4 contourpoint 7> <anchor 3 4>;
-    pos cursive five
-        <anchor 124 -4 <device 8 1, 9 2> <device 7 3>>
-        <anchor ANCH342>;
+    pos cursive five <anchor 124 -4 <device 8 1, 9 2> <device 7 3>> <anchor ANCH342>;
 } kern;

--- a/Lib/fontTools/feaLib/testdata/GPOS_4.fea
+++ b/Lib/fontTools/feaLib/testdata/GPOS_4.fea
@@ -6,13 +6,7 @@ markClass [cedilla] <anchor 222 22> @BOTTOM_MARKS;
 markClass [ogonek] <anchor 333 33> @SIDE_MARKS;
 
 feature test {
-    position base a
-        <anchor 11 1> mark @TOP_MARKS
-        <anchor 12 -1> mark @BOTTOM_MARKS;
-
-    position base [b c]
-        <anchor 22 -2> mark @BOTTOM_MARKS;
-
-    position base d
-        <anchor 33 3> mark @SIDE_MARKS;
+    pos base a <anchor 11 1> mark @TOP_MARKS <anchor 12 -1> mark @BOTTOM_MARKS;
+    pos base [b c] <anchor 22 -2> mark @BOTTOM_MARKS;
+    pos base d <anchor 33 3> mark @SIDE_MARKS;
 } test;

--- a/Lib/fontTools/feaLib/testdata/GPOS_5.fea
+++ b/Lib/fontTools/feaLib/testdata/GPOS_5.fea
@@ -5,32 +5,14 @@ markClass [ogonek] <anchor 800 -10> @OGONEK;
 
 feature test {
 
-    position
-        ligature [c_t s_t]
-            <anchor 500 800> mark @TOP_MARKS
-            <anchor 500 -200> mark @BOTTOM_MARKS
-        ligComponent
-            <anchor 1500 800> mark @TOP_MARKS
-            <anchor 1500 -200> mark @BOTTOM_MARKS
-            <anchor 1550 0> mark @OGONEK;
+    pos ligature [c_t s_t] <anchor 500 800> mark @TOP_MARKS <anchor 500 -200> mark @BOTTOM_MARKS
+        ligComponent <anchor 1500 800> mark @TOP_MARKS <anchor 1500 -200> mark @BOTTOM_MARKS <anchor 1550 0> mark @OGONEK;
 
-    position
-        ligature f_l
-            <anchor 300 800> mark @TOP_MARKS
-            <anchor 300 -200> mark @BOTTOM_MARKS
-        ligComponent
-            <anchor 600 800> mark @TOP_MARKS
-            <anchor 600 -200> mark @BOTTOM_MARKS;
+    pos ligature f_l <anchor 300 800> mark @TOP_MARKS <anchor 300 -200> mark @BOTTOM_MARKS
+        ligComponent <anchor 600 800> mark @TOP_MARKS <anchor 600 -200> mark @BOTTOM_MARKS;
 
-    position
-        ligature [f_f_l]
-            <anchor 300 800> mark @TOP_MARKS
-            <anchor 300 -200> mark @BOTTOM_MARKS
-        ligComponent
-            <anchor 600 800> mark @TOP_MARKS
-            <anchor 600 -200> mark @BOTTOM_MARKS
-        ligComponent
-            <anchor 900 800> mark @TOP_MARKS
-            <anchor 900 -200> mark @BOTTOM_MARKS;
+    pos ligature [f_f_l] <anchor 300 800> mark @TOP_MARKS <anchor 300 -200> mark @BOTTOM_MARKS
+        ligComponent <anchor 600 800> mark @TOP_MARKS <anchor 600 -200> mark @BOTTOM_MARKS
+        ligComponent <anchor 900 800> mark @TOP_MARKS <anchor 900 -200> mark @BOTTOM_MARKS;
 
 } test;

--- a/Lib/fontTools/feaLib/testdata/GPOS_6.fea
+++ b/Lib/fontTools/feaLib/testdata/GPOS_6.fea
@@ -5,9 +5,6 @@ markClass macron <anchor 2 2 contourpoint 22> @TOP_MARKS;
 markClass [cedilla] <anchor 3 3 contourpoint 33> @BOTTOM_MARKS;
 
 feature test {
-    position mark [acute grave macron ogonek]
-        <anchor 500 200> mark @TOP_MARKS
-        <anchor 500 -80> mark @BOTTOM_MARKS;
-    position mark [dieresis caron]
-        <anchor 500 200> mark @TOP_MARKS;
+    pos mark [acute grave macron ogonek] <anchor 500 200> mark @TOP_MARKS <anchor 500 -80> mark @BOTTOM_MARKS;
+    pos mark [dieresis caron] <anchor 500 200> mark @TOP_MARKS;
 } test;

--- a/Lib/fontTools/feaLib/testdata/GPOS_8.fea
+++ b/Lib/fontTools/feaLib/testdata/GPOS_8.fea
@@ -1,11 +1,17 @@
 languagesystem DFLT dflt;
 
 lookup ChainedSinglePos {
-    pos A one'1 two'2 one'-1 two'-2;
+    pos A one' 1 two' 2 one' -1 two' -2;
 } ChainedSinglePos;
 
-lookup L1 {pos one 100;} L1;
-lookup L2 {pos two 200;} L2;
+lookup L1 {
+    pos one 100;
+} L1;
+
+lookup L2 {
+    pos two 200;
+} L2;
+
 lookup ChainedContextualPos {
     pos [A a] [B b] I' lookup L1 N' lookup L2 P' [Y y] [Z z];
 } ChainedContextualPos;

--- a/Lib/fontTools/feaLib/testdata/bug453.fea
+++ b/Lib/fontTools/feaLib/testdata/bug453.fea
@@ -2,10 +2,10 @@
 feature mark {
     lookup mark1 {
         markClass [acute] <anchor 150 -10> @TOP_MARKS;
-        position base [e] <anchor 250 450> mark @TOP_MARKS;
+        pos base [e] <anchor 250 450> mark @TOP_MARKS;
     } mark1;
     lookup mark2 {
         markClass [acute] <anchor 150 -20> @TOP_MARKS_2;
-        position base [e] <anchor 250 450> mark @TOP_MARKS_2;
+        pos base [e] <anchor 250 450> mark @TOP_MARKS_2;
     } mark2;
 } mark;

--- a/Lib/fontTools/feaLib/testdata/bug457.fea
+++ b/Lib/fontTools/feaLib/testdata/bug457.fea
@@ -1,4 +1,4 @@
-@group = [\A \sub \lookup \feature \by \table];
+@group = [A \sub \lookup \feature \by \table];
 
 feature liga {
     sub @group by G;

--- a/Lib/fontTools/feaLib/testdata/enum.fea
+++ b/Lib/fontTools/feaLib/testdata/enum.fea
@@ -1,7 +1,7 @@
 languagesystem DFLT dflt;
 
 feature kern {
-  @Y_LC = [y yacute ydieresis];
-  @SMALL_PUNC = [comma semicolon period];
-  enum pos @Y_LC @SMALL_PUNC -100;
+    @Y_LC = [y yacute ydieresis];
+    @SMALL_PUNC = [comma semicolon period];
+    enum pos @Y_LC @SMALL_PUNC -100;
 } kern;

--- a/Lib/fontTools/feaLib/testdata/feature_aalt.fea
+++ b/Lib/fontTools/feaLib/testdata/feature_aalt.fea
@@ -19,10 +19,8 @@ feature frac {
 } frac;
 
 feature ordn {
-    sub [zero one two three four five six seven eight nine] [A a]'
-        by ordfeminine;
-    sub [zero one two three four five six seven eight nine] [O o]'
-        by ordmasculine;
+    sub [zero one two three four five six seven eight nine] [A a]' by ordfeminine;
+    sub [zero one two three four five six seven eight nine] [O o]' by ordmasculine;
 } ordn;
 
 feature liga {

--- a/Lib/fontTools/feaLib/testdata/lookupflag.fea
+++ b/Lib/fontTools/feaLib/testdata/lookupflag.fea
@@ -20,6 +20,7 @@ lookup C {
 } C;
 
 lookup D {
+#test-fea2fea: lookupflag RightToLeft IgnoreBaseGlyphs IgnoreLigatures;
     lookupflag 7;
     pos seven 7;
 } D;

--- a/Lib/fontTools/feaLib/testdata/size.fea
+++ b/Lib/fontTools/feaLib/testdata/size.fea
@@ -1,3 +1,4 @@
 feature size {
+#test-fea2fea: parameters 10.0 0;
   parameters 10.0 0 0 0;
 } size;

--- a/Lib/fontTools/feaLib/testdata/spec5d1.fea
+++ b/Lib/fontTools/feaLib/testdata/spec5d1.fea
@@ -2,7 +2,7 @@
 # http://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html
 
 feature F1 {
-  substitute [one one.oldstyle] [slash fraction] [two two.oldstyle] by onehalf;
+  sub [one one.oldstyle] [slash fraction] [two two.oldstyle] by onehalf;
 } F1;
 
 # Since the OpenType specification does not allow ligature substitutions
@@ -12,14 +12,14 @@ feature F1 {
 # example produces an identical representation in the font as if all
 # the sequences were manually enumerated by the font editor:
 feature F2 {
-  substitute one          slash    two          by onehalf;
-  substitute one.oldstyle slash    two          by onehalf;
-  substitute one          fraction two          by onehalf;
-  substitute one.oldstyle fraction two          by onehalf;
-  substitute one          slash    two.oldstyle by onehalf;
-  substitute one.oldstyle slash    two.oldstyle by onehalf;
-  substitute one          fraction two.oldstyle by onehalf;
-  substitute one.oldstyle fraction two.oldstyle by onehalf;
+  sub one slash two by onehalf;
+  sub one.oldstyle slash two by onehalf;
+  sub one fraction two by onehalf;
+  sub one.oldstyle fraction two by onehalf;
+  sub one slash two.oldstyle by onehalf;
+  sub one.oldstyle slash two.oldstyle by onehalf;
+  sub one fraction two.oldstyle by onehalf;
+  sub one.oldstyle fraction two.oldstyle by onehalf;
 } F2;
 
 # In the resulting OpenType GSUB table (spec5d1.ttx),

--- a/Lib/fontTools/feaLib/testdata/spec5d2.fea
+++ b/Lib/fontTools/feaLib/testdata/spec5d2.fea
@@ -7,18 +7,18 @@
 
 # So:
 feature F1 {
-  sub f f by f_f;
-  sub f i by f_i;
-  sub f f i by f_f_i;
-  sub o f f i by o_f_f_i;
+    sub f f by f_f;
+    sub f i by f_i;
+    sub f f i by f_f_i;
+    sub o f f i by o_f_f_i;
 } F1;
 
 # will produce an identical representation in the font as:
 feature F2 {
-  sub o f f i by o_f_f_i;
-  sub f f i by f_f_i;
-  sub f f by f_f;
-  sub f i by f_i;
+    sub o f f i by o_f_f_i;
+    sub f f i by f_f_i;
+    sub f f by f_f;
+    sub f i by f_i;
 } F2;
 
 # In the resulting OpenType GSUB table (spec5d2.ttx),

--- a/Lib/fontTools/feaLib/testdata/spec5f_ii_1.fea
+++ b/Lib/fontTools/feaLib/testdata/spec5f_ii_1.fea
@@ -3,7 +3,7 @@
 # http://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html
 
 feature test {
-    ignore substitute f [a e] d';
-    ignore substitute a d' d;
-    substitute [a e n] d' by d.alt;
+    ignore sub f [a e] d';
+    ignore sub a d' d;
+    sub [a e n] d' by d.alt;
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec5fi1.fea
+++ b/Lib/fontTools/feaLib/testdata/spec5fi1.fea
@@ -5,16 +5,16 @@
 languagesystem latn dflt;
 
 lookup CNTXT_LIGS {
-    substitute f i by f_i;
-    substitute c t by c_t;
+    sub f i by f_i;
+    sub c t by c_t;
 } CNTXT_LIGS;
 
 lookup CNTXT_SUB {
-    substitute n by n.end;
-    substitute s by s.end;
+    sub n by n.end;
+    sub s by s.end;
 } CNTXT_SUB;
  
 feature test {
-    substitute [a e i o u] f' lookup CNTXT_LIGS i' n' lookup CNTXT_SUB;
-    substitute [a e i o u] c' lookup CNTXT_LIGS t' s' lookup CNTXT_SUB;
+    sub [a e i o u] f' lookup CNTXT_LIGS i' n' lookup CNTXT_SUB;
+    sub [a e i o u] c' lookup CNTXT_LIGS t' s' lookup CNTXT_SUB;
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec5fi2.fea
+++ b/Lib/fontTools/feaLib/testdata/spec5fi2.fea
@@ -7,5 +7,5 @@ languagesystem latn dflt;
 feature test {
 #test-fea2fea: lookupflag RightToLeft IgnoreBaseGlyphs IgnoreLigatures;
     lookupflag 7;
-    substitute [a e n] d' by d.alt;
+    sub [a e n] d' by d.alt;
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec5fi2.fea
+++ b/Lib/fontTools/feaLib/testdata/spec5fi2.fea
@@ -5,6 +5,7 @@
 languagesystem latn dflt;
 
 feature test {
+#test-fea2fea: lookupflag RightToLeft IgnoreBaseGlyphs IgnoreLigatures;
     lookupflag 7;
     substitute [a e n] d' by d.alt;
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec5fi4.fea
+++ b/Lib/fontTools/feaLib/testdata/spec5fi4.fea
@@ -5,5 +5,5 @@
 languagesystem latn dflt;
 
 feature test {
-    substitute [e e.begin]' t' c by ampersand;
+    sub [e e.begin]' t' c by ampersand;
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec5h1.fea
+++ b/Lib/fontTools/feaLib/testdata/spec5h1.fea
@@ -4,5 +4,6 @@
 languagesystem DFLT dflt;
 
 feature test {
+#test-fea2fea: rsub [a e n] d' by d.alt;
     reversesub [a e n] d' by d.alt;
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec6b_ii.fea
+++ b/Lib/fontTools/feaLib/testdata/spec6b_ii.fea
@@ -7,6 +7,6 @@
 
 feature kern {
   enum pos @Y_LC semicolon -80;    # specific pairs
-  pos     f quoteright 30;         # specific pair
-  pos     @Y_LC @SMALL_PUNC -100;  # class pair
+  pos f quoteright 30;         # specific pair
+  pos @Y_LC @SMALL_PUNC -100;  # class pair
 } kern;

--- a/Lib/fontTools/feaLib/testdata/spec6d2.fea
+++ b/Lib/fontTools/feaLib/testdata/spec6d2.fea
@@ -9,10 +9,7 @@ markClass [dieresis umlaut] <anchor 300 -10> @TOP_MARKS;
 markClass [cedilla] <anchor 300 600> @BOTTOM_MARKS;
 
 feature test {
-    position base [e o]
-        <anchor 250 450> mark @TOP_MARKS
-        <anchor 250 -12> mark @BOTTOM_MARKS;
-    position base [a u]
-        <anchor 265 450> mark @TOP_MARKS
-        <anchor 250-10> mark @BOTTOM_MARKS;
+    pos base [e o] <anchor 250 450> mark @TOP_MARKS <anchor 250 -12> mark @BOTTOM_MARKS;
+#test-fea2fea: pos base [a u] <anchor 265 450> mark @TOP_MARKS <anchor 250 -10> mark @BOTTOM_MARKS;
+    position base [a u] <anchor 265 450> mark @TOP_MARKS <anchor 250-10> mark @BOTTOM_MARKS;
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec6e.fea
+++ b/Lib/fontTools/feaLib/testdata/spec6e.fea
@@ -1,13 +1,10 @@
 languagesystem DFLT dflt;
 
-markClass sukun    <anchor 261 488> @TOP_MARKS;
+markClass sukun <anchor 261 488> @TOP_MARKS;
 markClass kasratan <anchor 346 -98> @BOTTOM_MARKS;
 
 feature test {
-    position ligature lam_meem_jeem
-        <anchor 625 1800> mark @TOP_MARKS    # mark above lam
-        ligComponent     # start specifying marks for meem
-        <anchor 376 -368> mark @BOTTOM_MARKS    # mark below meem
-        ligComponent     # start specifying marks for jeem
-        <anchor NULL>;   # jeem has no marks
+    pos ligature lam_meem_jeem <anchor 625 1800> mark @TOP_MARKS    # mark above lam
+        ligComponent <anchor 376 -368> mark @BOTTOM_MARKS    # mark below meem
+        ligComponent <anchor NULL>;   # jeem has no marks
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec6f.fea
+++ b/Lib/fontTools/feaLib/testdata/spec6f.fea
@@ -2,5 +2,5 @@ languagesystem DFLT dflt;
 
 feature test {
     markClass damma <anchor 189 -103> @MARK_CLASS_1;
-    position mark hamza <anchor 221 301> mark @MARK_CLASS_1;
+    pos mark hamza <anchor 221 301> mark @MARK_CLASS_1;
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec6h_ii.fea
+++ b/Lib/fontTools/feaLib/testdata/spec6h_ii.fea
@@ -7,18 +7,15 @@ languagesystem DFLT dflt;
 markClass [acute grave] <anchor 150 -10> @ALL_MARKS;
 
 lookup CNTXT_PAIR_POS {
-    position T o -10;
-    position T c -12;
+    pos T o -10;
+    pos T c -12;
 } CNTXT_PAIR_POS;
  
 lookup CNTXT_MARK_TO_BASE {
-    position base o <anchor 250 450> mark @ALL_MARKS;
-    position base c <anchor 250 450> mark @ALL_MARKS;
+    pos base o <anchor 250 450> mark @ALL_MARKS;
+    pos base c <anchor 250 450> mark @ALL_MARKS;
 } CNTXT_MARK_TO_BASE;
 
 feature test {
-    position
-        T' lookup CNTXT_PAIR_POS
-        [o c]'
-        @ALL_MARKS' lookup CNTXT_MARK_TO_BASE;
+    pos T' lookup CNTXT_PAIR_POS [o c]' @ALL_MARKS' lookup CNTXT_MARK_TO_BASE;
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec6h_iii_1.fea
+++ b/Lib/fontTools/feaLib/testdata/spec6h_iii_1.fea
@@ -5,5 +5,6 @@
 languagesystem DFLT dflt;
 
 feature test {
+#test-fea2fea: pos [quoteleft quotedblleft] [Y T]' 20 [quoteright quotedblright];
     pos [quoteleft quotedblleft] [Y T]' <0 0 20 0> [quoteright quotedblright];
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec6h_iii_3d.fea
+++ b/Lib/fontTools/feaLib/testdata/spec6h_iii_3d.fea
@@ -3,5 +3,5 @@
 # http://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html
 
 feature test {
-    position L' quoteright' -150;
+    pos L' quoteright' -150;
 } test;

--- a/Lib/fontTools/feaLib/testdata/spec9a.fea
+++ b/Lib/fontTools/feaLib/testdata/spec9a.fea
@@ -1,6 +1,4 @@
 table BASE {
-   HorizAxis.BaseTagList                  ideo romn;
-   HorizAxis.BaseScriptList latn   romn   -120    0, cyrl   romn   -120    0,
-                            grek   romn   -120    0, hani   ideo   -120    0,
-                            kana   ideo   -120    0, hang   ideo   -120    0;
+   HorizAxis.BaseTagList ideo romn;
+   HorizAxis.BaseScriptList latn romn -120 0, cyrl romn -120 0, grek romn -120 0, hani ideo -120 0, kana ideo -120 0, hang ideo -120 0;
 } BASE;

--- a/Lib/fontTools/feaLib/testdata/spec9b.fea
+++ b/Lib/fontTools/feaLib/testdata/spec9b.fea
@@ -8,6 +8,6 @@ table GDEF {
     Attach noon.final 5;
     Attach noon.initial 4;
     LigatureCaretByPos f_i 400 380;
-    LigatureCaretByPos [c_t s_t]  500;
+    LigatureCaretByPos [c_t s_t] 500;
     LigatureCaretByIndex f_f_i 23 46;
 } GDEF;

--- a/Lib/fontTools/feaLib/testdata/spec9c1.fea
+++ b/Lib/fontTools/feaLib/testdata/spec9c1.fea
@@ -1,3 +1,4 @@
 table head {
+#test-fea2fea: FontRevision 1.100;
     FontRevision 1.1;
 } head;

--- a/Lib/fontTools/feaLib/testdata/spec9f.fea
+++ b/Lib/fontTools/feaLib/testdata/spec9f.fea
@@ -1,21 +1,16 @@
 table OS/2 {
-   FSType 4;
-   Panose 2 15 0 0 2 2 8 2 9 4;
-   TypoAscender 800;
-   TypoDescender -200; # Note that TypoDescender is negative for descent below the baseline.
-   winAscent 832;
-   winDescent 321; # Note that winDescent is positive for descent below the baseline.
-   UnicodeRange 0   # Basic Latin
-     1   # Latin-1 Supplement
-     9   # Cyrillic
-     55  # CJK Compatibility
-     59  # CJK Unified Ideographs
-     60  # Private Use Area
-     ;
-   CodePageRange  1252    # Latin 1
-   1251    # Cyrillic                           
-   932     # JIS/Japan
-   ;
+    FSType 4;
+    Panose 2 15 0 0 2 2 8 2 9 4;
+    TypoAscender 800;
+    TypoDescender -200; # Note that TypoDescender is negative for descent below the baseline.
+    winAscent 832;
+    winDescent 321; # Note that winDescent is positive for descent below the baseline.
+    UnicodeRange 0 1 9 55 59 60;
+#   0  - Basic Latin,            1  - Latin-1 Supplement
+#   9  - Cyrillic,               55 - CJK Compatibility
+#   59 - CJK Unified Ideographs, 60 - Private Use Area
+   CodePageRange 1252 1251 932;
+#   1252 - Latin 1, 1251 - Cyrllic, 932 - JIS/Japan
    XHeight 400;
    CapHeight 600;
    WeightClass 800;


### PR DESCRIPTION
This PR enables fonttools to generate fea syntax from a fea ast, as per issue #772. I notice that #479 is not ast based and simply generates text as it goes.

One calls asFea() on the output from a Parser().parse() and is returned a string containing the generated fea text.

At this point in the PR's history not all the tests are giving identical results. This is due to the following features not yet having been implemented:

- Ranges are expanded in the parser and not contracted in fea generation. This might be worked around by keeping a side copy of the original glyph list specification including ranges.
- nameid attributes are often defaulted and expanded in the parser. These are not defaulted out in the fea generation.

In order to get the tests to pass, many of them have been adjusted in layout and some keywords regularised. These need to be reviewed to ensure that the tests are still testing what the test was originally designed to test. A special comment can also be used to acknowledge different output from fea2fea for a test. E.g. feaLib/testdata/size.fea