### PR TITLE
Lookup type fixup

### DIFF
--- a/Lib/fontTools/feaLib/testdata/GPOS_1.ttx
+++ b/Lib/fontTools/feaLib/testdata/GPOS_1.ttx
@@ -38,7 +38,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=8 -->
         <SinglePos index="0" Format="1">
@@ -163,7 +163,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/GPOS_1_zero.ttx
+++ b/Lib/fontTools/feaLib/testdata/GPOS_1_zero.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=2 -->
         <SinglePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/GPOS_2.ttx
+++ b/Lib/fontTools/feaLib/testdata/GPOS_2.ttx
@@ -39,7 +39,7 @@
     <LookupList>
       <!-- LookupCount=3 -->
       <Lookup index="0">
-        <!-- LookupType=2 -->
+        <LookupType value="2"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=2 -->
         <PairPos index="0" Format="1">
@@ -84,7 +84,7 @@
         </PairPos>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=2 -->
+        <LookupType value="2"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=2 -->
         <PairPos index="0" Format="1">
@@ -159,7 +159,7 @@
         </PairPos>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=2 -->
+        <LookupType value="2"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/GPOS_2b.ttx
+++ b/Lib/fontTools/feaLib/testdata/GPOS_2b.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=2 -->
+        <LookupType value="2"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=3 -->
         <PairPos index="0" Format="2">

--- a/Lib/fontTools/feaLib/testdata/GPOS_3.ttx
+++ b/Lib/fontTools/feaLib/testdata/GPOS_3.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=3 -->
+        <LookupType value="3"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <CursivePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/GPOS_4.ttx
+++ b/Lib/fontTools/feaLib/testdata/GPOS_4.ttx
@@ -45,7 +45,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MarkBasePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/GPOS_5.ttx
+++ b/Lib/fontTools/feaLib/testdata/GPOS_5.ttx
@@ -45,7 +45,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=5 -->
+        <LookupType value="5"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MarkLigPos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/GPOS_6.ttx
+++ b/Lib/fontTools/feaLib/testdata/GPOS_6.ttx
@@ -43,7 +43,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MarkMarkPos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/GPOS_8.ttx
+++ b/Lib/fontTools/feaLib/testdata/GPOS_8.ttx
@@ -31,7 +31,7 @@
     <LookupList>
       <!-- LookupCount=6 -->
       <Lookup index="0">
-        <!-- LookupType=8 -->
+        <LookupType value="8"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextPos index="0" Format="3">
@@ -73,7 +73,7 @@
         </ChainContextPos>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="2">
@@ -88,7 +88,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="2">
@@ -103,7 +103,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="3">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -115,7 +115,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="4">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -127,7 +127,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="5">
-        <!-- LookupType=8 -->
+        <LookupType value="8"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextPos index="0" Format="3">

--- a/Lib/fontTools/feaLib/testdata/GSUB_2.ttx
+++ b/Lib/fontTools/feaLib/testdata/GSUB_2.ttx
@@ -38,7 +38,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=2 -->
+        <LookupType value="2"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MultipleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/GSUB_3.ttx
+++ b/Lib/fontTools/feaLib/testdata/GSUB_3.ttx
@@ -38,7 +38,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=3 -->
+        <LookupType value="3"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <AlternateSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/GSUB_6.ttx
+++ b/Lib/fontTools/feaLib/testdata/GSUB_6.ttx
@@ -34,7 +34,7 @@
     <LookupList>
       <!-- LookupCount=9 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=2 -->
         <ChainContextSubst index="0" Format="3">
@@ -81,7 +81,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
@@ -92,7 +92,7 @@
         </SingleSubst>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="3">
@@ -140,7 +140,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="3">
-        <!-- LookupType=2 -->
+        <LookupType value="2"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MultipleSubst index="0">
@@ -148,7 +148,7 @@
         </MultipleSubst>
       </Lookup>
       <Lookup index="4">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="3">
