### PR TITLE
[varLib] avar required value maps

### DIFF
--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -524,7 +524,7 @@ def compileTupleVariationStore(variations, pointCount,
 			data.append(privateData)
 	if someTuplesSharePoints:
 		data = bytechr(0) + bytesjoin(data)  # 0x00 = "all points in glyph"
-		tupleVariationCount = tv.TUPLES_SHARE_POINT_NUMBERS | len(tuples)
+		tupleVariationCount = TUPLES_SHARE_POINT_NUMBERS | len(tuples)
 	else:
 		data = bytesjoin(data)
 		tupleVariationCount = len(tuples)

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -97,7 +97,7 @@ def _add_fvar_avar(font, axes, instances):
 			interesting = True
 		if not axis.map:
 			# Deduce a default segment map for the axis
-			items = sorted(list(set([(axis.minimum, axis.minimum), (axis.default, axis.default), (axis.maximum, axis.maximum)])))
+			items = [(v, v) for v in sorted(list(set((axis.minimum, axis.default, axis.maximum))))]
 		else:
 			items = sorted(axis.map.items())
 		keys   = [item[0] for item in items]

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -96,6 +96,11 @@ def _add_fvar_avar(font, axes, instances):
 		interesting = True
 
 		items = sorted(axis.map.items())
+		if not axis.map:
+			# Deduce a default segment map for the axis
+			items = [(axis.minimum, axis.minimum), (axis.default, axis.default), (axis.maximum, axis.maximum)]
+		else:
+			items = sorted(axis.map.items())
 		keys   = [item[0] for item in items]
 		vals = [item[1] for item in items]
 

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -92,10 +92,9 @@ def _add_fvar_avar(font, axes, instances):
 	for axis in axes.values():
 		curve = avar.segments[axis.tag] = {}
 		if not axis.map or all(k==v for k,v in axis.map.items()):
-			continue
-		interesting = True
-
-		items = sorted(axis.map.items())
+			interesting |= False
+		else:
+			interesting = True
 		if not axis.map:
 			# Deduce a default segment map for the axis
 			items = [(axis.minimum, axis.minimum), (axis.default, axis.default), (axis.maximum, axis.maximum)]

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -97,7 +97,7 @@ def _add_fvar_avar(font, axes, instances):
 			interesting = True
 		if not axis.map:
 			# Deduce a default segment map for the axis
-			items = [(axis.minimum, axis.minimum), (axis.default, axis.default), (axis.maximum, axis.maximum)]
+			items = sorted(list(set([(axis.minimum, axis.minimum), (axis.default, axis.default), (axis.maximum, axis.maximum)])))
 		else:
 			items = sorted(axis.map.items())
 		keys   = [item[0] for item in items]

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -116,6 +116,17 @@ def _add_fvar_avar(font, axes, instances):
 
 		keys = [models.normalizeValue(v, keys_triple) for v in keys]
 		vals = [models.normalizeValue(v, vals_triple) for v in vals]
+
+		# If a SegmentMaps entry is present, it must at least contain records
+		# for all fromCoordinate values -1, 0, 1.
+		# Check if -1 and 1 are present, add a "flat" mapping otherwise.
+		if -1.0 not in keys:
+			keys.insert(0, -1.0)
+			vals.insert(0, min(vals))
+		if 1.0 not in keys:
+			keys.append(1.0)
+			vals.append(max(vals))
+
 		curve.update(zip(keys, vals))
 
 	if not interesting:

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -97,7 +97,7 @@ def _add_fvar_avar(font, axes, instances):
 			interesting = True
 		if not axis.map:
 			# Deduce a default segment map for the axis
-			items = [(v, v) for v in sorted(list(set((axis.minimum, axis.default, axis.maximum))))]
+			items = [(v, v) for v in sorted(set((axis.minimum, axis.default, axis.maximum)))]
 		else:
 			items = sorted(axis.map.items())
 		keys = [item[0] for item in items]

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -100,7 +100,7 @@ def _add_fvar_avar(font, axes, instances):
 			items = [(v, v) for v in sorted(list(set((axis.minimum, axis.default, axis.maximum))))]
 		else:
 			items = sorted(axis.map.items())
-		keys   = [item[0] for item in items]
+		keys = [item[0] for item in items]
 		vals = [item[1] for item in items]
 
 		# Current avar requirements.  We don't have to enforce


### PR DESCRIPTION
This adds the required value maps describes in #1011. Before merging, we must decide about the question in the issue regarding the spec intent.

It also changes the behaviour regarding empty avar segment maps:

If segment maps are present for any axis, DirectWrite currently requires to have explicit maps for all axes, even if they just contain the default entries. As can be verified in Chrome Canary on Windows Creators Update, the font is not loaded if any axis has an empty avar entry.