### PR TITLE
[testTools] have getXML() return a list of lines

### DIFF
--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -19,16 +19,17 @@ def parseXML(xmlSnippet):
     """
     # To support snippets with multiple elements, we add a fake root.
     reader = TestXMLReader_()
-    root = b"<root>%s</root>"
+    xml = b"<root>"
     if isinstance(xmlSnippet, bytes):
-        xml = root % xmlSnippet
+        xml += xmlSnippet
     elif isinstance(xmlSnippet, unicode):
-        xml = root % tobytes(xmlSnippet, 'utf-8')
+        xml += tobytes(xmlSnippet, 'utf-8')
     elif isinstance(xmlSnippet, collections.Iterable):
-        xml = root % b"".join(tobytes(s, 'utf-8') for s in xmlSnippet)
+        xml += b"".join(tobytes(s, 'utf-8') for s in xmlSnippet)
     else:
         raise TypeError("expected string or sequence of strings; found %r"
                         % type(xmlSnippet).__name__)
+    xml += b"</root>"
     reader.parser.Parse(xml, 0)
     return reader.root[2]
 

--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -1,6 +1,8 @@
 """Helpers for writing unit tests."""
 
 from __future__ import print_function, division, absolute_import
+from __future__ import unicode_literals
+import collections
 from fontTools.misc.py23 import *
 from fontTools.misc.xmlWriter import XMLWriter
 
@@ -8,13 +10,26 @@ from fontTools.misc.xmlWriter import XMLWriter
 def parseXML(xmlSnippet):
     """Parses a snippet of XML.
 
+    Input can be either a single string (unicode or UTF-8 bytes), or a
+    a sequence of strings.
+
     The result is in the same format that would be returned by
     XMLReader, but the parser imposes no constraints on the root
     element so it can be called on small snippets of TTX files.
     """
     # To support snippets with multiple elements, we add a fake root.
     reader = TestXMLReader_()
-    reader.parser.Parse("<root>%s</root>" % xmlSnippet, 0)
+    root = b"<root>%s</root>"
+    if isinstance(xmlSnippet, bytes):
+        xml = root % xmlSnippet
+    elif isinstance(xmlSnippet, unicode):
+        xml = root % tobytes(xmlSnippet, 'utf-8')
+    elif isinstance(xmlSnippet, collections.Iterable):
+        xml = root % b"".join(tobytes(s, 'utf-8') for s in xmlSnippet)
+    else:
+        raise TypeError("expected string or sequence of strings; found %r"
+                        % type(xmlSnippet).__name__)
+    reader.parser.Parse(xml, 0)
     return reader.root[2]
 
 
@@ -61,9 +76,9 @@ class TestXMLReader_(object):
         self.stack[-1][2].append(data)
 
 
-def makeXMLWriter():
+def makeXMLWriter(newlinestr='\n'):
     # don't write OS-specific new lines
-    writer = XMLWriter(BytesIO(), newlinestr='')
+    writer = XMLWriter(BytesIO(), newlinestr=newlinestr)
     # erase XML declaration
     writer.file.seek(0)
     writer.file.truncate()
@@ -71,10 +86,13 @@ def makeXMLWriter():
 
 
 def getXML(func, ttFont=None):
-    """Call the passed toXML function and return the written content as string.
+    """Call the passed toXML function and return the written content as a
+    list of lines (unicode strings).
     Result is stripped of XML declaration and OS-specific newline characters.
     """
     writer = makeXMLWriter()
     func(writer, ttFont)
     xml = writer.file.getvalue().decode("utf-8")
-    return xml
+    # toXML methods must always end with a writer.newline()
+    assert xml.endswith("\n")
+    return xml.splitlines()

--- a/Lib/fontTools/misc/testTools_test.py
+++ b/Lib/fontTools/misc/testTools_test.py
@@ -1,29 +1,81 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import
 from __future__ import unicode_literals
 from fontTools.misc.py23 import *
 import fontTools.misc.testTools as testTools
-import os
 import unittest
 
 
 class TestToolsTest(unittest.TestCase):
-    def test_parseXML(self):
+
+    def test_parseXML_str(self):
         self.assertEqual(testTools.parseXML(
             '<Foo n="1"/>'
             '<Foo n="2">'
-            '    some text'
+            '    some ünıcòðe text'
             '    <Bar color="red"/>'
             '    some more text'
             '</Foo>'
             '<Foo n="3"/>'), [
                 ("Foo", {"n": "1"}, []),
                 ("Foo", {"n": "2"}, [
-                    "    some text    ",
+                    "    some ünıcòðe text    ",
                     ("Bar", {"color": "red"}, []),
                     "    some more text",
                 ]),
                 ("Foo", {"n": "3"}, [])
             ])
+
+    def test_parseXML_bytes(self):
+        self.assertEqual(testTools.parseXML(
+            b'<Foo n="1"/>'
+            b'<Foo n="2">'
+            b'    some \xc3\xbcn\xc4\xb1c\xc3\xb2\xc3\xb0e text'
+            b'    <Bar color="red"/>'
+            b'    some more text'
+            b'</Foo>'
+            b'<Foo n="3"/>'), [
+                ("Foo", {"n": "1"}, []),
+                ("Foo", {"n": "2"}, [
+                    "    some ünıcòðe text    ",
+                    ("Bar", {"color": "red"}, []),
+                    "    some more text",
+                ]),
+                ("Foo", {"n": "3"}, [])
+            ])
+
+    def test_parseXML_str_list(self):
+        self.assertEqual(testTools.parseXML(
+            ['<Foo n="1"/>'
+             '<Foo n="2"/>']), [
+                ("Foo", {"n": "1"}, []),
+                ("Foo", {"n": "2"}, [])
+            ])
+
+    def test_parseXML_bytes_list(self):
+        self.assertEqual(testTools.parseXML(
+            [b'<Foo n="1"/>'
+             b'<Foo n="2"/>']), [
+                ("Foo", {"n": "1"}, []),
+                ("Foo", {"n": "2"}, [])
+            ])
+
+    def test_getXML(self):
+        def toXML(writer, ttFont):
+            writer.simpletag("simple")
+            writer.newline()
+            writer.begintag("tag", attr='value')
+            writer.newline()
+            writer.write("hello world")
+            writer.newline()
+            writer.endtag("tag")
+            writer.newline()  # toXML always ends with a newline
+
+        self.assertEqual(testTools.getXML(toXML),
+                         ['<simple/>',
+                          '<tag attr="value">',
+                          '  hello world',
+                          '</tag>'])
 
 
 if __name__ == "__main__":

--- a/Lib/fontTools/otlLib/builder_test.py
+++ b/Lib/fontTools/otlLib/builder_test.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from fontTools.misc.testTools import getXML
 from fontTools.otlLib import builder
 from fontTools.ttLib.tables import otTables
+from itertools import chain
 import unittest
 
 
@@ -25,64 +26,64 @@ class BuilderTest(unittest.TestCase):
     def test_buildAnchor_format1(self):
         anchor = builder.buildAnchor(23, 42)
         self.assertEqual(getXML(anchor.toXML),
-                         '<Anchor Format="1">'
-                         '  <XCoordinate value="23"/>'
-                         '  <YCoordinate value="42"/>'
-                         '</Anchor>')
+                         ['<Anchor Format="1">',
+                          '  <XCoordinate value="23"/>',
+                          '  <YCoordinate value="42"/>',
+                          '</Anchor>'])
 
     def test_buildAnchor_format2(self):
         anchor = builder.buildAnchor(23, 42, point=17)
         self.assertEqual(getXML(anchor.toXML),
-                         '<Anchor Format="2">'
-                         '  <XCoordinate value="23"/>'
-                         '  <YCoordinate value="42"/>'
-                         '  <AnchorPoint value="17"/>'
-                         '</Anchor>')
+                         ['<Anchor Format="2">',
+                          '  <XCoordinate value="23"/>',
+                          '  <YCoordinate value="42"/>',
+                          '  <AnchorPoint value="17"/>',
+                          '</Anchor>'])
 
     def test_buildAnchor_format3(self):
         anchor = builder.buildAnchor(
             23, 42,
-            deviceX=builder.buildDevice({1:1, 0:0}),
-            deviceY=builder.buildDevice({7:7}))
+            deviceX=builder.buildDevice({1: 1, 0: 0}),
+            deviceY=builder.buildDevice({7: 7}))
         self.assertEqual(getXML(anchor.toXML),
-                         '<Anchor Format="3">'
-                         '  <XCoordinate value="23"/>'
-                         '  <YCoordinate value="42"/>'
-                         '  <XDeviceTable>'
-                         '    <StartSize value="0"/>'
-                         '    <EndSize value="1"/>'
-                         '    <DeltaFormat value="1"/>'
-                         '    <DeltaValue value="[0, 1]"/>'
-                         '  </XDeviceTable>'
-                         '  <YDeviceTable>'
-                         '    <StartSize value="7"/>'
-                         '    <EndSize value="7"/>'
-                         '    <DeltaFormat value="2"/>'
-                         '    <DeltaValue value="[7]"/>'
-                         '  </YDeviceTable>'
-                         '</Anchor>')
+                         ['<Anchor Format="3">',
+                          '  <XCoordinate value="23"/>',
+                          '  <YCoordinate value="42"/>',
+                          '  <XDeviceTable>',
+                          '    <StartSize value="0"/>',
+                          '    <EndSize value="1"/>',
+                          '    <DeltaFormat value="1"/>',
+                          '    <DeltaValue value="[0, 1]"/>',
+                          '  </XDeviceTable>',
+                          '  <YDeviceTable>',
+                          '    <StartSize value="7"/>',
+                          '    <EndSize value="7"/>',
+                          '    <DeltaFormat value="2"/>',
+                          '    <DeltaValue value="[7]"/>',
+                          '  </YDeviceTable>',
+                          '</Anchor>'])
 
     def test_buildAttachList(self):
         attachList = builder.buildAttachList({
             "zero": [23, 7], "one": [1],
         }, self.GLYPHMAP)
         self.assertEqual(getXML(attachList.toXML),
-                         '<AttachList>'
-                         '  <Coverage>'
-                         '    <Glyph value="zero"/>'
-                         '    <Glyph value="one"/>'
-                         '  </Coverage>'
-                         '  <!-- GlyphCount=2 -->'
-                         '  <AttachPoint index="0">'
-                         '    <!-- PointCount=2 -->'
-                         '    <PointIndex index="0" value="7"/>'
-                         '    <PointIndex index="1" value="23"/>'
-                         '  </AttachPoint>'
-                         '  <AttachPoint index="1">'
-                         '    <!-- PointCount=1 -->'
-                         '    <PointIndex index="0" value="1"/>'
-                         '  </AttachPoint>'
-                         '</AttachList>')
+                         ['<AttachList>',
+                          '  <Coverage>',
+                          '    <Glyph value="zero"/>',
+                          '    <Glyph value="one"/>',
+                          '  </Coverage>',
+                          '  <!-- GlyphCount=2 -->',
+                          '  <AttachPoint index="0">',
+                          '    <!-- PointCount=2 -->',
+                          '    <PointIndex index="0" value="7"/>',
+                          '    <PointIndex index="1" value="23"/>',
+                          '  </AttachPoint>',
+                          '  <AttachPoint index="1">',
+                          '    <!-- PointCount=1 -->',
+                          '    <PointIndex index="0" value="1"/>',
+                          '  </AttachPoint>',
+                          '</AttachList>'])
 
     def test_buildAttachList_empty(self):
         self.assertIsNone(builder.buildAttachList({}, self.GLYPHMAP))
@@ -90,11 +91,11 @@ class BuilderTest(unittest.TestCase):
     def test_buildAttachPoint(self):
         attachPoint = builder.buildAttachPoint([7, 3])
         self.assertEqual(getXML(attachPoint.toXML),
-                         '<AttachPoint>'
-                         '  <!-- PointCount=2 -->'
-                         '  <PointIndex index="0" value="3"/>'
-                         '  <PointIndex index="1" value="7"/>'
-                         '</AttachPoint>')
+                         ['<AttachPoint>',
+                          '  <!-- PointCount=2 -->',
+                          '  <PointIndex index="0" value="3"/>',
+                          '  <PointIndex index="1" value="7"/>',
+                          '</AttachPoint>'])
 
     def test_buildAttachPoint_empty(self):
         self.assertIsNone(builder.buildAttachPoint([]))
@@ -102,11 +103,11 @@ class BuilderTest(unittest.TestCase):
     def test_buildAttachPoint_duplicate(self):
         attachPoint = builder.buildAttachPoint([7, 3, 7])
         self.assertEqual(getXML(attachPoint.toXML),
-                         '<AttachPoint>'
-                         '  <!-- PointCount=2 -->'
-                         '  <PointIndex index="0" value="3"/>'
-                         '  <PointIndex index="1" value="7"/>'
-                         '</AttachPoint>')
+                         ['<AttachPoint>',
+                          '  <!-- PointCount=2 -->',
+                          '  <PointIndex index="0" value="3"/>',
+                          '  <PointIndex index="1" value="7"/>',
+                          '</AttachPoint>'])
 
 
     def test_buildBaseArray(self):