@@ -171,7 +171,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="5">
-        <!-- LookupType=3 -->
+        <LookupType value="3"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <AlternateSubst index="0">
@@ -182,7 +182,7 @@
         </AlternateSubst>
       </Lookup>
       <Lookup index="6">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="3">
@@ -211,7 +211,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="7">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -226,7 +226,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="8">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="3">

--- a/Lib/fontTools/feaLib/testdata/GSUB_8.ttx
+++ b/Lib/fontTools/feaLib/testdata/GSUB_8.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=8 -->
+        <LookupType value="8"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=3 -->
         <ReverseChainSingleSubst index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/bug453.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug453.ttx
@@ -39,7 +39,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MarkBasePos index="0" Format="1">
@@ -72,7 +72,7 @@
         </MarkBasePos>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MarkBasePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/bug457.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug457.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/bug463.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug463.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=2 -->
         <ChainContextSubst index="0" Format="3">
@@ -87,7 +87,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/bug501.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug501.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/bug502.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug502.ttx
@@ -31,7 +31,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
@@ -39,7 +39,7 @@
         </SingleSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=3 -->
+        <LookupType value="3"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <AlternateSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/bug504.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug504.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/bug505.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug505.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/bug506.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug506.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="3">
@@ -51,7 +51,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/bug509.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug509.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=2 -->
         <ChainContextSubst index="0" Format="3">
@@ -59,7 +59,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/bug512.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug512.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=3 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=4 -->
         <ChainContextSubst index="0" Format="3">
@@ -87,7 +87,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
@@ -96,7 +96,7 @@
         </SingleSubst>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/bug568.ttx
+++ b/Lib/fontTools/feaLib/testdata/bug568.ttx
@@ -48,7 +48,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -60,7 +60,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/enum.ttx
+++ b/Lib/fontTools/feaLib/testdata/enum.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=2 -->
+        <LookupType value="2"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/feature_aalt.ttx
+++ b/Lib/fontTools/feaLib/testdata/feature_aalt.ttx
@@ -62,7 +62,7 @@
     <LookupList>
       <!-- LookupCount=6 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
@@ -76,7 +76,7 @@
         </SingleSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
@@ -86,7 +86,7 @@
         </SingleSubst>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -100,7 +100,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="3">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=2 -->
         <ChainContextSubst index="0" Format="3">
@@ -157,7 +157,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="4">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
@@ -168,7 +168,7 @@
         </SingleSubst>
       </Lookup>
       <Lookup index="5">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/ignore_pos.ttx
+++ b/Lib/fontTools/feaLib/testdata/ignore_pos.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=8 -->
+        <LookupType value="8"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=3 -->
         <ChainContextPos index="0" Format="3">
@@ -84,7 +84,7 @@
         </ChainContextPos>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/language_required.ttx
+++ b/Lib/fontTools/feaLib/testdata/language_required.ttx
@@ -71,7 +71,7 @@
     <LookupList>
       <!-- LookupCount=4 -->
       <Lookup index="0">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -81,7 +81,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -91,7 +91,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -101,7 +101,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="3">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/lookup.ttx
+++ b/Lib/fontTools/feaLib/testdata/lookup.ttx
@@ -54,7 +54,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -65,7 +65,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/lookupflag.ttx
+++ b/Lib/fontTools/feaLib/testdata/lookupflag.ttx
@@ -72,7 +72,7 @@
     <LookupList>
       <!-- LookupCount=12 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="1"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -84,7 +84,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="2"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -96,7 +96,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="4"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -108,7 +108,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="3">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="7"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -120,7 +120,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="4">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="8"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -132,7 +132,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="5">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="256"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -144,7 +144,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="6">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="512"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -156,7 +156,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="7">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="260"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -168,7 +168,7 @@
         </SinglePos>
       </Lookup>
       <Lookup index="8">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="16"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -181,7 +181,7 @@
         <MarkFilteringSet value="0"/>
       </Lookup>
       <Lookup index="9">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="16"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -194,7 +194,7 @@
         <MarkFilteringSet value="1"/>
       </Lookup>
       <Lookup index="10">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="20"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
