### PR TITLE
[feaLib] Compile zero values to different formats based on context

### DIFF
--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -66,6 +66,7 @@ class BuilderTest(unittest.TestCase):
         bug512 bug568
         name size size2 multiple_feature_blocks omitted_GlyphClassDef
         ZeroValue_SinglePos
+        ZeroValue_PairPos_horizontal ZeroValue_PairPos_vertical
     """.split()
 
     def __init__(self, methodName):

--- a/Tests/feaLib/data/ZeroValue_PairPos_horizontal.fea
+++ b/Tests/feaLib/data/ZeroValue_PairPos_horizontal.fea
@@ -1,0 +1,9 @@
+# For PairPos statements in horizontal compilation contexts,
+# zero values should get compiled to ValueRecord format 4.
+# https://github.com/fonttools/fonttools/issues/633
+feature kern {
+  pos A 0 A 0;
+  pos A 0 B <0 0 0 0>;
+  pos B <0 0 0 0> A 0;
+  pos B <0 0 0 0> B <0 0 0 0>;
+} kern;

--- a/Tests/feaLib/data/ZeroValue_PairPos_horizontal.ttx
+++ b/Tests/feaLib/data/ZeroValue_PairPos_horizontal.ttx
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="true" ttLibVersion="3.0">
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage>
+            <Glyph value="A"/>
+            <Glyph value="B"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="4"/>
+          <!-- PairSetCount=2 -->
+          <PairSet index="0">
+            <!-- PairValueCount=2 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="A"/>
+              <Value1 XAdvance="0"/>
+              <Value2 XAdvance="0"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="B"/>
+              <Value1 XAdvance="0"/>
+              <Value2 XAdvance="0"/>
+            </PairValueRecord>
+          </PairSet>
+          <PairSet index="1">
+            <!-- PairValueCount=2 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="A"/>
+              <Value1 XAdvance="0"/>
+              <Value2 XAdvance="0"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="B"/>
+              <Value1 XAdvance="0"/>
+              <Value2 XAdvance="0"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/feaLib/data/ZeroValue_PairPos_vertical.fea
+++ b/Tests/feaLib/data/ZeroValue_PairPos_vertical.fea
@@ -1,0 +1,9 @@
+# For PairPos statements in vertical compilation contexts,
+# zero values should get compiled to ValueRecord format 8.
+# https://github.com/fonttools/fonttools/issues/633
+feature vkrn {
+  pos A 0 A 0;
+  pos A 0 B <0 0 0 0>;
+  pos B <0 0 0 0> A 0;
+  pos B <0 0 0 0> B <0 0 0 0>;
+} vkrn;

--- a/Tests/feaLib/data/ZeroValue_PairPos_vertical.ttx
+++ b/Tests/feaLib/data/ZeroValue_PairPos_vertical.ttx
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="true" ttLibVersion="3.0">
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="vkrn"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage>
+            <Glyph value="A"/>
+            <Glyph value="B"/>
+          </Coverage>
+          <ValueFormat1 value="8"/>
+          <ValueFormat2 value="8"/>
+          <!-- PairSetCount=2 -->
+          <PairSet index="0">
+            <!-- PairValueCount=2 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="A"/>
+              <Value1 YAdvance="0"/>
+              <Value2 YAdvance="0"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="B"/>
+              <Value1 YAdvance="0"/>
+              <Value2 YAdvance="0"/>
+            </PairValueRecord>
+          </PairSet>
+          <PairSet index="1">
+            <!-- PairValueCount=2 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="A"/>
+              <Value1 YAdvance="0"/>
+              <Value2 YAdvance="0"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="B"/>
+              <Value1 YAdvance="0"/>
+              <Value2 YAdvance="0"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>


### PR DESCRIPTION
If a zero value appears in a SinglePos statement, feaLib continues to
produce ValueRecords of format 0. But if a zero value appears in a
PairPos statement inside a horizontal compilation context, feaLib now
produces ValueRecords of format 4. Likewise, if a zero value appears
in a PairPos statement inside a vertical compilation context, feaLib
now produces ValueRecords of format 8.

The OpenType Feature Syntax specification is completely silent about this,
but the new behavior matches that of makeotf.

https://github.com/fonttools/fonttools/issues/633