### PR TITLE
[t2CharStringPen] add "roundTolerance" option

### DIFF
--- a/Lib/fontTools/pens/t2CharStringPen.py
+++ b/Lib/fontTools/pens/t2CharStringPen.py
@@ -68,16 +68,16 @@ class RelativeCoordinatePen(BasePen):
 
 
 def makeRoundFuncs(tolerance):
-    assert 0 <= tolerance <= 1
+    assert 0 <= tolerance <= 0.5
 
     def _round(number):
         if tolerance == 0:
             return number  # no-op
         rounded = round(number)
-        # return rounded integer if the tolerance is >= 0.5, or if the
-        # absolute difference between the original float and the rounded
-        # integer is within the tolerance
-        if tolerance >= .5 or fabs(rounded - number) <= tolerance:
+        # return rounded integer if the tolerance is 0.5, or if the absolute
+        # difference between the original float and the rounded integer is
+        # within the tolerance
+        if tolerance == .5 or fabs(rounded - number) <= tolerance:
             return rounded
         else:
             # else return the value un-rounded
@@ -92,7 +92,7 @@ def makeRoundFuncs(tolerance):
 
 class T2CharStringPen(RelativeCoordinatePen):
 
-    def __init__(self, width, glyphSet, roundTolerance=0.0):
+    def __init__(self, width, glyphSet, roundTolerance=0.5):
         RelativeCoordinatePen.__init__(self, glyphSet)
         self.round, self.roundPoint = makeRoundFuncs(roundTolerance)
         self._heldMove = None

--- a/Lib/fontTools/pens/t2CharStringPen.py
+++ b/Lib/fontTools/pens/t2CharStringPen.py
@@ -7,7 +7,6 @@ from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools.misc.psCharStrings import T2CharString
 from fontTools.pens.basePen import BasePen
-from math import fabs
 
 
 class RelativeCoordinatePen(BasePen):
@@ -77,7 +76,7 @@ def makeRoundFunc(tolerance):
         # return rounded integer if the tolerance is 0.5, or if the absolute
         # difference between the original float and the rounded integer is
         # within the tolerance
-        if tolerance == .5 or fabs(rounded - number) <= tolerance:
+        if tolerance == .5 or abs(rounded - number) <= tolerance:
             return rounded
         else:
             # else return the value un-rounded

--- a/Lib/fontTools/pens/t2CharStringPen.py
+++ b/Lib/fontTools/pens/t2CharStringPen.py
@@ -67,17 +67,17 @@ class RelativeCoordinatePen(BasePen):
 
 
 def makeRoundFunc(tolerance):
-    if not (0 <= tolerance <= 0.5):
-        raise ValueError("Rounding tolerance out of range: %g" % tolerance)
+    if tolerance < 0:
+        raise ValueError("Rounding tolerance must be positive")
 
     def _round(number):
         if tolerance == 0:
             return number  # no-op
         rounded = round(number)
-        # return rounded integer if the tolerance is 0.5, or if the absolute
+        # return rounded integer if the tolerance >= 0.5, or if the absolute
         # difference between the original float and the rounded integer is
         # within the tolerance
-        if tolerance == .5 or abs(rounded - number) <= tolerance:
+        if tolerance >= .5 or abs(rounded - number) <= tolerance:
             return rounded
         else:
             # else return the value un-rounded

--- a/Lib/fontTools/pens/t2CharStringPen.py
+++ b/Lib/fontTools/pens/t2CharStringPen.py
@@ -67,7 +67,8 @@ class RelativeCoordinatePen(BasePen):
 
 
 def makeRoundFunc(tolerance):
-    assert 0 <= tolerance <= 0.5
+    if not (0 <= tolerance <= 0.5):
+        raise ValueError("Rounding tolerance out of range: %g" % tolerance)
 
     def _round(number):
         if tolerance == 0:

--- a/Lib/fontTools/pens/t2CharStringPen.py
+++ b/Lib/fontTools/pens/t2CharStringPen.py
@@ -67,7 +67,7 @@ class RelativeCoordinatePen(BasePen):
         raise NotImplementedError
 
 
-def makeRoundFuncs(tolerance):
+def makeRoundFunc(tolerance):
     assert 0 <= tolerance <= 0.5
 
     def _round(number):
@@ -83,22 +83,22 @@ def makeRoundFuncs(tolerance):
             # else return the value un-rounded
             return number
 
-    def _roundPoint(point):
+    def roundPoint(point):
         x, y = point
         return _round(x), _round(y)
 