@@ -207,7 +207,7 @@
         <MarkFilteringSet value="0"/>
       </Lookup>
       <Lookup index="11">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/multiple_feature_blocks.ttx
+++ b/Lib/fontTools/feaLib/testdata/multiple_feature_blocks.ttx
@@ -57,7 +57,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -67,7 +67,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec4h1.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec4h1.ttx
@@ -97,7 +97,7 @@
     <LookupList>
       <!-- LookupCount=4 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
@@ -130,7 +130,7 @@
         </SingleSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -142,7 +142,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -153,7 +153,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="3">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec4h2.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec4h2.ttx
@@ -123,7 +123,7 @@
     <LookupList>
       <!-- LookupCount=5 -->
       <Lookup index="0">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -134,7 +134,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -145,7 +145,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -155,7 +155,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="3">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -165,7 +165,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="4">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec5d1.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5d1.ttx
@@ -38,7 +38,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec5d2.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5d2.ttx
@@ -38,7 +38,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec5f_ii_1.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5f_ii_1.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=3 -->
         <ChainContextSubst index="0" Format="3">
@@ -84,7 +84,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec5f_ii_2.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5f_ii_2.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=2 -->
         <ChainContextSubst index="0" Format="3">
@@ -91,7 +91,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec5f_ii_3.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5f_ii_3.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=3 -->
         <ChainContextSubst index="0" Format="3">
@@ -140,7 +140,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec5f_ii_4.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5f_ii_4.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=4 -->
         <ChainContextSubst index="0" Format="3">
@@ -243,7 +243,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec5fi1.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5fi1.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=3 -->
       <Lookup index="0">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -43,7 +43,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
@@ -52,7 +52,7 @@
         </SingleSubst>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=2 -->
         <ChainContextSubst index="0" Format="3">

--- a/Lib/fontTools/feaLib/testdata/spec5fi2.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5fi2.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="7"/>
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="3">
@@ -53,7 +53,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="7"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec5fi3.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5fi3.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="3">
@@ -101,7 +101,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec5fi4.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5fi4.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="3">
@@ -55,7 +55,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec5h1.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec5h1.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=8 -->
+        <LookupType value="8"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ReverseChainSingleSubst index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/spec6b_ii.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec6b_ii.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=2 -->
+        <LookupType value="2"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=2 -->
         <PairPos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/spec6d2.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec6d2.ttx
@@ -45,7 +45,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MarkBasePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/spec6e.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec6e.ttx
@@ -39,7 +39,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=5 -->
+        <LookupType value="5"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MarkLigPos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/spec6f.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec6f.ttx
@@ -38,7 +38,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MarkMarkPos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/spec6h_ii.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec6h_ii.ttx
@@ -40,7 +40,7 @@
     <LookupList>
       <!-- LookupCount=3 -->
       <Lookup index="0">
-        <!-- LookupType=2 -->
+        <LookupType value="2"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
@@ -64,7 +64,7 @@
         </PairPos>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MarkBasePos index="0" Format="1">
@@ -112,7 +112,7 @@
         </MarkBasePos>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=8 -->
+        <LookupType value="8"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextPos index="0" Format="3">

--- a/Lib/fontTools/feaLib/testdata/spec6h_iii_1.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec6h_iii_1.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=8 -->
+        <LookupType value="8"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextPos index="0" Format="3">
@@ -57,7 +57,7 @@
         </ChainContextPos>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/spec6h_iii_3d.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec6h_iii_3d.ttx
@@ -30,7 +30,7 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <!-- LookupType=8 -->
+        <LookupType value="8"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextPos index="0" Format="3">
@@ -51,7 +51,7 @@
         </ChainContextPos>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">