@@ -116,76 +117,76 @@ class BuilderTest(unittest.TestCase):
             "c": {1: anchor(300, 80), 2: anchor(300, -20)}
         }, numMarkClasses=4, glyphMap=self.GLYPHMAP)
         self.assertEqual(getXML(baseArray.toXML),
-                         '<BaseArray>'
-                         '  <!-- BaseCount=2 -->'
-                         '  <BaseRecord index="0">'
-                         '    <BaseAnchor index="0" empty="1"/>'
-                         '    <BaseAnchor index="1" empty="1"/>'
-                         '    <BaseAnchor index="2" Format="1">'
-                         '      <XCoordinate value="300"/>'
-                         '      <YCoordinate value="80"/>'
-                         '    </BaseAnchor>'
-                         '    <BaseAnchor index="3" empty="1"/>'
-                         '  </BaseRecord>'
-                         '  <BaseRecord index="1">'
-                         '    <BaseAnchor index="0" empty="1"/>'
-                         '    <BaseAnchor index="1" Format="1">'
-                         '      <XCoordinate value="300"/>'
-                         '      <YCoordinate value="80"/>'
-                         '    </BaseAnchor>'
-                         '    <BaseAnchor index="2" Format="1">'
-                         '      <XCoordinate value="300"/>'
-                         '      <YCoordinate value="-20"/>'
-                         '    </BaseAnchor>'
-                         '    <BaseAnchor index="3" empty="1"/>'
-                         '  </BaseRecord>'
-                         '</BaseArray>')
+                         ['<BaseArray>',
+                          '  <!-- BaseCount=2 -->',
+                          '  <BaseRecord index="0">',
+                          '    <BaseAnchor index="0" empty="1"/>',
+                          '    <BaseAnchor index="1" empty="1"/>',
+                          '    <BaseAnchor index="2" Format="1">',
+                          '      <XCoordinate value="300"/>',
+                          '      <YCoordinate value="80"/>',
+                          '    </BaseAnchor>',
+                          '    <BaseAnchor index="3" empty="1"/>',
+                          '  </BaseRecord>',
+                          '  <BaseRecord index="1">',
+                          '    <BaseAnchor index="0" empty="1"/>',
+                          '    <BaseAnchor index="1" Format="1">',
+                          '      <XCoordinate value="300"/>',
+                          '      <YCoordinate value="80"/>',
+                          '    </BaseAnchor>',
+                          '    <BaseAnchor index="2" Format="1">',
+                          '      <XCoordinate value="300"/>',
+                          '      <YCoordinate value="-20"/>',
+                          '    </BaseAnchor>',
+                          '    <BaseAnchor index="3" empty="1"/>',
+                          '  </BaseRecord>',
+                          '</BaseArray>'])
 
     def test_buildBaseRecord(self):
         a = builder.buildAnchor
         rec = builder.buildBaseRecord([a(500, -20), None, a(300, -15)])
         self.assertEqual(getXML(rec.toXML),
-                         '<BaseRecord>'
-                         '  <BaseAnchor index="0" Format="1">'
-                         '    <XCoordinate value="500"/>'
-                         '    <YCoordinate value="-20"/>'
-                         '  </BaseAnchor>'
-                         '  <BaseAnchor index="1" empty="1"/>'
-                         '  <BaseAnchor index="2" Format="1">'
-                         '    <XCoordinate value="300"/>'
-                         '    <YCoordinate value="-15"/>'
-                         '  </BaseAnchor>'
-                         '</BaseRecord>')
+                         ['<BaseRecord>',
+                          '  <BaseAnchor index="0" Format="1">',
+                          '    <XCoordinate value="500"/>',
+                          '    <YCoordinate value="-20"/>',
+                          '  </BaseAnchor>',
+                          '  <BaseAnchor index="1" empty="1"/>',
+                          '  <BaseAnchor index="2" Format="1">',
+                          '    <XCoordinate value="300"/>',
+                          '    <YCoordinate value="-15"/>',
+                          '  </BaseAnchor>',
+                          '</BaseRecord>'])
 
     def test_buildCaretValueForCoord(self):
         caret = builder.buildCaretValueForCoord(500)
         self.assertEqual(getXML(caret.toXML),
-                         '<CaretValue Format="1">'
-                         '  <Coordinate value="500"/>'
-                         '</CaretValue>')
+                         ['<CaretValue Format="1">',
+                          '  <Coordinate value="500"/>',
+                          '</CaretValue>'])
 
     def test_buildCaretValueForPoint(self):
         caret = builder.buildCaretValueForPoint(23)
         self.assertEqual(getXML(caret.toXML),
-                         '<CaretValue Format="2">'
-                         '  <CaretValuePoint value="23"/>'
-                         '</CaretValue>')
+                         ['<CaretValue Format="2">',
+                          '  <CaretValuePoint value="23"/>',
+                          '</CaretValue>'])
 
     def test_buildComponentRecord(self):
         a = builder.buildAnchor
         rec = builder.buildComponentRecord([a(500, -20), None, a(300, -15)])
         self.assertEqual(getXML(rec.toXML),
-                         '<ComponentRecord>'
-                         '  <LigatureAnchor index="0" Format="1">'
-                         '    <XCoordinate value="500"/>'
-                         '    <YCoordinate value="-20"/>'
-                         '  </LigatureAnchor>'
-                         '  <LigatureAnchor index="1" empty="1"/>'
-                         '  <LigatureAnchor index="2" Format="1">'
-                         '    <XCoordinate value="300"/>'
-                         '    <YCoordinate value="-15"/>'
-                         '  </LigatureAnchor>'
-                         '</ComponentRecord>')
+                         ['<ComponentRecord>',
+                          '  <LigatureAnchor index="0" Format="1">',
+                          '    <XCoordinate value="500"/>',
+                          '    <YCoordinate value="-20"/>',
+                          '  </LigatureAnchor>',
+                          '  <LigatureAnchor index="1" empty="1"/>',
+                          '  <LigatureAnchor index="2" Format="1">',
+                          '    <XCoordinate value="300"/>',
+                          '    <YCoordinate value="-15"/>',
+                          '  </LigatureAnchor>',
+                          '</ComponentRecord>'])
 
     def test_buildComponentRecord_empty(self):
         self.assertIsNone(builder.buildComponentRecord([]))
@@ -196,10 +197,10 @@ class BuilderTest(unittest.TestCase):
     def test_buildCoverage(self):
         cov = builder.buildCoverage({"two", "four"}, {"two": 2, "four": 4})
         self.assertEqual(getXML(cov.toXML),
-                         '<Coverage>'
-                         '  <Glyph value="two"/>'
-                         '  <Glyph value="four"/>'
-                         '</Coverage>')
+                         ['<Coverage>',
+                          '  <Glyph value="two"/>',
+                          '  <Glyph value="four"/>',
+                          '</Coverage>'])
 
     def test_buildCursivePos(self):
         pos = builder.buildCursivePosSubtable({
@@ -207,63 +208,63 @@ class BuilderTest(unittest.TestCase):
             "four": (self.ANCHOR3, self.ANCHOR1)
         }, self.GLYPHMAP)
         self.assertEqual(getXML(pos.toXML),
-                         '<CursivePos Format="1">'
-                         '  <Coverage>'
-                         '    <Glyph value="two"/>'
-                         '    <Glyph value="four"/>'
-                         '  </Coverage>'
-                         '  <!-- EntryExitCount=2 -->'
-                         '  <EntryExitRecord index="0">'
-                         '    <EntryAnchor Format="1">'
-                         '      <XCoordinate value="11"/>'
-                         '      <YCoordinate value="-11"/>'
-                         '    </EntryAnchor>'
-                         '    <ExitAnchor Format="1">'
-                         '      <XCoordinate value="22"/>'
-                         '      <YCoordinate value="-22"/>'
-                         '    </ExitAnchor>'
-                         '  </EntryExitRecord>'
-                         '  <EntryExitRecord index="1">'
-                         '    <EntryAnchor Format="1">'
-                         '      <XCoordinate value="33"/>'
-                         '      <YCoordinate value="-33"/>'
-                         '    </EntryAnchor>'
-                         '    <ExitAnchor Format="1">'
-                         '      <XCoordinate value="11"/>'
-                         '      <YCoordinate value="-11"/>'
-                         '    </ExitAnchor>'
-                         '  </EntryExitRecord>'
-                         '</CursivePos>')
+                         ['<CursivePos Format="1">',
+                          '  <Coverage>',
+                          '    <Glyph value="two"/>',
+                          '    <Glyph value="four"/>',
+                          '  </Coverage>',
+                          '  <!-- EntryExitCount=2 -->',
+                          '  <EntryExitRecord index="0">',
+                          '    <EntryAnchor Format="1">',
+                          '      <XCoordinate value="11"/>',
+                          '      <YCoordinate value="-11"/>',
+                          '    </EntryAnchor>',
+                          '    <ExitAnchor Format="1">',
+                          '      <XCoordinate value="22"/>',
+                          '      <YCoordinate value="-22"/>',
+                          '    </ExitAnchor>',
+                          '  </EntryExitRecord>',
+                          '  <EntryExitRecord index="1">',
+                          '    <EntryAnchor Format="1">',
+                          '      <XCoordinate value="33"/>',
+                          '      <YCoordinate value="-33"/>',
+                          '    </EntryAnchor>',
+                          '    <ExitAnchor Format="1">',
+                          '      <XCoordinate value="11"/>',
+                          '      <YCoordinate value="-11"/>',
+                          '    </ExitAnchor>',
+                          '  </EntryExitRecord>',
+                          '</CursivePos>'])
 
     def test_buildDevice_format1(self):
         device = builder.buildDevice({1:1, 0:0})
         self.assertEqual(getXML(device.toXML),
-                         '<Device>'
-                         '  <StartSize value="0"/>'
-                         '  <EndSize value="1"/>'
-                         '  <DeltaFormat value="1"/>'
-                         '  <DeltaValue value="[0, 1]"/>'
-                         '</Device>')
+                         ['<Device>',
+                          '  <StartSize value="0"/>',
+                          '  <EndSize value="1"/>',
+                          '  <DeltaFormat value="1"/>',
+                          '  <DeltaValue value="[0, 1]"/>',
+                          '</Device>'])
 
     def test_buildDevice_format2(self):
         device = builder.buildDevice({2:2, 0:1, 1:0})
         self.assertEqual(getXML(device.toXML),
-                         '<Device>'
-                         '  <StartSize value="0"/>'
-                         '  <EndSize value="2"/>'
-                         '  <DeltaFormat value="2"/>'
-                         '  <DeltaValue value="[1, 0, 2]"/>'
-                         '</Device>')
+                         ['<Device>',
+                          '  <StartSize value="0"/>',
+                          '  <EndSize value="2"/>',
+                          '  <DeltaFormat value="2"/>',
+                          '  <DeltaValue value="[1, 0, 2]"/>',
+                          '</Device>'])
 
     def test_buildDevice_format3(self):
         device = builder.buildDevice({5:3, 1:77})
         self.assertEqual(getXML(device.toXML),
-                         '<Device>'
-                         '  <StartSize value="1"/>'
-                         '  <EndSize value="5"/>'
-                         '  <DeltaFormat value="3"/>'
-                         '  <DeltaValue value="[77, 0, 0, 0, 3]"/>'
-                         '</Device>')
+                         ['<Device>',
+                          '  <StartSize value="1"/>',
+                          '  <EndSize value="5"/>',
+                          '  <DeltaFormat value="3"/>',
+                          '  <DeltaValue value="[77, 0, 0, 0, 3]"/>',
+                          '</Device>'])
 
     def test_buildLigatureArray(self):
         anchor = builder.buildAnchor
@@ -273,48 +274,48 @@ class BuilderTest(unittest.TestCase):
         }, numMarkClasses=4, glyphMap=self.GLYPHMAP)
         self.maxDiff = None
         self.assertEqual(getXML(ligatureArray.toXML),
-                         '<LigatureArray>'
-                         '  <!-- LigatureCount=2 -->'
-                         '  <LigatureAttach index="0">'  # f_i
-                         '    <!-- ComponentCount=2 -->'
-                         '    <ComponentRecord index="0">'
-                         '      <LigatureAnchor index="0" empty="1"/>'
-                         '      <LigatureAnchor index="1" empty="1"/>'
-                         '      <LigatureAnchor index="2" Format="1">'
-                         '        <XCoordinate value="300"/>'
-                         '        <YCoordinate value="-20"/>'
-                         '      </LigatureAnchor>'
-                         '      <LigatureAnchor index="3" empty="1"/>'
-                         '    </ComponentRecord>'
-                         '    <ComponentRecord index="1">'
-                         '      <LigatureAnchor index="0" empty="1"/>'
-                         '      <LigatureAnchor index="1" empty="1"/>'
-                         '      <LigatureAnchor index="2" empty="1"/>'
-                         '      <LigatureAnchor index="3" empty="1"/>'
-                         '    </ComponentRecord>'
-                         '  </LigatureAttach>'
-                         '  <LigatureAttach index="1">'
-                         '    <!-- ComponentCount=2 -->'
-                         '    <ComponentRecord index="0">'
-                         '      <LigatureAnchor index="0" empty="1"/>'
-                         '      <LigatureAnchor index="1" empty="1"/>'
-                         '      <LigatureAnchor index="2" empty="1"/>'
-                         '      <LigatureAnchor index="3" empty="1"/>'
-                         '    </ComponentRecord>'
-                         '    <ComponentRecord index="1">'
-                         '      <LigatureAnchor index="0" empty="1"/>'
-                         '      <LigatureAnchor index="1" Format="1">'
-                         '        <XCoordinate value="500"/>'
-                         '        <YCoordinate value="350"/>'
-                         '      </LigatureAnchor>'
-                         '      <LigatureAnchor index="2" Format="1">'
-                         '        <XCoordinate value="1300"/>'
-                         '        <YCoordinate value="-20"/>'
-                         '      </LigatureAnchor>'
-                         '      <LigatureAnchor index="3" empty="1"/>'
-                         '    </ComponentRecord>'
-                         '  </LigatureAttach>'
-                         '</LigatureArray>')
+                         ['<LigatureArray>',
+                          '  <!-- LigatureCount=2 -->',
+                          '  <LigatureAttach index="0">',  # f_i
+                          '    <!-- ComponentCount=2 -->',
+                          '    <ComponentRecord index="0">',
+                          '      <LigatureAnchor index="0" empty="1"/>',
+                          '      <LigatureAnchor index="1" empty="1"/>',
+                          '      <LigatureAnchor index="2" Format="1">',
+                          '        <XCoordinate value="300"/>',
+                          '        <YCoordinate value="-20"/>',
+                          '      </LigatureAnchor>',
+                          '      <LigatureAnchor index="3" empty="1"/>',
+                          '    </ComponentRecord>',
+                          '    <ComponentRecord index="1">',
+                          '      <LigatureAnchor index="0" empty="1"/>',
+                          '      <LigatureAnchor index="1" empty="1"/>',
+                          '      <LigatureAnchor index="2" empty="1"/>',
+                          '      <LigatureAnchor index="3" empty="1"/>',
+                          '    </ComponentRecord>',
+                          '  </LigatureAttach>',
+                          '  <LigatureAttach index="1">',
+                          '    <!-- ComponentCount=2 -->',
+                          '    <ComponentRecord index="0">',
+                          '      <LigatureAnchor index="0" empty="1"/>',
+                          '      <LigatureAnchor index="1" empty="1"/>',
+                          '      <LigatureAnchor index="2" empty="1"/>',
+                          '      <LigatureAnchor index="3" empty="1"/>',
+                          '    </ComponentRecord>',
+                          '    <ComponentRecord index="1">',
+                          '      <LigatureAnchor index="0" empty="1"/>',
+                          '      <LigatureAnchor index="1" Format="1">',
+                          '        <XCoordinate value="500"/>',
+                          '        <YCoordinate value="350"/>',
+                          '      </LigatureAnchor>',
+                          '      <LigatureAnchor index="2" Format="1">',
+                          '        <XCoordinate value="1300"/>',
+                          '        <YCoordinate value="-20"/>',
+                          '      </LigatureAnchor>',
+                          '      <LigatureAnchor index="3" empty="1"/>',
+                          '    </ComponentRecord>',
+                          '  </LigatureAttach>',
+                          '</LigatureArray>'])
 
     def test_buildLigatureAttach(self):
         anchor = builder.buildAnchor
