### PR TITLE
Cleanup work in cffLib.py

### DIFF
--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -183,7 +183,7 @@ class CFFFontSet(object):
 				fontName = "CFF2Font"
 				self.fontNames.append(fontName)
 				cff2GetGlyphOrder = self.otFont.getGlyphOrder
-				topDict = TopDict2(GlobalSubrs=self.GlobalSubrs, cff2GetGlyphOrder=cff2GetGlyphOrder)
+				topDict = TopDict(GlobalSubrs=self.GlobalSubrs, cff2GetGlyphOrder=cff2GetGlyphOrder)
 				self.topDictIndex = TopDictData(None, cff2GetGlyphOrder, None)
 			self.topDictIndex.append(topDict)
 			for element in content:
@@ -673,7 +673,7 @@ class TopDictData(TopDictIndex):
 		return dataLength
 
 	def produceItem(self, index, data, file, offset, size):
-		top = TopDict2(self.strings, file, offset, self.GlobalSubrs, self.cff2GetGlyphOrder)
+		top = TopDict(self.strings, file, offset, self.GlobalSubrs, self.cff2GetGlyphOrder)
 		top.decompile(data)
 		return top
 
@@ -1105,23 +1105,18 @@ class TableConverter(SimpleConverter):
 
 class PrivateDictConverter(TableConverter):
 	def getClass(self):
-		if isCFF2:
-			return PrivateDict2
-		else:
-			return PrivateDict
+		return PrivateDict
 
 	def read(self, parent, value):
 		size, offset = value
 		file = parent.file
-		if isCFF2:
-			priv = PrivateDict2(parent.strings, file, offset, parent)
-		else:
-			priv = PrivateDict(parent.strings, file, offset, parent)
+		priv = PrivateDict(parent.strings, file, offset, parent)
 		file.seek(offset)
 		data = file.read(size)
 		assert len(data) == size
 		priv.decompile(data)
 		return priv
+
 	def write(self, parent, value):
 		return (0, 0)  # dummy value
 
@@ -2129,7 +2124,6 @@ class BaseDict(object):
 
 class TopDict(BaseDict):
 
-	defaults = buildDefaults(topDictOperators)
 	converters = buildConverters(topDictOperators)
 	compilerClass = TopDictCompiler
 	order = buildOrder(topDictOperators)
@@ -2139,6 +2133,14 @@ class TopDict(BaseDict):
 		BaseDict.__init__(self, strings, file, offset)
 		self.cff2GetGlyphOrder = cff2GetGlyphOrder
 		self.GlobalSubrs = GlobalSubrs
+		if isCFF2:
+			if cff2GetGlyphOrder == None:
+				import pdb
+				pdb.set_trace()
+			self.defaults = buildDefaults(topDictOperators2)
+			self.charset = cff2GetGlyphOrder()
+		else:
+			self.defaults = buildDefaults(topDictOperators)
 
 	def getGlyphOrder(self):
 		return self.charset
@@ -2180,16 +2182,7 @@ class TopDict(BaseDict):
 				progress.increment(0)  # update
 			i = i + 1
 
-class TopDict2(TopDict):
-	defaults = buildDefaults(topDictOperators2)
-
-	def __init__(self, strings=None, file=None, offset=None, GlobalSubrs=None, cff2GetGlyphOrder = None):
-		BaseDict.__init__(self, strings, file, offset)
-		self.cff2GetGlyphOrder = cff2GetGlyphOrder
-		self.charset = cff2GetGlyphOrder()
-		self.GlobalSubrs = GlobalSubrs
-
-class FontDict(TopDict):
+class FontDict(BaseDict):
 	#
 	# Since fonttools used to pass a lot of fields that are not relevant in the FDArray
 	# FontDict, there are 'ttx' files in the wild that contain all these. These got in
@@ -2217,15 +2210,17 @@ class FontDict(TopDict):
 	# - https://github.com/fonttools/fonttools/issues/601
 	# - https://github.com/adobe-type-tools/afdko/issues/137
 	#
-	order = ['FontName', 'FontMatrix', 'Weight', 'Private']
+	converters = buildConverters(topDictOperators)
 	compilerClass = FontDictCompiler
+	order = ['FontName', 'FontMatrix', 'Weight', 'Private']
+	decompilerClass = TopDictDecompiler
 
 	def __init__(self, strings=None, file=None, offset=None, GlobalSubrs=None, topDict = None):
-		super(FontDict, self).__init__(strings, file, offset, GlobalSubrs, None)
+		super(FontDict, self).__init__(strings, file, offset)
 		self.topDict = topDict
+		self.defaults = {}
 
 class PrivateDict(BaseDict):
