### PR TITLE
[varLib.merger] set initializer for reduce() to handle empty sequences

### DIFF
--- a/Lib/fontTools/varLib/interpolate_layout.py
+++ b/Lib/fontTools/varLib/interpolate_layout.py
@@ -6,7 +6,6 @@ from fontTools.misc.py23 import *
 from fontTools.ttLib import TTFont
 from fontTools.varLib import designspace, models
 from fontTools.varLib.merger import InstancerMerger
-from functools import reduce
 import os.path
 
 

--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -7,6 +7,8 @@ from fontTools.ttLib.tables import otTables as ot
 from fontTools.ttLib.tables import otBase as otBase
 from fontTools.ttLib.tables.DefaultTable import DefaultTable
 from fontTools.varLib import builder
+from functools import reduce
+
 
 class Merger(object):
 
@@ -197,7 +199,7 @@ def _Lookup_PairPos_get_effective_value_pair(self, firstGlyph, secondGlyph):
 
 @AligningMerger.merger(ot.SinglePos)
 def merge(merger, self, lst):
-	self.ValueFormat = valueFormat = reduce(int.__or__, [l.ValueFormat for l in lst])
+	self.ValueFormat = valueFormat = reduce(int.__or__, [l.ValueFormat for l in lst], 0)
 	assert valueFormat & ~0xF == 0, valueFormat
 
 	# If all have same coverage table and all are format 1,
@@ -360,8 +362,8 @@ def _Lookup_PairPosFormat1_subtables_merge_overlay(lst, font):
 	self = ot.PairPos()
 	self.Format = 1
 	self.Coverage = ot.Coverage()
-	self.ValueFormat1 = reduce(int.__or__, [l.ValueFormat1 for l in lst])
-	self.ValueFormat2 = reduce(int.__or__, [l.ValueFormat2 for l in lst])
+	self.ValueFormat1 = reduce(int.__or__, [l.ValueFormat1 for l in lst], 0)
+	self.ValueFormat2 = reduce(int.__or__, [l.ValueFormat2 for l in lst], 0)
 
 	# Align them
 	glyphs, padded = _merge_GlyphOrders(font,


### PR DESCRIPTION
When reduce() receives an empty sequence, it raises TypeError, unless it is also given a third 'initializer' argument

ValueFormat values should default to 0, so we shall use that as initializer.

Also, the reduce() built-in is no longer available on Python 3.
It's still accessible for both py2 and py3 from functools.

Should fix https://github.com/googlei18n/fontmake/issues/241