### PR TITLE
Recalculate ValueFormat when merging SinglePos

### DIFF
--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -202,6 +202,7 @@ def merge(merger, self, lst):
 	if all(v.Format == 1 for v in lst) and all(self.Coverage.glyphs == v.Coverage.glyphs for v in lst):
 		self.Value = otBase.ValueRecord(valueFormat)
 		merger.mergeThings(self.Value, [v.Value for v in lst])
+		self.ValueFormat = self.Value.getFormat()
 		return
 
 	# Upgrade everything to Format=2
@@ -231,6 +232,7 @@ def merge(merger, self, lst):
 	# Merge everything else; though, there shouldn't be anything else. :)
 	merger.mergeObjects(self, lst,
 			    exclude=('Format', 'Coverage', 'ValueRecord', 'Value', 'ValueCount'))
+	self.ValueFormat = self.Value.getFormat()
 
 @AligningMerger.merger(ot.PairSet)
 def merge(merger, self, lst):

--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -232,7 +232,7 @@ def merge(merger, self, lst):
 	# Merge everything else; though, there shouldn't be anything else. :)
 	merger.mergeObjects(self, lst,
 			    exclude=('Format', 'Coverage', 'ValueRecord', 'Value', 'ValueCount'))
-	self.ValueFormat = self.Value.getFormat()
+	self.ValueFormat = reduce(int.__or__, [v.getFormat() for v in self.Value], 0)
 
 @AligningMerger.merger(ot.PairSet)
 def merge(merger, self, lst):


### PR DESCRIPTION
The ValueFormat of the ValueRecord in a SinglePos must be recalculated after merging, or the reference to the item store will be discarded when the font is compiled. Fixes #995. 