### PR TITLE
Clean pull request for #840 (Change Merge Error for GSUB to Warning)

### DIFF
--- a/Lib/fontTools/merge.py
+++ b/Lib/fontTools/merge.py
@@ -566,6 +566,7 @@ def merge(self, m, tables):
 def mapLookups(self, lookupMap):
 	pass
 
+
 def getGlyphNameAndFontIndex(gid):
 	"""Gets glyph name and font index from the composite glyph id.
 
@@ -603,8 +604,8 @@ def isGlyphSame(fonts, gid_0, gid_1):
 	# Checks outline
 	pen_0 = RecordingPen()
 	pen_1 = RecordingPen()
-	gid_0, index_0 = getGlyphNameAndFontIndex(gid_0)
-	gid_1, index_1 = getGlyphNameAndFontIndex(gid_1)
+	index_0 = getGlyphNameAndFontIndex(gid_0)[1]
+	index_1 = getGlyphNameAndFontIndex(gid_1)[1]
 
 
 	fonts[index_0].getGlyphSet()[gid_0].draw(pen_0)
@@ -626,6 +627,7 @@ def isGlyphSame(fonts, gid_0, gid_1):
 	if not isEqual:
 		log.info("advance width is different: %s, %s" %(fonts[index_0]['hmtx'].metrics[gid_0], fonts[index_1]['hmtx'].metrics[gid_1]))
 	return isEqual
+
 
 # Copied and trimmed down from subset.py
 @_add_method(otTables.ContextSubst,
@@ -849,7 +851,6 @@ class Merger(object):
 		# TODO Is it necessary to reload font?  I think it is.  At least
 		# it's safer, in case tables were loaded to provide glyph names.
 		fonts = [ttLib.TTFont(fontfile) for fontfile in fontfiles]
-		self.fonts = copy.deepcopy(fonts)
 		for font,glyphOrder in zip(fonts, glyphOrders):
 			font.setGlyphOrder(glyphOrder)
 		mega.setGlyphOrder(megaGlyphOrder)
@@ -858,6 +859,7 @@ class Merger(object):
 			self._preMerge(font)
 
 		self.duplicateGlyphsPerFont = [{} for f in fonts]
+		self.fonts = fonts
 		self.fontfiles = fontfiles
 		allTags = reduce(set.union, (list(font.keys()) for font in fonts), set())
 		allTags.remove('GlyphOrder')

--- a/Lib/fontTools/merge.py
+++ b/Lib/fontTools/merge.py
@@ -837,8 +837,6 @@ class Merger(object):
 		self.options = options
 
 	def merge(self, fontfiles):
-		import copy
-
 		mega = ttLib.TTFont()
 
 		#

--- a/Lib/fontTools/merge.py
+++ b/Lib/fontTools/merge.py
@@ -98,7 +98,6 @@ def mergeObjects(lst):
 	lst = [item for item in lst if item is not None]
 	if not lst:
 		return None
-
 	clazz = lst[0].__class__
 	assert all(type(item) == clazz for item in lst), lst
 
@@ -581,6 +580,7 @@ def getGlyphNameAndFontIndex(gid):
 	Example:
 		'uni0000', 3 = getGlyphNameAndFontIndex('uni0000#3')
 	"""
+	# FIXME? This is too hacky. Find another way to wire down the fonts to this function.
 	assert '#' in gid and gid.rsplit('#', 1)[1].isdigit(), 'incorrect gid format'
 	return gid.rsplit('#', 1)[0], int(gid.rsplit('#', 1)[1])
 
