### PR TITLE
[feaLib] Make nameid parsing more robust

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,4 +1,7 @@
 - [feaLib] include statements now resolve relative paths like makeotf (#838)
+- [feaLib] `table name` now handles Unicode codepoints beyond the Basic
+  Multilingual Plane, also supports old-style MacOS platform encodings (#842)
+- [feaLib] correctly escape string literals when emitting feature syntax (#780)
 
 3.7.0 (released 2017-02-11)
 ---------------------------

--- a/Tests/feaLib/data/spec8b.fea
+++ b/Tests/feaLib/data/spec8b.fea
@@ -4,5 +4,9 @@ feature size {
 # 139 - range end (inclusive, decipoints)
    sizemenuname "Win MinionPro Size Name";
    sizemenuname 1 "Mac MinionPro Size Name";
-   sizemenuname 1 21 0 "Mac MinionPro Size Name";
+   # The specification says: sizemenuname 1 21 0 "Mac MinionPro Size Name";
+   # which means Macintosh platform, MacOS Thai encoding, English language.
+   # Since fonttools currently does not support the MacOS Thai encoding,
+   # we use instead MacOS Roman encoding (0), Swedish language (5) for our test.
+   sizemenuname 1 0 5 "Mac MinionPro Size Name";
 } size;

--- a/Tests/feaLib/data/spec8b.ttx
+++ b/Tests/feaLib/data/spec8b.ttx
@@ -8,7 +8,7 @@
     <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Mac MinionPro Size Name
     </namerecord>
-    <namerecord nameID="256" platformID="1" platEncID="21" langID="0x0" unicode="True">
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x5" unicode="True">
       Mac MinionPro Size Name
     </namerecord>
   </name>

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -928,12 +928,10 @@ class ParserTest(unittest.TestCase):
         self.assertEquals(name.asFea(), r'nameid 9 "Quotation \0022Mark\0022";')
 
     def test_nameid_windows_utf16_surroates(self):
-        pass
-        # TODO: https://github.com/fonttools/fonttools/issues/842
-        # doc = self.parse(r'table name { nameid 9 "Carrot \D83E\DD55"; } name;')
-        # name = doc.statements[0].statements[0]
-        # self.assertEquals(name.string, r"Carrot 🥕")
-        # self.assertEquals(name.asFea(), r'nameid 9 "Carrot \d83e\dd55";')
+        doc = self.parse(r'table name { nameid 9 "Carrot \D83E\DD55"; } name;')
+        name = doc.statements[0].statements[0]
+        self.assertEquals(name.string, r"Carrot 🥕")
+        self.assertEquals(name.asFea(), r'nameid 9 "Carrot \d83e\dd55";')
 
     def test_nameid_mac_roman(self):
         doc = self.parse(
@@ -956,9 +954,8 @@ class ParserTest(unittest.TestCase):
         self.assertEquals(name.platformID, 1)
         self.assertEquals(name.platEncID, 0)
         self.assertEquals(name.langID, 18)
-        # TODO: https://github.com/fonttools/fonttools/issues/842
-        # self.assertEquals(name.string, "Jovica Veljović")
-        # self.assertEquals(name.asFea(), r'nameid 9 1 0 18 "Jovica Veljovi\e6";')
+        self.assertEquals(name.string, "Jovica Veljović")
+        self.assertEquals(name.asFea(), r'nameid 9 1 0 18 "Jovica Veljovi\e6";')
 
     def test_nameid_unsupported_platform(self):
         self.assertRaisesRegex(


### PR DESCRIPTION
We now correctly handle nameid statements with surrogate pairs and
old-style macOS-encoded names (provided that fonttools supports the
specified encoding).

Resolves https://github.com/fonttools/fonttools/issues/842.