### PR TITLE
[varLib] Reactivate shared points logic, bugfixes

### DIFF
--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -512,11 +512,6 @@ def compileTupleVariationStore(variations, pointCount,
 			axisTags, sharedTupleIndices, sharedPoints=None)
 		sharedTuple, sharedData, usesSharedPoints = v.compile(
 			axisTags, sharedTupleIndices, sharedPoints=allPoints)
-		# TODO: Apple macOS 10.9.5 (maybe also earlier) up to 10.12 had a bug
-		# that broke variations if the `gvar` table contains shared tuples.
-		# Apple will likely fix this in macOS 10.13. But for the time being,
-		# we never emit shared points although the result would be more compact.
-		# https://rawgit.com/unicode-org/text-rendering-tests/master/reports/CoreText.html#GVAR-1
 		if (len(sharedTuple) + len(sharedData)) < (len(privateTuple) + len(privateData)):
 			tuples.append(sharedTuple)
 			data.append(sharedData)

--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -134,11 +134,12 @@ class TupleVariation(object):
 			flags |= INTERMEDIATE_REGION
 			tupleData.append(intermediateCoord)
 
-		if sharedPoints is not None:
+		points = self.getUsedPoints()
+		if sharedPoints == points:
+			# Only use the shared points if they are identical to the actually used points
 			auxData = self.compileDeltas(sharedPoints)
 		else:
 			flags |= PRIVATE_POINT_NUMBERS
-			points = self.getUsedPoints()
 			numPointsInGlyph = len(self.coordinates)
 			auxData = self.compilePoints(points, numPointsInGlyph) + self.compileDeltas(points)
 
