### PR TITLE
[feaLib] Clean up syntax tree for FeatureNames

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -225,25 +225,20 @@ class FeatureBlock(Block):
         builder.end_feature()
 
     def asFea(self, indent=""):
-        res = indent + "feature {} {{\n".format(self.name.strip())
-        indent += SHIFT
-        if len(self.statements) and isinstance(self.statements[0], FeatureNameStatement):
-            res += indent + "featureNames {\n"
-            res += indent + SHIFT
-            res += ("\n" + indent + SHIFT).join(
-                [s.asFea(indent=indent + SHIFT * 2)
-                 for s in self.statements if isinstance(s, FeatureNameStatement)])
-            res += "\n"
-            res += indent + "};\n" + indent
-            res += ("\n" + indent).join(
-                [s.asFea(indent=indent)
-                 for s in self.statements if not isinstance(s, FeatureNameStatement)])
-            res += "\n"
-        else:
-            res += indent
-            res += ("\n" + indent).join([s.asFea(indent=indent) for s in self.statements])
-            res += "\n"
-        res += "{}}} {};\n".format(indent[:-len(SHIFT)], self.name.strip())
+        res = indent + "feature %s {\n" % self.name.strip()
+        res += Block.asFea(self, indent=indent)
+        res += indent + "} %s;\n" % self.name.strip()
+        return res
+
+
+class FeatureNamesBlock(Block):
+    def __init__(self, location):
+        Block.__init__(self, location)
+
+    def asFea(self, indent=""):
+        res = indent + "featureNames {\n"
+        res += Block.asFea(self, indent=indent)
+        res += indent + "};\n"
         return res
 
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,5 +1,6 @@
 - [feaLib] Added (partial) support for parsing feature file comments ``# ...``
   appearing in between statements (#879).
+- [feaLib] Cleaned up syntax tree for FeatureNames.
 - [ttLib] Added support for reading/writing ``CFF2`` table (thanks to
   @readroberts at Adobe), and ``TTFA`` (ttfautohint) table.
 

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -202,6 +202,27 @@ class ParserTest(unittest.TestCase):
         self.assertIsInstance(ref, ast.FeatureReferenceStatement)
         self.assertEqual(ref.featureName, "salt")
 
+    def test_FeatureNames_bad(self):
+        self.assertRaisesRegex(
+            FeatureLibError, 'Expected "name"',
+            self.parse, "feature ss01 { featureNames { feature test; } ss01;")
+
+    def test_FeatureNames_comment(self):
+        [feature] = self.parse(
+            "feature ss01 { featureNames { # Comment\n }; } ss01;").statements
+        [featureNames] = feature.statements
+        self.assertIsInstance(featureNames, ast.FeatureNamesBlock)
+        [comment] = featureNames.statements
+        self.assertIsInstance(comment, ast.Comment)
+        self.assertEqual(comment.text, "# Comment")
+
+    def test_FeatureNames_emptyStatements(self):
+        [feature] = self.parse(
+            "feature ss01 { featureNames { ;;; }; } ss01;").statements
+        [featureNames] = feature.statements
+        self.assertIsInstance(featureNames, ast.FeatureNamesBlock)
+        self.assertEqual(featureNames.statements, [])
+
     def test_FontRevision(self):
         doc = self.parse("table head {FontRevision 2.5;} head;")
         s = doc.statements[0].statements[0]


### PR DESCRIPTION
The syntax tree representation now reflects the syntax of feature files.
Before this change, FeatureNames did not have their own `ast.Block`,
which had made the code quite messy.