### PR TITLE
[loggingTools] added LogMixin class

### DIFF
--- a/Lib/fontTools/misc/loggingTools.py
+++ b/Lib/fontTools/misc/loggingTools.py
@@ -471,6 +471,18 @@ class CapturingLogHandler(logging.Handler):
 				return True
 		assert 0, "Pattern '%s' not found in logger records" % regexp
 
+
+class LogMixin(object):
+	""" Mixin class that adds a 'log' property getter returning an instance
+	of logging.Logger class, which is named after self <module>.<class> name.
+	"""
+
+	@property
+	def log(self):
+		name = ".".join([self.__class__.__module__, self.__class__.__name__])
+		return logging.getLogger(name)
+
+
 def deprecateArgument(name, msg, category=UserWarning):
 	""" Raise a warning about deprecated function argument 'name'. """
 	warnings.warn(

--- a/Lib/fontTools/misc/loggingTools.py
+++ b/Lib/fontTools/misc/loggingTools.py
@@ -473,8 +473,29 @@ class CapturingLogHandler(logging.Handler):
 
 
 class LogMixin(object):
-	""" Mixin class that adds a 'log' property getter returning an instance
-	of logging.Logger class, which is named after self <module>.<class> name.
+	""" Mixin class that adds logging functionality to another class.
+	You can define a new class that subclasses from LogMixin as well as
+	other base classes through multiple inheritance.
+	All instances of that class will have a 'log' property that returns
+	a logging.Logger named after their respective <module>.<class>.
+	For example:
+
+	>>> class BaseClass(object):
+	...     pass
+	>>> class MyClass(LogMixin, BaseClass):
+	...     pass
+	>>> a = MyClass()
+	>>> isinstance(a.log, logging.Logger)
+	True
+	>>> print(a.log.name)
+	fontTools.misc.loggingTools.MyClass
+	>>> class AnotherClass(MyClass):
+	...     pass
+	>>> b = AnotherClass()
+	>>> isinstance(b.log, logging.Logger)
+	True
+	>>> print(b.log.name)
+	fontTools.misc.loggingTools.AnotherClass
 	"""
 
 	@property

--- a/Lib/fontTools/ttLib/tables/T_S_I__1.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__1.py
@@ -7,18 +7,14 @@ code, as well as the 'extra' programs 'fpgm', 'ppgm' (i.e. 'prep'), and 'cvt'.
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from . import DefaultTable
-import logging
+from fontTools.misc.loggingTools import LogMixin
 
 
-class table_T_S_I__1(DefaultTable.DefaultTable):
+class table_T_S_I__1(LogMixin, DefaultTable.DefaultTable):
 
 	extras = {0xfffa: "ppgm", 0xfffb: "cvt", 0xfffc: "reserved", 0xfffd: "fpgm"}
 
 	indextable = "TSI0"
-
-	def __init__(self, tag=None):
-		super(table_T_S_I__1, self).__init__(tag)
-		self.log = logging.getLogger(self.__class__.__module__)
 
 	def decompile(self, data, ttFont):
 		totalLength = len(data)

--- a/Tests/misc/loggingTools_test.py
+++ b/Tests/misc/loggingTools_test.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools.misc.loggingTools import (
-    LevelFormatter, Timer, configLogger, ChannelsFilter)
+    LevelFormatter, Timer, configLogger, ChannelsFilter, LogMixin)
 import logging
 import textwrap
 import time
@@ -148,3 +148,25 @@ def test_ChannelsFilter(logger):
 
     logging.getLogger(n+'.C.DE').debug('neither this one!')
     assert before == stream.getvalue()
+
+
+def test_LogMixin():
+
+    class Base(object):
+        pass
+
+    class A(LogMixin, Base):
+        pass
+
+    class B(A):
+        pass
+
+    a = A()
+    b = B()
+
+    assert hasattr(a, 'log')
+    assert hasattr(b, 'log')
+    assert isinstance(a.log, logging.Logger)
+    assert isinstance(b.log, logging.Logger)
+    assert a.log.name == "loggingTools_test.A"
+    assert b.log.name == "loggingTools_test.B"


### PR DESCRIPTION
This is useful to quickly add logging functionality to classes, and to reduce boilerplate.

It adds a `log` property to the class inheriting from it, which uses `logging.getLogger` to get a logging.Logger (sigleton) object named after `<module>.<class>` of `self`.