### PR TITLE
Add support for comments to parser

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -69,6 +69,18 @@ class Expression(object):
         pass
 
 
+class Comment(object):
+    def __init__(self, location, text):
+        self.location = location
+        self.text = text
+
+    def build(self, builder):
+        pass
+
+    def asFea(self, indent=""):
+        return self.text
+
+
 class GlyphName(Expression):
     """A single glyph name, such as cedilla."""
     def __init__(self, location, glyph):

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -5,6 +5,7 @@ from fontTools.feaLib.error import FeatureLibError
 import re
 import os
 
+
 class Lexer(object):
     NUMBER = "NUMBER"
     FLOAT = "FLOAT"

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -5,7 +5,6 @@ from fontTools.feaLib.error import FeatureLibError
 import re
 import os
 
-
 class Lexer(object):
     NUMBER = "NUMBER"
     FLOAT = "FLOAT"
@@ -33,6 +32,9 @@ class Lexer(object):
     MODE_NORMAL_ = "NORMAL"
     MODE_FILENAME_ = "FILENAME"
 
+    _OMITS = {NEWLINE}
+    _OMITC = {NEWLINE, COMMENT}
+
     def __init__(self, text, filename):
         self.filename_ = filename
         self.line_ = 1
@@ -45,13 +47,13 @@ class Lexer(object):
     def __iter__(self):
         return self
 
-    def next(self):  # Python 2
-        return self.__next__()
+    def next(self, comments = False):  # Python 2
+        return self.__next__(comments)
 
-    def __next__(self):  # Python 3
+    def __next__(self, comments = False):  # Python 3
         while True:
             token_type, token, location = self.next_()
-            if token_type not in {Lexer.COMMENT, Lexer.NEWLINE}:
+            if token_type not in (Lexer._OMITS if comments else Lexer._OMITC):
                 return (token_type, token, location)
 
     def location_(self):
@@ -193,14 +195,14 @@ class IncludingLexer(object):
     def __iter__(self):
         return self
 
-    def next(self):  # Python 2
-        return self.__next__()
+    def next(self, comments = False):  # Python 2
+        return self.__next__(comments)
 
-    def __next__(self):  # Python 3
+    def __next__(self, comments = False):  # Python 3
         while self.lexers_:
             lexer = self.lexers_[-1]
             try:
-                token_type, token, location = lexer.next()
+                token_type, token, location = lexer.next(comments)
             except StopIteration:
                 self.lexers_.pop()
                 continue

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -32,8 +32,8 @@ class Lexer(object):
     MODE_NORMAL_ = "NORMAL"
     MODE_FILENAME_ = "FILENAME"
 
-    _OMITS = {NEWLINE}
-    _OMITC = {NEWLINE, COMMENT}
+    _OMITMINIMUM = {NEWLINE}
+    _OMITCOMMENTS = {NEWLINE, COMMENT}
 
     def __init__(self, text, filename):
         self.filename_ = filename
@@ -47,13 +47,13 @@ class Lexer(object):
     def __iter__(self):
         return self
 
-    def next(self, comments = False):  # Python 2
+    def next(self, comments=False):  # Python 2
         return self.__next__(comments)
 
-    def __next__(self, comments = False):  # Python 3
+    def __next__(self, comments=False):  # Python 3
         while True:
             token_type, token, location = self.next_()
-            if token_type not in (Lexer._OMITS if comments else Lexer._OMITC):
+            if token_type not in (Lexer._OMITMINIMUM if comments else Lexer._OMITCOMMENTS):
                 return (token_type, token, location)
 
     def location_(self):
@@ -195,10 +195,10 @@ class IncludingLexer(object):
     def __iter__(self):
         return self
 
-    def next(self, comments = False):  # Python 2
+    def next(self, comments=False):  # Python 2
         return self.__next__(comments)
 
-    def __next__(self, comments = False):  # Python 3
+    def __next__(self, comments=False):  # Python 3
         while self.lexers_:
             lexer = self.lexers_[-1]
             try:

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -32,9 +32,6 @@ class Lexer(object):
     MODE_NORMAL_ = "NORMAL"
     MODE_FILENAME_ = "FILENAME"
 