-	defaults = buildDefaults(privateDictOperators)
 	converters = buildConverters(privateDictOperators)
 	order = buildOrder(privateDictOperators)
 	decompilerClass = PrivateDictDecompiler
@@ -2234,15 +2229,13 @@ class PrivateDict(BaseDict):
 	def __init__(self, strings=None, file=None, offset=None, parent= None):
 		super(PrivateDict, self).__init__(strings, file, offset)
 		self.fontDict = parent
-		self.isCFF2 = False
-
-class PrivateDict2(PrivateDict):
-	defaults = buildDefaults(privateDictOperators2)
-
-	def __init__(self, strings=None, file=None, offset=None, parent= None):
-		super(PrivateDict2, self).__init__(strings, file, offset, parent)
+		self.isCFF2 = isCFF2
 		self.vstore = None
 		self.isCFF2 = True
+		if self.isCFF2:
+			self.defaults = buildDefaults(privateDictOperators2)
+		else:
+			self.defaults = buildDefaults(privateDictOperators)
 
 	def getNumRegions(self, vi = None):
 		# if getNumRegions is being called, we can assume that VarStore exists.
@@ -2255,13 +2248,6 @@ class PrivateDict2(PrivateDict):
 				vi = 0
 		numRegions = self.vstore.getNumRegions(vi)
 		return numRegions
-
-	def decompile(self, data):
-		log.log(DEBUG, "    length %s is %d", self.__class__.__name__, len(data))
-		dec = self.decompilerClass(self.strings, self)
-		dec.decompile(data)
-		self.rawDict = dec.getDict()
-		self.postDecompile()
 
 class IndexedStrings(object):
 

--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -2182,6 +2182,7 @@ class TopDict(BaseDict):
 
 class TopDict2(TopDict):
 	defaults = buildDefaults(topDictOperators2)
+	order = buildOrder(topDictOperators2)
 
 	def __init__(self, strings=None, file=None, offset=None, GlobalSubrs=None, cff2GetGlyphOrder = None):
 		BaseDict.__init__(self, strings, file, offset)

--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -1116,7 +1116,7 @@ class TableConverter(SimpleConverter):
 		xmlWriter.endtag(name)
 		xmlWriter.newline()
 	def xmlRead(self, name, attrs, content, parent):
-		ob = self.getClass()()
+		ob = self.getClass()(parent.cffCtx)
 		for element in content:
 			if isinstance(element, basestring):
 				continue
@@ -1140,7 +1140,7 @@ class PrivateDictConverter(TableConverter):
 	def write(self, parent, value):
 		return (0, 0)  # dummy value
 	def xmlRead(self, name, attrs, content, parent):
-		ob = self.getClass()(parent.cffCtx, None, None, None)
+		ob = self.getClass()(parent.cffCtx)
 		for element in content:
 			if isinstance(element, basestring):
 				continue

--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -99,7 +99,7 @@ class CFFFontSet(object):
 			self.hdrSize = 5
 			writer.add(sstruct.pack(cffHeaderFormat, self))
 			# Note: topDictSize will most likely change in CFFWriter.toFile().
-			self.topDictSize  = topCompiler.getTopDictLen()
+			self.topDictSize  = topCompiler.getDataLength()
 			writer.add(struct.pack(">H", self.topDictSize))
 		else:
 			self.hdrSize = 4
@@ -426,10 +426,6 @@ class TopDictIndexCompiler(IndexCompiler):
 
 class TopDictDataCompiler(TopDictIndexCompiler):
 
-	def getTopDictLen(self):
-		topDictLen = self.items[0].getDataLength()
-		return topDictLen
-
 	def getOffsets(self):
 		offsets = [0, self.items[0].getDataLength()]
 		return offsets
@@ -663,10 +659,6 @@ class TopDictIndex(Index):
 		else:
 			dataLength = len(self)
 		return dataLength
-
-	def toFile(self, file):
-		topDict = self.items[0]
-		topDict.toFile(file)
 
 	def toXML(self, xmlWriter, progress):
 		for i in range(len(self)):

--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -62,7 +62,6 @@ class CFFFontSet(object):
 		if self.major == 1:
 			self.offSize = struct.unpack("B", file.read(1))[0]
 			file.seek(self.hdrSize)
-			self.cffCtx.isCFF2 = False
 			self.fontNames = list(Index(self.cffCtx, file))
 			self.topDictIndex = TopDictIndex(self.cffCtx, file)
 			self.strings = IndexedStrings(self.cffCtx, file)
@@ -72,7 +71,6 @@ class CFFFontSet(object):
 		elif self.major == 2:
 			self.topDictSize = struct.unpack(">H", file.read(2))[0]
 			file.seek(self.hdrSize)
