### PR TITLE
[varLib.interpolate_layout] Tests for GPOS LookupType 2 class pairs

### DIFF
--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -369,6 +369,10 @@ def _PairPosFormat2_merge(self, lst, merger):
 	# Align first classes
 	self.ClassDef1, classes = _ClassDef_merge_classify([l.ClassDef1 for l in lst], allGlyphs=glyphSet)
 	self.Class1Count = len(classes)
+	if self.Class1Count > 1:
+		self.ClassDef1.Format = 1
+	else:
+		self.ClassDef1.Format = 2
 	new_matrices = []
 	for l,matrix in zip(lst, matrices):
 		nullRow = None
@@ -396,6 +400,10 @@ def _PairPosFormat2_merge(self, lst, merger):
 	# Align second classes
 	self.ClassDef2, classes = _ClassDef_merge_classify([l.ClassDef2 for l in lst])
 	self.Class2Count = len(classes)
+	if self.Class2Count > 1:
+		self.ClassDef2.Format = 1
+	else:
+		self.ClassDef2.Format = 2
 	new_matrices = []
 	for l,matrix in zip(lst, matrices):
 		classDef2 = l.ClassDef2.classDefs

--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -322,10 +322,12 @@ def _ClassDef_merge_classify(lst, allGlyphs=None):
 		sets = _ClassDef_invert(l)
 		if allGlyphs is None:
 			sets = sets[1:]
-		else:
+		elif sets:
 			sets[0] = set(allGlyphs)
 			for s in sets[1:]:
 				sets[0].difference_update(s)
+		else:
+		    sets = [set(allGlyphs)]
 		classifier.update(sets)
 	classes = classifier.getClasses()
 
@@ -506,15 +508,18 @@ def _Lookup_PairPos_subtables_canonicalize(lst, font):
 	head = []
 	tail = []
 	it = iter(lst)
+	has_Format1 = False
 	for subtable in it:
 		if subtable.Format == 1:
 			head.append(subtable)
+			has_Format1 = True
 			continue
 		tail.append(subtable)
 		break
 	tail.extend(it)
-	# TODO Only do this if at least one font has a Format1.
-	tail.insert(0, _Lookup_PairPosFormat1_subtables_merge_overlay(head, font))
+	if has_Format1:
+	    # only insert if at least one font has a Format1
+	    tail.insert(0, _Lookup_PairPosFormat1_subtables_merge_overlay(head, font))
 	return tail
 
 @AligningMerger.merger(ot.Lookup)

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_diff.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_diff.ttx
@@ -39,15 +39,16 @@
           </Coverage>
           <ValueFormat1 value="4"/>
           <ValueFormat2 value="0"/>
-          <ClassDef1>
+          <ClassDef1 Format="2">
           </ClassDef1>
-          <ClassDef2>
+          <ClassDef2 Format="1">
             <ClassDef glyph="a" class="1"/>
           </ClassDef2>
           <!-- Class1Count=1 -->
           <!-- Class2Count=2 -->
           <Class1Record index="0">
             <Class2Record index="0">
+              <Value1 XAdvance="0"/>
             </Class2Record>
             <Class2Record index="1">
               <Value1 XAdvance="-40"/>

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_diff.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_diff.ttx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.8">
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="xxxx"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="A"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1>
+          </ClassDef1>
+          <ClassDef2>
+            <ClassDef glyph="a" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=1 -->
+          <!-- Class2Count=2 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-40"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_diff2.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_diff2.ttx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.8">
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="xxxx"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="A"/>
+            <Glyph value="a"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1>
+            <ClassDef glyph="A" class="1"/>
+          </ClassDef1>
+          <ClassDef2>
+            <ClassDef glyph="a" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=2 -->
+          <!-- Class2Count=2 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="10"/>
+            </Class2Record>
+          </Class1Record>
+          <Class1Record index="1">
+            <Class2Record index="0">
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-40"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_diff2.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_diff2.ttx
@@ -40,16 +40,17 @@
           </Coverage>
           <ValueFormat1 value="4"/>
           <ValueFormat2 value="0"/>
-          <ClassDef1>
+          <ClassDef1 Format="1">
             <ClassDef glyph="A" class="1"/>
           </ClassDef1>