--- a/Lib/fontTools/feaLib/testdata/spec8a.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec8a.ttx
@@ -86,7 +86,7 @@
     <LookupList>
       <!-- LookupCount=8 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
@@ -94,7 +94,7 @@
         </SingleSubst>
       </Lookup>
       <Lookup index="1">
-        <!-- LookupType=3 -->
+        <LookupType value="3"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <AlternateSubst index="0">
@@ -119,7 +119,7 @@
         </AlternateSubst>
       </Lookup>
       <Lookup index="2">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
@@ -129,7 +129,7 @@
         </SingleSubst>
       </Lookup>
       <Lookup index="3">
-        <!-- LookupType=4 -->
+        <LookupType value="4"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0">
@@ -139,7 +139,7 @@
         </LigatureSubst>
       </Lookup>
       <Lookup index="4">
-        <!-- LookupType=3 -->
+        <LookupType value="3"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <AlternateSubst index="0">
@@ -151,7 +151,7 @@
         </AlternateSubst>
       </Lookup>
       <Lookup index="5">
-        <!-- LookupType=6 -->
+        <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="3">
@@ -177,7 +177,7 @@
         </ChainContextSubst>
       </Lookup>
       <Lookup index="6">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
@@ -187,7 +187,7 @@
         </SingleSubst>
       </Lookup>
       <Lookup index="7">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/feaLib/testdata/spec8c.ttx
+++ b/Lib/fontTools/feaLib/testdata/spec8c.ttx
@@ -49,7 +49,7 @@
     <LookupList>
       <!-- LookupCount=1 -->
       <Lookup index="0">
-        <!-- LookupType=1 -->
+        <LookupType value="1"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">

--- a/Lib/fontTools/mtiLib/testdata/featurename-backward.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/featurename-backward.ttx.GSUB
@@ -48,7 +48,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=1 -->
+      <LookupType value="1"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <SingleSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/featurename-forward.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/featurename-forward.ttx.GSUB
@@ -48,7 +48,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=1 -->
+      <LookupType value="1"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <SingleSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/lookupnames-backward.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/lookupnames-backward.ttx.GSUB
@@ -36,7 +36,7 @@
   <LookupList>
     <!-- LookupCount=2 -->
     <Lookup index="0">
-      <!-- LookupType=1 -->
+      <LookupType value="1"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <SingleSubst index="0" Format="1">
@@ -45,7 +45,7 @@
       </SingleSubst>
     </Lookup>
     <Lookup index="1">
-      <!-- LookupType=6 -->
+      <LookupType value="6"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <ChainContextSubst index="0" Format="2">

--- a/Lib/fontTools/mtiLib/testdata/lookupnames-forward.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/lookupnames-forward.ttx.GSUB
@@ -36,7 +36,7 @@
   <LookupList>
     <!-- LookupCount=2 -->
     <Lookup index="0">
-      <!-- LookupType=6 -->
+      <LookupType value="6"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <ChainContextSubst index="0" Format="2">
@@ -75,7 +75,7 @@
       </ChainContextSubst>
     </Lookup>
     <Lookup index="1">
-      <!-- LookupType=1 -->
+      <LookupType value="1"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <SingleSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mixed-toplevels.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/mixed-toplevels.ttx.GSUB
@@ -36,7 +36,7 @@
   <LookupList>
     <!-- LookupCount=2 -->
     <Lookup index="0">
-      <!-- LookupType=6 -->
+      <LookupType value="6"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <ChainContextSubst index="0" Format="2">
@@ -75,7 +75,7 @@
       </ChainContextSubst>
     </Lookup>
     <Lookup index="1">
-      <!-- LookupType=1 -->
+      <LookupType value="1"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <SingleSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/chained-glyph.ttx.GPOS
+++ b/Lib/fontTools/mtiLib/testdata/mti/chained-glyph.ttx.GPOS
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=2 -->
     <Lookup index="0">
