### PR TITLE
Fix broken ttx tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,6 +24,7 @@ recursive-include Doc/man/man1 *.1
 recursive-include Doc/source *.py *.rst
 
 recursive-include Tests *.py *.ttx *.otx *.fea *.feax
+recursive-include Tests *.ttc *.ttf *.dfont *.woff *.woff2
 recursive-include Tests *.otf *.ttx.*
 recursive-include Tests *.glif *.plist
 recursive-include Tests *.txt README


### PR DESCRIPTION
Currently, running tests with the source distribution fails due to missing test font files.
This PR adds the missing files to the MANIFEST.in and fixes the issue.