### PR TITLE
Copy emptied Script and LangSys records between GSUB and GPOS if missing

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -85,13 +85,20 @@ class Builder(object):
         self.build_OS_2()
         for tag in ('GPOS', 'GSUB'):
             table = self.makeTable(tag)
-            if (table.ScriptList.ScriptCount > 0 or
-                    table.FeatureList.FeatureCount > 0 or
-                    table.LookupList.LookupCount > 0):
-                fontTable = self.font[tag] = newTable(tag)
-                fontTable.table = table
-            elif tag in self.font:
-                del self.font[tag]
+            fontTable = self.font[tag] = newTable(tag)
+            fontTable.table = table
+        # Only remove empty GPOS and GSUB tables if both are empty
+        # See https://github.com/googlei18n/fontmake/issues/258
+        gpos_table = self.font['GPOS'].table
+        gsub_table = self.font['GSUB'].table
+        if (not (gpos_table.ScriptList.ScriptCount > 0 or
+                 gpos_table.FeatureList.FeatureCount > 0 or
+                 gpos_table.LookupList.LookupCount > 0) and
+            not (gsub_table.ScriptList.ScriptCount > 0 or
+                 gsub_table.FeatureList.FeatureCount > 0 or
+                 gsub_table.LookupList.LookupCount > 0)):
+            del self.font['GPOS']
+            del self.font['GSUB']
         gdef = self.buildGDEF()
         if gdef:
             self.font["GDEF"] = gdef

--- a/Tests/feaLib/data/GPOS_1.ttx
+++ b/Tests/feaLib/data/GPOS_1.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GPOS_1.ttx
+++ b/Tests/feaLib/data/GPOS_1.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/GPOS_1_zero.ttx
+++ b/Tests/feaLib/data/GPOS_1_zero.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GPOS_1_zero.ttx
+++ b/Tests/feaLib/data/GPOS_1_zero.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont>
- 
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/GPOS_2.ttx
+++ b/Tests/feaLib/data/GPOS_2.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GPOS_2.ttx
+++ b/Tests/feaLib/data/GPOS_2.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/GPOS_2b.ttx
+++ b/Tests/feaLib/data/GPOS_2b.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GPOS_2b.ttx
+++ b/Tests/feaLib/data/GPOS_2b.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/GPOS_3.ttx
+++ b/Tests/feaLib/data/GPOS_3.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GPOS_3.ttx
+++ b/Tests/feaLib/data/GPOS_3.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/GPOS_4.ttx
+++ b/Tests/feaLib/data/GPOS_4.ttx
@@ -19,7 +19,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GPOS_4.ttx
+++ b/Tests/feaLib/data/GPOS_4.ttx
@@ -16,6 +16,19 @@
     </GlyphClassDef>
   </GDEF>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/GPOS_5.ttx
+++ b/Tests/feaLib/data/GPOS_5.ttx
@@ -19,7 +19,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GPOS_5.ttx
+++ b/Tests/feaLib/data/GPOS_5.ttx
@@ -16,6 +16,19 @@
     </GlyphClassDef>
   </GDEF>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/GPOS_6.ttx
+++ b/Tests/feaLib/data/GPOS_6.ttx
@@ -17,7 +17,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GPOS_6.ttx
+++ b/Tests/feaLib/data/GPOS_6.ttx
@@ -14,6 +14,19 @@
     </GlyphClassDef>
   </GDEF>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/GPOS_8.ttx
