### PR TITLE
[otlLib] only sort ClassDefBuilder input glyphs if they are unsorted

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -589,7 +589,10 @@ class ClassDefBuilder(object):
         self.useClass0_ = useClass0
 
     def canAdd(self, glyphs):
-        glyphs = tuple(glyphs)
+        if isinstance(glyphs, (set, frozenset)):
+            glyphs = tuple(sorted(glyphs))
+        elif not isinstance(glyphs, tuple):
+            glyphs = tuple(glyphs)
         if glyphs in self.classes_:
             return True
         for glyph in glyphs:
@@ -598,7 +601,10 @@ class ClassDefBuilder(object):
         return True
 
     def add(self, glyphs):
-        glyphs = tuple(glyphs)
+        if isinstance(glyphs, (set, frozenset)):
+            glyphs = tuple(sorted(glyphs))
+        elif not isinstance(glyphs, tuple):
+            glyphs = tuple(glyphs)
         if glyphs in self.classes_:
             return
         self.classes_.add(glyphs)


### PR DESCRIPTION
This fixes broken tests after 9e76d16, and should finally close https://github.com/fonttools/fonttools/issues/766

/cc @justvanrossum @behdad @brawer 