-    _OMITMINIMUM = {NEWLINE}
-    _OMITCOMMENTS = {NEWLINE, COMMENT}
-
     def __init__(self, text, filename):
         self.filename_ = filename
         self.line_ = 1
@@ -47,13 +44,13 @@ class Lexer(object):
     def __iter__(self):
         return self
 
-    def next(self, comments=False):  # Python 2
-        return self.__next__(comments)
+    def next(self):  # Python 2
+        return self.__next__()
 
-    def __next__(self, comments=False):  # Python 3
+    def __next__(self):  # Python 3
         while True:
             token_type, token, location = self.next_()
-            if token_type not in (Lexer._OMITMINIMUM if comments else Lexer._OMITCOMMENTS):
+            if token_type != Lexer.NEWLINE:
                 return (token_type, token, location)
 
     def location_(self):
@@ -195,14 +192,14 @@ class IncludingLexer(object):
     def __iter__(self):
         return self
 
-    def next(self, comments=False):  # Python 2
-        return self.__next__(comments)
+    def next(self):  # Python 2
+        return self.__next__()
 
-    def __next__(self, comments=False):  # Python 3
+    def __next__(self):  # Python 3
         while self.lexers_:
             lexer = self.lexers_[-1]
             try:
-                token_type, token, location = lexer.next(comments)
+                token_type, token, location = lexer.next()
             except StopIteration:
                 self.lexers_.pop()
                 continue

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -200,7 +200,7 @@ class IncludingLexer(object):
         while self.lexers_:
             lexer = self.lexers_[-1]
             try:
-                token_type, token, location = lexer.next()
+                token_type, token, location = next(lexer)
             except StopIteration:
                 self.lexers_.pop()
                 continue

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -10,7 +10,6 @@ import os
 import re
 
 
-
 log = logging.getLogger(__name__)
 
 
@@ -18,7 +17,7 @@ class Parser(object):
 
     extensions = {}
     ast = ast
-    ignore_comments=True
+    ignore_comments = True
 
     def __init__(self, featurefile, glyphMap):
         self.glyphMap_ = glyphMap

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1364,21 +1364,22 @@ class Parser(object):
         raise FeatureLibError("Expected a string", self.cur_token_location_)
 
     def advance_lexer_(self, comments = False):
-        if not self.ignore_comments and comments and len(self.cur_comments_) :
+        if not self.ignore_comments and comments and len(self.cur_comments_):
             self.cur_token_type_ = Lexer.COMMENT
             self.cur_token_, self.cur_token_location_ = self.cur_comments_.pop(0)
             return
-        else :
+        else 
             self.cur_token_type_, self.cur_token_, self.cur_token_location_ = (
                 self.next_token_type_, self.next_token_, self.next_token_location_)
             self.cur_comments_ = []
-        while True :
+        while True:
             try:
                 (self.next_token_type_, self.next_token_,
                  self.next_token_location_) = self.lexer_.next(comments = True)
             except StopIteration:
                 self.next_token_type_, self.next_token_ = (None, None)
-            if self.next_token_type_ != Lexer.COMMENT : break
+            if self.next_token_type_ != Lexer.COMMENT:
+                break
             self.cur_comments_.append((self.next_token_, self.next_token_location_))
 
     @staticmethod

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1375,7 +1375,7 @@ class Parser(object):
         while True:
             try:
                 (self.next_token_type_, self.next_token_,
-                 self.next_token_location_) = self.lexer_.next()
+                 self.next_token_location_) = next(self.lexer_)
             except StopIteration:
                 self.next_token_type_, self.next_token_ = (None, None)
             if self.next_token_type_ != Lexer.COMMENT:

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1368,7 +1368,7 @@ class Parser(object):
             self.cur_token_type_ = Lexer.COMMENT
             self.cur_token_, self.cur_token_location_ = self.cur_comments_.pop(0)
             return
-        else 
+        else:
             self.cur_token_type_, self.cur_token_, self.cur_token_location_ = (
                 self.next_token_type_, self.next_token_, self.next_token_location_)
             self.cur_comments_ = []

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1376,7 +1376,7 @@ class Parser(object):
         while True:
             try:
                 (self.next_token_type_, self.next_token_,
-                 self.next_token_location_) = self.lexer_.next(comments=True)
+                 self.next_token_location_) = self.lexer_.next()
             except StopIteration:
                 self.next_token_type_, self.next_token_ = (None, None)
             if self.next_token_type_ != Lexer.COMMENT:

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -10,6 +10,7 @@ import os
 import re
 
 
