### PR TITLE
drop support for jython; add support for python3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 2.7
-      env: TOXENV=jython
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
       env:
         - TOXENV=py35
         - BUILD_DIST=true
+    - python: 3.6
+      env: TOXENV=py36
     - python: pypy
       env: TOXENV=pypy
     - language: generic

--- a/.travis/before_deploy.sh
+++ b/.travis/before_deploy.sh
@@ -3,8 +3,7 @@
 set -e
 set -x
 
-source ~/.venv/bin/activate
-
 if [[ $BUILD_DIST == true ]]; then
+	python -m pip install --upgrade wheel
 	python setup.py sdist bdist_wheel
 fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,6 +3,9 @@
 set -e
 set -x
 
+pip_options="--upgrade"
+ci_requirements="pip setuptools tox"
+
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     # install pyenv from the git repo (quicker than using brew)
     git clone https://github.com/yyuu/pyenv.git ~/.pyenv
@@ -16,50 +19,18 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             curl -O https://bootstrap.pypa.io/get-pip.py
             python get-pip.py --user
             ;;
-        py34)
-            pyenv install 3.4.5
-            pyenv global 3.4.5
-            ;;
         py35)
             pyenv install 3.5.2
             pyenv global 3.5.2
             ;;
-        pypy)
-            pyenv install pypy-5.4.1
-            pyenv global pypy-5.4.1
-            ;;
     esac
     pyenv rehash
-    python -m pip install --user --upgrade pip virtualenv
+
+    # add --user option so we don't require sudo
+    pip_options="$pip_options --user"
 else
-    # on Linux, we only need pyenv to get the latest pypy and jython
-    if [[ "${TOXENV}" == "pypy" || "${TOXENV}" == "jython" ]]; then
-        git clone https://github.com/yyuu/pyenv.git ~/.pyenv
-        PYENV_ROOT="$HOME/.pyenv"
-        PATH="$PYENV_ROOT/bin:$PATH"
-        eval "$(pyenv init -)"
-
-        if [[ "${TOXENV}" == "pypy" ]]; then
-            pyenv install pypy-5.4.1
-            pyenv global pypy-5.4.1
-        else
-            pyenv install jython-2.7.1b3
-            pyenv global jython-2.7.1b3
-        fi
-        pyenv rehash
-    fi
-    if [[ "${TOXENV}" == "jython" ]]; then
-        # for jython we just run pytest for now, without virtualenv nor tox.
-        # See: https://github.com/behdad/fonttools/issues/575
-        jython -m pip install pytest
-    else
-        pip install --upgrade pip virtualenv
-    fi
+    # on Linux, we're already in a virtualenv; no --user required
+    :
 fi
 
-if [[ "${TOXENV}" != "jython" ]]; then
-    # activate virtualenv and install test requirements
-    python -m virtualenv ~/.venv
-    source ~/.venv/bin/activate
-    pip install -r dev-requirements.txt
-fi
+python -m pip install $pip_options $ci_requirements

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -3,19 +3,12 @@
 set -e
 set -x
 
-if [[ "$(uname -s)" == "Darwin" || "${TOXENV}" == "pypy" || "${TOXENV}" == "jython" ]]; then
+if [[ "$(uname -s)" == "Darwin" ]]; then
     PYENV_ROOT="$HOME/.pyenv"
     PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
 fi
 
-if [[ "${TOXENV}" == "jython" ]]; then
-    # tox is not working with Jython, so here we simply call py.test ourselves.
-    # See: https://bitbucket.org/hpk42/tox/issues/326/oserror-not-a-directory-when-creating-env
-    # We also ignore any error for now, until we fix the many test failures...
-    pyenv global jython-2.7.1b3
-    jython -m pytest || true
-else
-    source ~/.venv/bin/activate
-    tox
-fi
+# tox script may not be in the $PATH if we installed as --user
+# so we run it as module
+python -m tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py27, py35
+envlist = py27, py35, py36
+skip_missing_interpreters = true
 
 [testenv]
 basepython =
@@ -7,6 +8,7 @@ basepython =
     pypy: {env:TOXPYTHON:pypy}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
+    py36: {env:TOXPYTHON:python3.6}
 deps =
     pytest
     -rrequirements.txt


### PR DESCRIPTION
jython tests have been failing since day one, but no one was interested in fixing them.
https://github.com/fonttools/fonttools/issues/575
Also I hear google has now switched to CPython so I think we can drop Jython for good.

We shall replace the slot occupied by jython with Python 3.6, released the other day.
