### PR TITLE
run coverage on all python versions; upload combined data to codecov

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,32 +2,22 @@ environment:
   matrix:
     - JOB: "2.7.12 32-bit"
       PYTHON_HOME: "C:\\Python27"
-      TOXENV: "py27"
+      TOXENV: "py27-cov"
       TOXPYTHON: "C:\\Python27\\python.exe"
-
-    - JOB: "3.4.4 32-bit"
-      PYTHON_HOME: "C:\\Python34"
-      TOXENV: "py34"
-      TOXPYTHON: "C:\\Python34\\python.exe"
 
     - JOB: "3.5.2 32-bit"
       PYTHON_HOME: "C:\\Python35"
-      TOXENV: "py35"
+      TOXENV: "py35-cov"
       TOXPYTHON: "C:\\Python35\\python.exe"
 
     - JOB: "2.7.12 64-bit"
       PYTHON_HOME: "C:\\Python27-x64"
-      TOXENV: "py27"
+      TOXENV: "py27-cov"
       TOXPYTHON: "C:\\Python27-x64\\python.exe"
-
-    - JOB: "3.4.4 64-bit"
-      PYTHON_HOME: "C:\\Python34-x64"
-      TOXENV: "py34"
-      TOXPYTHON: "C:\\Python34-x64\\python.exe"
 
     - JOB: "3.5.2 64-bit"
       PYTHON_HOME: "C:\\Python35-x64"
-      TOXENV: "py35"
+      TOXENV: "py35-cov"
       TOXPYTHON: "C:\\Python35-x64\\python.exe"
 
 install:
@@ -50,16 +40,18 @@ install:
 
   # upgrade pip and setuptools to avoid out-of-date warnings
   - "python -m pip install --disable-pip-version-check --user --upgrade pip setuptools"
-  - "python -m pip --version"
 
   # install the dependencies to run the tests
-  - "python -m pip install -r dev-requirements.txt"
+  - "python -m pip install tox"
  
 
 build: false
 
 test_script:
   - "tox"
+
+after_test:
+  - "tox -e codecov"
 
 notifications:
   - provider: Email

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+comment: false
+coverage:
+    status:
+        project: off
+        patch: off

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,9 +3,15 @@
 # See: http://coverage.readthedocs.org/en/coverage-4.0.3/branch.html#branch
 branch = True
 
-# list of directories to measure
+# list of directories or packages to measure
+source = fontTools
+
+# these are treated as equivalent when combining data
+[paths]
 source =
     Lib/fontTools