@@ -514,8 +515,7 @@ def compileTupleVariationStore(variations, pointCount,
 		# Apple will likely fix this in macOS 10.13. But for the time being,
 		# we never emit shared points although the result would be more compact.
 		# https://rawgit.com/unicode-org/text-rendering-tests/master/reports/CoreText.html#GVAR-1
-		#if (len(sharedTuple) + len(sharedData)) < (len(privateTuple) + len(privateData)):
-		if False:
+		if (len(sharedTuple) + len(sharedData)) < (len(privateTuple) + len(privateData)):
 			tuples.append(sharedTuple)
 			data.append(sharedData)
 			someTuplesSharePoints = True

--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -524,7 +524,7 @@ def compileTupleVariationStore(variations, pointCount,
 			data.append(privateData)
 	if someTuplesSharePoints:
 		data = bytechr(0) + bytesjoin(data)  # 0x00 = "all points in glyph"
-		tupleVariationCount = tv.TUPLES_SHARE_POINT_NUMBERS | len(tuples)
+		tupleVariationCount = TUPLES_SHARE_POINT_NUMBERS | len(tuples)
 	else:
 		data = bytesjoin(data)
 		tupleVariationCount = len(tuples)

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -273,9 +273,9 @@ def _add_gvar(font, model, master_ttfs, tolerance=.5, optimize=True):
 					var_opt = TupleVariation(support, delta_opt)
 
 					axis_tags = sorted(support.keys()) # Shouldn't matter that this is different from fvar...?
-					tupleData, auxData = var.compile(axis_tags, [], None)
+					tupleData, auxData, _ = var.compile(axis_tags, [], None)
 					unoptimized_len = len(tupleData) + len(auxData)
-					tupleData, auxData = var_opt.compile(axis_tags, [], None)
+					tupleData, auxData, _ = var_opt.compile(axis_tags, [], None)
 					optimized_len = len(tupleData) + len(auxData)
 
 					if optimized_len < unoptimized_len:

--- a/Tests/ttLib/tables/TupleVariation_test.py
+++ b/Tests/ttLib/tables/TupleVariation_test.py
@@ -194,7 +194,7 @@ class TupleVariationTest(unittest.TestCase):
 			[(7,4), (8,5), (9,6)])
 		axisTags = ["wght", "wdth"]
 		sharedPeakIndices = { var.compileCoord(axisTags): 0x77 }
-		tup, deltas = var.compile(axisTags, sharedPeakIndices,
+		tup, deltas, _ = var.compile(axisTags, sharedPeakIndices,
 		                          sharedPoints={0,1,2})
 		# len(deltas)=8; flags=None; tupleIndex=0x77
 		# embeddedPeaks=[]; intermediateCoord=[]
@@ -209,7 +209,7 @@ class TupleVariationTest(unittest.TestCase):
 			[(7,4), (8,5), (9,6)])
 		axisTags = ["wght", "wdth"]
 		sharedPeakIndices = { var.compileCoord(axisTags): 0x77 }
-		tup, deltas = var.compile(axisTags, sharedPeakIndices,
+		tup, deltas, _ = var.compile(axisTags, sharedPeakIndices,
 		                          sharedPoints={0,1,2})
 		# len(deltas)=8; flags=INTERMEDIATE_REGION; tupleIndex=0x77
 		# embeddedPeak=[]; intermediateCoord=[(0.3, 0.1), (0.7, 0.9)]
@@ -224,7 +224,7 @@ class TupleVariationTest(unittest.TestCase):
 			[(7,4), (8,5), (9,6)])
 		axisTags = ["wght", "wdth"]
 		sharedPeakIndices = { var.compileCoord(axisTags): 0x77 }
-		tup, deltas = var.compile(axisTags, sharedPeakIndices,
+		tup, deltas, _ = var.compile(axisTags, sharedPeakIndices,
 		                          sharedPoints=None)
 		# len(deltas)=9; flags=PRIVATE_POINT_NUMBERS; tupleIndex=0x77
 		# embeddedPeak=[]; intermediateCoord=[]
@@ -240,7 +240,7 @@ class TupleVariationTest(unittest.TestCase):
 			[(7,4), (8,5), (9,6)])
 		axisTags = ["wght", "wdth"]
 		sharedPeakIndices = { var.compileCoord(axisTags): 0x77 }
-		tuple, deltas = var.compile(axisTags,
+		tuple, deltas, _ = var.compile(axisTags,
 		                            sharedPeakIndices, sharedPoints=None)
 		# len(deltas)=9; flags=PRIVATE_POINT_NUMBERS; tupleIndex=0x77
 		# embeddedPeak=[]; intermediateCoord=[(0.0, 0.0), (1.0, 1.0)]
@@ -255,7 +255,7 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.0, 0.5, 0.5), "wdth": (0.0, 0.8, 0.8)},
 			[(7,4), (8,5), (9,6)])
-		tup, deltas = var.compile(axisTags=["wght", "wdth"],
+		tup, deltas, _ = var.compile(axisTags=["wght", "wdth"],
 		                          sharedCoordIndices={}, sharedPoints={0, 1, 2})
 		# len(deltas)=8; flags=EMBEDDED_PEAK_TUPLE
 		# embeddedPeak=[(0.5, 0.8)]; intermediateCoord=[]
@@ -268,7 +268,7 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.0, 0.5, 0.5), "wdth": (0.0, 0.8, 0.8)},
 			[3, 1, 4])
-		tup, deltas = var.compile(axisTags=["wght", "wdth"],
+		tup, deltas, _ = var.compile(axisTags=["wght", "wdth"],
 		                          sharedCoordIndices={}, sharedPoints={0, 1, 2})
 		# len(deltas)=4; flags=EMBEDDED_PEAK_TUPLE
 		# embeddedPeak=[(0.5, 0.8)]; intermediateCoord=[]
@@ -280,7 +280,7 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.0, 0.5, 1.0), "wdth": (0.0, 0.8, 0.8)},
 			[(7,4), (8,5), (9,6)])
-		tup, deltas = var.compile(axisTags=["wght", "wdth"],
+		tup, deltas, _ = var.compile(axisTags=["wght", "wdth"],
 		                          sharedCoordIndices={},
 		                          sharedPoints={0, 1, 2})
 		# len(deltas)=8; flags=EMBEDDED_PEAK_TUPLE
@@ -295,7 +295,7 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.0, 0.5, 0.5), "wdth": (0.0, 0.8, 0.8)},
 			[(7,4), (8,5), (9,6)])
