### PR TITLE
[pens] add filterPen module

### DIFF
--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -1,0 +1,74 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from fontTools.pens.basePen import AbstractPen
+
+
+class FilterPen(AbstractPen):
+
+    """ Base class for pens that apply some transformation to the coordinates
+    they receive and pass them to another pen.
+
+    You can override any of its methods. The default implementation does
+    nothing, but passes the commands unmodified to the other pen.
+
+    >>> from fontTools.pens.recordingPen import RecordingPen
+    >>> rec = RecordingPen()
+    >>> pen = FilterPen(rec)
+    >>> v = iter(rec.value)
+
+    >>> pen.moveTo((0, 0))
+    >>> next(v)
+    ('moveTo', ((0, 0),))
+
+    >>> pen.lineTo((1, 1))
+    >>> next(v)
+    ('lineTo', ((1, 1),))
+
+    >>> pen.curveTo((2, 2), (3, 3), (4, 4))
+    >>> next(v)
+    ('curveTo', ((2, 2), (3, 3), (4, 4)))
+
+    >>> pen.qCurveTo((5, 5), (6, 6), (7, 7), (8, 8))
+    >>> next(v)
+    ('qCurveTo', ((5, 5), (6, 6), (7, 7), (8, 8)))
+
+    >>> pen.closePath()
+    >>> next(v)
+    ('closePath', ())
+
+    >>> pen.moveTo((9, 9))
+    >>> next(v)
+    ('moveTo', ((9, 9),))
+
+    >>> pen.endPath()
+    >>> next(v)
+    ('endPath', ())
+
+    >>> pen.addComponent('foo', (1, 0, 0, 1, 0, 0))
+    >>> next(v)
+    ('addComponent', ('foo', (1, 0, 0, 1, 0, 0)))
+    """
+
+    def __init__(self, outPen):
+        self._outPen = outPen
+
+    def moveTo(self, pt):
+        self._outPen.moveTo(pt)
+
+    def lineTo(self, pt):
+        self._outPen.lineTo(pt)
+
+    def curveTo(self, *points):
+        self._outPen.curveTo(*points)
+
+    def qCurveTo(self, *points):
+        self._outPen.qCurveTo(*points)
+
+    def closePath(self):
+        self._outPen.closePath()
+
+    def endPath(self):
+        self._outPen.endPath()
+
+    def addComponent(self, glyphName, transformation):
+        self._outPen.addComponent(glyphName, transformation)

--- a/Lib/fontTools/pens/transformPen.py
+++ b/Lib/fontTools/pens/transformPen.py
@@ -1,12 +1,12 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
-from fontTools.pens.basePen import AbstractPen
+from fontTools.pens.filterPen import FilterPen
 
 
 __all__ = ["TransformPen"]
 
 
-class TransformPen(AbstractPen):
+class TransformPen(FilterPen):
 
 	"""Pen that transforms all coordinates using a Affine transformation,
 	and passes them to another pen.
@@ -17,12 +17,12 @@ class TransformPen(AbstractPen):
 		transformed coordinates. The 'transformation' argument can either
 		be a six-tuple, or a fontTools.misc.transform.Transform object.
 		"""
+		super(TransformPen, self).__init__(outPen)
 		if not hasattr(transformation, "transformPoint"):
 			from fontTools.misc.transform import Transform
 			transformation = Transform(*transformation)
 		self._transformation = transformation
 		self._transformPoint = transformation.transformPoint
-		self._outPen = outPen
 		self._stack = []
 
 	def moveTo(self, pt):


### PR DESCRIPTION
The base `FilterPen` class is simply a pen that delegates the drawing to another one, which is passed as argument in the `__init__` method.

The existing `TransformPen` is an example of this class of pens.

The default implementation of `FilterPen` simply passes through the drawing commands to the sub-pen, without modifications.

One can subclass FilterPen and override any of its methods in order to manipulate the contours or components, before sending them to the other pen.