### PR TITLE
Decomposing pen

### DIFF
--- a/Lib/fontTools/pens/basePen.py
+++ b/Lib/fontTools/pens/basePen.py
@@ -141,7 +141,34 @@ class NullPen(object):
 		pass
 
 
-class BasePen(AbstractPen):
+class DecomposingPen(AbstractPen):
+
+	""" Implements a 'addComponent' method that decomposes components.
+	It can also be used as a mixin class (e.g. ContourRecordingPen).
+
+	You must override moveTo, lineTo, curveTo and qCurveTo. You may
+	additionally override closePath, endPath and addComponent.
+	"""
+
+	def __init__(self, glyphSet=None):
+		super(DecomposingPen, self).__init__()
+		self.glyphSet = glyphSet
+
+	def addComponent(self, glyphName, transformation):
+		"""This default implementation simply transforms the points
+		of the base glyph and draws it onto self.
+		"""
+		from fontTools.pens.transformPen import TransformPen
+		try:
+			glyph = self.glyphSet[glyphName]
+		except KeyError:
+			pass
+		else:
+			tPen = TransformPen(self, transformation)
+			glyph.draw(tPen)
+
+
+class BasePen(DecomposingPen):
 
 	"""Base class for drawing pens. You must override _moveTo, _lineTo and
 	_curveToOne. You may additionally override _closePath, _endPath,
@@ -150,7 +177,7 @@ class BasePen(AbstractPen):
 	"""
 
 	def __init__(self, glyphSet=None):
-		self.glyphSet = glyphSet
+		super(BasePen, self).__init__(glyphSet)
 		self.__currentPoint = None
 
 	# must override
@@ -185,19 +212,6 @@ class BasePen(AbstractPen):
 		mid2x = pt2x + 0.66666666666666667 * (pt1x - pt2x)
 		mid2y = pt2y + 0.66666666666666667 * (pt1y - pt2y)
 		self._curveToOne((mid1x, mid1y), (mid2x, mid2y), pt2)
-
-	def addComponent(self, glyphName, transformation):
-		"""This default implementation simply transforms the points
-		of the base glyph and draws it onto self.
-		"""
-		from fontTools.pens.transformPen import TransformPen
-		try:
-			glyph = self.glyphSet[glyphName]
-		except KeyError:
-			pass
-		else:
-			tPen = TransformPen(self, transformation)
-			glyph.draw(tPen)
 
 	# don't override
 

--- a/Lib/fontTools/pens/recordingPen.py
+++ b/Lib/fontTools/pens/recordingPen.py
@@ -1,10 +1,10 @@
 """Pen recording operations that can be accessed or replayed."""
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
-from fontTools.pens.basePen import AbstractPen
+from fontTools.pens.basePen import AbstractPen, DecomposingPen
 
 
-__all__ = ["RecordingPen"]
+__all__ = ["RecordingPen", "ContourRecordingPen"]
 
 
 class RecordingPen(AbstractPen):
@@ -49,6 +49,12 @@ class RecordingPen(AbstractPen):
 	def replay(self, pen):
 		for operator,operands in self.value:
 			getattr(pen, operator)(*operands)
+
+
+class ContourRecordingPen(DecomposingPen, RecordingPen):
+	""" Same as RecordingPen, except that it doesn't keep components
+	as references, but draws them decomposed as regular contours.
+	"""
 
 
 if __name__ == "__main__":

--- a/Tests/pens/recordingPen_test.py
+++ b/Tests/pens/recordingPen_test.py
@@ -1,0 +1,33 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from fontTools.pens.recordingPen import RecordingPen, ContourRecordingPen
+import unittest
+
+
+class _TestGlyph:
+
+    def draw(self, pen):
+        pen.moveTo((0.0, 0.0))
+        pen.lineTo((0.0, 100.0))
+        pen.curveTo((50.0, 75.0), (60.0, 50.0), (50.0, 0.0))
+        pen.closePath()
+
+
+class RecordingPenTest(unittest.TestCase):
+
+    def test_addComponent(self):
+        pen = RecordingPen()
+        pen.addComponent("a", (2, 0, 0, 3, -10, 5))
+        self.assertEqual([("addComponent", ("a", (2, 0, 0, 3, -10, 5)))],
+                         pen.value)
+
+
+class ContourRecordingPenTest(unittest.TestCase):
+
+    def test_addComponent_decomposed(self):
+        pen = ContourRecordingPen({"a": _TestGlyph()})
+        pen.addComponent("a", (2, 0, 0, 3, -10, 5))
+        self.assertEqual([('moveTo', ((-10.0, 5.0),)),
+                          ('lineTo', ((-10.0, 305.0),)),
+                          ('curveTo', ((90.0, 230.0), (110.0, 155.0), (90.0, 5.0),)),
+                          ('closePath', ())], pen.value)


### PR DESCRIPTION
Following @behdad's comment:
https://github.com/fonttools/fonttools/pull/880#issuecomment-288558012

> RecordingPen records component references. We want to compare outlines, not component references (which might be the same while components themselves are different.) We need a version of RecordingPen that does that.

Instead of inheriting from `BasePen`, I separated the `addComponent` method from BasePen into a distinct `DecomposingPen` class, and use that as a base class for both `BasePen` and the new `ContourRecordingPen`.

Inheriting from `BasePen` directly would have meant also splitting up curveTo and qCurveTo, and converting quadratics to cubics, which we don't want to do for a recording pen.