### PR TITLE
Ignore duplicates in MarkGlyphSetsDef and MarkAttachClassDef

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -672,6 +672,7 @@ class Builder(object):
             self.required_features_[key] = self.cur_feature_name_
 
     def getMarkAttachClass_(self, location, glyphs):
+        glyphs = frozenset(glyphs)
         id = self.markAttachClassID_.get(glyphs)
         if id is not None:
             return id
@@ -689,6 +690,7 @@ class Builder(object):
         return id
 
     def getMarkFilterSet_(self, location, glyphs):
+        glyphs = frozenset(glyphs)
         id = self.markFilterSets_.get(glyphs)
         if id is not None:
             return id

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -440,9 +440,10 @@ class Builder(object):
         return result
 
     def buildGDEFMarkGlyphSetsDef_(self):
-        sets = [None] * len(self.markFilterSets_)
-        for glyphs, id in self.markFilterSets_.items():
-            sets[id] = glyphs
+        sets = []
+        for glyphs, id in sorted(self.markFilterSets_.items(),
+                                 key=lambda item: item[1]):
+            sets.append(glyphs)
         return otl.buildMarkGlyphSetsDef(sets, self.glyphMap)
 
     def buildLookups_(self, tag):

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -441,7 +441,7 @@ class Builder(object):
 
     def buildGDEFMarkGlyphSetsDef_(self):
         sets = []
-        for glyphs, id in sorted(self.markFilterSets_.items(),
+        for glyphs, id_ in sorted(self.markFilterSets_.items(),
                                  key=lambda item: item[1]):
             sets.append(glyphs)
         return otl.buildMarkGlyphSetsDef(sets, self.glyphMap)
@@ -674,11 +674,11 @@ class Builder(object):
 
     def getMarkAttachClass_(self, location, glyphs):
         glyphs = frozenset(glyphs)
-        id = self.markAttachClassID_.get(glyphs)
-        if id is not None:
-            return id
-        id = len(self.markAttachClassID_) + 1
-        self.markAttachClassID_[glyphs] = id
+        id_ = self.markAttachClassID_.get(glyphs)
+        if id_ is not None:
+            return id_
+        id_ = len(self.markAttachClassID_) + 1
+        self.markAttachClassID_[glyphs] = id_
         for glyph in glyphs:
             if glyph in self.markAttach_:
                 _, loc = self.markAttach_[glyph]
@@ -687,17 +687,17 @@ class Builder(object):
                     "a MarkAttachmentType at %s:%d:%d" % (
                         glyph, loc[0], loc[1], loc[2]),
                     location)
-            self.markAttach_[glyph] = (id, location)
-        return id
+            self.markAttach_[glyph] = (id_, location)
+        return id_
 
     def getMarkFilterSet_(self, location, glyphs):
         glyphs = frozenset(glyphs)
-        id = self.markFilterSets_.get(glyphs)
-        if id is not None:
-            return id
-        id = len(self.markFilterSets_)
-        self.markFilterSets_[glyphs] = id
-        return id
+        id_ = self.markFilterSets_.get(glyphs)
+        if id_ is not None:
+            return id_
+        id_ = len(self.markFilterSets_)
+        self.markFilterSets_[glyphs] = id_
+        return id_
 
     def set_lookup_flag(self, location, value, markAttach, markFilter):
         value = value & 0xFF

--- a/Tests/feaLib/data/lookupflag.fea
+++ b/Tests/feaLib/data/lookupflag.fea
@@ -3,6 +3,7 @@ languagesystem DFLT dflt;
 @TOP_MARKS = [acute grave macron];
 markClass [cedilla ogonek] <anchor 350 -20> @BOTTOM_MARKS;
 @FRENCH_MARKS = [acute grave cedilla dieresis circumflex];