-		tup, deltas = var.compile(
+		tup, deltas, _ = var.compile(
 			axisTags=["wght", "wdth"], sharedCoordIndices={}, sharedPoints=None)
 		# len(deltas)=9; flags=PRIVATE_POINT_NUMBERS|EMBEDDED_PEAK_TUPLE
 		# embeddedPeak=[(0.5, 0.8)]; intermediateCoord=[]
@@ -309,7 +309,7 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.0, 0.5, 0.5), "wdth": (0.0, 0.8, 0.8)},
 			[7, 8, 9])
-		tup, deltas = var.compile(
+		tup, deltas, _ = var.compile(
 			axisTags=["wght", "wdth"], sharedCoordIndices={}, sharedPoints=None)
 		# len(deltas)=5; flags=PRIVATE_POINT_NUMBERS|EMBEDDED_PEAK_TUPLE
 		# embeddedPeak=[(0.5, 0.8)]; intermediateCoord=[]
@@ -322,7 +322,7 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.4, 0.5, 0.6), "wdth": (0.7, 0.8, 0.9)},
 			[(7,4), (8,5), (9,6)])
-		tup, deltas = var.compile(
+		tup, deltas, _ = var.compile(
 			axisTags = ["wght", "wdth"],
 			sharedCoordIndices={}, sharedPoints=None)
 		# len(deltas)=9;
@@ -339,7 +339,7 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.4, 0.5, 0.6), "wdth": (0.7, 0.8, 0.9)},
 			[7, 8, 9])