@@ -322,87 +323,87 @@ class BuilderTest(unittest.TestCase):
             [anchor(500, -10), None],
             [None, anchor(300, -20), None]])
         self.assertEqual(getXML(attach.toXML),
-                         '<LigatureAttach>'
-                         '  <!-- ComponentCount=2 -->'
-                         '  <ComponentRecord index="0">'
-                         '    <LigatureAnchor index="0" Format="1">'
-                         '      <XCoordinate value="500"/>'
-                         '      <YCoordinate value="-10"/>'
-                         '    </LigatureAnchor>'
-                         '    <LigatureAnchor index="1" empty="1"/>'
-                         '  </ComponentRecord>'
-                         '  <ComponentRecord index="1">'
-                         '    <LigatureAnchor index="0" empty="1"/>'
-                         '    <LigatureAnchor index="1" Format="1">'
-                         '      <XCoordinate value="300"/>'
-                         '      <YCoordinate value="-20"/>'
-                         '    </LigatureAnchor>'
-                         '    <LigatureAnchor index="2" empty="1"/>'
-                         '  </ComponentRecord>'
-                         '</LigatureAttach>')
+                         ['<LigatureAttach>',
+                          '  <!-- ComponentCount=2 -->',
+                          '  <ComponentRecord index="0">',
+                          '    <LigatureAnchor index="0" Format="1">',
+                          '      <XCoordinate value="500"/>',
+                          '      <YCoordinate value="-10"/>',
+                          '    </LigatureAnchor>',
+                          '    <LigatureAnchor index="1" empty="1"/>',
+                          '  </ComponentRecord>',
+                          '  <ComponentRecord index="1">',
+                          '    <LigatureAnchor index="0" empty="1"/>',
+                          '    <LigatureAnchor index="1" Format="1">',
+                          '      <XCoordinate value="300"/>',
+                          '      <YCoordinate value="-20"/>',
+                          '    </LigatureAnchor>',
+                          '    <LigatureAnchor index="2" empty="1"/>',
+                          '  </ComponentRecord>',
+                          '</LigatureAttach>'])
 
     def test_buildLigatureAttach_emptyComponents(self):
         attach = builder.buildLigatureAttach([[], None])
         self.assertEqual(getXML(attach.toXML),
-                         '<LigatureAttach>'
-                         '  <!-- ComponentCount=2 -->'
-                         '  <ComponentRecord index="0" empty="1"/>'
-                         '  <ComponentRecord index="1" empty="1"/>'
-                         '</LigatureAttach>')
+                         ['<LigatureAttach>',
+                          '  <!-- ComponentCount=2 -->',
+                          '  <ComponentRecord index="0" empty="1"/>',
+                          '  <ComponentRecord index="1" empty="1"/>',
+                          '</LigatureAttach>'])
 
     def test_buildLigatureAttach_noComponents(self):
         attach = builder.buildLigatureAttach([])
         self.assertEqual(getXML(attach.toXML),
-                         '<LigatureAttach>'
-                         '  <!-- ComponentCount=0 -->'
-                         '</LigatureAttach>')
+                         ['<LigatureAttach>',
+                          '  <!-- ComponentCount=0 -->',
+                          '</LigatureAttach>'])
 
     def test_buildLigCaretList(self):
         carets = builder.buildLigCaretList(
             {"f_f_i": [300, 600]}, {"c_t": [42]}, self.GLYPHMAP)
         self.assertEqual(getXML(carets.toXML),
-                         '<LigCaretList>'
-                         '  <Coverage>'
-                         '    <Glyph value="f_f_i"/>'
-                         '    <Glyph value="c_t"/>'
-                         '  </Coverage>'
-                         '  <!-- LigGlyphCount=2 -->'
-                         '  <LigGlyph index="0">'
-                         '    <!-- CaretCount=2 -->'
-                         '    <CaretValue index="0" Format="1">'
-                         '      <Coordinate value="300"/>'
-                         '    </CaretValue>'
-                         '    <CaretValue index="1" Format="1">'
-                         '      <Coordinate value="600"/>'
-                         '    </CaretValue>'
-                         '  </LigGlyph>'
-                         '  <LigGlyph index="1">'
-                         '    <!-- CaretCount=1 -->'
-                         '    <CaretValue index="0" Format="2">'
-                         '      <CaretValuePoint value="42"/>'
-                         '    </CaretValue>'
-                         '  </LigGlyph>'
-                         '</LigCaretList>')
+                         ['<LigCaretList>',
+                          '  <Coverage>',
+                          '    <Glyph value="f_f_i"/>',
+                          '    <Glyph value="c_t"/>',
+                          '  </Coverage>',
+                          '  <!-- LigGlyphCount=2 -->',
+                          '  <LigGlyph index="0">',
+                          '    <!-- CaretCount=2 -->',
+                          '    <CaretValue index="0" Format="1">',
+                          '      <Coordinate value="300"/>',
+                          '    </CaretValue>',
+                          '    <CaretValue index="1" Format="1">',
+                          '      <Coordinate value="600"/>',
+                          '    </CaretValue>',
+                          '  </LigGlyph>',
+                          '  <LigGlyph index="1">',
+                          '    <!-- CaretCount=1 -->',
+                          '    <CaretValue index="0" Format="2">',
+                          '      <CaretValuePoint value="42"/>',
+                          '    </CaretValue>',
+                          '  </LigGlyph>',
+                          '</LigCaretList>'])
 
     def test_buildLigCaretList_bothCoordsAndPointsForSameGlyph(self):
         carets = builder.buildLigCaretList(
             {"f_f_i": [300]}, {"f_f_i": [7]}, self.GLYPHMAP)
         self.assertEqual(getXML(carets.toXML),
-                         '<LigCaretList>'
-                         '  <Coverage>'
-                         '    <Glyph value="f_f_i"/>'
-                         '  </Coverage>'
-                         '  <!-- LigGlyphCount=1 -->'
-                         '  <LigGlyph index="0">'
-                         '    <!-- CaretCount=2 -->'
-                         '    <CaretValue index="0" Format="1">'
-                         '      <Coordinate value="300"/>'
-                         '    </CaretValue>'
-                         '    <CaretValue index="1" Format="2">'
-                         '      <CaretValuePoint value="7"/>'
-                         '    </CaretValue>'
-                         '  </LigGlyph>'
-                         '</LigCaretList>')
+                         ['<LigCaretList>',
+                          '  <Coverage>',
+                          '    <Glyph value="f_f_i"/>',
+                          '  </Coverage>',
+                          '  <!-- LigGlyphCount=1 -->',
+                          '  <LigGlyph index="0">',
+                          '    <!-- CaretCount=2 -->',
+                          '    <CaretValue index="0" Format="1">',
+                          '      <Coordinate value="300"/>',
+                          '    </CaretValue>',
+                          '    <CaretValue index="1" Format="2">',
+                          '      <CaretValuePoint value="7"/>',
+                          '    </CaretValue>',
+                          '  </LigGlyph>',
+                          '</LigCaretList>'])
 
     def test_buildLigCaretList_empty(self):
         self.assertIsNone(builder.buildLigCaretList({}, {}, self.GLYPHMAP))
@@ -413,15 +414,15 @@ class BuilderTest(unittest.TestCase):
     def test_buildLigGlyph_coords(self):
         lig = builder.buildLigGlyph([500, 800], None)
         self.assertEqual(getXML(lig.toXML),
-                         '<LigGlyph>'
-                         '  <!-- CaretCount=2 -->'
-                         '  <CaretValue index="0" Format="1">'
-                         '    <Coordinate value="500"/>'
-                         '  </CaretValue>'
-                         '  <CaretValue index="1" Format="1">'
-                         '    <Coordinate value="800"/>'
-                         '  </CaretValue>'
-                         '</LigGlyph>')
+                         ['<LigGlyph>',
+                          '  <!-- CaretCount=2 -->',
+                          '  <CaretValue index="0" Format="1">',
+                          '    <Coordinate value="500"/>',
+                          '  </CaretValue>',
+                          '  <CaretValue index="1" Format="1">',
+                          '    <Coordinate value="800"/>',
+                          '  </CaretValue>',
+                          '</LigGlyph>'])
 
     def test_buildLigGlyph_empty(self):
         self.assertIsNone(builder.buildLigGlyph([], []))
@@ -432,29 +433,29 @@ class BuilderTest(unittest.TestCase):
     def test_buildLigGlyph_points(self):
         lig = builder.buildLigGlyph(None, [2])
         self.assertEqual(getXML(lig.toXML),
-                         '<LigGlyph>'
-                         '  <!-- CaretCount=1 -->'
-                         '  <CaretValue index="0" Format="2">'
-                         '    <CaretValuePoint value="2"/>'
-                         '  </CaretValue>'
-                         '</LigGlyph>')
+                         ['<LigGlyph>',
+                          '  <!-- CaretCount=1 -->',
+                          '  <CaretValue index="0" Format="2">',
+                          '    <CaretValuePoint value="2"/>',
+                          '  </CaretValue>',
+                          '</LigGlyph>'])
 
     def test_buildLookup(self):
         s1 = builder.buildSingleSubstSubtable({"one": "two"})
         s2 = builder.buildSingleSubstSubtable({"three": "four"})
         lookup = builder.buildLookup([s1, s2], flags=7)
         self.assertEqual(getXML(lookup.toXML),
-                         '<Lookup>'
-                         '  <!-- LookupType=1 -->'
-                         '  <LookupFlag value="7"/>'
-                         '  <!-- SubTableCount=2 -->'
-                         '  <SingleSubst index="0">'
-                         '    <Substitution in="one" out="two"/>'
-                         '  </SingleSubst>'
-                         '  <SingleSubst index="1">'
-                         '    <Substitution in="three" out="four"/>'
-                         '  </SingleSubst>'
-                         '</Lookup>')
+                         ['<Lookup>',
+                          '  <!-- LookupType=1 -->',
+                          '  <LookupFlag value="7"/>',
+                          '  <!-- SubTableCount=2 -->',
+                          '  <SingleSubst index="0">',
+                          '    <Substitution in="one" out="two"/>',
+                          '  </SingleSubst>',
+                          '  <SingleSubst index="1">',
+                          '    <Substitution in="three" out="four"/>',
+                          '  </SingleSubst>',
+                          '</Lookup>'])
 
     def test_buildLookup_badFlags(self):
         s = builder.buildSingleSubstSubtable({"one": "two"})
@@ -490,15 +491,15 @@ class BuilderTest(unittest.TestCase):
                  builder.LOOKUP_FLAG_USE_MARK_FILTERING_SET)
         lookup = builder.buildLookup([s], flags, markFilterSet=999)
         self.assertEqual(getXML(lookup.toXML),
-                         '<Lookup>'
-                         '  <!-- LookupType=1 -->'
-                         '  <LookupFlag value="17"/>'
-                         '  <!-- SubTableCount=1 -->'
-                         '  <SingleSubst index="0">'
-                         '    <Substitution in="one" out="two"/>'
-                         '  </SingleSubst>'
-                         '  <MarkFilteringSet value="999"/>'
-                         '</Lookup>')
+                         ['<Lookup>',
+                          '  <!-- LookupType=1 -->',
+                          '  <LookupFlag value="17"/>',
+                          '  <!-- SubTableCount=1 -->',
+                          '  <SingleSubst index="0">',
+                          '    <Substitution in="one" out="two"/>',
+                          '  </SingleSubst>',
+                          '  <MarkFilteringSet value="999"/>',
+                          '</Lookup>'])
 
     def test_buildMarkArray(self):
         markArray = builder.buildMarkArray({
@@ -507,23 +508,23 @@ class BuilderTest(unittest.TestCase):
         }, self.GLYPHMAP)
         self.assertLess(self.GLYPHMAP["grave"], self.GLYPHMAP["acute"])
         self.assertEqual(getXML(markArray.toXML),
-                         '<MarkArray>'
-                         '  <!-- MarkCount=2 -->'
-                         '  <MarkRecord index="0">'
-                         '    <Class value="2"/>'
-                         '    <MarkAnchor Format="1">'
-                         '      <XCoordinate value="10"/>'
-                         '      <YCoordinate value="80"/>'
-                         '    </MarkAnchor>'
-                         '  </MarkRecord>'
-                         '  <MarkRecord index="1">'
-                         '    <Class value="7"/>'
-                         '    <MarkAnchor Format="1">'
-                         '      <XCoordinate value="300"/>'
-                         '      <YCoordinate value="800"/>'
-                         '    </MarkAnchor>'
-                         '  </MarkRecord>'
-                         '</MarkArray>')
+                         ['<MarkArray>',
+                          '  <!-- MarkCount=2 -->',
+                          '  <MarkRecord index="0">',
+                          '    <Class value="2"/>',
+                          '    <MarkAnchor Format="1">',
+                          '      <XCoordinate value="10"/>',
+                          '      <YCoordinate value="80"/>',
+                          '    </MarkAnchor>',
+                          '  </MarkRecord>',
+                          '  <MarkRecord index="1">',
+                          '    <Class value="7"/>',
+                          '    <MarkAnchor Format="1">',
+                          '      <XCoordinate value="300"/>',
+                          '      <YCoordinate value="800"/>',
+                          '    </MarkAnchor>',
+                          '  </MarkRecord>',
+                          '</MarkArray>'])
 
     def test_buildMarkBasePosSubtable(self):
         anchor = builder.buildAnchor
