### PR TITLE
[tests] Change `hhea` and `vhea` table version from float to hex to mute fontTools warnings

### DIFF
--- a/Tests/subset/data/TestCID-Regular.ttx
+++ b/Tests/subset/data/TestCID-Regular.ttx
@@ -31,7 +31,7 @@
   </head>
 
   <hhea>
-    <tableVersion value="1.0"/>
+    <tableVersion value="0x00010000"/>
     <ascent value="1000"/>
     <descent value="-320"/>
     <lineGap value="0"/>
@@ -360,7 +360,7 @@
   </hmtx>
 
   <vhea>
-    <tableVersion value="1.0625"/>
+    <tableVersion value="0x00011000"/>
     <ascent value="500"/>
     <descent value="-500"/>
     <lineGap value="0"/>

--- a/Tests/subset/data/TestCLR-Regular.ttx
+++ b/Tests/subset/data/TestCLR-Regular.ttx
@@ -37,7 +37,7 @@
   </head>
 
   <hhea>
-    <tableVersion value="1.0"/>
+    <tableVersion value="0x00010000"/>
     <ascent value="800"/>
     <descent value="0"/>
     <lineGap value="90"/>
@@ -685,7 +685,7 @@
       TestCLR
     </namerecord>
     <namerecord nameID="5" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Version 001.000 
+      Version 001.000
     </namerecord>
     <namerecord nameID="6" platformID="1" platEncID="0" langID="0x0" unicode="True">
       TestCLR-Regular
@@ -706,7 +706,7 @@
       TestCLR
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
-      Version 001.000 
+      Version 001.000
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
       TestCLR-Regular

--- a/Tests/subset/data/TestGVAR.ttx
+++ b/Tests/subset/data/TestGVAR.ttx
@@ -33,7 +33,7 @@
   </head>
 
   <hhea>
-    <tableVersion value="1.0"/>
+    <tableVersion value="0x00010000"/>
     <ascent value="1000"/>
     <descent value="-200"/>
     <lineGap value="0"/>

--- a/Tests/subset/data/TestMATH-Regular.ttx
+++ b/Tests/subset/data/TestMATH-Regular.ttx
@@ -319,7 +319,7 @@
   </head>
 
   <hhea>
-    <tableVersion value="1.0"/>
+    <tableVersion value="0x00010000"/>
     <ascent value="750"/>
     <descent value="-250"/>
     <lineGap value="0"/>

--- a/Tests/subset/data/TestOTF-Regular.ttx
+++ b/Tests/subset/data/TestOTF-Regular.ttx
@@ -31,7 +31,7 @@
   </head>
 
   <hhea>
-    <tableVersion value="1.0"/>
+    <tableVersion value="0x00010000"/>
     <ascent value="660"/>
     <descent value="-340"/>
     <lineGap value="200"/>

--- a/Tests/subset/data/TestTTF-Regular.ttx
+++ b/Tests/subset/data/TestTTF-Regular.ttx
@@ -31,7 +31,7 @@
   </head>
 
   <hhea>
-    <tableVersion value="1.0"/>
+    <tableVersion value="0x00010000"/>
     <ascent value="660"/>
     <descent value="-340"/>
     <lineGap value="200"/>

--- a/Tests/subset/data/google_color.ttx
+++ b/Tests/subset/data/google_color.ttx
@@ -30,7 +30,7 @@
   </head>
 
   <hhea>
-    <tableVersion value="1.0"/>
+    <tableVersion value="0x00010000"/>
     <ascent value="1536"/>
     <descent value="-512"/>
     <lineGap value="256"/>

--- a/Tests/ttLib/data/TestTTF-Regular.ttx
+++ b/Tests/ttLib/data/TestTTF-Regular.ttx
@@ -33,7 +33,7 @@
   </head>
 
   <hhea>
-    <tableVersion value="1.0"/>
+    <tableVersion value="0x00010000"/>
     <ascent value="900"/>
     <descent value="-300"/>
     <lineGap value="0"/>


### PR DESCRIPTION
Some housekeeping as I just noticed these warnings.