-		tup, deltas = var.compile(
+		tup, deltas, _ = var.compile(
 			axisTags = ["wght", "wdth"],
 			sharedCoordIndices={}, sharedPoints=None)
 		# len(deltas)=5;

--- a/Tests/ttLib/tables/_c_v_a_r_test.py
+++ b/Tests/ttLib/tables/_c_v_a_r_test.py
@@ -11,15 +11,16 @@ import unittest
 
 CVAR_DATA = deHexStr(
     "0001 0000 "      #  0: majorVersion=1 minorVersion=0
-    "0002 0018 "      #  4: tupleVariationCount=2 offsetToData=24
-    "0005 "           #  8: tvHeader[0].variationDataSize=5
-    "A000 "           # 10: tvHeader[0].tupleIndex=EMBEDDED_PEAK|PRIVATE_POINTS
+    "8002 0018 "      #  4: tupleVariationCount=2|TUPLES_SHARE_POINT_NUMBERS offsetToData=24
+    "0004 "           #  8: tvHeader[0].variationDataSize=5
+    "8000 "           # 10: tvHeader[0].tupleIndex=EMBEDDED_PEAK|PRIVATE_POINTS
     "4000 0000 "      # 12: tvHeader[0].peakTuple=[1.0, 0.0]
-    "0005 "           # 16: tvHeader[1].variationDataSize=5
-    "A000 "           # 18: tvHeader[1].tupleIndex=EMBEDDED_PEAK|PRIVATE_POINTS
+    "0004 "           # 16: tvHeader[1].variationDataSize=5
+    "8000 "           # 18: tvHeader[1].tupleIndex=EMBEDDED_PEAK|PRIVATE_POINTS
     "C000 3333 "      # 20: tvHeader[1].peakTuple=[-1.0, 0.8]
-    "00 02 03 01 04 " # 24: all values; deltas=[3, 1, 4]
-    "00 02 09 07 08") # 29: all values; deltas=[9, 7, 8]
+    "00 "             # 24: shared values = 00, all values
+    "02 03 01 04 "    # 25: deltas=[3, 1, 4]
+    "02 09 07 08")    # 29: deltas=[9, 7, 8]
 
 CVAR_XML = [
     '<version major="1" minor="0"/>',

--- a/Tests/ttLib/tables/_c_v_a_r_test.py
+++ b/Tests/ttLib/tables/_c_v_a_r_test.py
@@ -12,11 +12,11 @@ import unittest
 CVAR_DATA = deHexStr(
     "0001 0000 "      #  0: majorVersion=1 minorVersion=0
     "8002 0018 "      #  4: tupleVariationCount=2|TUPLES_SHARE_POINT_NUMBERS offsetToData=24
-    "0004 "           #  8: tvHeader[0].variationDataSize=5
-    "8000 "           # 10: tvHeader[0].tupleIndex=EMBEDDED_PEAK|PRIVATE_POINTS
+    "0004 "           #  8: tvHeader[0].variationDataSize=4
+    "8000 "           # 10: tvHeader[0].tupleIndex=EMBEDDED_PEAK
     "4000 0000 "      # 12: tvHeader[0].peakTuple=[1.0, 0.0]
-    "0004 "           # 16: tvHeader[1].variationDataSize=5
-    "8000 "           # 18: tvHeader[1].tupleIndex=EMBEDDED_PEAK|PRIVATE_POINTS
+    "0004 "           # 16: tvHeader[1].variationDataSize=4
+    "8000 "           # 18: tvHeader[1].tupleIndex=EMBEDDED_PEAK
     "C000 3333 "      # 20: tvHeader[1].peakTuple=[-1.0, 0.8]
     "00 "             # 24: shared values = 00, all values
     "02 03 01 04 "    # 25: deltas=[3, 1, 4]

--- a/Tests/ttLib/tables/_g_v_a_r_test.py
+++ b/Tests/ttLib/tables/_g_v_a_r_test.py
@@ -25,9 +25,9 @@ GVAR_DATA = deHexStr(
     #
     # 28: Glyph variation data for glyph #1, "space"
     # ----------------------------------------------
-    "0001 000C "      #  28: tupleVariationCount=1, offsetToData=12(+28=40)
-    "000B "           #  32: tvHeader[0].variationDataSize=11
-    "A000 "           #  34: tvHeader[0].tupleIndex=EMBEDDED_PEAK|PRIVATE_POINTS
+    "8001 000C "      #  28: tupleVariationCount=1|TUPLES_SHARE_POINT_NUMBERS, offsetToData=12(+28=40)
+    "000A "           #  32: tvHeader[0].variationDataSize=10
+    "8000 "           #  34: tvHeader[0].tupleIndex=EMBEDDED_PEAK
     "0000 2CCD "      #  36: tvHeader[0].peakTuple={wght:0.0, wdth:0.7}
     "00 "             #  40: all points
     "03 01 02 03 04 " #  41: deltaX=[1, 2, 3, 4]
@@ -36,10 +36,9 @@ GVAR_DATA = deHexStr(
     #
     # 52: Glyph variation data for glyph #2, "I"
     # ------------------------------------------
-    "0002 001c "      #  52: tupleVariationCount=2, offsetToData=28(+52=80)
-    "0013 "           #  56: tvHeader[0].variationDataSize=19
-    "E000 "           #  58: tvHeader[0].tupleIndex=
-    #                 #      EMBEDDED_PEAK|INTERMEDIATE_REGION|PRIVATE_POINTS
+    "8002 001c "      #  52: tupleVariationCount=2|TUPLES_SHARE_POINT_NUMBERS, offsetToData=28(+52=80)
+    "0012 "           #  56: tvHeader[0].variationDataSize=18
+    "C000 "           #  58: tvHeader[0].tupleIndex=EMBEDDED_PEAK|INTERMEDIATE_REGION
     "2000 0000 "      #  60: tvHeader[0].peakTuple={wght:0.5, wdth:0.0}
     "0000 0000 "      #  64: tvHeader[0].intermediateStart={wght:0.0, wdth:0.0}
     "4000 0000 "      #  68: tvHeader[0].intermediateEnd={wght:1.0, wdth:0.0}


### PR DESCRIPTION
Related to issue https://github.com/fonttools/fonttools/issues/1001, this reactivates the sharing of point indices in TupleVariations if doing so saves file size.

It also fixes the bug leading to invalid gvar data described in the issue.