@@ -544,103 +545,103 @@ class BuilderTest(unittest.TestCase):
         table = builder.buildMarkBasePosSubtable(marks, bases, self.GLYPHMAP)
         self.maxDiff = None
         self.assertEqual(getXML(table.toXML),
-                         '<MarkBasePos Format="1">'
-                         '  <MarkCoverage>'
-                         '    <Glyph value="grave"/>'
-                         '    <Glyph value="acute"/>'
-                         '    <Glyph value="cedilla"/>'
-                         '  </MarkCoverage>'
-                         '  <BaseCoverage>'
-                         '    <Glyph value="A"/>'
-                         '    <Glyph value="B"/>'
-                         '    <Glyph value="C"/>'
-                         '    <Glyph value="a"/>'
-                         '    <Glyph value="b"/>'
-                         '  </BaseCoverage>'
-                         '  <!-- ClassCount=2 -->'
-                         '  <MarkArray>'
-                         '    <!-- MarkCount=3 -->'
-                         '    <MarkRecord index="0">'  # grave
-                         '      <Class value="0"/>'
-                         '      <MarkAnchor Format="1">'
-                         '        <XCoordinate value="300"/>'
-                         '        <YCoordinate value="700"/>'
-                         '      </MarkAnchor>'
-                         '    </MarkRecord>'
-                         '    <MarkRecord index="1">'  # acute
-                         '      <Class value="0"/>'
-                         '      <MarkAnchor Format="1">'
-                         '        <XCoordinate value="300"/>'
-                         '        <YCoordinate value="700"/>'
-                         '      </MarkAnchor>'
-                         '    </MarkRecord>'
-                         '    <MarkRecord index="2">'  # cedilla
-                         '      <Class value="1"/>'
-                         '      <MarkAnchor Format="1">'
-                         '        <XCoordinate value="300"/>'
-                         '        <YCoordinate value="-100"/>'
-                         '      </MarkAnchor>'
-                         '    </MarkRecord>'
-                         '  </MarkArray>'
-                         '  <BaseArray>'
-                         '    <!-- BaseCount=5 -->'
-                         '    <BaseRecord index="0">'  # A
-                         '      <BaseAnchor index="0" empty="1"/>'
-                         '      <BaseAnchor index="1" empty="1"/>'
-                         '    </BaseRecord>'
-                         '    <BaseRecord index="1">'  # B
-                         '      <BaseAnchor index="0" Format="1">'
-                         '        <XCoordinate value="500"/>'
-                         '        <YCoordinate value="900"/>'
-                         '      </BaseAnchor>'
-                         '      <BaseAnchor index="1" empty="1"/>'
-                         '    </BaseRecord>'
-                         '    <BaseRecord index="2">'  # C
-                         '      <BaseAnchor index="0" empty="1"/>'
-                         '      <BaseAnchor index="1" Format="1">'
-                         '        <XCoordinate value="500"/>'
-                         '        <YCoordinate value="-10"/>'
-                         '      </BaseAnchor>'
-                         '    </BaseRecord>'
-                         '    <BaseRecord index="3">'  # a
-                         '      <BaseAnchor index="0" Format="1">'
-                         '        <XCoordinate value="500"/>'
-                         '        <YCoordinate value="400"/>'
-                         '      </BaseAnchor>'
-                         '      <BaseAnchor index="1" Format="1">'
-                         '        <XCoordinate value="500"/>'
-                         '        <YCoordinate value="-20"/>'
-                         '      </BaseAnchor>'
-                         '    </BaseRecord>'
-                         '    <BaseRecord index="4">'  # b
-                         '      <BaseAnchor index="0" Format="1">'
-                         '        <XCoordinate value="500"/>'
-                         '        <YCoordinate value="800"/>'
-                         '      </BaseAnchor>'
-                         '      <BaseAnchor index="1" Format="1">'
-                         '        <XCoordinate value="500"/>'
-                         '        <YCoordinate value="-20"/>'
-                         '      </BaseAnchor>'
-                         '    </BaseRecord>'
-                         '  </BaseArray>'
-                         '</MarkBasePos>')
+                         ['<MarkBasePos Format="1">',
+                          '  <MarkCoverage>',
+                          '    <Glyph value="grave"/>',
+                          '    <Glyph value="acute"/>',
+                          '    <Glyph value="cedilla"/>',
+                          '  </MarkCoverage>',
+                          '  <BaseCoverage>',
+                          '    <Glyph value="A"/>',
+                          '    <Glyph value="B"/>',
+                          '    <Glyph value="C"/>',
+                          '    <Glyph value="a"/>',
+                          '    <Glyph value="b"/>',
+                          '  </BaseCoverage>',
+                          '  <!-- ClassCount=2 -->',
+                          '  <MarkArray>',
+                          '    <!-- MarkCount=3 -->',
+                          '    <MarkRecord index="0">',  # grave
+                          '      <Class value="0"/>',
+                          '      <MarkAnchor Format="1">',
+                          '        <XCoordinate value="300"/>',
+                          '        <YCoordinate value="700"/>',
+                          '      </MarkAnchor>',
+                          '    </MarkRecord>',
+                          '    <MarkRecord index="1">',  # acute
+                          '      <Class value="0"/>',
+                          '      <MarkAnchor Format="1">',
+                          '        <XCoordinate value="300"/>',
+                          '        <YCoordinate value="700"/>',
+                          '      </MarkAnchor>',
+                          '    </MarkRecord>',
+                          '    <MarkRecord index="2">',  # cedilla
+                          '      <Class value="1"/>',
+                          '      <MarkAnchor Format="1">',
+                          '        <XCoordinate value="300"/>',
+                          '        <YCoordinate value="-100"/>',
+                          '      </MarkAnchor>',
+                          '    </MarkRecord>',
+                          '  </MarkArray>',
+                          '  <BaseArray>',
+                          '    <!-- BaseCount=5 -->',
+                          '    <BaseRecord index="0">',  # A
+                          '      <BaseAnchor index="0" empty="1"/>',
+                          '      <BaseAnchor index="1" empty="1"/>',
+                          '    </BaseRecord>',
+                          '    <BaseRecord index="1">',  # B
+                          '      <BaseAnchor index="0" Format="1">',
+                          '        <XCoordinate value="500"/>',
+                          '        <YCoordinate value="900"/>',
+                          '      </BaseAnchor>',
+                          '      <BaseAnchor index="1" empty="1"/>',
+                          '    </BaseRecord>',
+                          '    <BaseRecord index="2">',  # C
+                          '      <BaseAnchor index="0" empty="1"/>',
+                          '      <BaseAnchor index="1" Format="1">',
+                          '        <XCoordinate value="500"/>',
+                          '        <YCoordinate value="-10"/>',
+                          '      </BaseAnchor>',
+                          '    </BaseRecord>',
+                          '    <BaseRecord index="3">',  # a
+                          '      <BaseAnchor index="0" Format="1">',
+                          '        <XCoordinate value="500"/>',
+                          '        <YCoordinate value="400"/>',
+                          '      </BaseAnchor>',
+                          '      <BaseAnchor index="1" Format="1">',
+                          '        <XCoordinate value="500"/>',
+                          '        <YCoordinate value="-20"/>',
+                          '      </BaseAnchor>',
+                          '    </BaseRecord>',
+                          '    <BaseRecord index="4">',  # b
+                          '      <BaseAnchor index="0" Format="1">',
+                          '        <XCoordinate value="500"/>',
+                          '        <YCoordinate value="800"/>',
+                          '      </BaseAnchor>',
+                          '      <BaseAnchor index="1" Format="1">',
+                          '        <XCoordinate value="500"/>',
+                          '        <YCoordinate value="-20"/>',
+                          '      </BaseAnchor>',
+                          '    </BaseRecord>',
+                          '  </BaseArray>',
+                          '</MarkBasePos>'])
 
     def test_buildMarkGlyphSetsDef(self):
         marksets = builder.buildMarkGlyphSetsDef(
             [{"acute", "grave"}, {"cedilla", "grave"}], self.GLYPHMAP)
         self.assertEqual(getXML(marksets.toXML),
-                         '<MarkGlyphSetsDef>'
-                         '  <MarkSetTableFormat value="1"/>'
-                         '  <!-- MarkSetCount=2 -->'
-                         '  <Coverage index="0">'
-                         '    <Glyph value="grave"/>'
-                         '    <Glyph value="acute"/>'
-                         '  </Coverage>'
-                         '  <Coverage index="1">'
-                         '    <Glyph value="grave"/>'
-                         '    <Glyph value="cedilla"/>'
-                         '  </Coverage>'
-                         '</MarkGlyphSetsDef>')
+                         ['<MarkGlyphSetsDef>',
+                          '  <MarkSetTableFormat value="1"/>',
+                          '  <!-- MarkSetCount=2 -->',
+                          '  <Coverage index="0">',
+                          '    <Glyph value="grave"/>',
+                          '    <Glyph value="acute"/>',
+                          '  </Coverage>',
+                          '  <Coverage index="1">',
+                          '    <Glyph value="grave"/>',
+                          '    <Glyph value="cedilla"/>',
+                          '  </Coverage>',
+                          '</MarkGlyphSetsDef>'])
 
     def test_buildMarkGlyphSetsDef_empty(self):
         self.assertIsNone(builder.buildMarkGlyphSetsDef([], self.GLYPHMAP))
@@ -665,109 +666,109 @@ class BuilderTest(unittest.TestCase):
         table = builder.buildMarkLigPosSubtable(marks, bases, self.GLYPHMAP)
         self.maxDiff = None
         self.assertEqual(getXML(table.toXML),
-                         '<MarkLigPos Format="1">'
-                         '  <MarkCoverage>'
-                         '    <Glyph value="grave"/>'
-                         '    <Glyph value="acute"/>'
-                         '    <Glyph value="cedilla"/>'
-                         '  </MarkCoverage>'
-                         '  <LigatureCoverage>'
-                         '    <Glyph value="f_i"/>'
-                         '    <Glyph value="c_t"/>'
-                         '  </LigatureCoverage>'
-                         '  <!-- ClassCount=2 -->'
-                         '  <MarkArray>'
-                         '    <!-- MarkCount=3 -->'
-                         '    <MarkRecord index="0">'
-                         '      <Class value="0"/>'
-                         '      <MarkAnchor Format="1">'
-                         '        <XCoordinate value="300"/>'
-                         '        <YCoordinate value="700"/>'
-                         '      </MarkAnchor>'
-                         '    </MarkRecord>'
-                         '    <MarkRecord index="1">'
-                         '      <Class value="0"/>'
-                         '      <MarkAnchor Format="1">'
-                         '        <XCoordinate value="300"/>'
-                         '        <YCoordinate value="700"/>'
-                         '      </MarkAnchor>'
-                         '    </MarkRecord>'
-                         '    <MarkRecord index="2">'
-                         '      <Class value="1"/>'
-                         '      <MarkAnchor Format="1">'
-                         '        <XCoordinate value="300"/>'
-                         '        <YCoordinate value="-100"/>'
-                         '      </MarkAnchor>'
-                         '    </MarkRecord>'
-                         '  </MarkArray>'
-                         '  <LigatureArray>'
-                         '    <!-- LigatureCount=2 -->'
-                         '    <LigatureAttach index="0">'
-                         '      <!-- ComponentCount=2 -->'
-                         '      <ComponentRecord index="0">'
-                         '        <LigatureAnchor index="0" empty="1"/>'
-                         '        <LigatureAnchor index="1" empty="1"/>'
-                         '      </ComponentRecord>'
-                         '      <ComponentRecord index="1">'
-                         '        <LigatureAnchor index="0" Format="1">'
-                         '          <XCoordinate value="200"/>'
-                         '          <YCoordinate value="400"/>'
-                         '        </LigatureAnchor>'
-                         '        <LigatureAnchor index="1" empty="1"/>'
-                         '      </ComponentRecord>'
-                         '    </LigatureAttach>'
-                         '    <LigatureAttach index="1">'
-                         '      <!-- ComponentCount=2 -->'
-                         '      <ComponentRecord index="0">'
-                         '        <LigatureAnchor index="0" Format="1">'
-                         '          <XCoordinate value="500"/>'
-                         '          <YCoordinate value="600"/>'
-                         '        </LigatureAnchor>'
-                         '        <LigatureAnchor index="1" Format="1">'
-                         '          <XCoordinate value="500"/>'
-                         '          <YCoordinate value="-20"/>'
-                         '        </LigatureAnchor>'
-                         '      </ComponentRecord>'
-                         '      <ComponentRecord index="1">'
-                         '        <LigatureAnchor index="0" Format="1">'
-                         '          <XCoordinate value="1300"/>'
-                         '          <YCoordinate value="800"/>'
-                         '        </LigatureAnchor>'
-                         '        <LigatureAnchor index="1" Format="1">'
-                         '          <XCoordinate value="1300"/>'
-                         '          <YCoordinate value="-20"/>'
-                         '        </LigatureAnchor>'
-                         '      </ComponentRecord>'
-                         '    </LigatureAttach>'
-                         '  </LigatureArray>'
-                         '</MarkLigPos>')
+                         ['<MarkLigPos Format="1">',
+                          '  <MarkCoverage>',
+                          '    <Glyph value="grave"/>',
+                          '    <Glyph value="acute"/>',
+                          '    <Glyph value="cedilla"/>',
+                          '  </MarkCoverage>',
+                          '  <LigatureCoverage>',
+                          '    <Glyph value="f_i"/>',
+                          '    <Glyph value="c_t"/>',
+                          '  </LigatureCoverage>',
+                          '  <!-- ClassCount=2 -->',
+                          '  <MarkArray>',
+                          '    <!-- MarkCount=3 -->',
+                          '    <MarkRecord index="0">',
+                          '      <Class value="0"/>',
+                          '      <MarkAnchor Format="1">',
+                          '        <XCoordinate value="300"/>',
+                          '        <YCoordinate value="700"/>',
+                          '      </MarkAnchor>',
+                          '    </MarkRecord>',
+                          '    <MarkRecord index="1">',
+                          '      <Class value="0"/>',
+                          '      <MarkAnchor Format="1">',
+                          '        <XCoordinate value="300"/>',
+                          '        <YCoordinate value="700"/>',
+                          '      </MarkAnchor>',
+                          '    </MarkRecord>',
+                          '    <MarkRecord index="2">',
+                          '      <Class value="1"/>',
+                          '      <MarkAnchor Format="1">',
+                          '        <XCoordinate value="300"/>',
+                          '        <YCoordinate value="-100"/>',
+                          '      </MarkAnchor>',
+                          '    </MarkRecord>',
+                          '  </MarkArray>',
+                          '  <LigatureArray>',
+                          '    <!-- LigatureCount=2 -->',
+                          '    <LigatureAttach index="0">',
+                          '      <!-- ComponentCount=2 -->',
+                          '      <ComponentRecord index="0">',
+                          '        <LigatureAnchor index="0" empty="1"/>',
+                          '        <LigatureAnchor index="1" empty="1"/>',
+                          '      </ComponentRecord>',
+                          '      <ComponentRecord index="1">',
+                          '        <LigatureAnchor index="0" Format="1">',
+                          '          <XCoordinate value="200"/>',
+                          '          <YCoordinate value="400"/>',
+                          '        </LigatureAnchor>',
+                          '        <LigatureAnchor index="1" empty="1"/>',
+                          '      </ComponentRecord>',
+                          '    </LigatureAttach>',
+                          '    <LigatureAttach index="1">',
+                          '      <!-- ComponentCount=2 -->',
+                          '      <ComponentRecord index="0">',
+                          '        <LigatureAnchor index="0" Format="1">',
+                          '          <XCoordinate value="500"/>',
+                          '          <YCoordinate value="600"/>',
+                          '        </LigatureAnchor>',
+                          '        <LigatureAnchor index="1" Format="1">',
+                          '          <XCoordinate value="500"/>',
+                          '          <YCoordinate value="-20"/>',
+                          '        </LigatureAnchor>',
+                          '      </ComponentRecord>',
+                          '      <ComponentRecord index="1">',
+                          '        <LigatureAnchor index="0" Format="1">',
+                          '          <XCoordinate value="1300"/>',
+                          '          <YCoordinate value="800"/>',
+                          '        </LigatureAnchor>',
+                          '        <LigatureAnchor index="1" Format="1">',
+                          '          <XCoordinate value="1300"/>',
+                          '          <YCoordinate value="-20"/>',
+                          '        </LigatureAnchor>',
+                          '      </ComponentRecord>',
+                          '    </LigatureAttach>',
+                          '  </LigatureArray>',
+                          '</MarkLigPos>'])
 
     def test_buildMarkRecord(self):
         rec = builder.buildMarkRecord(17, builder.buildAnchor(500, -20))
         self.assertEqual(getXML(rec.toXML),
-                         '<MarkRecord> '
-                         ' <Class value="17"/>'
-                         '  <MarkAnchor Format="1">'
-                         '    <XCoordinate value="500"/>'
-                         '    <YCoordinate value="-20"/>'
-                         '  </MarkAnchor>'
-                         '</MarkRecord>')
+                         ['<MarkRecord>',
+                          '  <Class value="17"/>',
+                          '  <MarkAnchor Format="1">',
+                          '    <XCoordinate value="500"/>',
+                          '    <YCoordinate value="-20"/>',
+                          '  </MarkAnchor>',
+                          '</MarkRecord>'])
 
     def test_buildMark2Record(self):
         a = builder.buildAnchor
         rec = builder.buildMark2Record([a(500, -20), None, a(300, -15)])
         self.assertEqual(getXML(rec.toXML),
-                         '<Mark2Record>'
-                         '  <Mark2Anchor index="0" Format="1">'
-                         '    <XCoordinate value="500"/>'
-                         '    <YCoordinate value="-20"/>'
-                         '  </Mark2Anchor>'
-                         '  <Mark2Anchor index="1" empty="1"/>'
-                         '  <Mark2Anchor index="2" Format="1">'
-                         '    <XCoordinate value="300"/>'
-                         '    <YCoordinate value="-15"/>'
-                         '  </Mark2Anchor>'
-                         '</Mark2Record>')
+                         ['<Mark2Record>',
+                          '  <Mark2Anchor index="0" Format="1">',
+                          '    <XCoordinate value="500"/>',
+                          '    <YCoordinate value="-20"/>',
+                          '  </Mark2Anchor>',
+                          '  <Mark2Anchor index="1" empty="1"/>',
+                          '  <Mark2Anchor index="2" Format="1">',
+                          '    <XCoordinate value="300"/>',
+                          '    <YCoordinate value="-15"/>',
+                          '  </Mark2Anchor>',
+                          '</Mark2Record>'])
 
     def test_buildPairPosClassesSubtable(self):
         d20 = builder.buildValue({"XPlacement": -20})
