### PR TITLE
[cffLib/psCharStrings] fix IndexError with empty deltas

### DIFF
--- a/Lib/fontTools/cffLib.py
+++ b/Lib/fontTools/cffLib.py
@@ -1086,7 +1086,7 @@ class NumberConverter(SimpleConverter):
 
 class ArrayConverter(SimpleConverter):
 	def xmlWrite(self, xmlWriter, name, value, progress):
-		if isinstance(value[0], list):
+		if value and isinstance(value[0], list):
 			xmlWriter.begintag(name)
 			xmlWriter.newline()
 			xmlWriter.indent()

--- a/Lib/fontTools/cffLib.py
+++ b/Lib/fontTools/cffLib.py
@@ -1907,6 +1907,8 @@ class DictCompiler(object):
 			data.append(self.arg_number(num))
 		return bytesjoin(data)
 	def arg_delta(self, value):
+		if not value:
+			return b""
 		val0 = value[0]
 		if isinstance(val0, list):
 			data = self.arg_delta_blend(value)

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -1319,7 +1319,8 @@ class DictDecompiler(ByteCodeBase):
 	def arg_delta(self, name):
 		valueList = self.popall()
 		out = []
-		if isinstance(valueList[0], list): # arg_blendList() has already converted these to absolute values.
+		if valueList and isinstance(valueList[0], list):
+			# arg_blendList() has already converted these to absolute values.
 			out = valueList
 		else:
 			current = 0


### PR DESCRIPTION
After 2b2aca1, `DictCompiler` and `DictDecompiler`'s `arg_delta` method unconditionally attempts to get the first item to check if it's a list, but this fails with `IndexError` when the value is empty.

/cc @behdad @readroberts @miguelsousa 

```
Traceback (most recent call last):
  [...]
  File "/Users/cosimolupo/Documents/Github/ufo2ft/Lib/ufo2ft/otfPostProcessor.py", line 15, in __init__
    otf.save(stream)
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/ttLib/__init__.py", line 219, in save
    self._writeTable(tag, writer, done)
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/ttLib/__init__.py", line 658, in _writeTable
    tabledata = self.getTableData(tag)
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/ttLib/__init__.py", line 669, in getTableData
    return self.tables[tag].compile(self)
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/ttLib/tables/C_F_F_.py", line 20, in compile
    self.cff.compile(f, otFont)
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/cffLib.py", line 124, in compile
    writer.toFile(file)
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/cffLib.py", line 300, in toFile
    endPos = pos + item.getDataLength()
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/cffLib.py", line 1858, in getDataLength
    return len(self.compile("getDataLength"))
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/cffLib.py", line 1879, in compile
    data.append(arghandler(value))
  File "/Users/cosimolupo/Documents/Github/fonttools/Lib/fontTools/cffLib.py", line 1910, in arg_delta
    val0 = value[0]
IndexError: list index out of range
```