@@ -599,18 +599,20 @@ def isGlyphSame(fonts, gid_0, gid_1):
 	Returns:
 		A bool indicating whether the given glyphs are equal or not.
 	"""
+	from fontTools.pens.recordingPen import RecordingPen
 	# Checks outline
-	index_0 = getGlyphNameAndFontIndex(gid_0)[1]
-	index_1 = getGlyphNameAndFontIndex(gid_1)[1]
+	pen_0 = RecordingPen()
+	pen_1 = RecordingPen()
+	gid_0, index_0 = getGlyphNameAndFontIndex(gid_0)
+	gid_1, index_1 = getGlyphNameAndFontIndex(gid_1)
 
-	assert 'glyf' in fonts[index_0] and 'glyf' in fonts[index_1]
-	glyfTable_0 = fonts[index_0]['glyf']
-	glyfTable_1 = fonts[index_1]['glyf']
-	data_0 = glyfTable_0[gid_0].compile(glyfTable_0)
-	data_1 = glyfTable_1[gid_1].compile(glyfTable_1)
-	if data_0 != data_1:
-		# Binary data is not printable. Prints out coordinates instead.
-		log.info("outlines are different: %s:%s, %s:%s" % (gid_0, glyfTable_0[gid_0].getCoordinates(glyfTable_0), gid_1, glyfTable_1[gid_1].getCoordinates(glyfTable_1)))
+
+	fonts[index_0].getGlyphSet()[gid_0].draw(pen_0)
+	fonts[index_1].getGlyphSet()[gid_1].draw(pen_1)
+
+
+	if pen_0.value != pen_1.value:
+		log.info("outlines are different: %s:%s, %s:%s" % (gid_0, pen_0.value, gid_1, pen_1.value))
 		return False
 
 	# Checks advance width and left bearing
@@ -833,6 +835,7 @@ class Merger(object):
 		self.options = options
 
 	def merge(self, fontfiles):
+		import copy
 
 		mega = ttLib.TTFont()
 
@@ -846,6 +849,7 @@ class Merger(object):
 		# TODO Is it necessary to reload font?  I think it is.  At least
 		# it's safer, in case tables were loaded to provide glyph names.
 		fonts = [ttLib.TTFont(fontfile) for fontfile in fontfiles]
+		self.fonts = copy.deepcopy(fonts)
 		for font,glyphOrder in zip(fonts, glyphOrders):
 			font.setGlyphOrder(glyphOrder)
 		mega.setGlyphOrder(megaGlyphOrder)
@@ -854,7 +858,6 @@ class Merger(object):
 			self._preMerge(font)
 
 		self.duplicateGlyphsPerFont = [{} for f in fonts]
-		self.fonts = fonts
 		self.fontfiles = fontfiles
 		allTags = reduce(set.union, (list(font.keys()) for font in fonts), set())
 		allTags.remove('GlyphOrder')

--- a/Tests/merge_test.py
+++ b/Tests/merge_test.py
@@ -1,7 +1,21 @@
+import sys
+import unittest
+import contextlib
+
+import fontTools
 from fontTools.misc.py23 import *
 from fontTools import ttLib
 from fontTools.merge import *
-import unittest
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.ttLib.tables.otTables import GSUB, SingleSubst, LangSys, LookupList, Lookup, Feature, FeatureList, FeatureRecord, Script, ScriptList, ScriptRecord, LigatureSubst, Ligature
+
+
+@contextlib.contextmanager
+def mockIsGlyphSame(boolean):
+	tmp = fontTools.merge.isGlyphSame
+	fontTools.merge.isGlyphSame = lambda fonts, ogid, gid : boolean
+	yield
+	fontTools.merge.isGlyphSame = tmp
 
 
 class MergeIntegrationTest(unittest.TestCase):
@@ -9,10 +23,244 @@ class MergeIntegrationTest(unittest.TestCase):
 	pass
 
 
-class gaspMergeUnitTest(unittest.TestCase):
+class GSUBMergUnitTest(unittest.TestCase):
+	def buildGSUB(self):
+		"""Constructs a basic GSUB table. Test cases can modify this table for their
+			own usage.
+
+			Return:
+				{
+					LookupList: {
+						Lookup: [
+							{
+								LookupType: 4, # Ligature
+								LookupFlag: 0,
+								SubTable: [
+									ligatures: {
+										'f': {
+											LigGlyph: 'f_i',
+											Component: 'i',
+											CompCount: 2,
+										},
+									},
+									Format: 1,
+									LookupType: 4, # Ligature
+								],
+								SubTableCount = 1,
+							},
+						],
+						LookupCount = 1,
+					},
+					FeatureList: {
+						FeatureRecord: [
+							{
+								FeatureTag: 'liga',
+								Feature: {
+									FeatureParams: None,
+									LookupCount: 1,
+									LookupListIndex: [0],
+								},
+							},
+						],
+						FeatureCount: 1,
+					},
+					ScriptList: {
+						ScriptRecord: [
+							{
+								ScriptTag: 'tag1',
+								Script: {
+									DefaultLangSys: {
+										LookupOrder: None,
+										ReqFeatureIndex: 0xffff,
+										FeatureIndex: [0],
+										FeatureCount: 1,
+									}
+								}
+							}
+						],
+						ScriptCount: 1,
+					},
+				}
+		"""
+		# Construct GSUB table bottom-up.
+		li_fi = Ligature()
+		li_fi.LigGlyph = 'f_i'
+		li_fi.Component = ['i']
+		li_fi.CompCount = 2
+
+		liSubst = LigatureSubst()
+		liSubst.ligatures = {'f': li_fi}
+		liSubst.Format = 1
+		liSubst.LookupType = 4
+
+		lookup = Lookup()
+		lookup.LookupType = 4 # Ligature
+		lookup.LookupFlag = 0
+		lookup.SubTable = [liSubst]
+		lookup.SubTableCount = len(lookup.SubTable)
+
+		lookupList = LookupList()
+		lookupList.Lookup = [lookup]
+		lookupList.LookupCount = len(lookupList.Lookup)
+
+		fea = Feature()
+		fea.FeatureParams = None
+		fea.LookupCount = 1
+		fea.LookupListIndex = [0]
+
+		feaRecord = FeatureRecord()
+		feaRecord.FeatureTag = 'liga'
+		feaRecord.Feature = fea
+
+		feaList = FeatureList()
+		feaList.FeatureRecord = [feaRecord]
+		feaList.FeatureCount = len(feaList.FeatureRecord)
+
+		langSys = LangSys()
+		langSys.LookupOrder = None
+		langSys.ReqFeatureIndex = 0xFFFF
+		langSys.FeatureIndex = [0]
+		langSys.FeatureCount = len(langSys.FeatureIndex)
+
+		sct = Script()
+		sct.DefaultLangSys = langSys
+		sct.LangSysRecord = []
+		sct.LangSysCount = len(sct.LangSysRecord)
+
+		sctRec = ScriptRecord()
+		sctRec.ScriptTag = 'tag1'
+		sctRec.Script = sct
+
+		sctList = ScriptList()
+		sctList.ScriptRecord = [sctRec]
+		sctList.ScriptCount = len(sctList.ScriptRecord)
+
+		gsub = GSUB()
+		gsub.LookupList = lookupList
+		gsub.FeatureList = feaList
+		gsub.ScriptList = sctList
+
+		table = ttLib.newTable('GSUB')
+		table.table = gsub
+		return table
+
+	def preMerge(self, t):
+		"""Map indices to references. This part is copied from ttLib.merge._preMerge
+		"""
+		if t.table.LookupList:
+			lookupMap = {i:id(v) for i,v in enumerate(t.table.LookupList.Lookup)}
+			t.table.LookupList.mapLookups(lookupMap)
+			if t.table.FeatureList:
+				# XXX Handle present FeatureList but absent LookupList
+				t.table.FeatureList.mapLookups(lookupMap)
+
+		if t.table.FeatureList and t.table.ScriptList:
+			featureMap = {i:id(v) for i,v in enumerate(t.table.FeatureList.FeatureRecord)}
+			t.table.ScriptList.mapFeatures(featureMap)
+
+
 	def setUp(self):
 		self.merger = Merger()
 
+		self.table1 = self.buildGSUB()
+
+		self.table2 = self.buildGSUB()
+		self.table2.table.ScriptList.ScriptRecord[0].ScriptTag = 'tag2'
+		self.table2.table.FeatureList.FeatureRecord[0].FeatureTag = 'aalt'
+		self.table2.table.LookupList.Lookup[0].LookupType = 1 # single lookup type
+		sub = SingleSubst()
+		sub.SubstFormat = 1
+		sub.DeltaGlyphID = 1024
+		self.table2.table.LookupList.Lookup[0].SubTable[0] = sub
+
+		self.mergedTable = ttLib.newTable('GSUB')
+
+
+	def test_GSUB_merge_no_dups(self):
+		self.merger.duplicateGlyphsPerFont = [{}, {}]
+
+		self.mergedTable.merge(self.merger, [self.table1, self.table2])
+		table = self.mergedTable.table
+
+		# Checks ScriptList
+		self.assertEqual(table.ScriptList.ScriptCount, 2)
+		self.assertIn(self.table1.table.ScriptList.ScriptRecord[0], table.ScriptList.ScriptRecord)
+		self.assertIn(self.table2.table.ScriptList.ScriptRecord[0], table.ScriptList.ScriptRecord)
+
+		# Checks LookupList
+		self.assertEqual(table.LookupList.LookupCount, 2)
+		self.assertIn(self.table1.table.LookupList.Lookup[0], table.LookupList.Lookup)
+		self.assertIn(self.table2.table.LookupList.Lookup[0], table.LookupList.Lookup)
+
+		# Checks FeatureList
+		self.assertEqual(table.FeatureList.FeatureCount, 2)
+		self.assertIn(self.table1.table.FeatureList.FeatureRecord[0], table.FeatureList.FeatureRecord)
+		self.assertIn(self.table2.table.FeatureList.FeatureRecord[0], table.FeatureList.FeatureRecord)
+
+	def test_GSUB_merge_with_dups(self):
+		self.merger.duplicateGlyphsPerFont = [{}, {'uni0032#0': 'uni0032#1'}]
+		self.preMerge(self.table1)
+		self.preMerge(self.table2)
+
+		self.mergedTable.merge(self.merger, [self.table1, self.table2])
+		table = self.mergedTable.table
+
+		# Checks ScriptList
+		self.assertEqual(table.ScriptList.ScriptCount, 2)
+		self.assertIn(self.table1.table.ScriptList.ScriptRecord[0], table.ScriptList.ScriptRecord)
+		self.assertIn(self.table2.table.ScriptList.ScriptRecord[0], table.ScriptList.ScriptRecord)
+
+		# Checks LookupList
+		self.assertEqual(table.LookupList.LookupCount, 3)
+		self.assertIn(self.table1.table.LookupList.Lookup[0], table.LookupList.Lookup)
+		self.assertIn(self.table2.table.LookupList.Lookup[0], table.LookupList.Lookup)
+		self.assertEqual(table.LookupList.Lookup[-1].LookupFlag, 0)
+		self.assertEqual(table.LookupList.Lookup[-1].LookupType, 1)
+		self.assertEqual(table.LookupList.Lookup[-1].SubTableCount, 1)
+		self.assertEqual(table.LookupList.Lookup[-1].SubTable[0].mapping, self.merger.duplicateGlyphsPerFont[1])
+
+		# Checks FeatureList
+		self.assertEqual(table.FeatureList.FeatureCount, 3)
+		self.assertIn(self.table1.table.FeatureList.FeatureRecord[0], table.FeatureList.FeatureRecord)
+		self.assertIn(self.table2.table.FeatureList.FeatureRecord[0], table.FeatureList.FeatureRecord)
+		self.assertEqual(table.FeatureList.FeatureRecord[-1].FeatureTag, 'locl')
+
+	def test_GSUB_merge_with_same_dups_and_no_second_GSUB(self):
+		self.table2 = NotImplemented
+		self.merger.duplicateGlyphsPerFont = [{}, {'uni0032#0': 'uni0032#1'}]
+		self.merger.fonts = []
+		with mockIsGlyphSame(True):
+			self.mergedTable.merge(self.merger, [self.table1, self.table2])
+		table = self.mergedTable.table
+		self.assertEqual(table, self.table1.table)
+
+	def test_GSUB_merge_with_different_dups_and_no_second_GSUB(self):
+		self.table2 = NotImplemented
+		self.merger.duplicateGlyphsPerFont = [{}, {'uni0032#0': 'uni0032#1'}]
+		self.merger.fonts = []
+		self.merger.fontfiles = ['font1', 'font2']
+		with mockIsGlyphSame(False):
+			with CapturingLogHandler(fontTools.merge.log, "WARNING") as captor:
+				self.mergedTable.merge(self.merger, [self.table1, self.table2])
+
+		table = self.mergedTable.table
+		self.assertEqual(table, self.table1.table)
+		self.assertTrue(len([r for r in captor.records if r.msg != '']) > 0)
+
+
+class IsGlyphSame(unittest.TestCase):
+		def setUp(self):
+			# FIXME? This test requires at least one complete TTFont object including
+			# glyf, hmtx and vmtx tables.
+			# Importing 'data/TestTTF-Regular.ttx' file and adding 'hmtx', 'vmtx'
+			# manually doesn't work since its glyf table isn't intact. Probably we
+			# need to import a true Font file as our test case data source.
+			pass
+
+
+class gaspMergeUnitTest(unittest.TestCase):
+
+	def setUp(self):
 		self.table1 = ttLib.newTable('gasp')
 		self.table1.version = 1
 		self.table1.gaspRange = {
@@ -29,6 +277,8 @@ class gaspMergeUnitTest(unittest.TestCase):
 
 		self.result = ttLib.newTable('gasp')
 
+		self.merger = Merger()
+
 	def test_gasp_merge_basic(self):
 		result = self.result.merge(self.merger, [self.table1, self.table2])
 		self.assertEqual(result, self.table1)
@@ -44,6 +294,16 @@ class gaspMergeUnitTest(unittest.TestCase):
 		self.assertEqual(result, self.table1)
 
 
+class IsGlyphSame(unittest.TestCase):
+		def setUp(self):
+			# FIXME? This test requires lat least one complete TTFont object including
+			# glyf, hmtx, vmtx tables.
+			# Importing data/TestTTF-Regular.ttx and adding 'hmtx', 'vmtx' manually
+			# does not work since its glyf table isn't intact. Probably we need to
+			# import a true Font file as our test case data source.
+			pass
+
+
 class CmapMergeUnitTest(unittest.TestCase):
 	def setUp(self):
 		self.merger = Merger()
@@ -54,7 +314,6 @@ class CmapMergeUnitTest(unittest.TestCase):
 
 	def tearDown(self):
 		pass
-
 
 	def makeSubtable(self, format, platformID, platEncID, cmap):
 		module = ttLib.getTableModule('cmap')

--- a/Tests/merge_test.py
+++ b/Tests/merge_test.py
@@ -248,16 +248,6 @@ class GSUBMergUnitTest(unittest.TestCase):
 		self.assertTrue(len([r for r in captor.records if r.msg != '']) > 0)
 
 
-class IsGlyphSame(unittest.TestCase):
-		def setUp(self):
-			# FIXME? This test requires at least one complete TTFont object including
-			# glyf, hmtx and vmtx tables.
-			# Importing 'data/TestTTF-Regular.ttx' file and adding 'hmtx', 'vmtx'
-			# manually doesn't work since its glyf table isn't intact. Probably we
-			# need to import a true Font file as our test case data source.
-			pass
-
-
 class gaspMergeUnitTest(unittest.TestCase):
 
 	def setUp(self):

--- a/Tests/merge_test.py
+++ b/Tests/merge_test.py
@@ -245,7 +245,7 @@ class GSUBMergUnitTest(unittest.TestCase):
 
 		table = self.mergedTable.table
 		self.assertEqual(table, self.table1.table)
-		self.assertTrue(len([r for r in captor.records if r.msg != '']) > 0)
+		self.assertTrue(any('is dropped and replaced by' in r.msg for r in captor.records))
 
 
 class gaspMergeUnitTest(unittest.TestCase):

--- a/Tests/merge_test.py
+++ b/Tests/merge_test.py
@@ -8,6 +8,7 @@ class MergeIntegrationTest(unittest.TestCase):
 	# TODO
 	pass
 
+
 class gaspMergeUnitTest(unittest.TestCase):
 	def setUp(self):
 		self.merger = Merger()

--- a/Tests/merge_test.py
+++ b/Tests/merge_test.py
@@ -2,10 +2,10 @@ import sys
 import unittest
 import contextlib
 
-import fontTools
+import fontTools.merge
 from fontTools.misc.py23 import *
 from fontTools import ttLib
-from fontTools.merge import *
+from fontTools.merge import Merger
 from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.ttLib.tables.otTables import GSUB, SingleSubst, LangSys, LookupList, Lookup, Feature, FeatureList, FeatureRecord, Script, ScriptList, ScriptRecord, LigatureSubst, Ligature
 


### PR DESCRIPTION
Previous discussion could be found at https://github.com/fonttools/fonttools/pull/840#discussion_r105014246 
#840 

Basically, this PR does 3 things:

1. Downgrade assert error to warning when there are duplicated glyphs in merging fonts and there is no GSUB table. 
Rationale: In most cases the duplicated glyphs are comma, period and other language unrelated symbols. We can ignore the difference. Please see [Behdad's comment](https://github.com/fonttools/fonttools/issues/712) for more info. 

2. When duplicate glyphs occurs, using recordingPen to compare them. If they are the same, don't show warning message, just ignore duplicates. Otherwise shows warning messge.

3. Add test cases. 