@@ -781,46 +782,46 @@ class BuilderTest(unittest.TestCase):
         }, self.GLYPHMAP)
         self.maxDiff = None
         self.assertEqual(getXML(subtable.toXML),
-                         '<PairPos Format="2">'
-                         '  <Coverage>'
-                         '    <Glyph value="A"/>'
-                         '    <Glyph value="B"/>'
-                         '    <Glyph value="C"/>'
-                         '  </Coverage>'
-                         '  <ValueFormat1 value="3"/>'
-                         '  <ValueFormat2 value="1"/>'
-                         '  <ClassDef1>'
-                         '    <ClassDef glyph="A" class="1"/>'
-                         '  </ClassDef1>'
-                         '  <ClassDef2>'
-                         '    <ClassDef glyph="one" class="1"/>'
-                         '    <ClassDef glyph="two" class="1"/>'
-                         '    <ClassDef glyph="zero" class="2"/>'
-                         '  </ClassDef2>'
-                         '  <!-- Class1Count=2 -->'
-                         '  <!-- Class2Count=3 -->'
-                         '  <Class1Record index="0">'
-                         '    <Class2Record index="0">'
-                         '    </Class2Record>'
-                         '    <Class2Record index="1">'
-                         '    </Class2Record>'
-                         '    <Class2Record index="2">'
-                         '      <Value1 XPlacement="-80" YPlacement="-20"/>'
-                         '      <Value2 XPlacement="-50"/>'
-                         '    </Class2Record>'
-                         '  </Class1Record>'
-                         '  <Class1Record index="1">'
-                         '    <Class2Record index="0">'
-                         '    </Class2Record>'
-                         '    <Class2Record index="1">'
-                         '      <Value2 XPlacement="-20"/>'
-                         '    </Class2Record>'
-                         '    <Class2Record index="2">'
-                         '      <Value1/>'
-                         '      <Value2 XPlacement="-50"/>'
-                         '    </Class2Record>'
-                         '  </Class1Record>'
-                         '</PairPos>')
+                         ['<PairPos Format="2">',
+                          '  <Coverage>',
+                          '    <Glyph value="A"/>',
+                          '    <Glyph value="B"/>',
+                          '    <Glyph value="C"/>',
+                          '  </Coverage>',
+                          '  <ValueFormat1 value="3"/>',
+                          '  <ValueFormat2 value="1"/>',
+                          '  <ClassDef1>',
+                          '    <ClassDef glyph="A" class="1"/>',
+                          '  </ClassDef1>',
+                          '  <ClassDef2>',
+                          '    <ClassDef glyph="one" class="1"/>',
+                          '    <ClassDef glyph="two" class="1"/>',
+                          '    <ClassDef glyph="zero" class="2"/>',
+                          '  </ClassDef2>',
+                          '  <!-- Class1Count=2 -->',
+                          '  <!-- Class2Count=3 -->',
+                          '  <Class1Record index="0">',
+                          '    <Class2Record index="0">',
+                          '    </Class2Record>',
+                          '    <Class2Record index="1">',
+                          '    </Class2Record>',
+                          '    <Class2Record index="2">',
+                          '      <Value1 XPlacement="-80" YPlacement="-20"/>',
+                          '      <Value2 XPlacement="-50"/>',
+                          '    </Class2Record>',
+                          '  </Class1Record>',
+                          '  <Class1Record index="1">',
+                          '    <Class2Record index="0">',
+                          '    </Class2Record>',
+                          '    <Class2Record index="1">',
+                          '      <Value2 XPlacement="-20"/>',
+                          '    </Class2Record>',
+                          '    <Class2Record index="2">',
+                          '      <Value1/>',
+                          '      <Value2 XPlacement="-50"/>',
+                          '    </Class2Record>',
+                          '  </Class1Record>',
+                          '</PairPos>'])
 
     def test_buildPairPosGlyphs(self):
         d50 = builder.buildValue({"XPlacement": -50})
@@ -830,38 +831,38 @@ class BuilderTest(unittest.TestCase):
             ("A", "one"):  (d8020, d50),
         }, self.GLYPHMAP)
         self.maxDiff = None
-        self.assertEqual(''.join([getXML(t.toXML) for t in subtables]),
-                         '<PairPos Format="1">'
-                         '  <Coverage>'
-                         '    <Glyph value="A"/>'
-                         '  </Coverage>'
-                         '  <ValueFormat1 value="0"/>'
-                         '  <ValueFormat2 value="1"/>'
-                         '  <!-- PairSetCount=1 -->'
-                         '  <PairSet index="0">'
-                         '    <!-- PairValueCount=1 -->'
-                         '    <PairValueRecord index="0">'
-                         '      <SecondGlyph value="zero"/>'
-                         '      <Value2 XPlacement="-50"/>'
-                         '    </PairValueRecord>'
-                         '  </PairSet>'
-                         '</PairPos>'
-                         '<PairPos Format="1">'
-                         '  <Coverage>'
-                         '    <Glyph value="A"/>'
-                         '  </Coverage>'
-                         '  <ValueFormat1 value="3"/>'
-                         '  <ValueFormat2 value="1"/>'
-                         '  <!-- PairSetCount=1 -->'
-                         '  <PairSet index="0">'
-                         '    <!-- PairValueCount=1 -->'
-                         '    <PairValueRecord index="0">'
-                         '      <SecondGlyph value="one"/>'
-                         '      <Value1 XPlacement="-80" YPlacement="-20"/>'
-                         '      <Value2 XPlacement="-50"/>'
-                         '    </PairValueRecord>'
-                         '  </PairSet>'
-                         '</PairPos>')
+        self.assertEqual(sum([getXML(t.toXML) for t in subtables], []),
+                         ['<PairPos Format="1">',
+                          '  <Coverage>',
+                          '    <Glyph value="A"/>',
+                          '  </Coverage>',
+                          '  <ValueFormat1 value="0"/>',
+                          '  <ValueFormat2 value="1"/>',
+                          '  <!-- PairSetCount=1 -->',
+                          '  <PairSet index="0">',
+                          '    <!-- PairValueCount=1 -->',
+                          '    <PairValueRecord index="0">',
+                          '      <SecondGlyph value="zero"/>',
+                          '      <Value2 XPlacement="-50"/>',
+                          '    </PairValueRecord>',
+                          '  </PairSet>',
+                          '</PairPos>',
+                          '<PairPos Format="1">',
+                          '  <Coverage>',
+                          '    <Glyph value="A"/>',
+                          '  </Coverage>',
+                          '  <ValueFormat1 value="3"/>',
+                          '  <ValueFormat2 value="1"/>',
+                          '  <!-- PairSetCount=1 -->',
+                          '  <PairSet index="0">',
+                          '    <!-- PairValueCount=1 -->',
+                          '    <PairValueRecord index="0">',
+                          '      <SecondGlyph value="one"/>',
+                          '      <Value1 XPlacement="-80" YPlacement="-20"/>',
+                          '      <Value2 XPlacement="-50"/>',
+                          '    </PairValueRecord>',
+                          '  </PairSet>',
+                          '</PairPos>'])
 
     def test_buildPairPosGlyphsSubtable(self):
         d20 = builder.buildValue({"XPlacement": -20})
@@ -874,34 +875,34 @@ class BuilderTest(unittest.TestCase):
             ("B", "five"): (d8020, d50),
         }, self.GLYPHMAP)
         self.assertEqual(getXML(subtable.toXML),
-                         '<PairPos Format="1">'
-                         '  <Coverage>'
-                         '    <Glyph value="A"/>'
-                         '    <Glyph value="B"/>'
-                         '  </Coverage>'
-                         '  <ValueFormat1 value="3"/>'
-                         '  <ValueFormat2 value="1"/>'
-                         '  <!-- PairSetCount=2 -->'
-                         '  <PairSet index="0">'
-                         '    <!-- PairValueCount=2 -->'
-                         '    <PairValueRecord index="0">'
-                         '      <SecondGlyph value="zero"/>'
-                         '      <Value2 XPlacement="-50"/>'
-                         '    </PairValueRecord>'
-                         '    <PairValueRecord index="1">'
-                         '      <SecondGlyph value="one"/>'
-                         '      <Value2 XPlacement="-20"/>'
-                         '    </PairValueRecord>'
-                         '  </PairSet>'
-                         '  <PairSet index="1">'
-                         '    <!-- PairValueCount=1 -->'
-                         '    <PairValueRecord index="0">'
-                         '      <SecondGlyph value="five"/>'
-                         '      <Value1 XPlacement="-80" YPlacement="-20"/>'
-                         '      <Value2 XPlacement="-50"/>'
-                         '    </PairValueRecord>'
-                         '  </PairSet>'
-                         '</PairPos>')
+                         ['<PairPos Format="1">',
+                          '  <Coverage>',
+                          '    <Glyph value="A"/>',
+                          '    <Glyph value="B"/>',
+                          '  </Coverage>',
+                          '  <ValueFormat1 value="3"/>',
+                          '  <ValueFormat2 value="1"/>',
+                          '  <!-- PairSetCount=2 -->',
+                          '  <PairSet index="0">',
+                          '    <!-- PairValueCount=2 -->',
+                          '    <PairValueRecord index="0">',
+                          '      <SecondGlyph value="zero"/>',
+                          '      <Value2 XPlacement="-50"/>',
+                          '    </PairValueRecord>',
+                          '    <PairValueRecord index="1">',
+                          '      <SecondGlyph value="one"/>',
+                          '      <Value2 XPlacement="-20"/>',
+                          '    </PairValueRecord>',
+                          '  </PairSet>',
+                          '  <PairSet index="1">',
+                          '    <!-- PairValueCount=1 -->',
+                          '    <PairValueRecord index="0">',
+                          '      <SecondGlyph value="five"/>',
+                          '      <Value1 XPlacement="-80" YPlacement="-20"/>',
+                          '      <Value2 XPlacement="-50"/>',
+                          '    </PairValueRecord>',
+                          '  </PairSet>',
+                          '</PairPos>'])
 
     def test_buildSinglePos(self):
         subtables = builder.buildSinglePos({
@@ -912,45 +913,45 @@ class BuilderTest(unittest.TestCase):
             "five": builder.buildValue({"XPlacement": 500}),
             "six": builder.buildValue({"YPlacement": -6}),
         }, self.GLYPHMAP)
-        self.assertEqual(''.join([getXML(t.toXML) for t in subtables]),
-                         '<SinglePos Format="1">'
-                         '  <Coverage>'
-                         '    <Glyph value="one"/>'
-                         '    <Glyph value="two"/>'
-                         '    <Glyph value="five"/>'
-                         '  </Coverage>'
-                         '  <ValueFormat value="1"/>'
-                         '  <Value XPlacement="500"/>'
-                         '</SinglePos>'
-                         '<SinglePos Format="2">'
-                         '  <Coverage>'
-                         '    <Glyph value="three"/>'
-                         '    <Glyph value="four"/>'
-                         '  </Coverage>'
-                         '  <ValueFormat value="1"/>'
-                         '  <!-- ValueCount=2 -->'
-                         '  <Value index="0" XPlacement="200"/>'
-                         '  <Value index="1" XPlacement="400"/>'
-                         '</SinglePos>'
-                         '<SinglePos Format="1">'
-                         '  <Coverage>'
-                         '    <Glyph value="six"/>'
-                         '  </Coverage>'
-                         '  <ValueFormat value="2"/>'
-                         '  <Value YPlacement="-6"/>'
-                         '</SinglePos>')
+        self.assertEqual(sum([getXML(t.toXML) for t in subtables], []),
+                         ['<SinglePos Format="1">',
+                          '  <Coverage>',
+                          '    <Glyph value="one"/>',
+                          '    <Glyph value="two"/>',
+                          '    <Glyph value="five"/>',
+                          '  </Coverage>',
+                          '  <ValueFormat value="1"/>',
+                          '  <Value XPlacement="500"/>',
+                          '</SinglePos>',
+                          '<SinglePos Format="2">',
+                          '  <Coverage>',
+                          '    <Glyph value="three"/>',
+                          '    <Glyph value="four"/>',
+                          '  </Coverage>',
+                          '  <ValueFormat value="1"/>',
+                          '  <!-- ValueCount=2 -->',
+                          '  <Value index="0" XPlacement="200"/>',
+                          '  <Value index="1" XPlacement="400"/>',
+                          '</SinglePos>',
+                          '<SinglePos Format="1">',
+                          '  <Coverage>',
+                          '    <Glyph value="six"/>',
+                          '  </Coverage>',
+                          '  <ValueFormat value="2"/>',
+                          '  <Value YPlacement="-6"/>',
+                          '</SinglePos>'])
 
     def test_buildSinglePos_ValueFormat0(self):
         subtables = builder.buildSinglePos({
             "zero": builder.buildValue({})
         }, self.GLYPHMAP)
-        self.assertEqual(''.join([getXML(t.toXML) for t in subtables]),
-                         '<SinglePos Format="1">'
-                         '  <Coverage>'
-                         '    <Glyph value="zero"/>'
-                         '  </Coverage>'
-                         '  <ValueFormat value="0"/>'
-                         '</SinglePos>')
+        self.assertEqual(sum([getXML(t.toXML) for t in subtables], []),
+                         ['<SinglePos Format="1">',
+                          '  <Coverage>',
+                          '    <Glyph value="zero"/>',
+                          '  </Coverage>',
+                          '  <ValueFormat value="0"/>',
+                          '</SinglePos>'])
 
     def test_buildSinglePosSubtable_format1(self):
         subtable = builder.buildSinglePosSubtable({
@@ -958,14 +959,14 @@ class BuilderTest(unittest.TestCase):
             "two": builder.buildValue({"XPlacement": 777}),
         }, self.GLYPHMAP)
         self.assertEqual(getXML(subtable.toXML),
-                         '<SinglePos Format="1">'
-                         '  <Coverage>'
-                         '    <Glyph value="one"/>'
-                         '    <Glyph value="two"/>'
-                         '  </Coverage>'
-                         '  <ValueFormat value="1"/>'
-                         '  <Value XPlacement="777"/>'
-                         '</SinglePos>')
+                         ['<SinglePos Format="1">',
+                          '  <Coverage>',
+                          '    <Glyph value="one"/>',
+                          '    <Glyph value="two"/>',
+                          '  </Coverage>',
+                          '  <ValueFormat value="1"/>',
+                          '  <Value XPlacement="777"/>',
+                          '</SinglePos>'])
 
     def test_buildSinglePosSubtable_format2(self):
         subtable = builder.buildSinglePosSubtable({
@@ -973,22 +974,22 @@ class BuilderTest(unittest.TestCase):
             "two": builder.buildValue({"YPlacement": -888}),
         }, self.GLYPHMAP)
         self.assertEqual(getXML(subtable.toXML),
-                         '<SinglePos Format="2">'
-                         '  <Coverage>'
-                         '    <Glyph value="one"/>'
-                         '    <Glyph value="two"/>'
-                         '  </Coverage>'
-                         '  <ValueFormat value="3"/>'
-                         '  <!-- ValueCount=2 -->'
-                         '  <Value index="0" XPlacement="777"/>'
-                         '  <Value index="1" YPlacement="-888"/>'
-                         '</SinglePos>')
+                         ['<SinglePos Format="2">',
+                          '  <Coverage>',
+                          '    <Glyph value="one"/>',
+                          '    <Glyph value="two"/>',
+                          '  </Coverage>',
+                          '  <ValueFormat value="3"/>',
+                          '  <!-- ValueCount=2 -->',
+                          '  <Value index="0" XPlacement="777"/>',
+                          '  <Value index="1" YPlacement="-888"/>',
+                          '</SinglePos>'])
 
     def test_buildValue(self):
         value = builder.buildValue({"XPlacement": 7, "YPlacement": 23})
         func = lambda writer, font: value.toXML(writer, font, valueName="Val")
         self.assertEqual(getXML(func),
-                         '<Val XPlacement="7" YPlacement="23"/>')
+                         ['<Val XPlacement="7" YPlacement="23"/>'])
 
     def test_getLigatureKey(self):
         components = lambda s: [tuple(word) for word in s.split()]