+    .tox/*/lib/python*/site-packages/fontTools
+    .tox/pypy*/site-packages/fontTools
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist
 .tox/*
 .cache/
 .coverage
+.coverage.*
 htmlcov/
 
 # emacs backup files

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       env: TOXENV=py27-cov
     - language: generic
       os: osx
-      env: TOXENV=py35-cov
+      env: TOXENV=py36-cov
 
 install:
   - ./.travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,32 +5,33 @@ language: python
 matrix:
   include:
     - python: 2.7
-      env: TOXENV=py27
+      env: TOXENV=py27-cov
     - python: 3.4
-      env: TOXENV=py34
+      env: TOXENV=py34-cov
     - python: 3.5
       env:
-        - TOXENV=py35
+        - TOXENV=py35-cov
         - BUILD_DIST=true
     - python: 3.6
-      env: TOXENV=py36
+      env: TOXENV=py36-cov
     - python: pypy
-      env: TOXENV=pypy
+      # disable coverage.py on pypy because of performance problems
+      env: TOXENV=pypy-nocov
     - language: generic
       os: osx
-      env: TOXENV=py27
+      env: TOXENV=py27-cov
     - language: generic
       os: osx
-      env: TOXENV=py35
-    # coveralls is not listed in tox's envlist, but should run in travis
-    - python: 3.5
-      env: TOXENV=coveralls
+      env: TOXENV=py35-cov
 
 install:
   - ./.travis/install.sh
 
 script:
   - ./.travis/run.sh
+
+after_success:
+  - ./.travis/after_success.sh
 
 before_deploy:
   - ./.travis/before_deploy.sh

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# upload coverage data to Codecov.io
+[[ ${TOXENV} == *"-cov"* ]] && python -m tox -e codecov

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -3,5 +3,9 @@
 set -e
 set -x
 
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    source .venv/bin/activate
+fi
+
 # upload coverage data to Codecov.io
-[[ ${TOXENV} == *"-cov"* ]] && python -m tox -e codecov
+[[ ${TOXENV} == *"-cov"* ]] && tox -e codecov

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -3,12 +3,8 @@
 set -e
 set -x
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
-    PYENV_ROOT="$HOME/.pyenv"
-    PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init -)"
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    source .venv/bin/activate
 fi
 
-# tox script may not be in the $PATH if we installed as --user
-# so we run it as module
-python -m tox
+tox

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Travis Build Status](https://travis-ci.org/fonttools/fonttools.svg)](https://travis-ci.org/fonttools/fonttools)
 [![Appveyor Build status](https://ci.appveyor.com/api/projects/status/0f7fmee9as744sl7/branch/master?svg=true)](https://ci.appveyor.com/project/fonttools/fonttools/branch/master)
 [![Health](https://landscape.io/github/behdad/fonttools/master/landscape.svg?style=flat)](https://landscape.io/github/behdad/fonttools/master)
-[![Coverage Status](https://coveralls.io/repos/github/fonttools/fonttools/badge.svg?branch=master)](https://coveralls.io/github/fonttools/fonttools?branch=master)
+[![Coverage Status](https://codecov.io/gh/fonttools/fonttools/branch/master/graph/badge.svg)](https://codecov.io/gh/fonttools/fonttools)
 [![PyPI](https://img.shields.io/pypi/v/fonttools.svg)](https://pypi.org/project/FontTools)
 
 ### What is this?

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py{27,35,36}-cov, htmlcov
-skip_missing_interpreters = true
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36
+envlist = py{27,35,36}-cov, htmlcov
 skip_missing_interpreters = true
 
 [testenv]
@@ -10,33 +10,38 @@ basepython =
     py35: {env:TOXPYTHON:python3.5}
     py36: {env:TOXPYTHON:python3.6}
 deps =
+    # we install coverage from source until 4.3 is released, because of this:
+    # https://bitbucket.org/ned/coveragepy/pull-requests/118/check-source-isdir-not-just-exists-there/diff
+    cov: hg+https://bitbucket.org/ned/coveragepy#egg=coverage
     pytest
     -rrequirements.txt
 install_command =
-    {envpython} -m pip install -v {opts} {packages}
+    pip install -v {opts} {packages}
 commands =
-    # run the test suite against the package installed inside tox env
-    py.test {posargs:--pyargs fontTools}
+    # run the test suite against the package installed inside tox env.
+    # We use parallel mode and then combine later so that coverage.py will take
+    # paths like .tox/py36/lib/python3.6/site-packages/fontTools and collapse
+    # them into Lib/fontTools.
+    cov: coverage run --parallel-mode -m pytest {posargs:--pyargs fontTools}
+    nocov: pytest {posargs:--pyargs fontTools}
 
-[testenv:coverage]
+[testenv:htmlcov]
 basepython = {env:TOXPYTHON:python3.5}
 deps =
-    {[testenv]deps}
-    pytest-cov
+    hg+https://bitbucket.org/ned/coveragepy#egg=coverage
 skip_install = true
-commands=
-    # measure test coverage and create html report
-    py.test --cov --cov-report html {posargs}
+commands =
+    coverage combine
+    coverage html
 
-[testenv:coveralls]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-basepython=python3.5
+[testenv:codecov]
+passenv = *
+basepython = {env:TOXPYTHON:python}
 deps =
-    {[testenv:coverage]deps}
-    coveralls
+    hg+https://bitbucket.org/ned/coveragepy#egg=coverage
+    codecov
 skip_install = true
 ignore_outcome = true
-commands=
-    # measure test coverage and upload report to coveralls
-    py.test --cov
-    coveralls
+commands =
+    coverage combine
+    codecov --env TOXENV


### PR DESCRIPTION
This allows checking test coverage on all the supported python versions/platforms, instead of just python3.5 on Linux as it was before.

I also replaced Coveralls.io with Codecov.io, which seems to have a better UI and, unlike Coveralls, has built-in support for Appveyor.

I still have to tweak the notification settings, but I'll make sure it doesn't become too chatty.

Also, on OSX we now use homebrew python3 instead of compiling it from source, so we save a few minutes on the expensive Travis osx builds.

Finally, I decided to remove python3.4 from Appveyor; Windows people usually update to the latest version because, unlike Linux, python it's not pre-installed on the system. We still test 3.4 on Linux (hopefully for not too long).