+
 log = logging.getLogger(__name__)
 
 
@@ -17,7 +18,7 @@ class Parser(object):
 
     extensions = {}
     ast = ast
-    ignore_comments = True
+    ignore_comments=True
 
     def __init__(self, featurefile, glyphMap):
         self.glyphMap_ = glyphMap
@@ -33,12 +34,12 @@ class Parser(object):
         self.cur_comments_ = []
         self.next_token_location_ = None
         self.lexer_ = IncludingLexer(featurefile)
-        self.advance_lexer_(comments = True)
+        self.advance_lexer_(comments=True)
 
     def parse(self):
         statements = self.doc_.statements
         while self.next_token_type_ is not None:
-            self.advance_lexer_(comments = True)
+            self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(self.ast.Comment(self.cur_token_location_, self.cur_token_))
             elif self.cur_token_type_ is Lexer.GLYPHCLASS:
@@ -792,7 +793,7 @@ class Parser(object):
     def parse_table_GDEF_(self, table):
         statements = table.statements
         while self.next_token_ != "}" or (not self.ignore_comments and len(self.cur_comments_)):
-            self.advance_lexer_(comments = True)
+            self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(self.ast.Comment(self.cur_token_location_, self.cur_token_))
             elif self.is_cur_keyword_("Attach"):
@@ -812,7 +813,7 @@ class Parser(object):
     def parse_table_head_(self, table):
         statements = table.statements
         while self.next_token_ != "}" or (not self.ignore_comments and len(self.cur_comments_)):
-            self.advance_lexer_(comments = True)
+            self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(self.ast.Comment(self.cur_token_location_, self.cur_token_))
             elif self.is_cur_keyword_("FontRevision"):
@@ -825,7 +826,7 @@ class Parser(object):
         statements = table.statements
         fields = ("CaretOffset", "Ascender", "Descender", "LineGap")
         while self.next_token_ != "}" or (not self.ignore_comments and len(self.cur_comments_)):
-            self.advance_lexer_(comments = True)
+            self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(self.ast.Comment(self.cur_token_location_, self.cur_token_))
             elif self.cur_token_type_ is Lexer.NAME and self.cur_token_ in fields:
@@ -846,7 +847,7 @@ class Parser(object):
         statements = table.statements
         fields = ("VertTypoAscender", "VertTypoDescender", "VertTypoLineGap")
         while self.next_token_ != "}" or (not self.ignore_comments and len(self.cur_comments_)):
-            self.advance_lexer_(comments = True)
+            self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(self.ast.Comment(self.cur_token_location_, self.cur_token_))
             elif self.cur_token_type_ is Lexer.NAME and self.cur_token_ in fields:
@@ -866,7 +867,7 @@ class Parser(object):
     def parse_table_name_(self, table):
         statements = table.statements
         while self.next_token_ != "}" or (not self.ignore_comments and len(self.cur_comments_)):
-            self.advance_lexer_(comments = True)
+            self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(self.ast.Comment(self.cur_token_location_, self.cur_token_))
             elif self.is_cur_keyword_("nameid"):
@@ -949,7 +950,7 @@ class Parser(object):
     def parse_table_BASE_(self, table):
         statements = table.statements
         while self.next_token_ != "}" or (not self.ignore_comments and len(self.cur_comments_)):
-            self.advance_lexer_(comments = True)
+            self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(self.ast.Comment(self.cur_token_location_, self.cur_token_))
             elif self.is_cur_keyword_("HorizAxis.BaseTagList"):
@@ -976,7 +977,7 @@ class Parser(object):
                    "WeightClass", "WidthClass", "LowerOpSize", "UpperOpSize")
         ranges = ("UnicodeRange", "CodePageRange")
         while self.next_token_ != "}" or (not self.ignore_comments and len(self.cur_comments_)):
-            self.advance_lexer_(comments = True)
+            self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(self.ast.Comment(self.cur_token_location_, self.cur_token_))
             elif self.cur_token_type_ is Lexer.NAME:
