### PR TITLE
Change no GSUB assert to warning.

### DIFF
--- a/Lib/fontTools/merge.py
+++ b/Lib/fontTools/merge.py
@@ -505,7 +505,9 @@ def merge(self, m, tables):
 	assert len(tables) == len(m.duplicateGlyphsPerFont)
 	for i,(table,dups) in enumerate(zip(tables, m.duplicateGlyphsPerFont)):
 		if not dups: continue
-		assert (table is not None and table is not NotImplemented), "Have duplicates to resolve for font %d but no GSUB" % (i + 1)
+		if table is None or table is NotImplemented:
+			log.warn("Have duplicates %s to resolve for font %d but no GSUB" % (dups, (i + 1)))
+			continue
 		lookupMap = {id(v):v for v in table.table.LookupList.Lookup}
 		featureMap = {id(v):v for v in table.table.FeatureList.FeatureRecord}
 		synthFeature = None
@@ -923,7 +925,6 @@ __all__ = [
 @timer("make one with everything (TOTAL TIME)")
 def main(args=None):
 	from fontTools import configLogger
-
 	if args is None:
 		args = sys.argv[1:]
 


### PR DESCRIPTION
In most cases the dups are space, comma, period or other non language related simple symbols. It should be reasonable to degrade the assert to a warning and print the duplicated glyph names.