--- a/Lib/fontTools/otlLib/builder_test.py
+++ b/Lib/fontTools/otlLib/builder_test.py
@@ -23,6 +23,10 @@ class BuilderTest(unittest.TestCase):
         if not hasattr(self, "assertRaisesRegex"):
             self.assertRaisesRegex = self.assertRaisesRegexp
 
+    @classmethod
+    def setUpClass(cls):
+        cls.maxDiff = None
+
     def test_buildAnchor_format1(self):
         anchor = builder.buildAnchor(23, 42)
         self.assertEqual(getXML(anchor.toXML),
@@ -272,7 +276,6 @@ class BuilderTest(unittest.TestCase):
             "f_i": [{2: anchor(300, -20)}, {}],
             "c_t": [{}, {1: anchor(500, 350), 2: anchor(1300, -20)}]
         }, numMarkClasses=4, glyphMap=self.GLYPHMAP)
-        self.maxDiff = None
         self.assertEqual(getXML(ligatureArray.toXML),
                          ['<LigatureArray>',
                           '  <!-- LigatureCount=2 -->',
@@ -543,7 +546,6 @@ class BuilderTest(unittest.TestCase):
             "b": {0: anchor(500, 800), 1: anchor(500, -20)}
         }
         table = builder.buildMarkBasePosSubtable(marks, bases, self.GLYPHMAP)
-        self.maxDiff = None
         self.assertEqual(getXML(table.toXML),
                          ['<MarkBasePos Format="1">',
                           '  <MarkCoverage>',
@@ -664,7 +666,6 @@ class BuilderTest(unittest.TestCase):
             ]
         }
         table = builder.buildMarkLigPosSubtable(marks, bases, self.GLYPHMAP)
-        self.maxDiff = None
         self.assertEqual(getXML(table.toXML),
                          ['<MarkLigPos Format="1">',
                           '  <MarkCoverage>',
@@ -780,7 +781,6 @@ class BuilderTest(unittest.TestCase):
             (tuple("A",), tuple(["one", "two"])):  (None, d20),
             (tuple(["B", "C"]), tuple(["zero"])): (d8020, d50),
         }, self.GLYPHMAP)
-        self.maxDiff = None
         self.assertEqual(getXML(subtable.toXML),
                          ['<PairPos Format="2">',
                           '  <Coverage>',
@@ -830,7 +830,6 @@ class BuilderTest(unittest.TestCase):
             ("A", "zero"): (None, d50),
             ("A", "one"):  (d8020, d50),
         }, self.GLYPHMAP)
-        self.maxDiff = None
         self.assertEqual(sum([getXML(t.toXML) for t in subtables], []),
                          ['<PairPos Format="1">',
                           '  <Coverage>',

--- a/Lib/fontTools/ttLib/tables/C_P_A_L_test.py
+++ b/Lib/fontTools/ttLib/tables/C_P_A_L_test.py
@@ -144,16 +144,16 @@ class CPALTest(unittest.TestCase):
         cpal = newTable('CPAL')
         cpal.decompile(CPAL_DATA_V0, ttFont=None)
         self.assertEqual(getXML(cpal.toXML),
-                         '<version value="0"/>'
-                         '<numPaletteEntries value="2"/>'
-                         '<palette index="0">'
-                         '  <color index="0" value="#000000FF"/>'
-                         '  <color index="1" value="#66CCFFFF"/>'
-                         '</palette>'
-                         '<palette index="1">'
-                         '  <color index="0" value="#000000FF"/>'
-                         '  <color index="1" value="#800000FF"/>'
-                         '</palette>')
+                         ['<version value="0"/>',
+                          '<numPaletteEntries value="2"/>',
+                          '<palette index="0">',
+                          '  <color index="0" value="#000000FF"/>',
+                          '  <color index="1" value="#66CCFFFF"/>',
+                          '</palette>',
+                          '<palette index="1">',
+                          '  <color index="0" value="#000000FF"/>',
+                          '  <color index="1" value="#800000FF"/>',
+                          '</palette>'])
 
     def test_toXML_v1(self):
         name = FakeNameTable({258: "Spring theme", 259: "Winter theme",
@@ -162,25 +162,25 @@ class CPALTest(unittest.TestCase):
         ttFont = {"name": name, "CPAL": cpal}
         cpal.decompile(CPAL_DATA_V1, ttFont)
         self.assertEqual(getXML(cpal.toXML, ttFont),
-                         '<version value="1"/>'
-                         '<numPaletteEntries value="3"/>'
-                         '<palette index="0" label="258" type="1">'
-                         '  <!-- Spring theme -->'
-                         '  <color index="0" value="#CAFECAFE"/>'
-                         '  <color index="1" value="#22110033"/>'
-                         '  <color index="2" value="#66554477"/>'
-                         '</palette>'
-                         '<palette index="1" label="259" type="2">'
-                         '  <!-- Winter theme -->'
-                         '  <color index="0" value="#59413127"/>'
-                         '  <color index="1" value="#42424242"/>'
-                         '  <color index="2" value="#13330037"/>'
-                         '</palette>'
-                         '<paletteEntryLabels>'
-                         '  <label index="0" value="513"/><!-- darks -->'
-                         '  <label index="1" value="514"/>'
-                         '  <label index="2" value="515"/><!-- lights -->'
-                         '</paletteEntryLabels>')
+                         ['<version value="1"/>',
+                          '<numPaletteEntries value="3"/>',
+                          '<palette index="0" label="258" type="1">',
+                          '  <!-- Spring theme -->',
+                          '  <color index="0" value="#CAFECAFE"/>',
+                          '  <color index="1" value="#22110033"/>',
+                          '  <color index="2" value="#66554477"/>',
+                          '</palette>',
+                          '<palette index="1" label="259" type="2">',
+                          '  <!-- Winter theme -->',
+                          '  <color index="0" value="#59413127"/>',
+                          '  <color index="1" value="#42424242"/>',
+                          '  <color index="2" value="#13330037"/>',
+                          '</palette>',
+                          '<paletteEntryLabels>',
+                          '  <label index="0" value="513"/><!-- darks -->',
+                          '  <label index="1" value="514"/>',
+                          '  <label index="2" value="515"/><!-- lights -->',
+                          '</paletteEntryLabels>'])
 
     def test_fromXML_v0(self):
         cpal = newTable('CPAL')

--- a/Lib/fontTools/ttLib/tables/M_V_A_R_test.py
+++ b/Lib/fontTools/ttLib/tables/M_V_A_R_test.py
@@ -52,65 +52,65 @@ MVAR_DATA = deHexStr(
     '00C8 '       # 104: VarData.deltaSets[0]=200
 )
 
-MVAR_XML = (
-    '<Version value="0x00010000"/>'
-    '<!-- AxisCount=1 -->'
-    '<ValueRecordSize value="8"/>'
-    '<!-- ValueRecordCount=7 -->'
-    '<VarStore Format="1">'
-    '  <Format value="1"/>'
-    '  <VarRegionList>'
-    '    <!-- RegionAxisCount=1 -->'
-    '    <!-- RegionCount=1 -->'
-    '    <Region index="0">'
-    '      <VarRegionAxis index="0">'
-    '        <StartCoord value="0.0"/>'
-    '        <PeakCoord value="1.0"/>'
-    '        <EndCoord value="1.0"/>'
-    '      </VarRegionAxis>'
-    '    </Region>'
-    '  </VarRegionList>'
-    '  <!-- VarDataCount=1 -->'
-    '  <VarData index="0">'
-    '    <!-- ItemCount=4 -->'
-    '    <NumShorts value="1"/>'
-    '    <!-- VarRegionCount=1 -->'
-    '    <VarRegionIndex index="0" value="0"/>'
-    '    <Item index="0" value="[-200]"/>'
-    '    <Item index="1" value="[-50]"/>'
-    '    <Item index="2" value="[100]"/>'
-    '    <Item index="3" value="[200]"/>'
-    '  </VarData>'
-    '</VarStore>'
-    '<ValueRecord index="0">'
-    '  <ValueTag value="hasc"/>'
-    '  <VarIdx value="3"/>'
-    '</ValueRecord>'
-    '<ValueRecord index="1">'
-    '  <ValueTag value="hcla"/>'
-    '  <VarIdx value="3"/>'
-    '</ValueRecord>'
-    '<ValueRecord index="2">'
-    '  <ValueTag value="hcld"/>'
-    '  <VarIdx value="3"/>'
-    '</ValueRecord>'
-    '<ValueRecord index="3">'
-    '  <ValueTag value="hdsc"/>'
-    '  <VarIdx value="0"/>'
-    '</ValueRecord>'
-    '<ValueRecord index="4">'
-    '  <ValueTag value="hlgp"/>'
-    '  <VarIdx value="2"/>'
-    '</ValueRecord>'
-    '<ValueRecord index="5">'
-    '  <ValueTag value="sbyo"/>'
-    '  <VarIdx value="1"/>'
-    '</ValueRecord>'
-    '<ValueRecord index="6">'
-    '  <ValueTag value="spyo"/>'
-    '  <VarIdx value="2"/>'
-    '</ValueRecord>'
-)
+MVAR_XML = [
+    '<Version value="0x00010000"/>',
+    '<!-- AxisCount=1 -->',
+    '<ValueRecordSize value="8"/>',
+    '<!-- ValueRecordCount=7 -->',
+    '<VarStore Format="1">',
+    '  <Format value="1"/>',
+    '  <VarRegionList>',
+    '    <!-- RegionAxisCount=1 -->',
+    '    <!-- RegionCount=1 -->',
+    '    <Region index="0">',
+    '      <VarRegionAxis index="0">',
+    '        <StartCoord value="0.0"/>',
+    '        <PeakCoord value="1.0"/>',
+    '        <EndCoord value="1.0"/>',
+    '      </VarRegionAxis>',
+    '    </Region>',
+    '  </VarRegionList>',
+    '  <!-- VarDataCount=1 -->',
+    '  <VarData index="0">',
+    '    <!-- ItemCount=4 -->',
+    '    <NumShorts value="1"/>',
+    '    <!-- VarRegionCount=1 -->',
+    '    <VarRegionIndex index="0" value="0"/>',
+    '    <Item index="0" value="[-200]"/>',
+    '    <Item index="1" value="[-50]"/>',
+    '    <Item index="2" value="[100]"/>',
+    '    <Item index="3" value="[200]"/>',
+    '  </VarData>',
+    '</VarStore>',
+    '<ValueRecord index="0">',
+    '  <ValueTag value="hasc"/>',
+    '  <VarIdx value="3"/>',
+    '</ValueRecord>',
+    '<ValueRecord index="1">',
+    '  <ValueTag value="hcla"/>',
+    '  <VarIdx value="3"/>',
+    '</ValueRecord>',
+    '<ValueRecord index="2">',
+    '  <ValueTag value="hcld"/>',
+    '  <VarIdx value="3"/>',
+    '</ValueRecord>',
+    '<ValueRecord index="3">',
+    '  <ValueTag value="hdsc"/>',
+    '  <VarIdx value="0"/>',
+    '</ValueRecord>',
+    '<ValueRecord index="4">',
+    '  <ValueTag value="hlgp"/>',
+    '  <VarIdx value="2"/>',
+    '</ValueRecord>',
+    '<ValueRecord index="5">',
+    '  <ValueTag value="sbyo"/>',
+    '  <VarIdx value="1"/>',
+    '</ValueRecord>',
+    '<ValueRecord index="6">',
+    '  <ValueTag value="spyo"/>',
+    '  <VarIdx value="2"/>',
+    '</ValueRecord>',
+]
 
 
 class MVARTest(unittest.TestCase):

--- a/Lib/fontTools/ttLib/tables/M_V_A_R_test.py
+++ b/Lib/fontTools/ttLib/tables/M_V_A_R_test.py
@@ -115,17 +115,19 @@ MVAR_XML = [
 
 class MVARTest(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.maxDiff = None
+
     def test_decompile_toXML(self):
         mvar = newTable('MVAR')
         font = TTFont()
         mvar.decompile(MVAR_DATA, font)
-        self.maxDiff = None
         self.assertEqual(getXML(mvar.toXML), MVAR_XML)
 
     def test_compile_fromXML(self):
         mvar = newTable('MVAR')
         font = TTFont()
-        self.maxDiff = None
         for name, attrs, content in parseXML(MVAR_XML):
             mvar.fromXML(name, attrs, content, font=font)
         # Ignore AxisCount

--- a/Lib/fontTools/ttLib/tables/S_T_A_T_test.py
+++ b/Lib/fontTools/ttLib/tables/S_T_A_T_test.py
@@ -30,47 +30,47 @@ STAT_DATA = deHexStr(
 assert(len(STAT_DATA) == 88)
 
 
-STAT_XML = (
-    '<Version value="0x00010000"/>'
-    '<DesignAxisRecordSize value="8"/>'
-    '<!-- DesignAxisCount=2 -->'
-    '<DesignAxisRecord>'
-    '  <Axis index="0">'
-    '    <AxisTag value="wght"/>'
-    '    <AxisNameID value="301"/>'
-    '    <AxisOrdering value="2"/>'
-    '  </Axis>'
-    '  <Axis index="1">'
-    '    <AxisTag value="TEST"/>'
-    '    <AxisNameID value="302"/>'
-    '    <AxisOrdering value="1"/>'
-    '  </Axis>'
-    '</DesignAxisRecord>'
-    '<!-- AxisValueCount=3 -->'
-    '<AxisValueArray>'
-    '  <AxisValue index="0" Format="1">'
-    '    <AxisIndex value="0"/>'
-    '    <Flags value="0"/>'
-    '    <ValueNameID value="401"/>'
-    '    <Value value="400.0"/>'
-    '  </AxisValue>'
-    '  <AxisValue index="1" Format="2">'
-    '    <AxisIndex value="1"/>'
-    '    <Flags value="0"/>'
-    '    <ValueNameID value="402"/>'
-    '    <NominalValue value="2.0"/>'
-    '    <RangeMinValue value="1.0"/>'
-    '    <RangeMaxValue value="3.0"/>'
-    '  </AxisValue>'
-    '  <AxisValue index="2" Format="3">'
-    '    <AxisIndex value="0"/>'
-    '    <Flags value="0"/>'
-    '    <ValueNameID value="2"/>'
-    '    <Value value="400.0"/>'
-    '    <LinkedValue value="700.0"/>'
-    '  </AxisValue>'
-    '</AxisValueArray>'
-)
+STAT_XML = [
+    '<Version value="0x00010000"/>',
+    '<DesignAxisRecordSize value="8"/>',
+    '<!-- DesignAxisCount=2 -->',
+    '<DesignAxisRecord>',
+    '  <Axis index="0">',
+    '    <AxisTag value="wght"/>',
+    '    <AxisNameID value="301"/>',
+    '    <AxisOrdering value="2"/>',
+    '  </Axis>',
+    '  <Axis index="1">',
+    '    <AxisTag value="TEST"/>',
+    '    <AxisNameID value="302"/>',
+    '    <AxisOrdering value="1"/>',
+    '  </Axis>',
+    '</DesignAxisRecord>',
+    '<!-- AxisValueCount=3 -->',
+    '<AxisValueArray>',
+    '  <AxisValue index="0" Format="1">',
+    '    <AxisIndex value="0"/>',
+    '    <Flags value="0"/>',
+    '    <ValueNameID value="401"/>',
+    '    <Value value="400.0"/>',
+    '  </AxisValue>',
+    '  <AxisValue index="1" Format="2">',
+    '    <AxisIndex value="1"/>',
+    '    <Flags value="0"/>',
+    '    <ValueNameID value="402"/>',
+    '    <NominalValue value="2.0"/>',
+    '    <RangeMinValue value="1.0"/>',
+    '    <RangeMaxValue value="3.0"/>',
+    '  </AxisValue>',
+    '  <AxisValue index="2" Format="3">',
+    '    <AxisIndex value="0"/>',
+    '    <Flags value="0"/>',
+    '    <ValueNameID value="2"/>',
+    '    <Value value="400.0"/>',
+    '    <LinkedValue value="700.0"/>',
+    '  </AxisValue>',
+    '</AxisValueArray>',
+]
 
 
 # Contains junk data for making sure we get our offset decoding right.
@@ -90,28 +90,28 @@ STAT_DATA_WITH_AXIS_JUNK = deHexStr(
 assert(len(STAT_DATA_WITH_AXIS_JUNK) == 38)
 
 
-STAT_XML_WITH_AXIS_JUNK = (
-    '<Version value="0x00010000"/>'
-    '<DesignAxisRecordSize value="10"/>'
-    '<!-- DesignAxisCount=2 -->'
-    '<DesignAxisRecord>'
-    '  <Axis index="0">'
-    '    <AxisTag value="wght"/>'
-    '    <AxisNameID value="301"/>'
-    '    <AxisOrdering value="2"/>'
-    '    <MoreBytes index="0" value="222"/>'  # 0xDE
-    '    <MoreBytes index="1" value="173"/>'  # 0xAD
-    '  </Axis>'
-    '  <Axis index="1">'
-    '    <AxisTag value="TEST"/>'
-    '    <AxisNameID value="302"/>'
-    '    <AxisOrdering value="1"/>'
-    '    <MoreBytes index="0" value="190"/>'  # 0xBE
-    '    <MoreBytes index="1" value="239"/>'  # 0xEF
-    '  </Axis>'
-    '</DesignAxisRecord>'
-    '<!-- AxisValueCount=0 -->'
-)
+STAT_XML_WITH_AXIS_JUNK = [
+    '<Version value="0x00010000"/>',
+    '<DesignAxisRecordSize value="10"/>',
+    '<!-- DesignAxisCount=2 -->',
+    '<DesignAxisRecord>',
+    '  <Axis index="0">',
+    '    <AxisTag value="wght"/>',
+    '    <AxisNameID value="301"/>',
+    '    <AxisOrdering value="2"/>',
+    '    <MoreBytes index="0" value="222"/>',  # 0xDE
+    '    <MoreBytes index="1" value="173"/>',  # 0xAD
+    '  </Axis>',
+    '  <Axis index="1">',
+    '    <AxisTag value="TEST"/>',
+    '    <AxisNameID value="302"/>',
+    '    <AxisOrdering value="1"/>',
+    '    <MoreBytes index="0" value="190"/>',  # 0xBE
+    '    <MoreBytes index="1" value="239"/>',  # 0xEF
+    '  </Axis>',
+    '</DesignAxisRecord>',
+    '<!-- AxisValueCount=0 -->',
+]
 
 
 STAT_DATA_AXIS_VALUE_FORMAT3 = deHexStr(
@@ -133,28 +133,28 @@ STAT_DATA_AXIS_VALUE_FORMAT3 = deHexStr(
 assert(len(STAT_DATA_AXIS_VALUE_FORMAT3) == 44)
 
 
-STAT_XML_AXIS_VALUE_FORMAT3 = (
-    '<Version value="0x00010000"/>'
-    '<DesignAxisRecordSize value="8"/>'
-    '<!-- DesignAxisCount=1 -->'
-    '<DesignAxisRecord>'
-    '  <Axis index="0">'
-    '    <AxisTag value="wght"/>'
-    '    <AxisNameID value="258"/>'
-    '    <AxisOrdering value="0"/>'
-    '  </Axis>'
-    '</DesignAxisRecord>'
-    '<!-- AxisValueCount=1 -->'
-    '<AxisValueArray>'
-    '  <AxisValue index="0" Format="3">'
-    '    <AxisIndex value="0"/>'
-    '    <Flags value="2"/>'
-    '    <ValueNameID value="2"/>'
-    '    <Value value="400.0"/>'
-    '    <LinkedValue value="700.0"/>'
-    '  </AxisValue>'
-    '</AxisValueArray>'
-)
+STAT_XML_AXIS_VALUE_FORMAT3 = [
+    '<Version value="0x00010000"/>',
+    '<DesignAxisRecordSize value="8"/>',
+    '<!-- DesignAxisCount=1 -->',
+    '<DesignAxisRecord>',
+    '  <Axis index="0">',
+    '    <AxisTag value="wght"/>',
+    '    <AxisNameID value="258"/>',
+    '    <AxisOrdering value="0"/>',
+    '  </Axis>',
+    '</DesignAxisRecord>',
+    '<!-- AxisValueCount=1 -->',
+    '<AxisValueArray>',
+    '  <AxisValue index="0" Format="3">',
+    '    <AxisIndex value="0"/>',
+    '    <Flags value="2"/>',
+    '    <ValueNameID value="2"/>',
+    '    <Value value="400.0"/>',
+    '    <LinkedValue value="700.0"/>',
+    '  </AxisValue>',
+    '</AxisValueArray>',
+]
 
 
 STAT_DATA_VERSION_1_1 = deHexStr(
@@ -177,36 +177,40 @@ STAT_DATA_VERSION_1_1 = deHexStr(
 assert(len(STAT_DATA_VERSION_1_1) == 46)
 
 
-STAT_XML_VERSION_1_1 = (
-    '<Version value="0x00010001"/>'
-    '<DesignAxisRecordSize value="8"/>'
-    '<!-- DesignAxisCount=1 -->'
-    '<DesignAxisRecord>'
-    '  <Axis index="0">'
-    '    <AxisTag value="wght"/>'
-    '    <AxisNameID value="258"/>'
-    '    <AxisOrdering value="0"/>'
-    '  </Axis>'
-    '</DesignAxisRecord>'
-    '<!-- AxisValueCount=1 -->'
-    '<AxisValueArray>'
-    '  <AxisValue index="0" Format="3">'
-    '    <AxisIndex value="0"/>'
-    '    <Flags value="2"/>'
-    '    <ValueNameID value="2"/>'
-    '    <Value value="400.0"/>'
-    '    <LinkedValue value="700.0"/>'
-    '  </AxisValue>'
-    '</AxisValueArray>'
-    '<ElidedFallbackNameID value="257"/>'
-)
+STAT_XML_VERSION_1_1 = [
+    '<Version value="0x00010001"/>',
+    '<DesignAxisRecordSize value="8"/>',
+    '<!-- DesignAxisCount=1 -->',
+    '<DesignAxisRecord>',
+    '  <Axis index="0">',
+    '    <AxisTag value="wght"/>',
+    '    <AxisNameID value="258"/>',
+    '    <AxisOrdering value="0"/>',
+    '  </Axis>',
+    '</DesignAxisRecord>',
+    '<!-- AxisValueCount=1 -->',
+    '<AxisValueArray>',
+    '  <AxisValue index="0" Format="3">',
+    '    <AxisIndex value="0"/>',
+    '    <Flags value="2"/>',
+    '    <ValueNameID value="2"/>',
+    '    <Value value="400.0"/>',
+    '    <LinkedValue value="700.0"/>',
+    '  </AxisValue>',
+    '</AxisValueArray>',
+    '<ElidedFallbackNameID value="257"/>',
+]
 
 
 class STATTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.maxDiff = None
+
     def test_decompile_toXML(self):
         table = newTable('STAT')
         table.decompile(STAT_DATA, font=FakeFont(['.notdef']))
-        self.maxDiff = None
         self.assertEqual(getXML(table.toXML), STAT_XML)
 
     def test_decompile_toXML_withAxisJunk(self):
@@ -229,7 +233,6 @@ class STATTest(unittest.TestCase):
     def test_compile_fromXML(self):
         table = newTable('STAT')
         font = FakeFont(['.notdef'])
-        self.maxDiff = None
         for name, attrs, content in parseXML(STAT_XML):
             table.fromXML(name, attrs, content, font=font)
         self.assertEqual(table.compile(font), STAT_DATA)
@@ -237,7 +240,6 @@ class STATTest(unittest.TestCase):
     def test_compile_fromXML_withAxisJunk(self):
         table = newTable('STAT')
         font = FakeFont(['.notdef'])
-        self.maxDiff = None
         for name, attrs, content in parseXML(STAT_XML_WITH_AXIS_JUNK):
             table.fromXML(name, attrs, content, font=font)
         self.assertEqual(table.compile(font), STAT_DATA_WITH_AXIS_JUNK)
@@ -245,7 +247,6 @@ class STATTest(unittest.TestCase):
     def test_compile_fromXML_format3(self):
         table = newTable('STAT')
         font = FakeFont(['.notdef'])
-        self.maxDiff = None
         for name, attrs, content in parseXML(STAT_XML_AXIS_VALUE_FORMAT3):
             table.fromXML(name, attrs, content, font=font)
         self.assertEqual(table.compile(font), STAT_DATA_AXIS_VALUE_FORMAT3)
@@ -253,7 +254,6 @@ class STATTest(unittest.TestCase):
     def test_compile_fromXML_version_1_1(self):
         table = newTable('STAT')
         font = FakeFont(['.notdef'])
-        self.maxDiff = None
         for name, attrs, content in parseXML(STAT_XML_VERSION_1_1):
             table.fromXML(name, attrs, content, font=font)
         self.assertEqual(table.compile(font), STAT_DATA_VERSION_1_1)

--- a/Lib/fontTools/ttLib/tables/_h_h_e_a_test.py
+++ b/Lib/fontTools/ttLib/tables/_h_h_e_a_test.py
@@ -48,30 +48,29 @@ HHEA_AS_DICT = {
     'numberOfHMetrics': 42,
 }
 
-HHEA_XML = (
-    '<tableVersion value="0x00010000"/>'
-    '<ascent value="750"/>'
-    '<descent value="-250"/>'
-    '<lineGap value="200"/>'
-    '<advanceWidthMax value="1000"/>'
-    '<minLeftSideBearing value="-25"/>'
-    '<minRightSideBearing value="-20"/>'
-    '<xMaxExtent value="977"/>'
-    '<caretSlopeRise value="0"/>'
-    '<caretSlopeRun value="1"/>'
-    '<caretOffset value="16"/>'
-    '<reserved0 value="0"/>'
-    '<reserved1 value="0"/>'
-    '<reserved2 value="0"/>'
-    '<reserved3 value="0"/>'
-    '<metricDataFormat value="0"/>'
-    '<numberOfHMetrics value="42"/>'
-)
-
-HHEA_XML_VERSION_AS_FLOAT = HHEA_XML.replace(
+HHEA_XML = [
     '<tableVersion value="0x00010000"/>',
-    '<tableVersion value="1.0"/>'
-)
+    '<ascent value="750"/>',
+    '<descent value="-250"/>',
+    '<lineGap value="200"/>',
+    '<advanceWidthMax value="1000"/>',
+    '<minLeftSideBearing value="-25"/>',
+    '<minRightSideBearing value="-20"/>',
+    '<xMaxExtent value="977"/>',
+    '<caretSlopeRise value="0"/>',
+    '<caretSlopeRun value="1"/>',
+    '<caretOffset value="16"/>',
+    '<reserved0 value="0"/>',
+    '<reserved1 value="0"/>',
+    '<reserved2 value="0"/>',
+    '<reserved3 value="0"/>',
+    '<metricDataFormat value="0"/>',
+    '<numberOfHMetrics value="42"/>',
+]
+
+HHEA_XML_VERSION_AS_FLOAT = [
+    '<tableVersion value="1.0"/>',
+] + HHEA_XML[1:]
 
 
 class HheaCompileOrToXMLTest(unittest.TestCase):

--- a/Lib/fontTools/ttLib/tables/_h_m_t_x_test.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x_test.py
@@ -180,10 +180,10 @@ class HmtxTableTest(unittest.TestCase):
 
         self.assertEqual(
             getXML(mtxTable.toXML),
-            '<mtx name="A" %s="674" %s="-11"/>'
-            '<mtx name="B" %s="632" %s="79"/>' % (
+            ('<mtx name="A" %s="674" %s="-11"/>\n'
+             '<mtx name="B" %s="632" %s="79"/>' % (
                 (self.tableClass.advanceName,
-                 self.tableClass.sideBearingName) * 2))
+                 self.tableClass.sideBearingName) * 2)).split('\n'))
 
     def test_fromXML(self):
         mtxTable = newTable(self.tag)

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k_test.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k_test.py
@@ -30,46 +30,46 @@ OSAKA_VERT_TRACK_ENTRIES = {
 	 1.0: TrackTableEntry({24.0: 12, 12.0: 12}, nameIndex=267)
 	}
 
-OSAKA_TRAK_TABLE_XML = (
-	'<version value="1.0"/>'
-	'<format value="0"/>'
-	'<horizData>'
-	'  <!-- nTracks=3, nSizes=2 -->'
-	'  <trackEntry value="-1.0" nameIndex="262">'
-	'    <!-- Tight -->'
-	'    <track size="12.0" value="-12"/>'
-	'    <track size="24.0" value="-12"/>'
-	'  </trackEntry>'
-	'  <trackEntry value="0.0" nameIndex="263">'
-	'    <!-- Normal -->'
-	'    <track size="12.0" value="0"/>'
-	'    <track size="24.0" value="0"/>'
-	'  </trackEntry>'
-	'  <trackEntry value="1.0" nameIndex="264">'
-	'    <!-- Loose -->'
-	'    <track size="12.0" value="12"/>'
-	'    <track size="24.0" value="12"/>'
-	'  </trackEntry>'
-	'</horizData>'
-	'<vertData>'
-	'  <!-- nTracks=3, nSizes=2 -->'
-	'  <trackEntry value="-1.0" nameIndex="265">'
-	'    <!-- Tight -->'
-	'    <track size="12.0" value="-12"/>'
-	'    <track size="24.0" value="-12"/>'
-	'  </trackEntry>'
-	'  <trackEntry value="0.0" nameIndex="266">'
-	'    <!-- Normal -->'
-	'    <track size="12.0" value="0"/>'
-	'    <track size="24.0" value="0"/>'
-	'  </trackEntry>'
-	'  <trackEntry value="1.0" nameIndex="267">'
-	'    <!-- Loose -->'
-	'    <track size="12.0" value="12"/>'
-	'    <track size="24.0" value="12"/>'
-	'  </trackEntry>'
-	'</vertData>'
-	)
+OSAKA_TRAK_TABLE_XML = [
+	'<version value="1.0"/>',
+	'<format value="0"/>',
+	'<horizData>',
+	'  <!-- nTracks=3, nSizes=2 -->',
+	'  <trackEntry value="-1.0" nameIndex="262">',
+	'    <!-- Tight -->',
+	'    <track size="12.0" value="-12"/>',
+	'    <track size="24.0" value="-12"/>',
+	'  </trackEntry>',
+	'  <trackEntry value="0.0" nameIndex="263">',
+	'    <!-- Normal -->',
+	'    <track size="12.0" value="0"/>',
+	'    <track size="24.0" value="0"/>',
+	'  </trackEntry>',
+	'  <trackEntry value="1.0" nameIndex="264">',
+	'    <!-- Loose -->',
+	'    <track size="12.0" value="12"/>',
+	'    <track size="24.0" value="12"/>',
+	'  </trackEntry>',
+	'</horizData>',
+	'<vertData>',
+	'  <!-- nTracks=3, nSizes=2 -->',
+	'  <trackEntry value="-1.0" nameIndex="265">',
+	'    <!-- Tight -->',
+	'    <track size="12.0" value="-12"/>',
+	'    <track size="24.0" value="-12"/>',
+	'  </trackEntry>',
+	'  <trackEntry value="0.0" nameIndex="266">',
+	'    <!-- Normal -->',
+	'    <track size="12.0" value="0"/>',
+	'    <track size="24.0" value="0"/>',
+	'  </trackEntry>',
+	'  <trackEntry value="1.0" nameIndex="267">',
+	'    <!-- Loose -->',
+	'    <track size="12.0" value="12"/>',
+	'    <track size="24.0" value="12"/>',
+	'  </trackEntry>',
+	'</vertData>',
+]
 
 # made-up table containing only vertData (no horizData)
 OSAKA_VERT_ONLY_TRAK_TABLE_DATA = deHexStr(
@@ -77,31 +77,31 @@ OSAKA_VERT_ONLY_TRAK_TABLE_DATA = deHexStr(
 	'00 00 01 09 00 34 00 00 00 00 01 0a 00 38 00 01 00 00 01 0b 00 3c '
 	'00 0c 00 00 00 18 00 00 ff f4 ff f4 00 00 00 00 00 0c 00 0c')
 
-OSAKA_VERT_ONLY_TRAK_TABLE_XML = (
-	'<version value="1.0"/>'
-	'<format value="0"/>'
-	'<horizData>'
-	'  <!-- nTracks=0, nSizes=0 -->'
-	'</horizData>'
-	'<vertData>'
-	'  <!-- nTracks=3, nSizes=2 -->'
-	'  <trackEntry value="-1.0" nameIndex="265">'
-	'    <!-- Tight -->'
-	'    <track size="12.0" value="-12"/>'
-	'    <track size="24.0" value="-12"/>'
-	'  </trackEntry>'
-	'  <trackEntry value="0.0" nameIndex="266">'
-	'    <!-- Normal -->'
-	'    <track size="12.0" value="0"/>'
-	'    <track size="24.0" value="0"/>'
-	'  </trackEntry>'
-	'  <trackEntry value="1.0" nameIndex="267">'
-	'    <!-- Loose -->'
-	'    <track size="12.0" value="12"/>'
-	'    <track size="24.0" value="12"/>'
-	'  </trackEntry>'
-	'</vertData>'
-	)
+OSAKA_VERT_ONLY_TRAK_TABLE_XML = [
+	'<version value="1.0"/>',
+	'<format value="0"/>',
+	'<horizData>',
+	'  <!-- nTracks=0, nSizes=0 -->',
+	'</horizData>',
+	'<vertData>',
+	'  <!-- nTracks=3, nSizes=2 -->',
+	'  <trackEntry value="-1.0" nameIndex="265">',
+	'    <!-- Tight -->',
+	'    <track size="12.0" value="-12"/>',
+	'    <track size="24.0" value="-12"/>',
+	'  </trackEntry>',
+	'  <trackEntry value="0.0" nameIndex="266">',
+	'    <!-- Normal -->',
+	'    <track size="12.0" value="0"/>',
+	'    <track size="24.0" value="0"/>',
+	'  </trackEntry>',
+	'  <trackEntry value="1.0" nameIndex="267">',
+	'    <!-- Loose -->',
+	'    <track size="12.0" value="12"/>',
+	'    <track size="24.0" value="12"/>',
+	'  </trackEntry>',
+	'</vertData>',
+]
 
 
 # also /Library/Fonts/Skia.ttf contains a trak table with horizData
@@ -121,40 +121,40 @@ SKIA_TRACK_ENTRIES = {
 	 	{9.0: 140, 10.0: 130, 19.0: 115, 12.0: 125, 18.0: 115}, nameIndex=276)
 	}
 
-SKIA_TRAK_TABLE_XML = (
-	'<version value="1.0"/>'
-	'<format value="0"/>'
-	'<horizData>'
-	'  <!-- nTracks=3, nSizes=5 -->'
-	'  <trackEntry value="-1.0" nameIndex="275">'
-	'    <!-- Tight -->'
-	'    <track size="9.0" value="-10"/>'
-	'    <track size="10.0" value="-30"/>'
-	'    <track size="12.0" value="-60"/>'
-	'    <track size="18.0" value="-63"/>'
-	'    <track size="19.0" value="-63"/>'
-	'  </trackEntry>'
-	'  <trackEntry value="0.0" nameIndex="303">'
-	'    <!-- Normal -->'
-	'    <track size="9.0" value="15"/>'
-	'    <track size="10.0" value="0"/>'
-	'    <track size="12.0" value="-5"/>'
-	'    <track size="18.0" value="-25"/>'
-	'    <track size="19.0" value="-25"/>'
-	'  </trackEntry>'
-	'  <trackEntry value="1.0" nameIndex="276">'
-	'    <!-- Loose -->'
-	'    <track size="9.0" value="140"/>'
-	'    <track size="10.0" value="130"/>'
-	'    <track size="12.0" value="125"/>'
-	'    <track size="18.0" value="115"/>'
-	'    <track size="19.0" value="115"/>'
-	'  </trackEntry>'
-	'</horizData>'
-	'<vertData>'
-	'  <!-- nTracks=0, nSizes=0 -->'
-	'</vertData>'
-	)
+SKIA_TRAK_TABLE_XML = [
+	'<version value="1.0"/>',
+	'<format value="0"/>',
+	'<horizData>',
+	'  <!-- nTracks=3, nSizes=5 -->',
+	'  <trackEntry value="-1.0" nameIndex="275">',
+	'    <!-- Tight -->',
+	'    <track size="9.0" value="-10"/>',
+	'    <track size="10.0" value="-30"/>',
+	'    <track size="12.0" value="-60"/>',
+	'    <track size="18.0" value="-63"/>',
+	'    <track size="19.0" value="-63"/>',
+	'  </trackEntry>',
+	'  <trackEntry value="0.0" nameIndex="303">',
+	'    <!-- Normal -->',
+	'    <track size="9.0" value="15"/>',
+	'    <track size="10.0" value="0"/>',
+	'    <track size="12.0" value="-5"/>',
+	'    <track size="18.0" value="-25"/>',
+	'    <track size="19.0" value="-25"/>',
+	'  </trackEntry>',
+	'  <trackEntry value="1.0" nameIndex="276">',
+	'    <!-- Loose -->',
+	'    <track size="9.0" value="140"/>',
+	'    <track size="10.0" value="130"/>',
+	'    <track size="12.0" value="125"/>',
+	'    <track size="18.0" value="115"/>',
+	'    <track size="19.0" value="115"/>',
+	'  </trackEntry>',
+	'</horizData>',
+	'<vertData>',
+	'  <!-- nTracks=0, nSizes=0 -->',
+	'</vertData>',
+]
 
 
 class TrackingTableTest(unittest.TestCase):
@@ -273,8 +273,9 @@ class TrackingTableTest(unittest.TestCase):
 		add_name(self.font, 'Tight', nameID=275)
 		add_name(self.font, 'Normal', nameID=303)
 		add_name(self.font, 'Loose', nameID=276)
-		self.assertEqual(SKIA_TRAK_TABLE_XML,
-			         getXML(table.toXML, self.font))
+		self.assertEqual(
+			SKIA_TRAK_TABLE_XML,
+			getXML(table.toXML, self.font))
 
 	def test_toXML_horiz_and_vert(self):
 		table = self.font['trak']
@@ -286,8 +287,9 @@ class TrackingTableTest(unittest.TestCase):
 		add_name(self.font, 'Tight', nameID=265)
 		add_name(self.font, 'Normal', nameID=266)
 		add_name(self.font, 'Loose', nameID=267)
-		self.assertEqual(OSAKA_TRAK_TABLE_XML,
-				 getXML(table.toXML, self.font))
+		self.assertEqual(
+			OSAKA_TRAK_TABLE_XML,
+			getXML(table.toXML, self.font))
 
 	def test_toXML_vert(self):
 		table = self.font['trak']
@@ -295,8 +297,9 @@ class TrackingTableTest(unittest.TestCase):
 		add_name(self.font, 'Tight', nameID=265)
 		add_name(self.font, 'Normal', nameID=266)
 		add_name(self.font, 'Loose', nameID=267)
-		self.assertEqual(OSAKA_VERT_ONLY_TRAK_TABLE_XML,
-                                 getXML(table.toXML, self.font))
+		self.assertEqual(
+			OSAKA_VERT_ONLY_TRAK_TABLE_XML,
+			getXML(table.toXML, self.font))
 
 	def test_roundtrip_fromXML_toXML(self):
 		font = {}

--- a/Lib/fontTools/ttLib/tables/_v_h_e_a_test.py
+++ b/Lib/fontTools/ttLib/tables/_v_h_e_a_test.py
@@ -53,40 +53,37 @@ VHEA_VERSION_11_AS_DICT = {
 VHEA_VERSION_10_AS_DICT = dict(VHEA_VERSION_11_AS_DICT)
 VHEA_VERSION_10_AS_DICT['tableVersion'] = 0x00010000
 
-VHEA_XML_VERSION_11 = (
-    '<tableVersion value="0x00011000"/>'
-    '<ascent value="500"/>'
-    '<descent value="-500"/>'
-    '<lineGap value="0"/>'
-    '<advanceHeightMax value="3000"/>'
-    '<minTopSideBearing value="-1002"/>'
-    '<minBottomSideBearing value="-677"/>'
-    '<yMaxExtent value="2928"/>'
-    '<caretSlopeRise value="0"/>'
-    '<caretSlopeRun value="1"/>'
-    '<caretOffset value="0"/>'
-    '<reserved1 value="0"/>'
-    '<reserved2 value="0"/>'
-    '<reserved3 value="0"/>'
-    '<reserved4 value="0"/>'
-    '<metricDataFormat value="0"/>'
-    '<numberOfVMetrics value="12"/>'
-)
-
-VHEA_XML_VERSION_11_AS_FLOAT = VHEA_XML_VERSION_11.replace(
+VHEA_XML_VERSION_11 = [
     '<tableVersion value="0x00011000"/>',
-    '<tableVersion value="1.0625"/>'
-)
+    '<ascent value="500"/>',
+    '<descent value="-500"/>',
+    '<lineGap value="0"/>',
+    '<advanceHeightMax value="3000"/>',
+    '<minTopSideBearing value="-1002"/>',
+    '<minBottomSideBearing value="-677"/>',
+    '<yMaxExtent value="2928"/>',
+    '<caretSlopeRise value="0"/>',
+    '<caretSlopeRun value="1"/>',
+    '<caretOffset value="0"/>',
+    '<reserved1 value="0"/>',
+    '<reserved2 value="0"/>',
+    '<reserved3 value="0"/>',
+    '<reserved4 value="0"/>',
+    '<metricDataFormat value="0"/>',
+    '<numberOfVMetrics value="12"/>',
+]
 
-VHEA_XML_VERSION_10 = VHEA_XML_VERSION_11.replace(
-    '<tableVersion value="0x00011000"/>',
-    '<tableVersion value="0x00010000"/>'
-)
+VHEA_XML_VERSION_11_AS_FLOAT = [
+    '<tableVersion value="1.0625"/>',
+] + VHEA_XML_VERSION_11[1:]
 
-VHEA_XML_VERSION_10_AS_FLOAT = VHEA_XML_VERSION_11.replace(
-    '<tableVersion value="0x00011000"/>',
-    '<tableVersion value="1.0"/>'
-)
+VHEA_XML_VERSION_10 = [
+    '<tableVersion value="0x00010000"/>',
+] + VHEA_XML_VERSION_11[1:]
+
+VHEA_XML_VERSION_10_AS_FLOAT = [
+    '<tableVersion value="1.0"/>',
+] + VHEA_XML_VERSION_11[1:]
 
 
 class VheaCompileOrToXMLTest(unittest.TestCase):

--- a/Lib/fontTools/ttLib/tables/otConverters_test.py
+++ b/Lib/fontTools/ttLib/tables/otConverters_test.py
@@ -52,7 +52,7 @@ class NameIDTest(unittest.TestCase):
         writer = makeXMLWriter()
         self.converter.xmlWrite(writer, self.makeFont(), 291,
                                 "FooNameID", [("attr", "val")])
-        xml = writer.file.getvalue().decode("utf-8")
+        xml = writer.file.getvalue().decode("utf-8").rstrip()
         self.assertEqual(
             xml,
             '<FooNameID attr="val" value="291"/>  <!-- Demibold Condensed -->')
@@ -64,7 +64,7 @@ class NameIDTest(unittest.TestCase):
                                     "Entity", [("attrib", "val")])
         self.assertIn("name id 666 missing from name table",
                       [r.msg for r in captor.records])
-        xml = writer.file.getvalue().decode("utf-8")
+        xml = writer.file.getvalue().decode("utf-8").rstrip()
         self.assertEqual(
             xml,
             '<Entity attrib="val"'


### PR DESCRIPTION
When writing unit tests for XML data, it is more convenient to compare list of lines, instead of a single string without newlines.

This helps identifying which lines in the diff printed on the console don't match the expected result.

So this makes `getXML()` returns a list of lines.

Similarly, the complementary function `parseXML()` now also accepts a list of
strings, as well as a single string, to allow reusing the same data for to/fromXML round-trip tests.

/cc @brawer @moyogo 