@@ -1187,7 +1188,7 @@ class Parser(object):
 
         statements = block.statements
         while self.next_token_ != "}" or (not self.ignore_comments and len(self.cur_comments_)):
-            self.advance_lexer_(comments = True)
+            self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(self.ast.Comment(self.cur_token_location_, self.cur_token_))
             elif self.cur_token_type_ is Lexer.GLYPHCLASS:
@@ -1375,7 +1376,7 @@ class Parser(object):
         while True:
             try:
                 (self.next_token_type_, self.next_token_,
-                 self.next_token_location_) = self.lexer_.next(comments = True)
+                 self.next_token_location_) = self.lexer_.next(comments=True)
             except StopIteration:
                 self.next_token_type_, self.next_token_ = (None, None)
             if self.next_token_type_ != Lexer.COMMENT:

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -138,6 +138,8 @@ class BuilderTest(unittest.TestCase):
     def check_fea2fea_file(self, name, base=None, parser=Parser):
         font = makeTTFont()
         fname = (name + ".fea") if '.' not in name else name
+        temp = parser.ignore_comments
+        parser.ignore_comments = False
         p = parser(self.getpath(fname), glyphMap=font.getReverseGlyphMap())
         doc = p.parse()
         actual = self.normal_fea(doc.asFea().split("\n"))
@@ -154,6 +156,7 @@ class BuilderTest(unittest.TestCase):
                 sys.stderr.write(line+"\n")
             self.fail("Fea2Fea output is different from expected. "
                       "Generated:\n{}\n".format("\n".join(actual)))
+        parser.ignore_comments = temp
 
     def normal_fea(self, lines):
         output = []

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -140,23 +140,25 @@ class BuilderTest(unittest.TestCase):
         fname = (name + ".fea") if '.' not in name else name
         temp = parser.ignore_comments
         parser.ignore_comments = False
-        p = parser(self.getpath(fname), glyphMap=font.getReverseGlyphMap())
-        doc = p.parse()
-        actual = self.normal_fea(doc.asFea().split("\n"))
+        try:
+            p = parser(self.getpath(fname), glyphMap=font.getReverseGlyphMap())
+            doc = p.parse()
+            actual = self.normal_fea(doc.asFea().split("\n"))
 
-        with open(self.getpath(base or fname), "r", encoding="utf-8") as ofile:
-            expected = self.normal_fea(ofile.readlines())
+            with open(self.getpath(base or fname), "r", encoding="utf-8") as ofile:
+                expected = self.normal_fea(ofile.readlines())
 
-        if expected != actual:
-            fname = name.rsplit(".", 1)[0] + ".fea"
-            for line in difflib.unified_diff(
-                    expected, actual,
-                    fromfile=fname + " (expected)",
-                    tofile=fname + " (actual)"):
-                sys.stderr.write(line+"\n")
-            self.fail("Fea2Fea output is different from expected. "
-                      "Generated:\n{}\n".format("\n".join(actual)))
-        parser.ignore_comments = temp
+            if expected != actual:
+                fname = name.rsplit(".", 1)[0] + ".fea"
+                for line in difflib.unified_diff(
+                        expected, actual,
+                        fromfile=fname + " (expected)",
+                        tofile=fname + " (actual)"):
+                    sys.stderr.write(line+"\n")
+                self.fail("Fea2Fea output is different from expected. "
+                          "Generated:\n{}\n".format("\n".join(actual)))
+        finally:
+            parser.ignore_comments = temp
 
     def normal_fea(self, lines):
         output = []

--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -9,6 +9,16 @@ import unittest
 def lex(s):
     return [(typ, tok) for (typ, tok, _) in Lexer(s, "test.fea")]
 
+def lex_with_comments(s):
+    l = Lexer(s, "test.fea")
+    res = []
+    while True:
+        try:
+            (typ, tok, _) = l.next(comments=True)
+            res.append((typ, tok))
+        except StopIteration :
+            break
+    return res
 
 class LexerTest(unittest.TestCase):
     def __init__(self, methodName):
@@ -82,6 +92,10 @@ class LexerTest(unittest.TestCase):
     def test_comment(self):
         self.assertEqual(lex("# Comment\n#"), [])
 
