### PR TITLE
TupleVariation: round deltas before encoding

### DIFF
--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -366,7 +366,7 @@ class TupleVariation(object):
 		assert runLength >= 1 and runLength <= 64
 		stream.write(bytechr(runLength - 1))
 		for i in range(offset, pos):
-			stream.write(struct.pack('b', deltas[i]))
+			stream.write(struct.pack('b', round(deltas[i])))
 		return pos
 
 	@staticmethod
@@ -400,7 +400,7 @@ class TupleVariation(object):
 		assert runLength >= 1 and runLength <= 64
 		stream.write(bytechr(DELTAS_ARE_WORDS | (runLength - 1)))
 		for i in range(offset, pos):
-			stream.write(struct.pack('>h', deltas[i]))
+			stream.write(struct.pack('>h', round(deltas[i])))
 		return pos
 
 	@staticmethod

--- a/Tests/ttLib/tables/TupleVariation_test.py
+++ b/Tests/ttLib/tables/TupleVariation_test.py
@@ -512,6 +512,11 @@ class TupleVariationTest(unittest.TestCase):
 		# words, zeroes
 		self.assertEqual("40 66 66 80", compileDeltaValues([0x6666, 0]))
 		self.assertEqual("40 66 66 81", compileDeltaValues([0x6666, 0, 0]))
+		# bytes or words from floats
+		self.assertEqual("00 01", compileDeltaValues([1.1]))
+		self.assertEqual("00 02", compileDeltaValues([1.9]))
+		self.assertEqual("40 66 66", compileDeltaValues([0x6666 + 0.1]))
+		self.assertEqual("40 66 66", compileDeltaValues([0x6665 + 0.9]))
 
 	def test_decompileDeltas(self):
 		decompileDeltas = TupleVariation.decompileDeltas_


### PR DESCRIPTION
Python 3 was raising 'struct.error: required argument is not an integer' and Python 2 was truncating when deltas are floats