-			self.cffCtx.isCFF2 = True
 			self.fontNames = ["CFF2Font"]
 			cff2GetGlyphOrder = otFont.getGlyphOrder
 			self.topDictIndex = TopDictIndex(self.cffCtx, file, cff2GetGlyphOrder, self.topDictSize) # in CFF2, offsetSize is the size of the TopDict data.

--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -2188,16 +2188,6 @@ class TopDict(BaseDict):
 				progress.increment(0)  # update
 			i = i + 1
 
-class TopDict2(BaseDict):
-	defaults = buildDefaults(topDictOperators2)
-	order = buildOrder(topDictOperators2)
-
-	def __init__(self, strings=None, file=None, offset=None, GlobalSubrs=None, cff2GetGlyphOrder = None):
-		BaseDict.__init__(self, strings, file, offset)
-		self.cff2GetGlyphOrder = cff2GetGlyphOrder
-		self.charset = cff2GetGlyphOrder()
-		self.GlobalSubrs = GlobalSubrs
-
 class FontDict(BaseDict):
 	#
 	# Since fonttools used to pass a lot of fields that are not relevant in the FDArray

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -1167,10 +1167,11 @@ class DictDecompiler(ByteCodeBase):
 
 	operandEncoding = cffDictOperandEncoding
 
-	def __init__(self, strings):
+	def __init__(self, strings, parent = None):
 		self.stack = []
 		self.strings = strings
 		self.dict = {}
+		self.parent = parent
 
 	def getDict(self):
 		assert len(self.stack) == 0, "non-empty stack"

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -267,7 +267,13 @@ class SimpleT2Decompiler(object):
 		self.numRegions = 0
 
 	def check_program(self, program):
-		if self.private and self.private.isCFF2():
+		try:
+			isCFF2 = self.private.isCFF2()
+			# Type 1 charstrings don't have self.private.
+			# Type2 CFF chrstrings may have self.private == None.
+		except AttributeError:
+			isCFF2 = False
+		if isCFF2:
 			if program:
 				assert program[-1] not in ("seac"), "illegal CharString Terminator"
 		else:
@@ -973,7 +979,13 @@ class T2CharString(ByteCodeBase):
 		self.width = extractor.width
 
 	def check_program(self, program):
