### PR TITLE
explicitly require 'head' table in TTFont.save()

### DIFF
--- a/Lib/fontTools/ttLib/__init__.py
+++ b/Lib/fontTools/ttLib/__init__.py
@@ -203,8 +203,11 @@ class TTFont(object):
 			# assume "file" is a writable file object
 			closeStream = False
 
-		if self.recalcTimestamp and 'head' in self:
-			self['head']  # make sure 'head' is loaded so the recalculation is actually done
+		if 'head' not in self:
+			raise TTLibError("missing required table: head")
+		elif self.recalcTimestamp and not self.isLoaded('head'):
+			# make sure 'head' is loaded so the recalculation is actually done
+			self['head']
 
 		tags = list(self.keys())
 		if "GlyphOrder" in tags:

--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -274,7 +274,10 @@ def ttCompile(input, output, options):
 	if not options.recalcTimestamp:
 		# use TTX file modification time for head "modified" timestamp
 		mtime = os.path.getmtime(input)
-		ttf['head'].modified = timestampSinceEpoch(mtime)
+		try:
+			ttf['head'].modified = timestampSinceEpoch(mtime)
+		except KeyError:
+			raise TTLibError("missing required table: head")
 
 	ttf.save(output)
 


### PR DESCRIPTION
it's implicitly required anyway, e.g. see ttx's `ttCompile`, maxp's `recalc`, OS/2 `compile`, etc.

/cc @justvanrossum 