### PR TITLE
[feaLib] fix check for redefined glyph between multiple markClass definitions

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -319,8 +319,8 @@ class MarkClass(object):
         assert isinstance(definition, MarkClassDefinition)
         self.definitions.append(definition)
         for glyph in definition.glyphSet():
-            if glyph in self.definitions:
-                otherLoc = self.definitions[glyph].location
+            if glyph in self.glyphs:
+                otherLoc = self.glyphs[glyph].location
                 raise FeatureLibError(
                     "Glyph %s already defined at %s:%d:%d" % (
                         glyph, otherLoc[0], otherLoc[1], otherLoc[2]),

--- a/Lib/fontTools/feaLib/builder_test.py
+++ b/Lib/fontTools/feaLib/builder_test.py
@@ -448,6 +448,13 @@ class BuilderTest(unittest.TestCase):
         self.check_fea2fea_file(
             "baseClass.feax", base="baseClass.fea", parser=testParser)
 
+    def test_markClass_same_glyph_redefined(self):
+        self.assertRaisesRegex(
+            FeatureLibError,
+            "Glyph acute already defined",
+            self.build,
+            "markClass [acute] <anchor 350 0> @TOP_MARKS;"*2)
+
 
 def generate_feature_file_test(name):
     return lambda self: self.check_feature_file(name)

--- a/Lib/fontTools/feaLib/testdata/markClass.fea
+++ b/Lib/fontTools/feaLib/testdata/markClass.fea
@@ -3,7 +3,7 @@ languagesystem DFLT dflt;
 markClass [acute] <anchor 350 0> @TOP_MARKS;
 
 feature foo {
-    markClass [acute grave] <anchor 350 0> @TOP_MARKS;
+    markClass [grave] <anchor 350 0> @TOP_MARKS;
     markClass cedilla <anchor 300 0> @BOTTOM_MARKS;
 } foo;
 


### PR DESCRIPTION
In `feaLib.ast.MarkClass` we check that a glyph is not defined more than once across multiple definitions of the same markClass.

However, as @mhosken pointed out in https://github.com/fonttools/fonttools/pull/794/files/3b79d51755dda83782dcf1b180f6098d38951539#r94622074, the code is looking for the glyph name in the wrong list.

The problem is that by fixing the code, the markClass.fea test case fails, as it does indeed contain a duplicate glyph definition for "acute".

I'm not sure whether this was intentional or not, so I'll leave it to Sascha to review.