-      <!-- LookupType=8 -->
+      <LookupType value="8"/>
       <LookupFlag value="512"/>
       <!-- SubTableCount=1 -->
       <ChainContextPos index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/chained-glyph.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/mti/chained-glyph.ttx.GSUB
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=2 -->
     <Lookup index="0">
-      <!-- LookupType=6 -->
+      <LookupType value="6"/>
       <LookupFlag value="512"/>
       <!-- SubTableCount=1 -->
       <ChainContextSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/chainedclass.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/mti/chainedclass.ttx.GSUB
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=2 -->
     <Lookup index="0">
-      <!-- LookupType=6 -->
+      <LookupType value="6"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <ChainContextSubst index="0" Format="2">
@@ -43,7 +43,7 @@
       </ChainContextSubst>
     </Lookup>
     <Lookup index="1">
-      <!-- LookupType=1 -->
+      <LookupType value="1"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <SingleSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/chainedcoverage.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/mti/chainedcoverage.ttx.GSUB
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=2 -->
     <Lookup index="0">
-      <!-- LookupType=6 -->
+      <LookupType value="6"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <ChainContextSubst index="0" Format="3">
@@ -46,7 +46,7 @@
       </ChainContextSubst>
     </Lookup>
     <Lookup index="1">
-      <!-- LookupType=1 -->
+      <LookupType value="1"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <SingleSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/gposcursive.ttx.GPOS
+++ b/Lib/fontTools/mtiLib/testdata/mti/gposcursive.ttx.GPOS
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=3 -->
+      <LookupType value="3"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <CursivePos index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/gposkernset.ttx.GPOS
+++ b/Lib/fontTools/mtiLib/testdata/mti/gposkernset.ttx.GPOS
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=2 -->
+      <LookupType value="2"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=2 -->
       <PairPos index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/gposmarktobase.ttx.GPOS
+++ b/Lib/fontTools/mtiLib/testdata/mti/gposmarktobase.ttx.GPOS
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=4 -->
+      <LookupType value="4"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <MarkBasePos index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/gpospairclass.ttx.GPOS
+++ b/Lib/fontTools/mtiLib/testdata/mti/gpospairclass.ttx.GPOS
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=2 -->
+      <LookupType value="2"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <PairPos index="0" Format="2">

--- a/Lib/fontTools/mtiLib/testdata/mti/gpospairglyph.ttx.GPOS
+++ b/Lib/fontTools/mtiLib/testdata/mti/gpospairglyph.ttx.GPOS
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=2 -->
+      <LookupType value="2"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <PairPos index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/gpossingle.ttx.GPOS
+++ b/Lib/fontTools/mtiLib/testdata/mti/gpossingle.ttx.GPOS
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=1 -->
+      <LookupType value="1"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <SinglePos index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/gsubalternate.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/mti/gsubalternate.ttx.GSUB
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=3 -->
+      <LookupType value="3"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <AlternateSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/gsubligature.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/mti/gsubligature.ttx.GSUB
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=4 -->
+      <LookupType value="4"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <LigatureSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/gsubmultiple.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/mti/gsubmultiple.ttx.GSUB
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=2 -->
+      <LookupType value="2"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <MultipleSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/gsubreversechanined.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/mti/gsubreversechanined.ttx.GSUB
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=8 -->
+      <LookupType value="8"/>
       <LookupFlag value="9"/>
       <!-- SubTableCount=3 -->
       <ReverseChainSingleSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/gsubsingle.ttx.GSUB
+++ b/Lib/fontTools/mtiLib/testdata/mti/gsubsingle.ttx.GSUB
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=1 -->
+      <LookupType value="1"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <SingleSubst index="0" Format="1">

--- a/Lib/fontTools/mtiLib/testdata/mti/mark-to-ligature.ttx.GPOS
+++ b/Lib/fontTools/mtiLib/testdata/mti/mark-to-ligature.ttx.GPOS
@@ -4,7 +4,7 @@
   <LookupList>
     <!-- LookupCount=1 -->
     <Lookup index="0">
