### PR TITLE
Support glyph names with dashes

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -75,7 +75,7 @@ class Builder(object):
         self.vhea_ = {}
 
     def build(self):
-        self.parseTree = Parser(self.file).parse()
+        self.parseTree = Parser(self.file, self.glyphMap).parse()
         self.parseTree.build(self)
         self.build_feature_aalt_()
         self.build_head()

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -26,7 +26,7 @@ class Lexer(object):
     CHAR_HEXDIGIT_ = "0123456789ABCDEFabcdef"
     CHAR_LETTER_ = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
     CHAR_NAME_START_ = CHAR_LETTER_ + "_+*:.^~!\\"
-    CHAR_NAME_CONTINUATION_ = CHAR_LETTER_ + CHAR_DIGIT_ + "_.+*:^~!/"
+    CHAR_NAME_CONTINUATION_ = CHAR_LETTER_ + CHAR_DIGIT_ + "_.+*:^~!/-"
 
     RE_GLYPHCLASS = re.compile(r"^[A-Za-z_0-9.]+$")
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,6 @@
+- [feaLib] Glyph names can have dashes, as per new AFDKO syntax v1.20 (#559).
+- [feaLib] feaLib.Parser now needs the font's glyph map for parsing.
+
 3.6.3 (released 2017-02-06)
 ---------------------------
 

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -134,8 +134,9 @@ class BuilderTest(unittest.TestCase):
                 font[tag].compile(font)
 
     def check_fea2fea_file(self, name, base=None, parser=Parser):
+        font = makeTTFont()
         fname = (name + ".fea") if '.' not in name else name
-        p = parser(self.getpath(fname))
+        p = parser(self.getpath(fname), glyphMap=font.getReverseGlyphMap())
         doc = p.parse()
         actual = self.normal_fea(doc.asFea().split("\n"))
 

--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -29,6 +29,7 @@ class LexerTest(unittest.TestCase):
         self.assertEqual(lex("_"), [(Lexer.NAME, "_")])
         self.assertEqual(lex("\\table"), [(Lexer.NAME, "\\table")])
         self.assertEqual(lex("a+*:^~!"), [(Lexer.NAME, "a+*:^~!")])
+        self.assertEqual(lex("with-dash"), [(Lexer.NAME, "with-dash")])
 
     def test_cid(self):
         self.assertEqual(lex("\\0 \\987"), [(Lexer.CID, 0), (Lexer.CID, 987)])
@@ -72,6 +73,8 @@ class LexerTest(unittest.TestCase):
 
     def test_symbol(self):
         self.assertEqual(lex("a'"), [(Lexer.NAME, "a"), (Lexer.SYMBOL, "'")])
+        self.assertEqual(lex("-A-B"),
+                         [(Lexer.SYMBOL, "-"), (Lexer.NAME, "A-B")])
         self.assertEqual(
             lex("foo - -2"),
             [(Lexer.NAME, "foo"), (Lexer.SYMBOL, "-"), (Lexer.NUMBER, -2)])


### PR DESCRIPTION
The OpenType Feature File Syntax has been changed to support dashes:
https://github.com/adobe-type-tools/afdko/issues/152

Resolves https://github.com/fonttools/fonttools/issues/559.
Needed for https://github.com/googlei18n/fontmake/issues/249.