-		if self.private and self.private.isCFF2():
+		try:
+			isCFF2 = self.private.isCFF2()
+			# Type 1 charstrings don't have self.private.
+			# Type 2 CFF chrstrings may have self.private == None.
+		except AttributeError:
+			isCFF2 = False
+		if isCFF2:
 			if self.program:
 				assert self.program[-1] not in ("seac",), "illegal CFF2 CharString Termination"
 		else:

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -124,7 +124,7 @@ t2Operators = [
 	(10,		'callsubr'),
 	(11,		'return'),
 	(14,		'endchar'),
-
+	(15,		'vsindex'),
 	(16,		'blend'),
 	(18,		'hstemhm'),
 	(19,		'hintmask'),
@@ -169,22 +169,6 @@ t2Operators = [
 	((12, 36),	'hflex1'),
 	((12, 37),	'flex1'),
 ]
-
-CFF2Operators = [entry for entry in t2Operators if ((isinstance(entry[0], int) or
-											(entry[0][1] < 34)) and (not entry[0] in [11,14])) ]
-CFF2Operators.extend(
-[
-	(15,		'vsindex'),
-	(16,		'blend'),
-])
-
-def sortOps(entry):
-	opCode = entry[0]
-	if isinstance(opCode, int):
-		opCode = (opCode,)
-	return opCode
-
-CFF2Operators.sort(key=sortOps)
 
 def getIntEncoder(format):
 	if format == "cff":
@@ -1044,6 +1028,7 @@ class T2CharString(ByteCodeBase):
 		self.setBytecode(bytecode)
 
 		if self.isCFF2:
+			# If present, remove endchar operator.
 			if self.bytecode and (byteord(self.bytecode[-1]) in (11, 14)):
 				self.bytecode = self.bytecode[:-1]
 
@@ -1153,8 +1138,6 @@ class T2CharString(ByteCodeBase):
 
 class CFF2CharString(T2CharString):
 
-	operandEncoding = t2OperandEncoding
-	operators, opcodes = buildOperatorDict(CFF2Operators)
 	decompilerClass = SimpleCFF2Decompiler
 
 	def __init__(self, bytecode=None, program=None, private=None, globalSubrs=None, isCFF2 = True):

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -267,7 +267,7 @@ class SimpleT2Decompiler(object):
 		self.numRegions = 0
 
 	def check_program(self, program):
-		if self.private and self.private.isCFF2:
+		if self.private and self.private.isCFF2():
 			if program:
 				assert program[-1] not in ("seac"), "illegal CharString Terminator"
 		else:
@@ -973,7 +973,7 @@ class T2CharString(ByteCodeBase):
 		self.width = extractor.width
 
 	def check_program(self, program):
-		if self.private and self.private.isCFF2:
+		if self.private and self.private.isCFF2():
 			if self.program:
 				assert self.program[-1] not in ("seac",), "illegal CFF2 CharString Termination"
 		else:
@@ -1016,7 +1016,7 @@ class T2CharString(ByteCodeBase):
 			raise
 		self.setBytecode(bytecode)
 
-		if self.private and self.private.isCFF2:
+		if self.private and self.private.isCFF2():
 			# If present, remove return and endchar operators.
 			if self.bytecode and (byteord(self.bytecode[-1]) in (11, 14)):
 				self.bytecode = self.bytecode[:-1]

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -1179,7 +1179,7 @@ class DictDecompiler(ByteCodeBase):
 
 	operandEncoding = cffDictOperandEncoding
 
-	def __init__(self, strings, parent = None):
+	def __init__(self, strings, parent=None):
 		self.stack = []
 		self.strings = strings
 		self.dict = {}

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -251,7 +251,7 @@ class CharStringCompileError(Exception): pass
 
 class SimpleT2Decompiler(object):
 
-	def __init__(self, localSubrs, globalSubrs, private):
+	def __init__(self, localSubrs, globalSubrs, private=None):
 		self.localSubrs = localSubrs
 		self.localBias = calcSubrBias(localSubrs)
 		self.globalSubrs = globalSubrs

--- a/Lib/fontTools/ttLib/tables/C_F_F_.py
+++ b/Lib/fontTools/ttLib/tables/C_F_F_.py
@@ -44,4 +44,4 @@ class table_C_F_F_(DefaultTable.DefaultTable):
 	def fromXML(self, name, attrs, content, otFont):
 		if not hasattr(self, "cff"):
 			self.cff = cffLib.CFFFontSet()
-		self.cff.fromXML(name, attrs, content)
+		self.cff.fromXML(name, attrs, content, otFont)

--- a/Lib/fontTools/ttLib/tables/C_F_F__2.py
+++ b/Lib/fontTools/ttLib/tables/C_F_F__2.py
@@ -1,47 +1,8 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools import cffLib
-from . import DefaultTable
+from fontTools.ttLib.tables.C_F_F_ import table_C_F_F_
 
 
-class table_C_F_F__2(DefaultTable.DefaultTable):
-
-	def __init__(self, tag=None):
-		DefaultTable.DefaultTable.__init__(self, tag)
-		self.cff = cffLib.CFFFontSet()
-		self._gaveGlyphOrder = False
-
-	def decompile(self, data, otFont):
-		self.cff.decompile(BytesIO(data), otFont)
-		assert len(self.cff) < 2, "can't deal with multi-font CFF tables."
-
-	def compile(self, otFont):
-		f = BytesIO()
-		self.cff.compile(f, otFont)
-		return f.getvalue()
-
-	def haveGlyphNames(self):
-		if hasattr(self.cff[self.cff.fontNames[0]], "ROS"):
-			return False  # CID-keyed font
-		else:
-			return True
-
-	def getGlyphOrder(self):
-		if self._gaveGlyphOrder:
-			from fontTools import ttLib
-			raise ttLib.TTLibError("illegal use of getGlyphOrder()")
-		self._gaveGlyphOrder = True
-		return self.cff[self.cff.fontNames[0]].getGlyphOrder()
-
-	def setGlyphOrder(self, glyphOrder):
-		pass
-		# XXX
-		#self.cff[self.cff.fontNames[0]].setGlyphOrder(glyphOrder)
-
-	def toXML(self, writer, otFont, progress=None):
-		self.cff.toXML(writer, progress)
-
-	def fromXML(self, name, attrs, content, otFont):
-		if not hasattr(self, "cff"):
-			self.cff = cffLib.CFFFontSet()
-		self.cff.fromXML(name, attrs, content, otFont)
+class table_C_F_F__2(table_C_F_F_):
+	pass

--- a/Tests/ttLib/tables/data/C_F_F__2.ttx
+++ b/Tests/ttLib/tables/data/C_F_F__2.ttx
@@ -66,7 +66,6 @@
       <FontMatrix value="0.001 0 0 0.001 0 0"/>
       <FDArray>
         <FontDict index="0">
-          <FontMatrix value="0.001 0 0 0.001 0 0"/>
           <Private>
             <BlueValues>
                 <blend value="-20 -15 -13 -20 -15 -13"/>


### PR DESCRIPTION
Remove specialized classes for CFF2: move logic into regular classes. To change a CFF table from CFF to CFF2, you now need only to set cff.major = 2, and move the Private Dict from the TopDict to a FontDict in an FDArray.
Removed global state: use instead a context class.