+++ b/Tests/feaLib/data/GPOS_8.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.0">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/GPOS_8.ttx
+++ b/Tests/feaLib/data/GPOS_8.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GSUB_2.ttx
+++ b/Tests/feaLib/data/GSUB_2.ttx
@@ -60,4 +60,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/GSUB_2.ttx
+++ b/Tests/feaLib/data/GSUB_2.ttx
@@ -63,7 +63,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GSUB_3.ttx
+++ b/Tests/feaLib/data/GSUB_3.ttx
@@ -81,7 +81,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GSUB_3.ttx
+++ b/Tests/feaLib/data/GSUB_3.ttx
@@ -78,4 +78,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/GSUB_6.ttx
+++ b/Tests/feaLib/data/GSUB_6.ttx
@@ -267,7 +267,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GSUB_6.ttx
+++ b/Tests/feaLib/data/GSUB_6.ttx
@@ -264,4 +264,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/GSUB_8.ttx
+++ b/Tests/feaLib/data/GSUB_8.ttx
@@ -129,7 +129,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/GSUB_8.ttx
+++ b/Tests/feaLib/data/GSUB_8.ttx
@@ -126,4 +126,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/ZeroValue_ChainSinglePos_horizontal.ttx
+++ b/Tests/feaLib/data/ZeroValue_ChainSinglePos_horizontal.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.7">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/ZeroValue_ChainSinglePos_horizontal.ttx
+++ b/Tests/feaLib/data/ZeroValue_ChainSinglePos_horizontal.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/ZeroValue_ChainSinglePos_vertical.ttx
+++ b/Tests/feaLib/data/ZeroValue_ChainSinglePos_vertical.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.7">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/ZeroValue_ChainSinglePos_vertical.ttx
+++ b/Tests/feaLib/data/ZeroValue_ChainSinglePos_vertical.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/ZeroValue_PairPos_horizontal.ttx
+++ b/Tests/feaLib/data/ZeroValue_PairPos_horizontal.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.0">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/ZeroValue_PairPos_horizontal.ttx
+++ b/Tests/feaLib/data/ZeroValue_PairPos_horizontal.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/ZeroValue_PairPos_vertical.ttx
+++ b/Tests/feaLib/data/ZeroValue_PairPos_vertical.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.0">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/ZeroValue_PairPos_vertical.ttx
+++ b/Tests/feaLib/data/ZeroValue_PairPos_vertical.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/ZeroValue_SinglePos_horizontal.ttx
+++ b/Tests/feaLib/data/ZeroValue_SinglePos_horizontal.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.0">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/ZeroValue_SinglePos_horizontal.ttx
+++ b/Tests/feaLib/data/ZeroValue_SinglePos_horizontal.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/ZeroValue_SinglePos_vertical.ttx
+++ b/Tests/feaLib/data/ZeroValue_SinglePos_vertical.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.0">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/ZeroValue_SinglePos_vertical.ttx
+++ b/Tests/feaLib/data/ZeroValue_SinglePos_vertical.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug453.ttx
+++ b/Tests/feaLib/data/bug453.ttx
@@ -12,7 +12,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug453.ttx
+++ b/Tests/feaLib/data/bug453.ttx
@@ -9,6 +9,19 @@
     </GlyphClassDef>
   </GDEF>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/bug457.ttx
+++ b/Tests/feaLib/data/bug457.ttx
@@ -48,7 +48,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug457.ttx
+++ b/Tests/feaLib/data/bug457.ttx
@@ -45,4 +45,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/bug463.ttx
+++ b/Tests/feaLib/data/bug463.ttx
@@ -100,4 +100,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/bug463.ttx
+++ b/Tests/feaLib/data/bug463.ttx
@@ -103,7 +103,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug501.ttx
+++ b/Tests/feaLib/data/bug501.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.0">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/bug501.ttx
+++ b/Tests/feaLib/data/bug501.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="grek"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug502.ttx
+++ b/Tests/feaLib/data/bug502.ttx
@@ -53,4 +53,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/bug502.ttx
+++ b/Tests/feaLib/data/bug502.ttx
@@ -56,7 +56,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug504.ttx
+++ b/Tests/feaLib/data/bug504.ttx
@@ -46,7 +46,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug504.ttx
+++ b/Tests/feaLib/data/bug504.ttx
@@ -43,4 +43,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/bug505.ttx
+++ b/Tests/feaLib/data/bug505.ttx
@@ -40,4 +40,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/bug505.ttx
+++ b/Tests/feaLib/data/bug505.ttx
@@ -43,7 +43,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="vai "/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug506.ttx
+++ b/Tests/feaLib/data/bug506.ttx
@@ -66,7 +66,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug506.ttx
+++ b/Tests/feaLib/data/bug506.ttx
@@ -63,4 +63,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/bug509.ttx
+++ b/Tests/feaLib/data/bug509.ttx
@@ -71,4 +71,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/bug509.ttx
+++ b/Tests/feaLib/data/bug509.ttx
@@ -74,7 +74,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug512.ttx
+++ b/Tests/feaLib/data/bug512.ttx
@@ -107,4 +107,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/bug512.ttx
+++ b/Tests/feaLib/data/bug512.ttx
@@ -110,7 +110,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug514.ttx
+++ b/Tests/feaLib/data/bug514.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.7">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/bug514.ttx
+++ b/Tests/feaLib/data/bug514.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug568.ttx
+++ b/Tests/feaLib/data/bug568.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/bug568.ttx
+++ b/Tests/feaLib/data/bug568.ttx
@@ -4,7 +4,27 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=2 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/bug633.ttx
+++ b/Tests/feaLib/data/bug633.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.0">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/bug633.ttx
+++ b/Tests/feaLib/data/bug633.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/enum.ttx
+++ b/Tests/feaLib/data/enum.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/enum.ttx
+++ b/Tests/feaLib/data/enum.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/feature_aalt.ttx
+++ b/Tests/feaLib/data/feature_aalt.ttx
@@ -181,4 +181,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/feature_aalt.ttx
+++ b/Tests/feaLib/data/feature_aalt.ttx
@@ -184,7 +184,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/ignore_pos.ttx
+++ b/Tests/feaLib/data/ignore_pos.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.0">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/ignore_pos.ttx
+++ b/Tests/feaLib/data/ignore_pos.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/language_required.ttx
+++ b/Tests/feaLib/data/language_required.ttx
@@ -147,7 +147,28 @@
             <ReqFeatureIndex value="65535"/>
             <!-- FeatureCount=0 -->
           </DefaultLangSys>