-          <ClassDef2>
+          <ClassDef2 Format="1">
             <ClassDef glyph="a" class="1"/>
           </ClassDef2>
           <!-- Class1Count=2 -->
           <!-- Class2Count=2 -->
           <Class1Record index="0">
             <Class2Record index="0">
+              <Value1 XAdvance="10"/>
             </Class2Record>
             <Class2Record index="1">
               <Value1 XAdvance="10"/>
@@ -57,6 +58,7 @@
           </Class1Record>
           <Class1Record index="1">
             <Class2Record index="0">
+              <Value1 XAdvance="0"/>
             </Class2Record>
             <Class2Record index="1">
               <Value1 XAdvance="-40"/>

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_same.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_same.ttx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.8">
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="xxxx"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="A"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1>
+          </ClassDef1>
+          <ClassDef2>
+            <ClassDef glyph="a" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=1 -->
+          <!-- Class2Count=2 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-53"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_same.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_2_class_same.ttx
@@ -39,15 +39,16 @@
           </Coverage>
           <ValueFormat1 value="4"/>
           <ValueFormat2 value="0"/>
-          <ClassDef1>
+          <ClassDef1 Format="2">
           </ClassDef1>
-          <ClassDef2>
+          <ClassDef2 Format="1">
             <ClassDef glyph="a" class="1"/>
           </ClassDef2>
           <!-- Class1Count=1 -->
           <!-- Class2Count=2 -->
           <Class1Record index="0">
             <Class2Record index="0">
+              <Value1 XAdvance="0"/>
             </Class2Record>
             <Class2Record index="1">
               <Value1 XAdvance="-53"/>

--- a/Tests/varLib/interpolate_layout_test.py
+++ b/Tests/varLib/interpolate_layout_test.py
@@ -401,6 +401,104 @@ class InterpolateLayoutTest(unittest.TestCase):
         self.check_ttx_dump(instfont, expected_ttx_path, tables, suffix)
 
 
+    def test_varlib_interpolate_layout_GPOS_only_LookupType_2_class_pairs_same_val_ttf(self):
+        """Only GPOS; LookupType 2 class pairs; same values in all masters.
+        """
+        suffix = '.ttf'
+        ds_path = self.get_test_input('InterpolateLayout.designspace')
+        ufo_dir = self.get_test_input('master_ufo')
+        ttx_dir = self.get_test_input('master_ttx_interpolatable_ttf')
+
+        fea_str = """
+        feature xxxx {
+            pos [A] [a] -53;
+        } xxxx;
+        """
+        features = [fea_str] * 2
+
+        self.temp_dir()
+        ttx_paths = self.get_file_list(ttx_dir, '.ttx', 'TestFamily2-')
+        for i, path in enumerate(ttx_paths):
+            self.compile_font(path, suffix, self.tempdir, features[i])
+
+        finder = lambda s: s.replace(ufo_dir, self.tempdir).replace('.ufo', suffix)
+        instfont = interpolate_layout(ds_path, {'weight': 500}, finder)
+
+        tables = ['GPOS']
+        expected_ttx_path = self.get_test_output('InterpolateLayoutGPOS_2_class_same.ttx')
+        self.expect_ttx(instfont, expected_ttx_path, tables)
+        self.check_ttx_dump(instfont, expected_ttx_path, tables, suffix)
+
+
+    def test_varlib_interpolate_layout_GPOS_only_LookupType_2_class_pairs_diff_val_ttf(self):
+        """Only GPOS; LookupType 2 class pairs; different values in each master.
+        """
+        suffix = '.ttf'
+        ds_path = self.get_test_input('InterpolateLayout.designspace')
+        ufo_dir = self.get_test_input('master_ufo')
+        ttx_dir = self.get_test_input('master_ttx_interpolatable_ttf')
+
+        fea_str_0 = """
+        feature xxxx {
+            pos [A] [a] -53;
+        } xxxx;
+        """
+        fea_str_1 = """
+        feature xxxx {
+            pos [A] [a] -27;
+        } xxxx;
+        """
+        features = [fea_str_0, fea_str_1]
+
+        self.temp_dir()
+        ttx_paths = self.get_file_list(ttx_dir, '.ttx', 'TestFamily2-')
+        for i, path in enumerate(ttx_paths):
+            self.compile_font(path, suffix, self.tempdir, features[i])
+
+        finder = lambda s: s.replace(ufo_dir, self.tempdir).replace('.ufo', suffix)
+        instfont = interpolate_layout(ds_path, {'weight': 500}, finder)
+
+        tables = ['GPOS']
+        expected_ttx_path = self.get_test_output('InterpolateLayoutGPOS_2_class_diff.ttx')
+        self.expect_ttx(instfont, expected_ttx_path, tables)
+        self.check_ttx_dump(instfont, expected_ttx_path, tables, suffix)
+
+
+    def test_varlib_interpolate_layout_GPOS_only_LookupType_2_class_pairs_diff2_val_ttf(self):
+        """Only GPOS; LookupType 2 class pairs; different values and items in each master.
+        """
+        suffix = '.ttf'
+        ds_path = self.get_test_input('InterpolateLayout.designspace')
+        ufo_dir = self.get_test_input('master_ufo')
+        ttx_dir = self.get_test_input('master_ttx_interpolatable_ttf')
+
+        fea_str_0 = """
+        feature xxxx {
+            pos [A] [a] -53;
+        } xxxx;
+        """
+        fea_str_1 = """
+        feature xxxx {
+            pos [A] [a] -27;
+            pos [a] [a] 19;
+        } xxxx;
+        """
+        features = [fea_str_0, fea_str_1]
+
+        self.temp_dir()
+        ttx_paths = self.get_file_list(ttx_dir, '.ttx', 'TestFamily2-')
+        for i, path in enumerate(ttx_paths):
+            self.compile_font(path, suffix, self.tempdir, features[i])
+
+        finder = lambda s: s.replace(ufo_dir, self.tempdir).replace('.ufo', suffix)
+        instfont = interpolate_layout(ds_path, {'weight': 500}, finder)
+
+        tables = ['GPOS']
+        expected_ttx_path = self.get_test_output('InterpolateLayoutGPOS_2_class_diff2.ttx')
+        self.expect_ttx(instfont, expected_ttx_path, tables)
+        self.check_ttx_dump(instfont, expected_ttx_path, tables, suffix)
+
+
     def test_varlib_interpolate_layout_GPOS_only_LookupType_3_same_val_ttf(self):
         """Only GPOS; LookupType 3; same values in all masters.
         """


