### PR TITLE
builder: throw when a mark is defined in multiple mark classes

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -887,6 +887,13 @@ class Builder(object):
                         otMarkAnchor = makeOpenTypeAnchor(markClassDef.anchor)
                         lookupBuilder.marks[mark] = (
                             markClass.name, otMarkAnchor)
+                    else:
+                        existingMarkClass = lookupBuilder.marks[mark][0]
+                        if markClass.name != existingMarkClass:
+                            raise FeatureLibError(
+                                "Glyph %s cannot be in both @%s and @%s" % (
+                                    mark, existingMarkClass, markClass.name),
+                                location)
 
     def add_mark_base_pos(self, location, bases, marks):
         builder = self.get_lookup_(location, MarkBasePosBuilder)

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -457,6 +457,18 @@ class BuilderTest(unittest.TestCase):
             self.build,
             "markClass [acute] <anchor 350 0> @TOP_MARKS;"*2)
 
+    def test_markClass_same_glyph_multiple_classes(self):
+        self.assertRaisesRegex(
+            FeatureLibError,
+            'Glyph uni0327 cannot be in both @ogonek and @cedilla',
+            self.build,
+            "feature mark {"
+            "    markClass [uni0327 uni0328] <anchor 0 0> @ogonek;"
+            "    pos base [a] <anchor 399 0> mark @ogonek;"
+            "    markClass [uni0327] <anchor 0 0> @cedilla;"
+            "    pos base [a] <anchor 244 0> mark @cedilla;"
+            "} mark;")
+
 
 def generate_feature_file_test(name):
     return lambda self: self.check_feature_file(name)


### PR DESCRIPTION
(within the same lookup)

See #453.

r? @brawer

cc @madig: this will throw a explicit error for the file you sent me instead of putting a KeyError down the line.