-          <!-- LangSysCount=0 -->
+          <!-- LangSysCount=3 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="DEU "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=0 -->
+            </LangSys>
+          </LangSysRecord>
+          <LangSysRecord index="1">
+            <LangSysTag value="FRA "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=0 -->
+            </LangSys>
+          </LangSysRecord>
+          <LangSysRecord index="2">
+            <LangSysTag value="ITA "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=0 -->
+            </LangSys>
+          </LangSysRecord>
         </Script>
       </ScriptRecord>
     </ScriptList>

--- a/Tests/feaLib/data/language_required.ttx
+++ b/Tests/feaLib/data/language_required.ttx
@@ -139,7 +139,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/language_required.ttx
+++ b/Tests/feaLib/data/language_required.ttx
@@ -136,4 +136,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/lookup.ttx
+++ b/Tests/feaLib/data/lookup.ttx
@@ -78,7 +78,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/lookup.ttx
+++ b/Tests/feaLib/data/lookup.ttx
@@ -75,4 +75,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/lookupflag.ttx
+++ b/Tests/feaLib/data/lookupflag.ttx
@@ -43,7 +43,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/lookupflag.ttx
+++ b/Tests/feaLib/data/lookupflag.ttx
@@ -40,6 +40,19 @@
     </MarkGlyphSetsDef>
   </GDEF>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/multiple_feature_blocks.ttx
+++ b/Tests/feaLib/data/multiple_feature_blocks.ttx
@@ -100,7 +100,14 @@
             <ReqFeatureIndex value="65535"/>
             <!-- FeatureCount=0 -->
           </DefaultLangSys>
-          <!-- LangSysCount=0 -->
+          <!-- LangSysCount=1 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="TRK "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=0 -->
+            </LangSys>
+          </LangSysRecord>
         </Script>
       </ScriptRecord>
     </ScriptList>

--- a/Tests/feaLib/data/multiple_feature_blocks.ttx
+++ b/Tests/feaLib/data/multiple_feature_blocks.ttx
@@ -82,7 +82,27 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=2 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/multiple_feature_blocks.ttx
+++ b/Tests/feaLib/data/multiple_feature_blocks.ttx
@@ -79,4 +79,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/size.ttx
+++ b/Tests/feaLib/data/size.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/size.ttx
+++ b/Tests/feaLib/data/size.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/size2.ttx
+++ b/Tests/feaLib/data/size2.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/size2.ttx
+++ b/Tests/feaLib/data/size2.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/spec4h1.ttx
+++ b/Tests/feaLib/data/spec4h1.ttx
@@ -166,4 +166,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec4h1.ttx
+++ b/Tests/feaLib/data/spec4h1.ttx
@@ -169,7 +169,37 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=3 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec4h1.ttx
+++ b/Tests/feaLib/data/spec4h1.ttx
@@ -197,7 +197,21 @@
             <ReqFeatureIndex value="65535"/>
             <!-- FeatureCount=0 -->
           </DefaultLangSys>