+@MARKS_WITH_DUPLICATES = [breve caron umlaut breve caron umlaut];
 
 lookup A {
     lookupflag RightToLeft;
@@ -68,6 +69,16 @@ lookup L {
     pos L 1;
 } L;
 
+lookup M {
+    lookupflag UseMarkFilteringSet @MARKS_WITH_DUPLICATES;
+    pos M 1;
+} M;
+
+lookup N {
+    lookupflag MarkAttachmentType @MARKS_WITH_DUPLICATES;
+    pos N 1;
+} N;
+
 feature test {
     lookup A;
     lookup B;
@@ -81,4 +92,6 @@ feature test {
     lookup J;
     lookup K;
     lookup L;
+    lookup M;
+    lookup N;
 } test;

--- a/Tests/feaLib/data/lookupflag.ttx
+++ b/Tests/feaLib/data/lookupflag.ttx
@@ -9,14 +9,17 @@
     </GlyphClassDef>
     <MarkAttachClassDef>
       <ClassDef glyph="acute" class="1"/>
+      <ClassDef glyph="breve" class="3"/>
+      <ClassDef glyph="caron" class="3"/>
       <ClassDef glyph="cedilla" class="2"/>
       <ClassDef glyph="grave" class="1"/>
       <ClassDef glyph="macron" class="1"/>
       <ClassDef glyph="ogonek" class="2"/>
+      <ClassDef glyph="umlaut" class="3"/>
     </MarkAttachClassDef>
     <MarkGlyphSetsDef>
       <MarkSetTableFormat value="1"/>
-      <!-- MarkSetCount=2 -->
+      <!-- MarkSetCount=3 -->
       <Coverage index="0">
         <Glyph value="grave"/>
         <Glyph value="acute"/>
@@ -28,6 +31,11 @@
         <Glyph value="dieresis"/>
         <Glyph value="circumflex"/>
         <Glyph value="cedilla"/>
+      </Coverage>
+      <Coverage index="2">
+        <Glyph value="breve"/>
+        <Glyph value="umlaut"/>
+        <Glyph value="caron"/>
       </Coverage>
     </MarkGlyphSetsDef>
   </GDEF>
@@ -53,7 +61,7 @@
       <FeatureRecord index="0">
         <FeatureTag value="test"/>
         <Feature>
-          <!-- LookupCount=12 -->
+          <!-- LookupCount=14 -->
           <LookupListIndex index="0" value="0"/>
           <LookupListIndex index="1" value="1"/>
           <LookupListIndex index="2" value="2"/>
@@ -66,11 +74,13 @@
           <LookupListIndex index="9" value="9"/>
           <LookupListIndex index="10" value="10"/>
           <LookupListIndex index="11" value="11"/>
+          <LookupListIndex index="12" value="12"/>
+          <LookupListIndex index="13" value="13"/>
         </Feature>
       </FeatureRecord>
     </FeatureList>
     <LookupList>
-      <!-- LookupCount=12 -->
+      <!-- LookupCount=14 -->
       <Lookup index="0">
         <LookupType value="1"/>
         <LookupFlag value="1"/>
@@ -213,6 +223,31 @@
         <SinglePos index="0" Format="1">
           <Coverage>
             <Glyph value="L"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="1"/>
+        </SinglePos>
+      </Lookup>
+      <Lookup index="12">
+        <LookupType value="1"/>
+        <LookupFlag value="16"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="M"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="1"/>
+        </SinglePos>
+        <MarkFilteringSet value="2"/>
+      </Lookup>
+      <Lookup index="13">
+        <LookupType value="1"/>
+        <LookupFlag value="768"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="N"/>
           </Coverage>
           <ValueFormat value="4"/>
           <Value XAdvance="1"/>


### PR DESCRIPTION
ufo2ft markFeatureWriter adds `UseMarkFilteringSet` statements in `mkmk` lookups (googlei18n/ufo2ft#57). Sometimes the glyph classes used to define these can contain duplicate glyphs.

Since feaLib parser by default treats glyph classes in feature file as tuples of string (with an inner order and possibly duplicates), the generated `Coverage` in `MarkGlyphSetsDef` (in `GDEF`) end up with unnecessary duplicate glyphs.

See https://github.com/googlei18n/glyphsLib/issues/89

This patch changes the feaLib builder so that it casts tuples to frozensets when collecting glyph classes that defines MarkGlyphSetsDef, as well as MarkAttachClassDef.

I checked makeotf, and this also does the same.

/cc @brawer @behdad 