### PR DESCRIPTION
Merging of class kerning pairs seems to be broken.
```python
Traceback (most recent call last):
  File "interpolate_layout_test.py", line 425, in test_varlib_interpolate_layout_GPOS_only_LookupType_2_class_pairs_same_val_ttf
    instfont = interpolate_layout(ds_path, {'weight': 500}, finder)
  File "fonttools/Lib/fontTools/varLib/interpolate_layout.py", line 85, in interpolate_layout
    merger.mergeTables(font, master_fonts, axes_dict, base_idx, ['GPOS'])
  File "fonttools/Lib/fontTools/varLib/merger.py", line 107, in mergeTables
    self.mergeThings(font[tag], [m[tag] for m in master_ttfs])
  File "fonttools/Lib/fontTools/varLib/merger.py", line 93, in mergeThings
    self.mergeObjects(out, lst)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 70, in mergeObjects
    mergerFunc(self, value, values)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 93, in mergeThings
    self.mergeObjects(out, lst)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 70, in mergeObjects
    mergerFunc(self, value, values)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 93, in mergeThings
    self.mergeObjects(out, lst)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 70, in mergeObjects
    mergerFunc(self, value, values)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 95, in mergeThings
    self.mergeLists(out, lst)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 80, in mergeLists
    self.mergeThings(value, values)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 91, in mergeThings
    mergerFunc(self, out, lst)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 531, in merge
    merger.mergeLists(self.SubTable, subtables)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 80, in mergeLists
    self.mergeThings(value, values)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 91, in mergeThings
    mergerFunc(self, out, lst)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 430, in merge
    _PairPosFormat2_merge(self, lst, merger)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 368, in _PairPosFormat2_merge
    self.ClassDef1, classes = _ClassDef_merge_classify([l.ClassDef1 for l in lst], allGlyphs=glyphSet)
  File "fonttools/Lib/fontTools/varLib/merger.py", line 326, in _ClassDef_merge_classify
    sets[0] = set(allGlyphs)
IndexError: ('list assignment index out of range', 'PairPos', '[1]', 'Lookup', '[0]', 'list', '.Lookup', 'LookupList', '.LookupList', 'GPOS', '.table', 'table_G_P_O_S_')
```