-          <!-- LangSysCount=0 -->
+          <!-- LangSysCount=2 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="DEU "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=0 -->
+            </LangSys>
+          </LangSysRecord>
+          <LangSysRecord index="1">
+            <LangSysTag value="TRK "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=0 -->
+            </LangSys>
+          </LangSysRecord>
         </Script>
       </ScriptRecord>
     </ScriptList>

--- a/Tests/feaLib/data/spec4h2.ttx
+++ b/Tests/feaLib/data/spec4h2.ttx
@@ -198,7 +198,14 @@
             <ReqFeatureIndex value="65535"/>
             <!-- FeatureCount=0 -->
           </DefaultLangSys>
-          <!-- LangSysCount=0 -->
+          <!-- LangSysCount=1 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="SRB "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=0 -->
+            </LangSys>
+          </LangSysRecord>
         </Script>
       </ScriptRecord>
       <ScriptRecord index="2">
@@ -218,7 +225,21 @@
             <ReqFeatureIndex value="65535"/>
             <!-- FeatureCount=0 -->
           </DefaultLangSys>
-          <!-- LangSysCount=0 -->
+          <!-- LangSysCount=2 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="DEU "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=0 -->
+            </LangSys>
+          </LangSysRecord>
+          <LangSysRecord index="1">
+            <LangSysTag value="TRK "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=0 -->
+            </LangSys>
+          </LangSysRecord>
         </Script>
       </ScriptRecord>
     </ScriptList>

--- a/Tests/feaLib/data/spec4h2.ttx
+++ b/Tests/feaLib/data/spec4h2.ttx
@@ -177,4 +177,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec4h2.ttx
+++ b/Tests/feaLib/data/spec4h2.ttx
@@ -180,7 +180,47 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=4 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="grek"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="3">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec5d1.ttx
+++ b/Tests/feaLib/data/spec5d1.ttx
@@ -81,7 +81,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec5d1.ttx
+++ b/Tests/feaLib/data/spec5d1.ttx
@@ -78,4 +78,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec5d2.ttx
+++ b/Tests/feaLib/data/spec5d2.ttx
@@ -70,4 +70,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec5d2.ttx
+++ b/Tests/feaLib/data/spec5d2.ttx
@@ -73,7 +73,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec5f_ii_1.ttx
+++ b/Tests/feaLib/data/spec5f_ii_1.ttx
@@ -97,7 +97,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec5f_ii_1.ttx
+++ b/Tests/feaLib/data/spec5f_ii_1.ttx
@@ -94,4 +94,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec5f_ii_2.ttx
+++ b/Tests/feaLib/data/spec5f_ii_2.ttx
@@ -106,7 +106,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec5f_ii_2.ttx
+++ b/Tests/feaLib/data/spec5f_ii_2.ttx
@@ -103,4 +103,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec5f_ii_3.ttx
+++ b/Tests/feaLib/data/spec5f_ii_3.ttx
@@ -152,4 +152,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec5f_ii_3.ttx
+++ b/Tests/feaLib/data/spec5f_ii_3.ttx
@@ -155,7 +155,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec5f_ii_4.ttx
+++ b/Tests/feaLib/data/spec5f_ii_4.ttx
@@ -285,7 +285,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec5f_ii_4.ttx
+++ b/Tests/feaLib/data/spec5f_ii_4.ttx
@@ -282,4 +282,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec5fi1.ttx
+++ b/Tests/feaLib/data/spec5fi1.ttx
@@ -122,7 +122,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec5fi1.ttx
+++ b/Tests/feaLib/data/spec5fi1.ttx
@@ -119,4 +119,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec5fi2.ttx
+++ b/Tests/feaLib/data/spec5fi2.ttx
@@ -63,4 +63,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec5fi2.ttx
+++ b/Tests/feaLib/data/spec5fi2.ttx
@@ -66,7 +66,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec5fi3.ttx
+++ b/Tests/feaLib/data/spec5fi3.ttx
@@ -139,7 +139,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec5fi3.ttx
+++ b/Tests/feaLib/data/spec5fi3.ttx
@@ -136,4 +136,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec5fi4.ttx
+++ b/Tests/feaLib/data/spec5fi4.ttx
@@ -70,4 +70,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec5fi4.ttx
+++ b/Tests/feaLib/data/spec5fi4.ttx
@@ -73,7 +73,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec5h1.ttx
+++ b/Tests/feaLib/data/spec5h1.ttx
@@ -51,4 +51,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec5h1.ttx
+++ b/Tests/feaLib/data/spec5h1.ttx
@@ -54,7 +54,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec6b_ii.ttx
+++ b/Tests/feaLib/data/spec6b_ii.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.0">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/spec6b_ii.ttx
+++ b/Tests/feaLib/data/spec6b_ii.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec6d2.ttx
+++ b/Tests/feaLib/data/spec6d2.ttx
@@ -19,7 +19,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec6d2.ttx
+++ b/Tests/feaLib/data/spec6d2.ttx
@@ -16,6 +16,19 @@
     </GlyphClassDef>
   </GDEF>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/spec6e.ttx
