### PR TITLE
Decomposing pen, using composition instead of inheritance

### DIFF
--- a/Lib/fontTools/pens/decomposingPen.py
+++ b/Lib/fontTools/pens/decomposingPen.py
@@ -1,0 +1,22 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from fontTools.pens.filterPen import FilterPen
+from fontTools.pens.transformPen import TransformPen
+
+
+class DecomposingPen(FilterPen):
+
+    """A filter pen that decomposes components before drawing them with
+    another pen.
+    """
+
+    def __init__(self, outPen, glyphSet):
+        super(DecomposingPen, self).__init__(outPen)
+        self.glyphSet = glyphSet
+
+    def addComponent(self, glyphName, transformation):
+        """Transform the points of the base glyph and draw it onto self.
+        """
+        glyph = self.glyphSet[glyphName]
+        tPen = TransformPen(self, transformation)
+        glyph.draw(tPen)

--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -1,0 +1,37 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from fontTools.pens.basePen import AbstractPen
+
+
+class FilterPen(AbstractPen):
+
+    """ Base class for pens that apply some transformation to the coordinates
+    they receive and pass them to another pen.
+
+    You can override any of its methods. The default implementation does
+    nothing, but passes the commands unmodified to the other pen.
+    """
+
+    def __init__(self, outPen, *args, **kwargs):
+        self._outPen = outPen
+
+    def moveTo(self, pt):
+        self._outPen.moveTo(pt)
+
+    def lineTo(self, pt):
+        self._outPen.lineTo(pt)
+
+    def curveTo(self, *points):
+        self._outPen.curveTo(*points)
+
+    def qCurveTo(self, *points):
+        self._outPen.qCurveTo(*points)
+
+    def closePath(self):
+        self._outPen.closePath()
+
+    def endPath(self):
+        self._outPen.endPath()
+
+    def addComponent(self, glyphName, transformation):
+        self._outPen.addComponent(glyphName, transformation)

--- a/Lib/fontTools/pens/transformPen.py
+++ b/Lib/fontTools/pens/transformPen.py
@@ -1,12 +1,12 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
-from fontTools.pens.basePen import AbstractPen
+from fontTools.pens.filterPen import FilterPen
 
 
 __all__ = ["TransformPen"]
 
 
-class TransformPen(AbstractPen):
+class TransformPen(FilterPen):
 
 	"""Pen that transforms all coordinates using a Affine transformation,
 	and passes them to another pen.
@@ -17,12 +17,12 @@ class TransformPen(AbstractPen):
 		transformed coordinates. The 'transformation' argument can either
 		be a six-tuple, or a fontTools.misc.transform.Transform object.
 		"""
+		super(TransformPen, self).__init__(outPen)
 		if not hasattr(transformation, "transformPoint"):
 			from fontTools.misc.transform import Transform
 			transformation = Transform(*transformation)
 		self._transformation = transformation
 		self._transformPoint = transformation.transformPoint
-		self._outPen = outPen
 		self._stack = []
 
 	def moveTo(self, pt):

--- a/Tests/pens/decomposingPen_test.py
+++ b/Tests/pens/decomposingPen_test.py
@@ -1,0 +1,35 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from fontTools.pens.recordingPen import RecordingPen
+from fontTools.pens.decomposingPen import DecomposingPen
+import unittest
+
+
+class _TestGlyph:
+
+    def draw(self, pen):
+        pen.moveTo((0.0, 0.0))
+        pen.lineTo((0.0, 100.0))
+        pen.curveTo((50.0, 75.0), (60.0, 50.0), (50.0, 0.0))
+        pen.closePath()
+
+
+class RecordingPenTest(unittest.TestCase):
+
+    def test_addComponent(self):
+        pen = RecordingPen()
+        pen.addComponent("a", (2, 0, 0, 3, -10, 5))
+        self.assertEqual([("addComponent", ("a", (2, 0, 0, 3, -10, 5)))],
+                         pen.value)
+
+
+class DecomposingPenTest(unittest.TestCase):
+
+    def test_addComponent_decomposed(self):
+        recpen = RecordingPen()
+        pen = DecomposingPen(recpen, {"a": _TestGlyph()})
+        pen.addComponent("a", (2, 0, 0, 3, -10, 5))
+        self.assertEqual([('moveTo', ((-10.0, 5.0),)),
+                          ('lineTo', ((-10.0, 305.0),)),
+                          ('curveTo', ((90.0, 230.0), (110.0, 155.0), (90.0, 5.0),)),
+                          ('closePath', ())], recpen.value)


### PR DESCRIPTION
actually, I changed my mind.. I believe it's better to have a filter pen that wraps another pen (e.g. a recording pen) for decomposing components.

Both the new filterPen and decomposingPen modules can be useful for other stuff, e.g. ufo2ft filters (https://github.com/googlei18n/ufo2ft/issues/120)

So this supersedes #894 