### PR TITLE
[_g_l_y_f] fix float precision loss in GlyphCoordinates

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1170,13 +1170,13 @@ class GlyphCoordinates(object):
 		return self._a
 
 	def isFloat(self):
-		return self._a.typecode == 'f'
+		return self._a.typecode == 'd'
 
 	def _ensureFloat(self):
 		if self.isFloat():
 			return
 		# The conversion to list() is to work around Jython bug
-		self._a = array.array("f", list(self._a))
+		self._a = array.array("d", list(self._a))
 
 	def _checkFloat(self, p):
 		if self.isFloat():

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -143,3 +143,13 @@ class GlyphCoordinatesTest(object):
         assert bool(g) == True
         g = GlyphCoordinates([(0,.5), (0,0)])
         assert bool(g) == True
+
+    def test_double_precision_float(self):
+        # https://github.com/fonttools/fonttools/issues/963
+        afloat = 242.50000000000003
+        g = GlyphCoordinates([(afloat, 0)])
+        g.toInt()
+        # this would return 242 if the internal array.array typecode is 'f',
+        # since the Python float is truncated to a C float.
+        # when using typecode 'd' it should return the correct value 243
+        assert g[0][0] == round(afloat)


### PR DESCRIPTION
This failing test is to show the issue #963.
The patch below fixes it.

I don't see problems with changing GlyphCoordinates to using doubles instead of floats, but I'd like to hear from others before committing the change in case I may be missing something.


```diff
diff --git a/Lib/fontTools/ttLib/tables/_g_l_y_f.py b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
index 1e255506..b4586e39 100644
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1170,13 +1170,13 @@ class GlyphCoordinates(object):
 		return self._a
 
 	def isFloat(self):
-		return self._a.typecode == 'f'
+		return self._a.typecode == 'd'
 
 	def _ensureFloat(self):
 		if self.isFloat():
 			return
 		# The conversion to list() is to work around Jython bug
-		self._a = array.array("f", list(self._a))
+		self._a = array.array("d", list(self._a))
 
 	def _checkFloat(self, p):
 		if self.isFloat():
```