+++ b/Tests/feaLib/data/spec6e.ttx
@@ -13,7 +13,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec6e.ttx
+++ b/Tests/feaLib/data/spec6e.ttx
@@ -10,6 +10,19 @@
     </GlyphClassDef>
   </GDEF>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/spec6f.ttx
+++ b/Tests/feaLib/data/spec6f.ttx
@@ -12,7 +12,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec6f.ttx
+++ b/Tests/feaLib/data/spec6f.ttx
@@ -9,6 +9,19 @@
     </GlyphClassDef>
   </GDEF>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/spec6h_ii.ttx
+++ b/Tests/feaLib/data/spec6h_ii.ttx
@@ -11,6 +11,19 @@
     </GlyphClassDef>
   </GDEF>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/spec6h_ii.ttx
+++ b/Tests/feaLib/data/spec6h_ii.ttx
@@ -14,7 +14,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec6h_iii_1.ttx
+++ b/Tests/feaLib/data/spec6h_iii_1.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.0">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/spec6h_iii_1.ttx
+++ b/Tests/feaLib/data/spec6h_iii_1.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec6h_iii_3d.ttx
+++ b/Tests/feaLib/data/spec6h_iii_3d.ttx
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="true" ttLibVersion="3.0">
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/spec6h_iii_3d.ttx
+++ b/Tests/feaLib/data/spec6h_iii_3d.ttx
@@ -4,7 +4,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec8a.ttx
+++ b/Tests/feaLib/data/spec8a.ttx
@@ -197,4 +197,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec8a.ttx
+++ b/Tests/feaLib/data/spec8a.ttx
@@ -228,7 +228,14 @@
             <ReqFeatureIndex value="65535"/>
             <!-- FeatureCount=0 -->
           </DefaultLangSys>
-          <!-- LangSysCount=0 -->
+          <!-- LangSysCount=1 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="TRK "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=0 -->
+            </LangSys>
+          </LangSysRecord>
         </Script>
       </ScriptRecord>
     </ScriptList>

--- a/Tests/feaLib/data/spec8a.ttx
+++ b/Tests/feaLib/data/spec8a.ttx
@@ -200,7 +200,37 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=3 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec8b.ttx
+++ b/Tests/feaLib/data/spec8b.ttx
@@ -13,6 +13,19 @@
     </namerecord>
   </name>
 
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GSUB>
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>

--- a/Tests/feaLib/data/spec8b.ttx
+++ b/Tests/feaLib/data/spec8b.ttx
@@ -16,7 +16,17 @@
   <GSUB>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->

--- a/Tests/feaLib/data/spec8c.ttx
+++ b/Tests/feaLib/data/spec8c.ttx
@@ -59,4 +59,17 @@
     </LookupList>
   </GSUB>
 
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
 </ttFont>

--- a/Tests/feaLib/data/spec8c.ttx
+++ b/Tests/feaLib/data/spec8c.ttx
@@ -62,7 +62,17 @@
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>
-      <!-- ScriptCount=0 -->
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
     </ScriptList>
     <FeatureList>
       <!-- FeatureCount=0 -->


### PR DESCRIPTION
This replicates VOLT’s and FontForge’s behaviour of adding empty Script and LangSys records if one of GPOS or GSUB is empty. Older versions of Uniscribe need Script and LangSys to be in both GPOS and GSUB for features to be applied in some cases.

See https://github.com/googlei18n/fontmake/issues/258