-      <!-- LookupType=5 -->
+      <LookupType value="5"/>
       <LookupFlag value="0"/>
       <!-- SubTableCount=1 -->
       <MarkLigPos index="0" Format="1">

--- a/Lib/fontTools/otlLib/builder_test.py
+++ b/Lib/fontTools/otlLib/builder_test.py
@@ -449,7 +449,7 @@ class BuilderTest(unittest.TestCase):
         lookup = builder.buildLookup([s1, s2], flags=7)
         self.assertEqual(getXML(lookup.toXML),
                          ['<Lookup>',
-                          '  <!-- LookupType=1 -->',
+                          '  <LookupType value="1"/>',
                           '  <LookupFlag value="7"/>',
                           '  <!-- SubTableCount=2 -->',
                           '  <SingleSubst index="0">',
@@ -495,7 +495,7 @@ class BuilderTest(unittest.TestCase):
         lookup = builder.buildLookup([s], flags, markFilterSet=999)
         self.assertEqual(getXML(lookup.toXML),
                          ['<Lookup>',
-                          '  <!-- LookupType=1 -->',
+                          '  <LookupType value="1"/>',
                           '  <LookupFlag value="17"/>',
                           '  <!-- SubTableCount=1 -->',
                           '  <SingleSubst index="0">',

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -36,26 +36,14 @@ class BaseTTXConverter(DefaultTable):
 
 	def decompile(self, data, font):
 		from . import otTables
-		cachingStats = None if True else {}
 		class GlobalState(object):
-			def __init__(self, tableType, cachingStats):
+			def __init__(self, tableType):
 				self.tableType = tableType
-				self.cachingStats = cachingStats
-		globalState = GlobalState(tableType=self.tableTag,
-					cachingStats=cachingStats)
+		globalState = GlobalState(tableType=self.tableTag)
 		reader = OTTableReader(data, globalState)
 		tableClass = getattr(otTables, self.tableTag)
 		self.table = tableClass()
 		self.table.decompile(reader, font)
-		if cachingStats:
-			stats = sorted([(v, k) for k, v in cachingStats.items()])
-			stats.reverse()
-			log.debug("cachingStats for %s", self.tableTag)
-			for v, k in stats:
-				if v < 2:
-					break
-				log.debug("%s %s", v, k)
-			log.debug("--- %s", len(stats))
 
 	def compile(self, font):
 		""" Create a top-level OTFWriter for the GPOS/GSUB table.

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -666,8 +666,10 @@ class BaseTable(object):
 				if conv.isPropagated:
 					writer[conv.name] = ref
 			elif conv.isLookupType:
+				# We make sure that subtables have the same lookup type,
+				# and that the type is the same as the one set on the
+				# Lookup object, if any is set.
 				ref = writer.writeCountReference(table, conv.name, conv.staticSize, table.get(conv.name))
-				table[conv.name] = None
 				writer['LookupType'] = ref
 			else:
 				if conv.aux and not eval(conv.aux, None, table):

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -36,11 +36,7 @@ class BaseTTXConverter(DefaultTable):
 
 	def decompile(self, data, font):
 		from . import otTables
-		class GlobalState(object):
-			def __init__(self, tableType):
-				self.tableType = tableType
-		globalState = GlobalState(tableType=self.tableTag)
-		reader = OTTableReader(data, globalState)
+		reader = OTTableReader(data, tableTag=self.tableTag)
 		tableClass = getattr(otTables, self.tableTag)
 		self.table = tableClass()
 		self.table.decompile(reader, font)
@@ -66,15 +62,11 @@ class BaseTTXConverter(DefaultTable):
 
 				If a lookup subtable overflows an offset, we have to start all over.
 		"""
-		class GlobalState(object):
-			def __init__(self, tableType):
-				self.tableType = tableType
-		globalState = GlobalState(tableType=self.tableTag)
 		overflowRecord = None
 
 		while True:
 			try:
-				writer = OTTableWriter(globalState)
+				writer = OTTableWriter(tableTag=self.tableTag)
 				self.table.compile(writer, font)
 				return writer.getAllData()
 
@@ -112,14 +104,14 @@ class OTTableReader(object):
 
 	"""Helper class to retrieve data from an OpenType table."""
 
-	__slots__ = ('data', 'offset', 'pos', 'globalState', 'localState')
+	__slots__ = ('data', 'offset', 'pos', 'localState', 'tableTag')
 
-	def __init__(self, data, globalState={}, localState=None, offset=0):
+	def __init__(self, data, localState=None, offset=0, tableTag=None):
 		self.data = data
 		self.offset = offset
 		self.pos = offset
-		self.globalState = globalState
 		self.localState = localState
+		self.tableTag = tableTag
 
 	def advance(self, count):
 		self.pos += count
@@ -128,13 +120,13 @@ class OTTableReader(object):
 		self.pos = pos
 
 	def copy(self):
-		other = self.__class__(self.data, self.globalState, self.localState, self.offset)
+		other = self.__class__(self.data, self.localState, self.offset, self.tableTag)
 		other.pos = self.pos
 		return other
 
 	def getSubReader(self, offset):
 		offset = self.offset + offset
-		return self.__class__(self.data, self.globalState, self.localState, offset)
+		return self.__class__(self.data, self.localState, offset, self.tableTag)
 
 	def readUShort(self):
 		pos = self.pos
@@ -225,11 +217,11 @@ class OTTableWriter(object):
 
 	"""Helper class to gather and assemble data for OpenType tables."""
 
-	def __init__(self, globalState={}, localState=None):
+	def __init__(self, localState=None, tableTag=None):
 		self.items = []
 		self.pos = None
-		self.globalState = globalState
 		self.localState = localState
+		self.tableTag = tableTag
 		self.longOffset = False
 		self.parent = None
 
@@ -412,7 +404,7 @@ class OTTableWriter(object):
 	# interface for gathering data, as used by table.compile()
 
 	def getSubWriter(self):
-		subwriter = self.__class__(self.globalState, self.localState)
+		subwriter = self.__class__(self.localState, self.tableTag)
 		subwriter.parent = self # because some subtables have idential values, we discard
 					# the duplicates under the getAllData method. Hence some
 					# subtable writers can have more than one parent writer.
@@ -497,7 +489,7 @@ class OTTableWriter(object):
 						LookupListIndex = p1.parent.repeatIndex
 						SubTableIndex = p1.repeatIndex
 
-		return OverflowErrorRecord( (self.globalState.tableType, LookupListIndex, SubTableIndex, itemName, itemIndex) )
+		return OverflowErrorRecord( (self.tableTag, LookupListIndex, SubTableIndex, itemName, itemIndex) )
 
 
 class CountReference(object):
@@ -582,10 +574,10 @@ class BaseTable(object):
 		converters = self.getConverters()
 		for conv in converters:
 			if conv.name == "SubTable":
-				conv = conv.getConverter(reader.globalState.tableType,
+				conv = conv.getConverter(reader.tableTag,
 						table["LookupType"])
 			if conv.name == "ExtSubTable":
-				conv = conv.getConverter(reader.globalState.tableType,
+				conv = conv.getConverter(reader.tableTag,
 						table["ExtensionLookupType"])
 			if conv.name == "FeatureParams":
 				conv = conv.getConverter(reader["FeatureTag"])

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -237,7 +237,7 @@ class OTTableWriter(object):
 
 	"""Helper class to gather and assemble data for OpenType tables."""
 
-	def __init__(self, globalState, localState=None):
+	def __init__(self, globalState={}, localState=None):
 		self.items = []
 		self.pos = None
 		self.globalState = globalState

--- a/Lib/fontTools/ttLib/tables/otBase_test.py
+++ b/Lib/fontTools/ttLib/tables/otBase_test.py
@@ -61,32 +61,32 @@ class OTTableReaderTest(unittest.TestCase):
 
 class OTTableWriterTest(unittest.TestCase):
     def test_writeShort(self):
-        writer = OTTableWriter(globalState={})
+        writer = OTTableWriter()
         writer.writeShort(-12345)
         self.assertEqual(writer.getData(), deHexStr("CF C7"))
 
     def test_writeLong(self):
-        writer = OTTableWriter(globalState={})
+        writer = OTTableWriter()
         writer.writeLong(-12345678)
         self.assertEqual(writer.getData(), deHexStr("FF 43 9E B2"))
 
     def test_writeUInt8(self):
-        writer = OTTableWriter(globalState={})
+        writer = OTTableWriter()
         writer.writeUInt8(0xBE)
         self.assertEqual(writer.getData(), deHexStr("BE"))
 
     def test_writeUShort(self):
-        writer = OTTableWriter(globalState={})
+        writer = OTTableWriter()
         writer.writeUShort(0xBEEF)
         self.assertEqual(writer.getData(), deHexStr("BE EF"))
 
     def test_writeUInt24(self):
-        writer = OTTableWriter(globalState={})
+        writer = OTTableWriter()
         writer.writeUInt24(0xBEEF77)
         self.assertEqual(writer.getData(), deHexStr("BE EF 77"))
 
     def test_writeULong(self):
-        writer = OTTableWriter(globalState={})
+        writer = OTTableWriter()
         writer.writeULong(0xBEEFCAFE)
         self.assertEqual(writer.getData(), deHexStr("BE EF CA FE"))
 

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -23,7 +23,7 @@ def buildConverters(tableSpec, tableNamespace):
 		if name.startswith("ValueFormat"):
 			assert tp == "uint16"
 			converterClass = ValueFormat
-		elif name.endswith("Count") or name.endswith("LookupType"):
+		elif name.endswith("Count"):
 			assert tp in ("uint16", "uint32")
 			converterClass = ComputedUShort if tp == 'uint16' else ComputedULong
 		elif name == "SubTable":

--- a/Lib/fontTools/ttLib/tables/otConverters_test.py
+++ b/Lib/fontTools/ttLib/tables/otConverters_test.py
@@ -25,7 +25,7 @@ class GlyphIDTest(unittest.TestCase):
         self.assertEqual(reader.pos, 2)
 
     def test_write(self):
-        writer = OTTableWriter(globalState={})
+        writer = OTTableWriter()
         self.converter.write(writer, self.font, {}, "B")
         self.assertEqual(writer.getData(), deHexStr("0002"))
 
@@ -44,7 +44,7 @@ class NameIDTest(unittest.TestCase):
         self.assertEqual(self.converter.read(reader, font, {}), 0x123)
 
     def test_write(self):
-        writer = OTTableWriter(globalState={})
+        writer = OTTableWriter()
         self.converter.write(writer, self.makeFont(), {}, 0x123)
         self.assertEqual(writer.getData(), deHexStr("0123"))
 


### PR DESCRIPTION
Don't ignore Lookup.LookupType
A while back I changed code such that Lookup.LookupType is written as a
comment in XML, and ignored when compiling.  The LookupType from type
of actual subtables in a lookup were used during compilation instead.
This caused the problem where an empty lookup (one with no subtables)
would lose its lookup types, among other subtle problems.

With this change we revert above behavior, but keep the benefits: if
Lookup.LookupType is different from actual lookup type of the subtables,
compilation raises an exception.  Setting LookupType on Lookup object
or in XML is optional now, but written out by default in XML (instead
of as a comment).

This changes XML output for all GSUB/GPOS tables.  I'm sorry for the
noise.  Please update your sources.

Fixes #789