### PR TITLE
varLib. Use designspace <axes> element to define the axisMap and order.

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -29,6 +29,7 @@ from fontTools.ttLib.tables._g_v_a_r import TupleVariation
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.varLib import builder, designspace, models
 from fontTools.varLib.merger import VariationMerger
+import collections
 import warnings
 import os.path
 import logging
@@ -59,7 +60,9 @@ def _add_fvar(font, axes, instances, axis_map):
 	font['fvar'] = fvar = newTable('fvar')
 	nameTable = font['name']
 
-	for iden in sorted(axes.keys(), key=lambda k: axis_map[k][0]):
+	for iden in axis_map.keys():
+		if not axes.has_key(iden):
+			continue
 		axis = Axis()
 		axis.axisTag = Tag(axis_map[iden][0])
 		axis.minValue, axis.defaultValue, axis.maxValue = axes[iden]
@@ -265,7 +268,7 @@ def build(designspace_filename, master_finder=lambda s:s, axisMap=None):
 	(axis-tag, axis-name).
 	"""
 
-	masters, instances = designspace.load(designspace_filename)
+	masters, instances, axisMapDS = designspace.load(designspace_filename)
 	base_idx = None
 	for i,m in enumerate(masters):
 		if 'info' in m and m['info']['copy']:
@@ -281,18 +284,14 @@ def build(designspace_filename, master_finder=lambda s:s, axisMap=None):
 	master_ttfs = [master_finder(os.path.join(basedir, m['filename'])) for m in masters]
 	master_fonts = [TTFont(ttf_path) for ttf_path in master_ttfs]
 
-	standard_axis_map = {
-		'weight':  ('wght', 'Weight'),
-		'width':   ('wdth', 'Width'),
-		'slant':   ('slnt', 'Slant'),
-		'optical': ('opsz', 'Optical Size'),
-		'custom':  ('xxxx', 'Custom'),
-	}
-
-	axis_map = standard_axis_map
 	if axisMap:
-		axis_map = axis_map.copy()
+		axis_map = designspace.standard_axis_map.copy()
 		axis_map.update(axisMap)
+	elif axisMapDS:
+		axis_map = axisMapDS
+	else:
+		axis_map = designspace.standard_axis_map
+	
 
 	# TODO: For weight & width, use OS/2 values and setup 'avar' mapping.
 

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -61,7 +61,7 @@ def _add_fvar(font, axes, instances, axis_map):
 	nameTable = font['name']
 
 	for iden in axis_map.keys():
-		if not axes.has_key(iden):
+		if not iden in axes:
 			continue
 		axis = Axis()
 		axis.axisTag = Tag(axis_map[iden][0])

--- a/Lib/fontTools/varLib/interpolate_layout.py
+++ b/Lib/fontTools/varLib/interpolate_layout.py
@@ -12,7 +12,7 @@ import os.path
 
 def interpolate_layout(designspace_filename, loc, finder):
 
-	masters, instances = designspace.load(designspace_filename)
+	masters, instances, axisMap = designspace.load(designspace_filename)
 	base_idx = None
 	for i,m in enumerate(masters):
 		if 'info' in m and m['info']['copy']:


### PR DESCRIPTION
Here is a method to use the designspace <axes> element  to define the axis map, and preserve the axis order. If the <axes> element does not exist, still uses the standard_map, but with the order preserved.