+    def test_comment_kept(self):
+        self.assertEqual(lex_with_comments("# Comment\n#"),
+                         [(Lexer.COMMENT, "# Comment"), (Lexer.COMMENT, "#")])
+            
     def test_string(self):
         self.assertEqual(lex('"foo" "bar"'),
                          [(Lexer.STRING, "foo"), (Lexer.STRING, "bar")])

--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -9,17 +9,6 @@ import unittest
 def lex(s):
     return [(typ, tok) for (typ, tok, _) in Lexer(s, "test.fea")]
 
-def lex_with_comments(s):
-    l = Lexer(s, "test.fea")
-    res = []
-    while True:
-        try:
-            (typ, tok, _) = l.next(comments=True)
-            res.append((typ, tok))
-        except StopIteration :
-            break
-    return res
-
 class LexerTest(unittest.TestCase):
     def __init__(self, methodName):
         unittest.TestCase.__init__(self, methodName)
@@ -65,6 +54,7 @@ class LexerTest(unittest.TestCase):
         ])
         self.assertEqual(lex("include # Comment\n    (foo) \n;"), [
             (Lexer.NAME, "include"),
+            (Lexer.COMMENT, "# Comment"),
             (Lexer.FILENAME, "foo"),
             (Lexer.SYMBOL, ";")
         ])
@@ -89,11 +79,11 @@ class LexerTest(unittest.TestCase):
             lex("foo - -2"),
             [(Lexer.NAME, "foo"), (Lexer.SYMBOL, "-"), (Lexer.NUMBER, -2)])
 
-    def test_comment(self):
-        self.assertEqual(lex("# Comment\n#"), [])
+    #def test_comment(self):
+    #    self.assertEqual(lex("# Comment\n#"), [])
 
     def test_comment_kept(self):
-        self.assertEqual(lex_with_comments("# Comment\n#"),
+        self.assertEqual(lex("# Comment\n#"),
                          [(Lexer.COMMENT, "# Comment"), (Lexer.COMMENT, "#")])
             
     def test_string(self):
@@ -126,7 +116,7 @@ class LexerTest(unittest.TestCase):
         def locs(s):
             return ["%s:%d:%d" % loc for (_, _, loc) in Lexer(s, "test.fea")]
         self.assertEqual(locs("a b # Comment\n12 @x"), [
-            "test.fea:1:1", "test.fea:1:3", "test.fea:2:1",
+            "test.fea:1:1", "test.fea:1:3", "test.fea:1:5", "test.fea:2:1",
             "test.fea:2:4"
         ])
 

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -55,6 +55,20 @@ class ParserTest(unittest.TestCase):
         if not hasattr(self, "assertRaisesRegex"):
             self.assertRaisesRegex = self.assertRaisesRegexp
 
+    def test_comments(self):
+        doc = self.parse(
+            """ # Initial
+                feature test {
+                    sub A by B; # simple
+                } test;""", comments=True)
+        c1 = doc.statements[0]
+        c2 = doc.statements[1].statements[1]
+        self.assertEqual(type(c1), ast.Comment)
+        self.assertEqual(c1.text, "# Initial")
+        self.assertEqual(type(c2), ast.Comment)
+        self.assertEqual(c2.text, "# simple")
+        self.assertEqual(doc.statements[1].name, "test")
+
     def test_anchor_format_a(self):
         doc = self.parse(
             "feature test {"
@@ -1424,9 +1438,12 @@ class ParserTest(unittest.TestCase):
         doc = self.parse(";;;")
         self.assertFalse(doc.statements)
 
-    def parse(self, text, glyphMap=GLYPHMAP):
+    def parse(self, text, glyphMap=GLYPHMAP, comments=False):
         featurefile = UnicodeIO(text)
-        return Parser(featurefile, glyphMap).parse()
+        p = Parser(featurefile, glyphMap)
+        if comments :
+            p.ignore_comments = False
+        return p.parse()
 
     @staticmethod
     def getpath(testfile):


### PR DESCRIPTION
This addresses issue #829. All comments end up on a line of their own and there are plenty of places where comments are still not allowed. But I hope this does support all the sensible places where people might put comments. The only ones of interest that may get missed are:

- Inside classes
- Within a rule
- Within lists of values for some tables

I.e. comments are only supported between statements.