-    return _round, _roundPoint
+    return roundPoint
 
 
 class T2CharStringPen(RelativeCoordinatePen):
 
     def __init__(self, width, glyphSet, roundTolerance=0.5):
         RelativeCoordinatePen.__init__(self, glyphSet)
-        self.round, self.roundPoint = makeRoundFuncs(roundTolerance)
+        self.roundPoint = makeRoundFunc(roundTolerance)
         self._heldMove = None
         self._program = []
         if width is not None:
-            self._program.append(self.round(width))
+            self._program.append(round(width))
 
     def _moveTo(self, pt):
         RelativeCoordinatePen._moveTo(self, self.roundPoint(pt))

--- a/Lib/fontTools/pens/t2CharStringPen_test.py
+++ b/Lib/fontTools/pens/t2CharStringPen_test.py
@@ -63,7 +63,7 @@ class T2CharStringPenTest(unittest.TestCase):
         charstring = pen.getCharString(None, None)
 
         self.assertAlmostEqualProgram(
-            [100.1,
+            [100,  # we always round the advance width
              0, 0, 'rmoveto',
              10.1, 0.1, 9.8, 9.8, 0.59, 10.59, 'rrcurveto',
              0, 10, -10.59, 9.41, -9.8, 0.2, 'rrcurveto',

--- a/Lib/fontTools/pens/t2CharStringPen_test.py
+++ b/Lib/fontTools/pens/t2CharStringPen_test.py
@@ -114,11 +114,10 @@ class T2CharStringPenTest(unittest.TestCase):
             charstring.program)
 
     def test_invalid_tolerance(self):
-        for value in (-0.1, 0.6):
-            self.assertRaisesRegex(
-                ValueError,
-                "Rounding tolerance out of range",
-                T2CharStringPen, None, {}, roundTolerance=value)
+        self.assertRaisesRegex(
+            ValueError,
+            "Rounding tolerance must be positive",
+            T2CharStringPen, None, {}, roundTolerance=-0.1)
 
 
 if __name__ == '__main__':

--- a/Lib/fontTools/pens/t2CharStringPen_test.py
+++ b/Lib/fontTools/pens/t2CharStringPen_test.py
@@ -55,7 +55,6 @@ class T2CharStringPenTest(unittest.TestCase):
         self.assertEqual(['endchar'], charstring.program)
 
     def test_no_round(self):
-        # no rounding is the default
         pen = T2CharStringPen(100.1, {}, roundTolerance=0.0)
         pen.moveTo((0, 0))
         pen.curveTo((10.1, 0.1), (19.9, 9.9), (20.49, 20.49))
@@ -72,8 +71,7 @@ class T2CharStringPenTest(unittest.TestCase):
             charstring.program)
 
     def test_round_all(self):
-        # 1.0 rounds everything
-        pen = T2CharStringPen(100.1, {}, roundTolerance=1.0)
+        pen = T2CharStringPen(100.1, {}, roundTolerance=0.5)
         pen.moveTo((0, 0))
         pen.curveTo((10.1, 0.1), (19.9, 9.9), (20.49, 20.49))
         pen.curveTo((20.49, 30.49), (9.9, 39.9), (0.1, 40.1))

--- a/Lib/fontTools/pens/t2CharStringPen_test.py
+++ b/Lib/fontTools/pens/t2CharStringPen_test.py
@@ -1,0 +1,114 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from fontTools.pens.t2CharStringPen import T2CharStringPen
+import unittest
+
+
+class T2CharStringPenTest(unittest.TestCase):
+
+    def assertAlmostEqualProgram(self, expected, actual):
+        self.assertEqual(len(expected), len(actual))
+        for i1, i2 in zip(expected, actual):
+            if isinstance(i1, basestring):
+                self.assertIsInstance(i2, basestring)
+                self.assertEqual(i1, i2)
+            else:
+                self.assertAlmostEqual(i1, i2)
+
+    def test_draw_lines(self):
+        pen = T2CharStringPen(100, {})
+        pen.moveTo((0, 0))
+        pen.lineTo((10, 0))
+        pen.lineTo((10, 10))
+        pen.lineTo((0, 10))
+        pen.closePath()  # no-op
+        charstring = pen.getCharString(None, None)
+
+        self.assertEqual(
+            [100,
+             0, 0, 'rmoveto',
+             10, 0, 'rlineto',
+             0, 10, 'rlineto',
+             -10, 0, 'rlineto',
+             'endchar'],
+            charstring.program)
+
+    def test_draw_curves(self):
+        pen = T2CharStringPen(100, {})
+        pen.moveTo((0, 0))
+        pen.curveTo((10, 0), (20, 10), (20, 20))
+        pen.curveTo((20, 30), (10, 40), (0, 40))
+        pen.endPath()  # no-op
+        charstring = pen.getCharString(None, None)
+
+        self.assertEqual(
+            [100,
+             0, 0, 'rmoveto',
+             10, 0, 10, 10, 0, 10, 'rrcurveto',
+             0, 10, -10, 10, -10, 0, 'rrcurveto',
+             'endchar'],
+            charstring.program)
+
+    def test_default_width(self):
+        pen = T2CharStringPen(None, {})
+        charstring = pen.getCharString(None, None)
+        self.assertEqual(['endchar'], charstring.program)
+
+    def test_no_round(self):
+        # no rounding is the default
+        pen = T2CharStringPen(100.1, {}, roundTolerance=0.0)
+        pen.moveTo((0, 0))
+        pen.curveTo((10.1, 0.1), (19.9, 9.9), (20.49, 20.49))
+        pen.curveTo((20.49, 30.49), (9.9, 39.9), (0.1, 40.1))
+        pen.closePath()
+        charstring = pen.getCharString(None, None)
+
+        self.assertAlmostEqualProgram(
+            [100.1,
+             0, 0, 'rmoveto',
+             10.1, 0.1, 9.8, 9.8, 0.59, 10.59, 'rrcurveto',
+             0, 10, -10.59, 9.41, -9.8, 0.2, 'rrcurveto',
+             'endchar'],
+            charstring.program)
+
+    def test_round_all(self):
+        # 1.0 rounds everything
+        pen = T2CharStringPen(100.1, {}, roundTolerance=1.0)
+        pen.moveTo((0, 0))
+        pen.curveTo((10.1, 0.1), (19.9, 9.9), (20.49, 20.49))
+        pen.curveTo((20.49, 30.49), (9.9, 39.9), (0.1, 40.1))
+        pen.closePath()
+        charstring = pen.getCharString(None, None)
+
+        self.assertEqual(
+            [100,
+             0, 0, 'rmoveto',
+             10, 0, 10, 10, 0, 10, 'rrcurveto',
+             0, 10, -10, 10, -10, 0, 'rrcurveto',
+             'endchar'],
+            charstring.program)
+
+    def test_round_some(self):
+        pen = T2CharStringPen(100, {}, roundTolerance=0.2)
+        pen.moveTo((0, 0))
+        # the following two are rounded as within the tolerance
+        pen.lineTo((10.1, 0.1))
+        pen.lineTo((19.9, 9.9))
+        # this one is not rounded as it exceeds the tolerance
+        pen.lineTo((20.49, 20.49))
+        pen.closePath()
+        charstring = pen.getCharString(None, None)
+
+        self.assertAlmostEqualProgram(
+            [100,
+             0, 0, 'rmoveto',
+             10, 0, 'rlineto',
+             10, 10, 'rlineto',
+             0.49, 10.49, 'rlineto',
+             'endchar'],
+            charstring.program)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(unittest.main())

--- a/Lib/fontTools/pens/t2CharStringPen_test.py
+++ b/Lib/fontTools/pens/t2CharStringPen_test.py
@@ -6,6 +6,13 @@ import unittest
 
 class T2CharStringPenTest(unittest.TestCase):
 
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+        # Python 3 renamed assertRaisesRegexp to assertRaisesRegex,
+        # and fires deprecation warnings if a program uses the old name.
+        if not hasattr(self, "assertRaisesRegex"):
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
     def assertAlmostEqualProgram(self, expected, actual):
         self.assertEqual(len(expected), len(actual))
         for i1, i2 in zip(expected, actual):
@@ -105,6 +112,13 @@ class T2CharStringPenTest(unittest.TestCase):
              0.49, 10.49, 'rlineto',
              'endchar'],
             charstring.program)
+
+    def test_invalid_tolerance(self):
+        for value in (-0.1, 0.6):
+            self.assertRaisesRegex(
+                ValueError,
+                "Rounding tolerance out of range",
+                T2CharStringPen, None, {}, roundTolerance=value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I went for the easy route, and simply added a `roundTolerance` argument to the `T2CharStringPen` as @behdad was discussing in #769.

I personally think that doing more clever things would be a bit beyond the scope of fontTools.
But I'm happy to be convinced otherwise ;)

PTAL, thanks