### PR TITLE
[cffLib/psCharStrings] remove cffCtx, pass down isCFF2

### DIFF
--- a/Lib/fontTools/ttLib/tables/C_F_F_.py
+++ b/Lib/fontTools/ttLib/tables/C_F_F_.py
@@ -12,12 +12,12 @@ class table_C_F_F_(DefaultTable.DefaultTable):
 		self._gaveGlyphOrder = False
 
 	def decompile(self, data, otFont):
-		self.cff.decompile(BytesIO(data), otFont)
+		self.cff.decompile(BytesIO(data), otFont, isCFF2=False)
 		assert len(self.cff) == 1, "can't deal with multi-font CFF tables."
 
 	def compile(self, otFont):
 		f = BytesIO()
-		self.cff.compile(f, otFont)
+		self.cff.compile(f, otFont, isCFF2=False)
 		return f.getvalue()
 
 	def haveGlyphNames(self):

--- a/Lib/fontTools/ttLib/tables/C_F_F__2.py
+++ b/Lib/fontTools/ttLib/tables/C_F_F__2.py
@@ -5,4 +5,12 @@ from fontTools.ttLib.tables.C_F_F_ import table_C_F_F_
 
 
 class table_C_F_F__2(table_C_F_F_):
-	pass
+
+    def decompile(self, data, otFont):
+        self.cff.decompile(BytesIO(data), otFont, isCFF2=True)
+        assert len(self.cff) == 1, "can't deal with multi-font CFF tables."
+
+    def compile(self, otFont):
+        f = BytesIO()
+        self.cff.compile(f, otFont, isCFF2=True)
+        return f.getvalue()


### PR DESCRIPTION
As discussed in https://github.com/fonttools/fonttools/pull/968#issuecomment-309920007 and in private conversation with @behdad, here is an (admittedly huge) patch that should break the current deadlock, and allow us to keep backward compatibility with the old cffLib interface (so fontmake or robofont don't break).

* Removed `CFFContext`
* Added `isCFF2` argument to CFFFontSet.decompile/compile, used from respective ttLib classes
* Index classes get a `isCFF2` argument in constructor (used for decompiling); must be True/False if `file` argument is not None; it is stored as self._isCFF2 to support lazy loading
* Removed `TopDictData` class; reuse same `TopDictIndexCompiler` for both CFF and CFF2
* `CFFWriter` and all `*Compiler` classes get an `isCFF2` argument; defaults to the parent compiler's `isCFF2` attribute
* Removed `size` argument from `produceItem` method as unused and useless (`len(data)` is the same)
* psCharStrings: removed useless ByteCodeBase class
* A reference to the TopDict's VarStoreData is passed down to all the FontDicts' PrivateDict, so it can be used to get the number of regions while decompiling blend and vsindex operators

I know I should have broken this into smaller patches, but... 😬 

/cc @readroberts 