### PR TITLE
Do not emit MVAR if there are no entries in the variation store

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -414,13 +414,14 @@ def _add_MVAR(font, model, master_ttfs, axisTags):
 		rec.VarIdx = varIdx
 		records.append(rec)
 
-	assert "MVAR" not in font
-	MVAR = font["MVAR"] = newTable('MVAR')
-	mvar = MVAR.table = ot.MVAR()
-	mvar.Version = 0x00010000
-	mvar.Reserved = 0
-	mvar.VarStore = store_builder.finish()
-	mvar.ValueRecord = sorted(records, key=lambda r: r.ValueTag)
+	if len(records) > 0 :
+		assert "MVAR" not in font
+		MVAR = font["MVAR"] = newTable('MVAR')
+		mvar = MVAR.table = ot.MVAR()
+		mvar.Version = 0x00010000
+		mvar.Reserved = 0
+		mvar.VarStore = store_builder.finish()
+		mvar.ValueRecord = sorted(records, key=lambda r: r.ValueTag)
 
 
 def _merge_OTL(font, model, master_fonts, axisTags):

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -414,7 +414,7 @@ def _add_MVAR(font, model, master_ttfs, axisTags):
 		rec.VarIdx = varIdx
 		records.append(rec)
 
-	if len(records) > 0 :
+	if records:
 		assert "MVAR" not in font
 		MVAR = font["MVAR"] = newTable('MVAR')
 		mvar = MVAR.table = ot.MVAR()


### PR DESCRIPTION
I've several typefaces that do not change any of the properties that MVAR tracks. These do not need an MVAR table, yet varLib was unconditionally emitting one. I just added an if to check that there are varying records, thus a reason to have an MVAR before storing it to the TTFont object.