### PR TITLE
[varLib] add tests for avar; always include default maps

### DIFF
--- a/Lib/fontTools/ttLib/tables/_a_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r.py
@@ -76,6 +76,10 @@ class table__a_v_a_r(DefaultTable.DefaultTable):
             writer.begintag("segment", axis=axis)
             writer.newline()
             for key, value in sorted(self.segments[axis].items()):
+                # roundtrip float -> fixed -> float to normalize TTX output
+                # as dumped after decompiling or straight from varLib
+                key = fixedToFloat(floatToFixed(key, 14), 14)
+                value = fixedToFloat(floatToFixed(value, 14), 14)
                 writer.simpletag("mapping", **{"from": key, "to": value})
                 writer.newline()
             writer.endtag("segment")

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -109,7 +109,14 @@ def _add_avar(font, axes):
 
 	interesting = False
 	for axis in axes.values():
-		curve = avar.segments[axis.tag] = {}
+		# Currently, some rasterizers require that the default value maps
+		# (-1 to -1, 0 to 0, and 1 to 1) be present for all the segment
+		# maps, even when the default normalization mapping for the axis
+		# was not modified.
+		# https://github.com/googlei18n/fontmake/issues/295
+		# https://github.com/fonttools/fonttools/issues/1011
+		# TODO(anthrotype) revert this (and 19c4b37) when issue is fixed
+		curve = avar.segments[axis.tag] = {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}
 		if not axis.map:
 			continue
 
@@ -134,16 +141,6 @@ def _add_avar(font, axes):
 
 		keys = [models.normalizeValue(v, keys_triple) for v in keys]
 		vals = [models.normalizeValue(v, vals_triple) for v in vals]
-
-		# Work around rendering issue with CoreText when avar table
-		# contains segment maps with zero axis value maps.
-		# Currently, CoreText requires that the three default value maps
-		# (-1 to -1, 0 to 0, and 1 to 1) be present for all the segment
-		# maps, even when the default normalization mapping for the axis
-		# was not modified.
-		# https://github.com/googlei18n/fontmake/issues/295
-		# TODO(anthrotype) revert this change once CoreText is modified
-		curve.update({-1.0: -1.0, 0.0: 0.0, 1.0: 1.0})
 
 		if all(k == v for k, v in zip(keys, vals)):
 			continue

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -182,7 +182,7 @@ class VariationModel(object):
 			axis = next(iter(loc))
 			value = loc[axis]
 			if axis not in axisPoints:
-				axisPoints[axis] = {0}
+				axisPoints[axis] = {0.}
 			assert value not in axisPoints[axis]
 			axisPoints[axis].add(value)
 

--- a/Tests/varLib/data/BuildAvarEmptyAxis.designspace
+++ b/Tests/varLib/data/BuildAvarEmptyAxis.designspace
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="3">
+    <axes>
+        <axis default="400.0" maximum="900.0" minimum="100.0" name="weight" tag="wght">
+            <map input="100.0" output="26" />
+            <map input="400.0" output="90" />
+            <map input="700.0" output="151" />
+            <map input="900.0" output="190" />
+            <labelname xml:lang="en">Weight</labelname>
+        </axis>
+        <axis default="100" maximum="100" minimum="70" name="width" tag="wdth">
+            <labelname xml:lang="en">Width</labelname>
+        </axis>
+    </axes>
+    <sources>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-Light.ufo" name="Test Family 3 Light" stylename="Light">
+            <location>
+                <dimension name="weight" xvalue="26.000000" />
+                <dimension name="width" xvalue="100.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-Regular.ufo" name="Test Family 3 Regular" stylename="Regular">
+            <lib copy="1" />
+            <groups copy="1" />
+            <features copy="1" />
+            <info copy="1" />
+            <location>
+                <dimension name="weight" xvalue="90.000000" />
+                <dimension name="width" xvalue="100.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-Bold.ufo" name="Test Family 3 Bold" stylename="Bold">
+            <location>
+                <dimension name="weight" xvalue="190.000000" />
+                <dimension name="width" xvalue="100.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-CondensedLight.ufo" name="Test Family 3 Condensed Light" stylename="Condensed Light">
+            <location>
+                <dimension name="weight" xvalue="26.000000" />
+                <dimension name="width" xvalue="70.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-Condensed.ufo" name="Test Family 3 Condensed" stylename="Condensed">
+            <location>
+                <dimension name="weight" xvalue="90.000000" />
+                <dimension name="width" xvalue="70.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-CondensedBold.ufo" name="Test Family 3 Condensed Bold" stylename="Condensed Bold">
+            <location>
+                <dimension name="weight" xvalue="190.000000" />
+                <dimension name="width" xvalue="70.000000" />
+            </location>
+        </source>
+    </sources>
+    <instances>
+    </instances>
+</designspace>

--- a/Tests/varLib/data/BuildAvarIdentityMaps.designspace
+++ b/Tests/varLib/data/BuildAvarIdentityMaps.designspace
@@ -1,0 +1,80 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="3">
+    <axes>
+        <axis default="400.0" maximum="900.0" minimum="100.0" name="weight" tag="wght">
+            <map input="100.0" output="26" />
+            <map input="200.0" output="39" />
+            <map input="300.0" output="58" />
+            <map input="400.0" output="90" />
+            <map input="500.0" output="108" />
+            <map input="600.0" output="128" />
+            <map input="700.0" output="151" />
+            <map input="800.0" output="169" />
+            <map input="900.0" output="190" />
+            <labelname xml:lang="en">Weight</labelname>
+        </axis>
+        <axis default="100" maximum="100" minimum="70" name="width" tag="wdth">
+            <map input="70" output="70" />
+            <map input="79" output="79" />
+            <map input="89" output="89" />
+            <map input="100" output="100" />
+            <labelname xml:lang="en">Width</labelname>
+        </axis>
+    </axes>
+    <sources>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-Light.ufo" name="Test Family 3 Light" stylename="Light">
+            <location>
+                <dimension name="weight" xvalue="26.000000" />
+                <dimension name="width" xvalue="100.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-Regular.ufo" name="Test Family 3 Regular" stylename="Regular">
+            <lib copy="1" />
+            <groups copy="1" />
+            <features copy="1" />
+            <info copy="1" />
+            <location>
+                <dimension name="weight" xvalue="90.000000" />
+                <dimension name="width" xvalue="100.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-SemiBold.ufo" name="Test Family 3 SemiBold" stylename="SemiBold">
+            <location>
+                <dimension name="weight" xvalue="151.000000" />
+                <dimension name="width" xvalue="100.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-Bold.ufo" name="Test Family 3 Bold" stylename="Bold">
+            <location>
+                <dimension name="weight" xvalue="190.000000" />
+                <dimension name="width" xvalue="100.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-CondensedLight.ufo" name="Test Family 3 Condensed Light" stylename="Condensed Light">
+            <location>
+                <dimension name="weight" xvalue="26.000000" />
+                <dimension name="width" xvalue="70.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-Condensed.ufo" name="Test Family 3 Condensed" stylename="Condensed">
+            <location>
+                <dimension name="weight" xvalue="90.000000" />
+                <dimension name="width" xvalue="70.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-CondensedSemiBold.ufo" name="Test Family 3 Condensed SemiBold" stylename="Condensed SemiBold">
+            <location>
+                <dimension name="weight" xvalue="151.000000" />
+                <dimension name="width" xvalue="70.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-CondensedBold.ufo" name="Test Family 3 Condensed Bold" stylename="Condensed Bold">
+            <location>
+                <dimension name="weight" xvalue="190.000000" />
+                <dimension name="width" xvalue="70.000000" />
+            </location>
+        </source>
+    </sources>
+    <instances>
+    </instances>
+</designspace>

--- a/Tests/varLib/data/BuildAvarSingleAxis.designspace
+++ b/Tests/varLib/data/BuildAvarSingleAxis.designspace
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="3">
+    <axes>
+        <axis default="400.0" maximum="900.0" minimum="100.0" name="weight" tag="wght">
+            <map input="100.0" output="26" />
+            <map input="200.0" output="39" />
+            <map input="300.0" output="58" />
+            <map input="400.0" output="90" />
+            <map input="500.0" output="108" />
+            <map input="600.0" output="128" />
+            <map input="700.0" output="151" />
+            <map input="800.0" output="169" />
+            <map input="900.0" output="190" />
+            <labelname xml:lang="en">Weight</labelname>
+        </axis>
+    </axes>
+    <sources>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-Light.ufo" name="Test Family 3 Light" stylename="Light">
+            <location>
+                <dimension name="weight" xvalue="26.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-Regular.ufo" name="Test Family 3 Regular" stylename="Regular">
+            <lib copy="1" />
+            <groups copy="1" />
+            <features copy="1" />
+            <info copy="1" />
+            <location>
+                <dimension name="weight" xvalue="90.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-SemiBold.ufo" name="Test Family 3 SemiBold" stylename="SemiBold">
+            <location>
+                <dimension name="weight" xvalue="151.000000" />
+            </location>
+        </source>
+        <source familyname="Test Family 3" filename="master_ufo/TestFamily3-Bold.ufo" name="Test Family 3 Bold" stylename="Bold">
+            <location>
+                <dimension name="weight" xvalue="190.000000" />
+            </location>
+        </source>
+    </sources>
+    <instances>
+    </instances>
+</designspace>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Bold.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Bold.ttx
@@ -1,0 +1,520 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.14">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="F"/>
+    <GlyphID id="2" name="T"/>
+    <GlyphID id="3" name="l"/>
+    <GlyphID id="4" name="n"/>
+    <GlyphID id="5" name="o"/>
+    <GlyphID id="6" name="s"/>
+    <GlyphID id="7" name="t"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.902"/>
+    <checkSumAdjustment value="0xad920bcc"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Tue Mar 15 19:50:39 2016"/>
+    <modified value="Wed Aug 16 14:03:23 2017"/>
+    <xMin value="25"/>
+    <yMin value="-240"/>
+    <xMax value="606"/>
+    <yMax value="760"/>
+    <macStyle value="00000000 00000001"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1069"/>
+    <descent value="-293"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="670"/>
+    <minLeftSideBearing value="25"/>
+    <minRightSideBearing value="25"/>
+    <xMaxExtent value="606"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="43"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="530"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="332"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="10"/>
+      <bProportion value="2"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="4"/>
+      <bLetterForm value="2"/>
+      <bMidline value="2"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="11100000 00000000 00000010 11111111"/>
+    <ulUnicodeRange2 value="01000000 00000000 00000000 00011111"/>
+    <ulUnicodeRange3 value="00001000 00000000 00000000 00101001"/>
+    <ulUnicodeRange4 value="00000000 00010000 00000000 00000000"/>
+    <achVendID value="GOOG"/>
+    <fsSelection value="00000001 00100000"/>
+    <usFirstCharIndex value="70"/>
+    <usLastCharIndex value="116"/>
+    <sTypoAscender value="1069"/>
+    <sTypoDescender value="-293"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1069"/>
+    <usWinDescent value="293"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="553"/>
+    <sCapHeight value="714"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="F" width="539" lsb="77"/>
+    <mtx name="T" width="591" lsb="25"/>
+    <mtx name="l" width="323" lsb="66"/>
+    <mtx name="n" width="670" lsb="66"/>
+    <mtx name="o" width="637" lsb="42"/>
+    <mtx name="s" width="517" lsb="42"/>
+    <mtx name="t" width="460" lsb="26"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-240" xMax="450" yMax="760">
+      <contour>
+        <pt x="50" y="-240" on="1"/>
+        <pt x="450" y="-240" on="1"/>
+        <pt x="450" y="760" on="1"/>
+        <pt x="50" y="760" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-190" on="1"/>
+        <pt x="100" y="710" on="1"/>
+        <pt x="400" y="710" on="1"/>
+        <pt x="400" y="-190" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="77" yMin="0" xMax="499" yMax="714">
+      <contour>
+        <pt x="267" y="0" on="1"/>
+        <pt x="77" y="0" on="1"/>
+        <pt x="77" y="714" on="1"/>
+        <pt x="499" y="714" on="1"/>
+        <pt x="499" y="559" on="1"/>
+        <pt x="267" y="559" on="1"/>
+        <pt x="267" y="423" on="1"/>
+        <pt x="481" y="423" on="1"/>
+        <pt x="481" y="268" on="1"/>
+        <pt x="267" y="268" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="T" xMin="25" yMin="0" xMax="566" yMax="714">
+      <contour>
+        <pt x="392" y="0" on="1"/>
+        <pt x="199" y="0" on="1"/>
+        <pt x="199" y="556" on="1"/>
+        <pt x="25" y="556" on="1"/>
+        <pt x="25" y="714" on="1"/>
+        <pt x="566" y="714" on="1"/>
+        <pt x="566" y="556" on="1"/>
+        <pt x="392" y="556" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="l" xMin="66" yMin="0" xMax="257" yMax="760">
+      <contour>
+        <pt x="257" y="0" on="1"/>
+        <pt x="66" y="0" on="1"/>
+        <pt x="66" y="760" on="1"/>
+        <pt x="257" y="760" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="n" xMin="66" yMin="0" xMax="606" yMax="563">
+      <contour>
+        <pt x="412" y="563" on="1"/>
+        <pt x="498" y="563" on="0"/>
+        <pt x="606" y="466" on="0"/>
+        <pt x="606" y="360" on="1"/>
+        <pt x="606" y="0" on="1"/>
+        <pt x="415" y="0" on="1"/>
+        <pt x="415" y="302" on="1"/>
+        <pt x="415" y="357" on="0"/>
+        <pt x="383" y="413" on="0"/>
+        <pt x="348" y="413" on="1"/>
+        <pt x="294" y="413" on="0"/>
+        <pt x="257" y="324" on="0"/>
+        <pt x="257" y="242" on="1"/>
+        <pt x="257" y="0" on="1"/>
+        <pt x="66" y="0" on="1"/>
+        <pt x="66" y="553" on="1"/>
+        <pt x="210" y="553" on="1"/>
+        <pt x="236" y="480" on="1"/>
+        <pt x="243" y="480" on="1"/>
+        <pt x="260" y="506" on="0"/>
+        <pt x="310" y="543" on="0"/>
+        <pt x="373" y="563" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="o" xMin="42" yMin="-10" xMax="594" yMax="563">
+      <contour>
+        <pt x="594" y="278" on="1"/>
+        <pt x="594" y="209" on="0"/>
+        <pt x="556" y="101" on="0"/>
+        <pt x="484" y="28" on="0"/>
+        <pt x="382" y="-10" on="0"/>
+        <pt x="317" y="-10" on="1"/>
+        <pt x="257" y="-10" on="0"/>
+        <pt x="156" y="28" on="0"/>
+        <pt x="83" y="101" on="0"/>
+        <pt x="42" y="209" on="0"/>
+        <pt x="42" y="278" on="1"/>
+        <pt x="42" y="370" on="0"/>
+        <pt x="109" y="497" on="0"/>
+        <pt x="233" y="563" on="0"/>
+        <pt x="320" y="563" on="1"/>
+        <pt x="400" y="563" on="0"/>
+        <pt x="523" y="497" on="0"/>
+        <pt x="594" y="370" on="0"/>
+      </contour>
+      <contour>
+        <pt x="236" y="278" on="1"/>
+        <pt x="236" y="230" on="0"/>
+        <pt x="252" y="165" on="0"/>
+        <pt x="289" y="132" on="0"/>
+        <pt x="319" y="132" on="1"/>
+        <pt x="348" y="132" on="0"/>
+        <pt x="384" y="165" on="0"/>
+        <pt x="400" y="230" on="0"/>
+        <pt x="400" y="278" on="1"/>
+        <pt x="400" y="325" on="0"/>
+        <pt x="384" y="389" on="0"/>
+        <pt x="348" y="421" on="0"/>
+        <pt x="318" y="421" on="1"/>
+        <pt x="274" y="421" on="0"/>
+        <pt x="236" y="348" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="s" xMin="42" yMin="-10" xMax="477" yMax="563">
+      <contour>
+        <pt x="477" y="170" on="1"/>
+        <pt x="477" y="118" on="0"/>
+        <pt x="430" y="36" on="0"/>
+        <pt x="327" y="-10" on="0"/>
+        <pt x="243" y="-10" on="1"/>
+        <pt x="184" y="-10" on="0"/>
+        <pt x="91" y="3" on="0"/>
+        <pt x="43" y="21" on="1"/>
+        <pt x="43" y="174" on="1"/>
+        <pt x="96" y="150" on="0"/>
+        <pt x="204" y="129" on="0"/>
+        <pt x="235" y="129" on="1"/>
+        <pt x="267" y="129" on="0"/>
+        <pt x="297" y="143" on="0"/>
+        <pt x="297" y="157" on="1"/>
+        <pt x="297" y="169" on="0"/>
+        <pt x="277" y="187" on="0"/>
+        <pt x="226" y="209" on="0"/>
+        <pt x="179" y="228" on="1"/>
+        <pt x="133" y="247" on="0"/>
+        <pt x="72" y="292" on="0"/>
+        <pt x="42" y="354" on="0"/>
+        <pt x="42" y="400" on="1"/>
+        <pt x="42" y="481" on="0"/>
+        <pt x="167" y="563" on="0"/>
+        <pt x="270" y="563" on="1"/>
+        <pt x="325" y="563" on="0"/>
+        <pt x="421" y="539" on="0"/>
+        <pt x="473" y="516" on="1"/>
+        <pt x="421" y="393" on="1"/>
+        <pt x="380" y="412" on="0"/>
+        <pt x="296" y="434" on="0"/>
+        <pt x="271" y="434" on="1"/>
+        <pt x="248" y="434" on="0"/>
+        <pt x="224" y="422" on="0"/>
+        <pt x="224" y="411" on="1"/>
+        <pt x="224" y="400" on="0"/>
+        <pt x="241" y="385" on="0"/>
+        <pt x="289" y="364" on="0"/>
+        <pt x="335" y="346" on="1"/>
+        <pt x="383" y="326" on="0"/>
+        <pt x="446" y="282" on="0"/>
+        <pt x="477" y="218" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="t" xMin="26" yMin="-10" xMax="429" yMax="664">
+      <contour>
+        <pt x="337" y="141" on="1"/>
+        <pt x="362" y="141" on="0"/>
+        <pt x="406" y="152" on="0"/>
+        <pt x="429" y="160" on="1"/>
+        <pt x="429" y="21" on="1"/>
+        <pt x="398" y="8" on="0"/>
+        <pt x="328" y="-10" on="0"/>
+        <pt x="274" y="-10" on="1"/>
+        <pt x="220" y="-10" on="0"/>
+        <pt x="138" y="24" on="0"/>
+        <pt x="93" y="107" on="0"/>
+        <pt x="93" y="182" on="1"/>
+        <pt x="93" y="410" on="1"/>
+        <pt x="26" y="410" on="1"/>
+        <pt x="26" y="488" on="1"/>
+        <pt x="111" y="548" on="1"/>
+        <pt x="160" y="664" on="1"/>
+        <pt x="285" y="664" on="1"/>
+        <pt x="285" y="553" on="1"/>
+        <pt x="421" y="553" on="1"/>
+        <pt x="421" y="410" on="1"/>
+        <pt x="285" y="410" on="1"/>
+        <pt x="285" y="195" on="1"/>
+        <pt x="285" y="168" on="0"/>
+        <pt x="312" y="141" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2015 Google Inc. All Rights Reserved.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Bold
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.902;GOOG;TestFamily3-Bold
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Bold
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.902
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      TestFamily3-Bold
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Noto is a trademark of Google Inc.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Monotype Imaging Inc.
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Monotype Design Team
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Designed by Monotype design team.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.google.com/get/noto/
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://www.monotype.com/studio
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="T"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1 Format="2">
+          </ClassDef1>
+          <ClassDef2 Format="1">
+            <ClassDef glyph="T" class="4"/>
+            <ClassDef glyph="n" class="3"/>
+            <ClassDef glyph="o" class="2"/>
+            <ClassDef glyph="s" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=1 -->
+          <!-- Class2Count=5 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+              <Value1 XAdvance="0"/>
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-60"/>
+            </Class2Record>
+            <Class2Record index="2">
+              <Value1 XAdvance="-70"/>
+            </Class2Record>
+            <Class2Record index="3">
+              <Value1 XAdvance="-50"/>
+            </Class2Record>
+            <Class2Record index="4">
+              <Value1 XAdvance="20"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Condensed.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Condensed.ttx
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.14">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="F"/>
+    <GlyphID id="2" name="T"/>
+    <GlyphID id="3" name="l"/>
+    <GlyphID id="4" name="n"/>
+    <GlyphID id="5" name="o"/>
+    <GlyphID id="6" name="s"/>
+    <GlyphID id="7" name="t"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.902"/>
+    <checkSumAdjustment value="0x7c6d2210"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Tue Mar 15 19:50:39 2016"/>
+    <modified value="Wed Aug 16 14:03:23 2017"/>
+    <xMin value="10"/>
+    <yMin value="-240"/>
+    <xMax value="450"/>
+    <yMax value="760"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1069"/>
+    <descent value="-293"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="10"/>
+    <minRightSideBearing value="11"/>
+    <xMaxExtent value="450"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="43"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="371"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="322"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="5"/>
+      <bProportion value="6"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="4"/>
+      <bLetterForm value="2"/>
+      <bMidline value="2"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="11100000 00000000 00000010 11111111"/>
+    <ulUnicodeRange2 value="01000000 00000000 00000000 00011111"/>
+    <ulUnicodeRange3 value="00001000 00000000 00000000 00101001"/>
+    <ulUnicodeRange4 value="00000000 00010000 00000000 00000000"/>
+    <achVendID value="GOOG"/>
+    <fsSelection value="00000001 01000000"/>
+    <usFirstCharIndex value="70"/>
+    <usLastCharIndex value="116"/>
+    <sTypoAscender value="1069"/>
+    <sTypoDescender value="-293"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1069"/>
+    <usWinDescent value="293"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="537"/>
+    <sCapHeight value="714"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="F" width="380" lsb="73"/>
+    <mtx name="T" width="381" lsb="10"/>
+    <mtx name="l" width="210" lsb="65"/>
+    <mtx name="n" width="456" lsb="65"/>
+    <mtx name="o" width="445" lsb="42"/>
+    <mtx name="s" width="339" lsb="33"/>
+    <mtx name="t" width="259" lsb="17"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-240" xMax="450" yMax="760">
+      <contour>
+        <pt x="50" y="-240" on="1"/>
+        <pt x="450" y="-240" on="1"/>
+        <pt x="450" y="760" on="1"/>
+        <pt x="50" y="760" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-190" on="1"/>
+        <pt x="100" y="710" on="1"/>
+        <pt x="400" y="710" on="1"/>
+        <pt x="400" y="-190" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="73" yMin="0" xMax="357" yMax="714">
+      <contour>
+        <pt x="157" y="0" on="1"/>
+        <pt x="73" y="0" on="1"/>
+        <pt x="73" y="714" on="1"/>
+        <pt x="357" y="714" on="1"/>
+        <pt x="357" y="639" on="1"/>
+        <pt x="157" y="639" on="1"/>
+        <pt x="157" y="381" on="1"/>
+        <pt x="345" y="381" on="1"/>
+        <pt x="345" y="305" on="1"/>
+        <pt x="157" y="305" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="T" xMin="10" yMin="0" xMax="370" yMax="714">
+      <contour>
+        <pt x="232" y="0" on="1"/>
+        <pt x="148" y="0" on="1"/>
+        <pt x="148" y="638" on="1"/>
+        <pt x="10" y="638" on="1"/>
+        <pt x="10" y="714" on="1"/>
+        <pt x="370" y="714" on="1"/>
+        <pt x="370" y="638" on="1"/>
+        <pt x="232" y="638" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="l" xMin="65" yMin="0" xMax="146" yMax="760">
+      <contour>
+        <pt x="146" y="0" on="1"/>
+        <pt x="65" y="0" on="1"/>
+        <pt x="65" y="760" on="1"/>
+        <pt x="146" y="760" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="n" xMin="65" yMin="0" xMax="393" yMax="547">
+      <contour>
+        <pt x="262" y="547" on="1"/>
+        <pt x="326" y="547" on="0"/>
+        <pt x="393" y="457" on="0"/>
+        <pt x="393" y="364" on="1"/>
+        <pt x="393" y="0" on="1"/>
+        <pt x="312" y="0" on="1"/>
+        <pt x="312" y="348" on="1"/>
+        <pt x="312" y="411" on="0"/>
+        <pt x="280" y="475" on="0"/>
+        <pt x="244" y="475" on="1"/>
+        <pt x="192" y="475" on="0"/>
+        <pt x="146" y="382" on="0"/>
+        <pt x="146" y="279" on="1"/>
+        <pt x="146" y="0" on="1"/>
+        <pt x="65" y="0" on="1"/>
+        <pt x="65" y="537" on="1"/>
+        <pt x="130" y="537" on="1"/>
+        <pt x="139" y="464" on="1"/>
+        <pt x="144" y="464" on="1"/>
+        <pt x="156" y="490" on="0"/>
+        <pt x="191" y="528" on="0"/>
+        <pt x="236" y="547" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="o" xMin="42" yMin="-10" xMax="403" yMax="547">
+      <contour>
+        <pt x="403" y="269" on="1"/>
+        <pt x="403" y="206" on="0"/>
+        <pt x="381" y="104" on="0"/>
+        <pt x="337" y="30" on="0"/>
+        <pt x="268" y="-10" on="0"/>
+        <pt x="221" y="-10" on="1"/>
+        <pt x="176" y="-10" on="0"/>
+        <pt x="109" y="30" on="0"/>
+        <pt x="64" y="103" on="0"/>
+        <pt x="42" y="206" on="0"/>
+        <pt x="42" y="269" on="1"/>
+        <pt x="42" y="358" on="0"/>
+        <pt x="81" y="482" on="0"/>
+        <pt x="161" y="547" on="0"/>
+        <pt x="223" y="547" on="1"/>
+        <pt x="280" y="547" on="0"/>
+        <pt x="360" y="484" on="0"/>
+        <pt x="403" y="360" on="0"/>
+      </contour>
+      <contour>
+        <pt x="125" y="269" on="1"/>
+        <pt x="125" y="200" on="0"/>
+        <pt x="146" y="108" on="0"/>
+        <pt x="189" y="61" on="0"/>
+        <pt x="223" y="61" on="1"/>
+        <pt x="256" y="61" on="0"/>
+        <pt x="300" y="107" on="0"/>
+        <pt x="321" y="200" on="0"/>
+        <pt x="321" y="269" on="1"/>
+        <pt x="321" y="338" on="0"/>
+        <pt x="300" y="430" on="0"/>
+        <pt x="256" y="476" on="0"/>
+        <pt x="223" y="476" on="1"/>
+        <pt x="171" y="476" on="0"/>
+        <pt x="125" y="372" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="s" xMin="33" yMin="-10" xMax="307" yMax="547">
+      <contour>
+        <pt x="307" y="144" on="1"/>
+        <pt x="307" y="94" on="0"/>
+        <pt x="271" y="26" on="0"/>
+        <pt x="203" y="-10" on="0"/>
+        <pt x="155" y="-10" on="1"/>
+        <pt x="118" y="-10" on="0"/>
+        <pt x="56" y="7" on="0"/>
+        <pt x="33" y="20" on="1"/>
+        <pt x="33" y="104" on="1"/>
+        <pt x="55" y="86" on="0"/>
+        <pt x="119" y="63" on="0"/>
+        <pt x="152" y="63" on="1"/>
+        <pt x="187" y="63" on="0"/>
+        <pt x="227" y="104" on="0"/>
+        <pt x="227" y="141" on="1"/>
+        <pt x="227" y="162" on="0"/>
+        <pt x="211" y="195" on="0"/>
+        <pt x="175" y="225" on="0"/>
+        <pt x="145" y="242" on="1"/>
+        <pt x="112" y="262" on="0"/>
+        <pt x="61" y="306" on="0"/>
+        <pt x="33" y="364" on="0"/>
+        <pt x="33" y="406" on="1"/>
+        <pt x="33" y="470" on="0"/>
+        <pt x="116" y="547" on="0"/>
+        <pt x="183" y="547" on="1"/>
+        <pt x="218" y="547" on="0"/>
+        <pt x="278" y="529" on="0"/>
+        <pt x="306" y="512" on="1"/>
+        <pt x="276" y="447" on="1"/>
+        <pt x="255" y="461" on="0"/>
+        <pt x="209" y="478" on="0"/>
+        <pt x="184" y="478" on="1"/>
+        <pt x="150" y="478" on="0"/>
+        <pt x="111" y="440" on="0"/>
+        <pt x="111" y="408" on="1"/>
+        <pt x="111" y="386" on="0"/>
+        <pt x="127" y="355" on="0"/>
+        <pt x="164" y="326" on="0"/>
+        <pt x="196" y="307" on="1"/>
+        <pt x="229" y="286" on="0"/>
+        <pt x="279" y="242" on="0"/>
+        <pt x="307" y="185" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="t" xMin="17" yMin="-10" xMax="245" yMax="658">
+      <contour>
+        <pt x="197" y="62" on="1"/>
+        <pt x="209" y="62" on="0"/>
+        <pt x="233" y="68" on="0"/>
+        <pt x="245" y="72" on="1"/>
+        <pt x="245" y="6" on="1"/>
+        <pt x="229" y="-2" on="0"/>
+        <pt x="192" y="-10" on="0"/>
+        <pt x="170" y="-10" on="1"/>
+        <pt x="134" y="-10" on="0"/>
+        <pt x="89" y="22" on="0"/>
+        <pt x="67" y="85" on="0"/>
+        <pt x="67" y="133" on="1"/>
+        <pt x="67" y="469" on="1"/>
+        <pt x="17" y="469" on="1"/>
+        <pt x="17" y="513" on="1"/>
+        <pt x="71" y="535" on="1"/>
+        <pt x="93" y="658" on="1"/>
+        <pt x="148" y="658" on="1"/>
+        <pt x="148" y="537" on="1"/>
+        <pt x="238" y="537" on="1"/>
+        <pt x="238" y="469" on="1"/>
+        <pt x="148" y="469" on="1"/>
+        <pt x="148" y="143" on="1"/>
+        <pt x="148" y="102" on="0"/>
+        <pt x="168" y="62" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2015 Google Inc. All Rights Reserved.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Condensed
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.902;GOOG;TestFamily3-Condensed
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Condensed
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.902
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      TestFamily3-Condensed
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Noto is a trademark of Google Inc.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Monotype Imaging Inc.
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Monotype Design Team
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Designed by Monotype design team.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.google.com/get/noto/
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://www.monotype.com/studio
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="16" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      Condensed
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="T"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1 Format="2">
+          </ClassDef1>
+          <ClassDef2 Format="1">
+            <ClassDef glyph="T" class="4"/>
+            <ClassDef glyph="n" class="3"/>
+            <ClassDef glyph="o" class="2"/>
+            <ClassDef glyph="s" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=1 -->
+          <!-- Class2Count=5 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+              <Value1 XAdvance="0"/>
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-36"/>
+            </Class2Record>
+            <Class2Record index="2">
+              <Value1 XAdvance="-42"/>
+            </Class2Record>
+            <Class2Record index="3">
+              <Value1 XAdvance="-30"/>
+            </Class2Record>
+            <Class2Record index="4">
+              <Value1 XAdvance="12"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedBold.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedBold.ttx
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.14">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="F"/>
+    <GlyphID id="2" name="T"/>
+    <GlyphID id="3" name="l"/>
+    <GlyphID id="4" name="n"/>
+    <GlyphID id="5" name="o"/>
+    <GlyphID id="6" name="s"/>
+    <GlyphID id="7" name="t"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.902"/>
+    <checkSumAdjustment value="0x7946b7f2"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Tue Mar 15 19:50:39 2016"/>
+    <modified value="Wed Aug 16 14:03:23 2017"/>
+    <xMin value="7"/>
+    <yMin value="-240"/>
+    <xMax value="483"/>
+    <yMax value="760"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1069"/>
+    <descent value="-293"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="529"/>
+    <minLeftSideBearing value="7"/>
+    <minRightSideBearing value="17"/>
+    <xMaxExtent value="483"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="43"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="432"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="332"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="10"/>
+      <bProportion value="6"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="4"/>
+      <bLetterForm value="2"/>
+      <bMidline value="2"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="11100000 00000000 00000010 11111111"/>
+    <ulUnicodeRange2 value="01000000 00000000 00000000 00011111"/>
+    <ulUnicodeRange3 value="00001000 00000000 00000000 00101001"/>
+    <ulUnicodeRange4 value="00000000 00010000 00000000 00000000"/>
+    <achVendID value="GOOG"/>
+    <fsSelection value="00000001 01000000"/>
+    <usFirstCharIndex value="70"/>
+    <usLastCharIndex value="116"/>
+    <sTypoAscender value="1069"/>
+    <sTypoDescender value="-293"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1069"/>
+    <usWinDescent value="293"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="553"/>
+    <sCapHeight value="714"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="F" width="436" lsb="59"/>
+    <mtx name="T" width="460" lsb="17"/>
+    <mtx name="l" width="263" lsb="50"/>
+    <mtx name="n" width="529" lsb="50"/>
+    <mtx name="o" width="516" lsb="32"/>
+    <mtx name="s" width="396" lsb="25"/>
+    <mtx name="t" width="354" lsb="7"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-240" xMax="450" yMax="760">
+      <contour>
+        <pt x="50" y="-240" on="1"/>
+        <pt x="450" y="-240" on="1"/>
+        <pt x="450" y="760" on="1"/>
+        <pt x="50" y="760" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-190" on="1"/>
+        <pt x="100" y="710" on="1"/>
+        <pt x="400" y="710" on="1"/>
+        <pt x="400" y="-190" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="59" yMin="0" xMax="401" yMax="714">
+      <contour>
+        <pt x="229" y="0" on="1"/>
+        <pt x="59" y="0" on="1"/>
+        <pt x="59" y="714" on="1"/>
+        <pt x="401" y="714" on="1"/>
+        <pt x="401" y="570" on="1"/>
+        <pt x="229" y="570" on="1"/>
+        <pt x="229" y="417" on="1"/>
+        <pt x="388" y="417" on="1"/>
+        <pt x="388" y="273" on="1"/>
+        <pt x="229" y="273" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="T" xMin="17" yMin="0" xMax="443" yMax="714">
+      <contour>
+        <pt x="315" y="0" on="1"/>
+        <pt x="146" y="0" on="1"/>
+        <pt x="146" y="567" on="1"/>
+        <pt x="17" y="567" on="1"/>
+        <pt x="17" y="714" on="1"/>
+        <pt x="443" y="714" on="1"/>
+        <pt x="443" y="567" on="1"/>
+        <pt x="315" y="567" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="l" xMin="50" yMin="0" xMax="212" yMax="760">
+      <contour>
+        <pt x="212" y="0" on="1"/>
+        <pt x="50" y="0" on="1"/>
+        <pt x="50" y="760" on="1"/>
+        <pt x="212" y="760" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="n" xMin="50" yMin="0" xMax="480" yMax="563">
+      <contour>
+        <pt x="328" y="563" on="1"/>
+        <pt x="400" y="563" on="0"/>
+        <pt x="480" y="457" on="0"/>
+        <pt x="480" y="360" on="1"/>
+        <pt x="480" y="0" on="1"/>
+        <pt x="318" y="0" on="1"/>
+        <pt x="318" y="308" on="1"/>
+        <pt x="318" y="363" on="0"/>
+        <pt x="300" y="419" on="0"/>
+        <pt x="270" y="419" on="1"/>
+        <pt x="236" y="419" on="0"/>
+        <pt x="212" y="347" on="0"/>
+        <pt x="212" y="253" on="1"/>
+        <pt x="212" y="0" on="1"/>
+        <pt x="50" y="0" on="1"/>
+        <pt x="50" y="553" on="1"/>
+        <pt x="177" y="553" on="1"/>
+        <pt x="195" y="485" on="1"/>
+        <pt x="204" y="485" on="1"/>
+        <pt x="216" y="511" on="0"/>
+        <pt x="252" y="546" on="0"/>
+        <pt x="298" y="563" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="o" xMin="32" yMin="-10" xMax="483" yMax="563">
+      <contour>
+        <pt x="483" y="278" on="1"/>
+        <pt x="483" y="225" on="0"/>
+        <pt x="460" y="122" on="0"/>
+        <pt x="408" y="39" on="0"/>
+        <pt x="321" y="-10" on="0"/>
+        <pt x="257" y="-10" on="1"/>
+        <pt x="198" y="-10" on="0"/>
+        <pt x="113" y="38" on="0"/>
+        <pt x="58" y="120" on="0"/>
+        <pt x="32" y="223" on="0"/>
+        <pt x="32" y="278" on="1"/>
+        <pt x="32" y="358" on="0"/>
+        <pt x="78" y="487" on="0"/>
+        <pt x="178" y="563" on="0"/>
+        <pt x="259" y="563" on="1"/>
+        <pt x="326" y="563" on="0"/>
+        <pt x="427" y="496" on="0"/>
+        <pt x="483" y="369" on="0"/>
+      </contour>
+      <contour>
+        <pt x="196" y="276" on="1"/>
+        <pt x="196" y="226" on="0"/>
+        <pt x="209" y="159" on="0"/>
+        <pt x="236" y="125" on="0"/>
+        <pt x="258" y="125" on="1"/>
+        <pt x="280" y="125" on="0"/>
+        <pt x="307" y="159" on="0"/>
+        <pt x="319" y="227" on="0"/>
+        <pt x="319" y="278" on="1"/>
+        <pt x="319" y="328" on="0"/>
+        <pt x="307" y="395" on="0"/>
+        <pt x="280" y="428" on="0"/>
+        <pt x="258" y="428" on="1"/>
+        <pt x="226" y="428" on="0"/>
+        <pt x="196" y="354" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="s" xMin="25" yMin="-10" xMax="372" yMax="563">
+      <contour>
+        <pt x="372" y="170" on="1"/>
+        <pt x="372" y="111" on="0"/>
+        <pt x="327" y="30" on="0"/>
+        <pt x="242" y="-10" on="0"/>
+        <pt x="183" y="-10" on="1"/>
+        <pt x="142" y="-10" on="0"/>
+        <pt x="64" y="4" on="0"/>
+        <pt x="26" y="21" on="1"/>
+        <pt x="26" y="174" on="1"/>
+        <pt x="56" y="156" on="0"/>
+        <pt x="128" y="129" on="0"/>
+        <pt x="166" y="129" on="1"/>
+        <pt x="188" y="129" on="0"/>
+        <pt x="211" y="144" on="0"/>
+        <pt x="211" y="161" on="1"/>
+        <pt x="211" y="170" on="0"/>
+        <pt x="202" y="188" on="0"/>
+        <pt x="166" y="212" on="0"/>
+        <pt x="128" y="231" on="1"/>
+        <pt x="94" y="248" on="0"/>
+        <pt x="48" y="297" on="0"/>
+        <pt x="25" y="361" on="0"/>
+        <pt x="25" y="400" on="1"/>
+        <pt x="25" y="477" on="0"/>
+        <pt x="119" y="563" on="0"/>
+        <pt x="205" y="563" on="1"/>
+        <pt x="248" y="563" on="0"/>
+        <pt x="324" y="539" on="0"/>
+        <pt x="364" y="516" on="1"/>
+        <pt x="324" y="393" on="1"/>
+        <pt x="299" y="410" on="0"/>
+        <pt x="244" y="434" on="0"/>
+        <pt x="215" y="434" on="1"/>
+        <pt x="198" y="434" on="0"/>
+        <pt x="181" y="422" on="0"/>
+        <pt x="181" y="408" on="1"/>
+        <pt x="181" y="399" on="0"/>
+        <pt x="190" y="385" on="0"/>
+        <pt x="224" y="363" on="0"/>
+        <pt x="259" y="342" on="1"/>
+        <pt x="292" y="323" on="0"/>
+        <pt x="343" y="276" on="0"/>
+        <pt x="372" y="212" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="t" xMin="7" yMin="-10" xMax="336" yMax="664">
+      <contour>
+        <pt x="265" y="130" on="1"/>
+        <pt x="280" y="130" on="0"/>
+        <pt x="316" y="140" on="0"/>
+        <pt x="336" y="149" on="1"/>
+        <pt x="336" y="21" on="1"/>
+        <pt x="309" y="6" on="0"/>
+        <pt x="250" y="-10" on="0"/>
+        <pt x="216" y="-10" on="1"/>
+        <pt x="162" y="-10" on="0"/>
+        <pt x="94" y="32" on="0"/>
+        <pt x="63" y="117" on="0"/>
+        <pt x="63" y="182" on="1"/>
+        <pt x="63" y="420" on="1"/>
+        <pt x="7" y="420" on="1"/>
+        <pt x="7" y="506" on="1"/>
+        <pt x="77" y="548" on="1"/>
+        <pt x="115" y="664" on="1"/>
+        <pt x="225" y="664" on="1"/>
+        <pt x="225" y="553" on="1"/>
+        <pt x="329" y="553" on="1"/>
+        <pt x="329" y="420" on="1"/>
+        <pt x="225" y="420" on="1"/>
+        <pt x="225" y="184" on="1"/>
+        <pt x="225" y="157" on="0"/>
+        <pt x="245" y="130" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2015 Google Inc. All Rights Reserved.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Condensed Bold
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.902;GOOG;TestFamily3-CondensedBold
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Condensed Bold
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.902
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      TestFamily3-CondensedBold
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Noto is a trademark of Google Inc.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Monotype Imaging Inc.
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Monotype Design Team
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Designed by Monotype design team.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.google.com/get/noto/
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://www.monotype.com/studio
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="16" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      Condensed Bold
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="T"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1 Format="2">
+          </ClassDef1>
+          <ClassDef2 Format="1">
+            <ClassDef glyph="T" class="4"/>
+            <ClassDef glyph="n" class="3"/>
+            <ClassDef glyph="o" class="2"/>
+            <ClassDef glyph="s" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=1 -->
+          <!-- Class2Count=5 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+              <Value1 XAdvance="0"/>
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-36"/>
+            </Class2Record>
+            <Class2Record index="2">
+              <Value1 XAdvance="-42"/>
+            </Class2Record>
+            <Class2Record index="3">
+              <Value1 XAdvance="-30"/>
+            </Class2Record>
+            <Class2Record index="4">
+              <Value1 XAdvance="12"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedLight.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedLight.ttx
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.14">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="F"/>
+    <GlyphID id="2" name="T"/>
+    <GlyphID id="3" name="l"/>
+    <GlyphID id="4" name="n"/>
+    <GlyphID id="5" name="o"/>
+    <GlyphID id="6" name="s"/>
+    <GlyphID id="7" name="t"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.902"/>
+    <checkSumAdjustment value="0x52bdf18e"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Tue Mar 15 19:50:39 2016"/>
+    <modified value="Wed Aug 16 14:03:23 2017"/>
+    <xMin value="7"/>
+    <yMin value="-232"/>
+    <xMax value="450"/>
+    <yMax value="760"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1069"/>
+    <descent value="-293"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="7"/>
+    <minRightSideBearing value="8"/>
+    <xMaxExtent value="450"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="43"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="336"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="316"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="2"/>
+      <bProportion value="6"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="4"/>
+      <bLetterForm value="2"/>
+      <bMidline value="2"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="11100000 00000000 00000010 11111111"/>
+    <ulUnicodeRange2 value="01000000 00000000 00000000 00011111"/>
+    <ulUnicodeRange3 value="00001000 00000000 00000000 00101001"/>
+    <ulUnicodeRange4 value="00000000 00010000 00000000 00000000"/>
+    <achVendID value="GOOG"/>
+    <fsSelection value="00000001 01000000"/>
+    <usFirstCharIndex value="70"/>
+    <usLastCharIndex value="116"/>
+    <sTypoAscender value="1069"/>
+    <sTypoDescender value="-293"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1069"/>
+    <usWinDescent value="293"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="527"/>
+    <sCapHeight value="714"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="F" width="352" lsb="78"/>
+    <mtx name="T" width="336" lsb="7"/>
+    <mtx name="l" width="167" lsb="71"/>
+    <mtx name="n" width="408" lsb="71"/>
+    <mtx name="o" width="403" lsb="46"/>
+    <mtx name="s" width="312" lsb="36"/>
+    <mtx name="t" width="209" lsb="21"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-232" xMax="450" yMax="760">
+      <contour>
+        <pt x="50" y="-232" on="1"/>
+        <pt x="450" y="-232" on="1"/>
+        <pt x="450" y="760" on="1"/>
+        <pt x="50" y="760" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-182" on="1"/>
+        <pt x="100" y="710" on="1"/>
+        <pt x="400" y="710" on="1"/>
+        <pt x="400" y="-182" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="78" yMin="0" xMax="334" yMax="714">
+      <contour>
+        <pt x="104" y="0" on="1"/>
+        <pt x="78" y="0" on="1"/>
+        <pt x="78" y="714" on="1"/>
+        <pt x="334" y="714" on="1"/>
+        <pt x="334" y="689" on="1"/>
+        <pt x="104" y="689" on="1"/>
+        <pt x="104" y="354" on="1"/>
+        <pt x="322" y="354" on="1"/>
+        <pt x="322" y="329" on="1"/>
+        <pt x="104" y="329" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="T" xMin="7" yMin="0" xMax="328" yMax="714">
+      <contour>
+        <pt x="180" y="0" on="1"/>
+        <pt x="154" y="0" on="1"/>
+        <pt x="154" y="689" on="1"/>
+        <pt x="7" y="689" on="1"/>
+        <pt x="7" y="714" on="1"/>
+        <pt x="328" y="714" on="1"/>
+        <pt x="328" y="689" on="1"/>
+        <pt x="180" y="689" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="l" xMin="71" yMin="0" xMax="97" yMax="760">
+      <contour>
+        <pt x="97" y="0" on="1"/>
+        <pt x="71" y="0" on="1"/>
+        <pt x="71" y="760" on="1"/>
+        <pt x="97" y="760" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="n" xMin="71" yMin="0" xMax="339" yMax="537">
+      <contour>
+        <pt x="225" y="537" on="1"/>
+        <pt x="280" y="537" on="0"/>
+        <pt x="339" y="460" on="0"/>
+        <pt x="339" y="375" on="1"/>
+        <pt x="339" y="0" on="1"/>
+        <pt x="313" y="0" on="1"/>
+        <pt x="313" y="365" on="1"/>
+        <pt x="313" y="444" on="0"/>
+        <pt x="266" y="513" on="0"/>
+        <pt x="225" y="513" on="1"/>
+        <pt x="173" y="513" on="0"/>
+        <pt x="97" y="412" on="0"/>
+        <pt x="97" y="311" on="1"/>
+        <pt x="97" y="0" on="1"/>
+        <pt x="71" y="0" on="1"/>
+        <pt x="71" y="527" on="1"/>
+        <pt x="91" y="527" on="1"/>
+        <pt x="92" y="415" on="1"/>
+        <pt x="94" y="415" on="1"/>
+        <pt x="101" y="444" on="0"/>
+        <pt x="132" y="501" on="0"/>
+        <pt x="185" y="537" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="o" xMin="46" yMin="-10" xMax="357" yMax="537">
+      <contour>
+        <pt x="357" y="264" on="1"/>
+        <pt x="357" y="194" on="0"/>
+        <pt x="338" y="91" on="0"/>
+        <pt x="300" y="23" on="0"/>
+        <pt x="242" y="-10" on="0"/>
+        <pt x="204" y="-10" on="1"/>
+        <pt x="165" y="-10" on="0"/>
+        <pt x="106" y="24" on="0"/>
+        <pt x="66" y="93" on="0"/>
+        <pt x="46" y="196" on="0"/>
+        <pt x="46" y="266" on="1"/>
+        <pt x="46" y="355" on="0"/>
+        <pt x="80" y="476" on="0"/>
+        <pt x="149" y="537" on="0"/>
+        <pt x="202" y="537" on="1"/>
+        <pt x="258" y="537" on="0"/>
+        <pt x="327" y="471" on="0"/>
+        <pt x="357" y="348" on="0"/>
+      </contour>
+      <contour>
+        <pt x="72" y="266" on="1"/>
+        <pt x="72" y="184" on="0"/>
+        <pt x="100" y="72" on="0"/>
+        <pt x="158" y="15" on="0"/>
+        <pt x="203" y="15" on="1"/>
+        <pt x="247" y="15" on="0"/>
+        <pt x="304" y="69" on="0"/>
+        <pt x="331" y="180" on="0"/>
+        <pt x="331" y="265" on="1"/>
+        <pt x="331" y="342" on="0"/>
+        <pt x="306" y="452" on="0"/>
+        <pt x="250" y="512" on="0"/>
+        <pt x="202" y="512" on="1"/>
+        <pt x="133" y="512" on="0"/>
+        <pt x="72" y="384" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="s" xMin="36" yMin="-10" xMax="278" yMax="537">
+      <contour>
+        <pt x="278" y="123" on="1"/>
+        <pt x="278" y="83" on="0"/>
+        <pt x="249" y="23" on="0"/>
+        <pt x="191" y="-10" on="0"/>
+        <pt x="147" y="-10" on="1"/>
+        <pt x="110" y="-10" on="0"/>
+        <pt x="53" y="10" on="0"/>
+        <pt x="36" y="21" on="1"/>
+        <pt x="36" y="52" on="1"/>
+        <pt x="58" y="36" on="0"/>
+        <pt x="116" y="16" on="0"/>
+        <pt x="147" y="16" on="1"/>
+        <pt x="200" y="16" on="0"/>
+        <pt x="251" y="73" on="0"/>
+        <pt x="251" y="125" on="1"/>
+        <pt x="251" y="160" on="0"/>
+        <pt x="229" y="203" on="0"/>
+        <pt x="186" y="236" on="0"/>
+        <pt x="157" y="254" on="1"/>
+        <pt x="123" y="275" on="0"/>
+        <pt x="70" y="316" on="0"/>
+        <pt x="39" y="369" on="0"/>
+        <pt x="39" y="408" on="1"/>
+        <pt x="39" y="461" on="0"/>
+        <pt x="105" y="537" on="0"/>
+        <pt x="175" y="537" on="1"/>
+        <pt x="204" y="537" on="0"/>
+        <pt x="256" y="523" on="0"/>
+        <pt x="275" y="510" on="1"/>
+        <pt x="262" y="487" on="1"/>
+        <pt x="246" y="499" on="0"/>
+        <pt x="198" y="512" on="0"/>
+        <pt x="174" y="512" on="1"/>
+        <pt x="125" y="512" on="0"/>
+        <pt x="65" y="458" on="0"/>
+        <pt x="65" y="407" on="1"/>
+        <pt x="65" y="378" on="0"/>
+        <pt x="87" y="336" on="0"/>
+        <pt x="130" y="300" on="0"/>
+        <pt x="162" y="280" on="1"/>
+        <pt x="195" y="260" on="0"/>
+        <pt x="247" y="221" on="0"/>
+        <pt x="278" y="166" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="t" xMin="21" yMin="-10" xMax="196" yMax="656">
+      <contour>
+        <pt x="147" y="14" on="1"/>
+        <pt x="160" y="14" on="0"/>
+        <pt x="184" y="20" on="0"/>
+        <pt x="192" y="25" on="1"/>
+        <pt x="192" y="0" on="1"/>
+        <pt x="182" y="-4" on="0"/>
+        <pt x="160" y="-10" on="0"/>
+        <pt x="146" y="-10" on="1"/>
+        <pt x="116" y="-10" on="0"/>
+        <pt x="83" y="18" on="0"/>
+        <pt x="71" y="72" on="0"/>
+        <pt x="71" y="112" on="1"/>
+        <pt x="71" y="503" on="1"/>
+        <pt x="21" y="503" on="1"/>
+        <pt x="21" y="521" on="1"/>
+        <pt x="69" y="528" on="1"/>
+        <pt x="76" y="656" on="1"/>
+        <pt x="97" y="656" on="1"/>
+        <pt x="97" y="527" on="1"/>
+        <pt x="196" y="527" on="1"/>
+        <pt x="196" y="503" on="1"/>
+        <pt x="97" y="503" on="1"/>
+        <pt x="97" y="108" on="1"/>
+        <pt x="97" y="60" on="0"/>
+        <pt x="117" y="14" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2015 Google Inc. All Rights Reserved.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Condensed Light
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.902;GOOG;TestFamily3-CondensedLight
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Condensed Light
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.902
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      TestFamily3-CondensedLight
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Noto is a trademark of Google Inc.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Monotype Imaging Inc.
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Monotype Design Team
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Designed by Monotype design team.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.google.com/get/noto/
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://www.monotype.com/studio
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="16" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      Condensed Light
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="T"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1 Format="2">
+          </ClassDef1>
+          <ClassDef2 Format="1">
+            <ClassDef glyph="T" class="4"/>
+            <ClassDef glyph="n" class="3"/>
+            <ClassDef glyph="o" class="2"/>
+            <ClassDef glyph="s" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=1 -->
+          <!-- Class2Count=5 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+              <Value1 XAdvance="0"/>
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-36"/>
+            </Class2Record>
+            <Class2Record index="2">
+              <Value1 XAdvance="-42"/>
+            </Class2Record>
+            <Class2Record index="3">
+              <Value1 XAdvance="-30"/>
+            </Class2Record>
+            <Class2Record index="4">
+              <Value1 XAdvance="12"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedSemiBold.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedSemiBold.ttx
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.14">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="F"/>
+    <GlyphID id="2" name="T"/>
+    <GlyphID id="3" name="l"/>
+    <GlyphID id="4" name="n"/>
+    <GlyphID id="5" name="o"/>
+    <GlyphID id="6" name="s"/>
+    <GlyphID id="7" name="t"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.902"/>
+    <checkSumAdjustment value="0x52e61490"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Tue Mar 15 19:50:39 2016"/>
+    <modified value="Wed Aug 16 14:03:23 2017"/>
+    <xMin value="11"/>
+    <yMin value="-240"/>
+    <xMax value="452"/>
+    <yMax value="760"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1069"/>
+    <descent value="-293"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="501"/>
+    <minLeftSideBearing value="11"/>
+    <minRightSideBearing value="15"/>
+    <xMaxExtent value="452"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="43"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="408"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="328"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="8"/>
+      <bProportion value="6"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="4"/>
+      <bLetterForm value="2"/>
+      <bMidline value="2"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="11100000 00000000 00000010 11111111"/>
+    <ulUnicodeRange2 value="01000000 00000000 00000000 00011111"/>
+    <ulUnicodeRange3 value="00001000 00000000 00000000 00101001"/>
+    <ulUnicodeRange4 value="00000000 00010000 00000000 00000000"/>
+    <achVendID value="GOOG"/>
+    <fsSelection value="00000001 01000000"/>
+    <usFirstCharIndex value="70"/>
+    <usLastCharIndex value="116"/>
+    <sTypoAscender value="1069"/>
+    <sTypoDescender value="-293"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1069"/>
+    <usWinDescent value="293"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="547"/>
+    <sCapHeight value="714"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="F" width="414" lsb="64"/>
+    <mtx name="T" width="429" lsb="14"/>
+    <mtx name="l" width="242" lsb="56"/>
+    <mtx name="n" width="501" lsb="56"/>
+    <mtx name="o" width="488" lsb="36"/>
+    <mtx name="s" width="374" lsb="28"/>
+    <mtx name="t" width="317" lsb="11"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-240" xMax="450" yMax="760">
+      <contour>
+        <pt x="50" y="-240" on="1"/>
+        <pt x="450" y="-240" on="1"/>
+        <pt x="450" y="760" on="1"/>
+        <pt x="50" y="760" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-190" on="1"/>
+        <pt x="100" y="710" on="1"/>
+        <pt x="400" y="710" on="1"/>
+        <pt x="400" y="-190" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="64" yMin="0" xMax="383" yMax="714">
+      <contour>
+        <pt x="201" y="0" on="1"/>
+        <pt x="64" y="0" on="1"/>
+        <pt x="64" y="714" on="1"/>
+        <pt x="383" y="714" on="1"/>
+        <pt x="383" y="597" on="1"/>
+        <pt x="201" y="597" on="1"/>
+        <pt x="201" y="403" on="1"/>
+        <pt x="371" y="403" on="1"/>
+        <pt x="371" y="286" on="1"/>
+        <pt x="201" y="286" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="T" xMin="14" yMin="0" xMax="414" yMax="714">
+      <contour>
+        <pt x="282" y="0" on="1"/>
+        <pt x="147" y="0" on="1"/>
+        <pt x="147" y="595" on="1"/>
+        <pt x="14" y="595" on="1"/>
+        <pt x="14" y="714" on="1"/>
+        <pt x="414" y="714" on="1"/>
+        <pt x="414" y="595" on="1"/>
+        <pt x="282" y="595" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="l" xMin="56" yMin="0" xMax="186" yMax="760">
+      <contour>
+        <pt x="186" y="0" on="1"/>
+        <pt x="56" y="0" on="1"/>
+        <pt x="56" y="760" on="1"/>
+        <pt x="186" y="760" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="n" xMin="56" yMin="0" xMax="446" yMax="557">
+      <contour>
+        <pt x="302" y="557" on="1"/>
+        <pt x="371" y="557" on="0"/>
+        <pt x="446" y="457" on="0"/>
+        <pt x="446" y="362" on="1"/>
+        <pt x="446" y="0" on="1"/>
+        <pt x="316" y="0" on="1"/>
+        <pt x="316" y="324" on="1"/>
+        <pt x="316" y="382" on="0"/>
+        <pt x="292" y="441" on="0"/>
+        <pt x="260" y="441" on="1"/>
+        <pt x="219" y="441" on="0"/>
+        <pt x="186" y="360" on="0"/>
+        <pt x="186" y="263" on="1"/>
+        <pt x="186" y="0" on="1"/>
+        <pt x="56" y="0" on="1"/>
+        <pt x="56" y="547" on="1"/>
+        <pt x="159" y="547" on="1"/>
+        <pt x="173" y="477" on="1"/>
+        <pt x="181" y="477" on="1"/>
+        <pt x="193" y="503" on="0"/>
+        <pt x="229" y="539" on="0"/>
+        <pt x="274" y="557" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="o" xMin="36" yMin="-10" xMax="452" yMax="557">
+      <contour>
+        <pt x="452" y="275" on="1"/>
+        <pt x="452" y="218" on="0"/>
+        <pt x="429" y="115" on="0"/>
+        <pt x="380" y="36" on="0"/>
+        <pt x="300" y="-10" on="0"/>
+        <pt x="243" y="-10" on="1"/>
+        <pt x="190" y="-10" on="0"/>
+        <pt x="112" y="35" on="0"/>
+        <pt x="61" y="114" on="0"/>
+        <pt x="36" y="217" on="0"/>
+        <pt x="36" y="275" on="1"/>
+        <pt x="36" y="358" on="0"/>
+        <pt x="79" y="485" on="0"/>
+        <pt x="172" y="557" on="0"/>
+        <pt x="245" y="557" on="1"/>
+        <pt x="308" y="557" on="0"/>
+        <pt x="401" y="492" on="0"/>
+        <pt x="452" y="366" on="0"/>
+      </contour>
+      <contour>
+        <pt x="168" y="273" on="1"/>
+        <pt x="168" y="216" on="0"/>
+        <pt x="184" y="139" on="0"/>
+        <pt x="218" y="100" on="0"/>
+        <pt x="244" y="100" on="1"/>
+        <pt x="271" y="100" on="0"/>
+        <pt x="304" y="139" on="0"/>
+        <pt x="319" y="216" on="0"/>
+        <pt x="319" y="275" on="1"/>
+        <pt x="319" y="332" on="0"/>
+        <pt x="304" y="409" on="0"/>
+        <pt x="271" y="447" on="0"/>
+        <pt x="244" y="447" on="1"/>
+        <pt x="204" y="447" on="0"/>
+        <pt x="168" y="362" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="s" xMin="28" yMin="-10" xMax="347" yMax="557">
+      <contour>
+        <pt x="347" y="160" on="1"/>
+        <pt x="347" y="104" on="0"/>
+        <pt x="305" y="29" on="0"/>
+        <pt x="227" y="-10" on="0"/>
+        <pt x="172" y="-10" on="1"/>
+        <pt x="132" y="-10" on="0"/>
+        <pt x="60" y="5" on="0"/>
+        <pt x="29" y="21" on="1"/>
+        <pt x="29" y="147" on="1"/>
+        <pt x="55" y="129" on="0"/>
+        <pt x="125" y="103" on="0"/>
+        <pt x="160" y="103" on="1"/>
+        <pt x="188" y="103" on="0"/>
+        <pt x="217" y="128" on="0"/>
+        <pt x="217" y="153" on="1"/>
+        <pt x="217" y="166" on="0"/>
+        <pt x="205" y="190" on="0"/>
+        <pt x="170" y="217" on="0"/>
+        <pt x="135" y="235" on="1"/>
+        <pt x="101" y="254" on="0"/>
+        <pt x="53" y="301" on="0"/>
+        <pt x="28" y="362" on="0"/>
+        <pt x="28" y="402" on="1"/>
+        <pt x="28" y="474" on="0"/>
+        <pt x="118" y="557" on="0"/>
+        <pt x="196" y="557" on="1"/>
+        <pt x="236" y="557" on="0"/>
+        <pt x="306" y="535" on="0"/>
+        <pt x="341" y="514" on="1"/>
+        <pt x="305" y="414" on="1"/>
+        <pt x="282" y="430" on="0"/>
+        <pt x="230" y="451" on="0"/>
+        <pt x="203" y="451" on="1"/>
+        <pt x="179" y="451" on="0"/>
+        <pt x="154" y="428" on="0"/>
+        <pt x="154" y="408" on="1"/>
+        <pt x="154" y="394" on="0"/>
+        <pt x="166" y="373" on="0"/>
+        <pt x="200" y="348" on="0"/>
+        <pt x="234" y="328" on="1"/>
+        <pt x="268" y="308" on="0"/>
+        <pt x="318" y="263" on="0"/>
+        <pt x="347" y="202" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="t" xMin="11" yMin="-10" xMax="300" yMax="662">
+      <contour>
+        <pt x="239" y="104" on="1"/>
+        <pt x="252" y="104" on="0"/>
+        <pt x="284" y="112" on="0"/>
+        <pt x="300" y="119" on="1"/>
+        <pt x="300" y="15" on="1"/>
+        <pt x="278" y="3" on="0"/>
+        <pt x="227" y="-10" on="0"/>
+        <pt x="198" y="-10" on="1"/>
+        <pt x="151" y="-10" on="0"/>
+        <pt x="92" y="28" on="0"/>
+        <pt x="65" y="104" on="0"/>
+        <pt x="65" y="163" on="1"/>
+        <pt x="65" y="439" on="1"/>
+        <pt x="11" y="439" on="1"/>
+        <pt x="11" y="509" on="1"/>
+        <pt x="75" y="543" on="1"/>
+        <pt x="106" y="662" on="1"/>
+        <pt x="195" y="662" on="1"/>
+        <pt x="195" y="547" on="1"/>
+        <pt x="293" y="547" on="1"/>
+        <pt x="293" y="439" on="1"/>
+        <pt x="195" y="439" on="1"/>
+        <pt x="195" y="168" on="1"/>
+        <pt x="195" y="136" on="0"/>
+        <pt x="215" y="104" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2015 Google Inc. All Rights Reserved.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Condensed SemiBold
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.902;GOOG;TestFamily3-CondensedSemiBold
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Condensed SemiBold
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.902
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      TestFamily3-CondensedSemiBold
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Noto is a trademark of Google Inc.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Monotype Imaging Inc.
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Monotype Design Team
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Designed by Monotype design team.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.google.com/get/noto/
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://www.monotype.com/studio
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="16" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      Condensed SemiBold
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="T"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1 Format="2">
+          </ClassDef1>
+          <ClassDef2 Format="1">
+            <ClassDef glyph="T" class="4"/>
+            <ClassDef glyph="n" class="3"/>
+            <ClassDef glyph="o" class="2"/>
+            <ClassDef glyph="s" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=1 -->
+          <!-- Class2Count=5 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+              <Value1 XAdvance="0"/>
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-36"/>
+            </Class2Record>
+            <Class2Record index="2">
+              <Value1 XAdvance="-42"/>
+            </Class2Record>
+            <Class2Record index="3">
+              <Value1 XAdvance="-30"/>
+            </Class2Record>
+            <Class2Record index="4">
+              <Value1 XAdvance="12"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Light.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Light.ttx
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.14">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="F"/>
+    <GlyphID id="2" name="T"/>
+    <GlyphID id="3" name="l"/>
+    <GlyphID id="4" name="n"/>
+    <GlyphID id="5" name="o"/>
+    <GlyphID id="6" name="s"/>
+    <GlyphID id="7" name="t"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.902"/>
+    <checkSumAdjustment value="0x4e9cc8d4"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Tue Mar 15 19:50:39 2016"/>
+    <modified value="Wed Aug 16 14:03:23 2017"/>
+    <xMin value="2"/>
+    <yMin value="-240"/>
+    <xMax value="515"/>
+    <yMax value="760"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1069"/>
+    <descent value="-293"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="575"/>
+    <minLeftSideBearing value="2"/>
+    <minRightSideBearing value="2"/>
+    <xMaxExtent value="515"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="43"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="454"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="317"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="2"/>
+      <bProportion value="2"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="4"/>
+      <bLetterForm value="2"/>
+      <bMidline value="2"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="11100000 00000000 00000010 11111111"/>
+    <ulUnicodeRange2 value="01000000 00000000 00000000 00011111"/>
+    <ulUnicodeRange3 value="00001000 00000000 00000000 00101001"/>
+    <ulUnicodeRange4 value="00000000 00010000 00000000 00000000"/>
+    <achVendID value="GOOG"/>
+    <fsSelection value="00000001 01000000"/>
+    <usFirstCharIndex value="70"/>
+    <usLastCharIndex value="116"/>
+    <sTypoAscender value="1069"/>
+    <sTypoDescender value="-293"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1069"/>
+    <usWinDescent value="293"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="528"/>
+    <sCapHeight value="714"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="F" width="492" lsb="103"/>
+    <mtx name="T" width="505" lsb="2"/>
+    <mtx name="l" width="207" lsb="91"/>
+    <mtx name="n" width="573" lsb="90"/>
+    <mtx name="o" width="575" lsb="59"/>
+    <mtx name="s" width="458" lsb="39"/>
+    <mtx name="t" width="319" lsb="10"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-240" xMax="450" yMax="760">
+      <contour>
+        <pt x="50" y="-240" on="1"/>
+        <pt x="450" y="-240" on="1"/>
+        <pt x="450" y="760" on="1"/>
+        <pt x="50" y="760" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-190" on="1"/>
+        <pt x="100" y="710" on="1"/>
+        <pt x="400" y="710" on="1"/>
+        <pt x="400" y="-190" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="103" yMin="0" xMax="489" yMax="714">
+      <contour>
+        <pt x="129" y="0" on="1"/>
+        <pt x="103" y="0" on="1"/>
+        <pt x="103" y="714" on="1"/>
+        <pt x="489" y="714" on="1"/>
+        <pt x="489" y="689" on="1"/>
+        <pt x="129" y="689" on="1"/>
+        <pt x="129" y="354" on="1"/>
+        <pt x="470" y="354" on="1"/>
+        <pt x="470" y="329" on="1"/>
+        <pt x="129" y="329" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="T" xMin="2" yMin="0" xMax="503" yMax="714">
+      <contour>
+        <pt x="265" y="0" on="1"/>
+        <pt x="239" y="0" on="1"/>
+        <pt x="239" y="689" on="1"/>
+        <pt x="2" y="689" on="1"/>
+        <pt x="2" y="714" on="1"/>
+        <pt x="503" y="714" on="1"/>
+        <pt x="503" y="689" on="1"/>
+        <pt x="265" y="689" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="l" xMin="91" yMin="0" xMax="117" yMax="760">
+      <contour>
+        <pt x="117" y="0" on="1"/>
+        <pt x="91" y="0" on="1"/>
+        <pt x="91" y="760" on="1"/>
+        <pt x="117" y="760" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="n" xMin="90" yMin="0" xMax="489" yMax="538">
+      <contour>
+        <pt x="309" y="538" on="1"/>
+        <pt x="394" y="538" on="0"/>
+        <pt x="489" y="444" on="0"/>
+        <pt x="489" y="346" on="1"/>
+        <pt x="489" y="0" on="1"/>
+        <pt x="463" y="0" on="1"/>
+        <pt x="463" y="345" on="1"/>
+        <pt x="463" y="433" on="0"/>
+        <pt x="382" y="513" on="0"/>
+        <pt x="309" y="513" on="1"/>
+        <pt x="223" y="513" on="0"/>
+        <pt x="116" y="410" on="0"/>
+        <pt x="116" y="302" on="1"/>
+        <pt x="116" y="0" on="1"/>
+        <pt x="90" y="0" on="1"/>
+        <pt x="90" y="528" on="1"/>
+        <pt x="111" y="528" on="1"/>
+        <pt x="115" y="417" on="1"/>
+        <pt x="117" y="417" on="1"/>
+        <pt x="128" y="448" on="0"/>
+        <pt x="176" y="503" on="0"/>
+        <pt x="253" y="538" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="o" xMin="59" yMin="-10" xMax="515" yMax="538">
+      <contour>
+        <pt x="515" y="264" on="1"/>
+        <pt x="515" y="206" on="0"/>
+        <pt x="488" y="106" on="0"/>
+        <pt x="431" y="32" on="0"/>
+        <pt x="345" y="-10" on="0"/>
+        <pt x="286" y="-10" on="1"/>
+        <pt x="229" y="-10" on="0"/>
+        <pt x="144" y="31" on="0"/>
+        <pt x="87" y="105" on="0"/>
+        <pt x="59" y="205" on="0"/>
+        <pt x="59" y="264" on="1"/>
+        <pt x="59" y="348" on="0"/>
+        <pt x="114" y="471" on="0"/>
+        <pt x="218" y="538" on="0"/>
+        <pt x="292" y="538" on="1"/>
+        <pt x="372" y="538" on="0"/>
+        <pt x="470" y="465" on="0"/>
+        <pt x="515" y="340" on="0"/>
+      </contour>
+      <contour>
+        <pt x="86" y="264" on="1"/>
+        <pt x="86" y="190" on="0"/>
+        <pt x="130" y="78" on="0"/>
+        <pt x="218" y="15" on="0"/>
+        <pt x="286" y="15" on="1"/>
+        <pt x="356" y="15" on="0"/>
+        <pt x="445" y="79" on="0"/>
+        <pt x="488" y="192" on="0"/>
+        <pt x="488" y="264" on="1"/>
+        <pt x="488" y="333" on="0"/>
+        <pt x="449" y="446" on="0"/>
+        <pt x="362" y="513" on="0"/>
+        <pt x="292" y="513" on="1"/>
+        <pt x="193" y="513" on="0"/>
+        <pt x="86" y="381" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="s" xMin="39" yMin="-10" xMax="411" yMax="538">
+      <contour>
+        <pt x="411" y="134" on="1"/>
+        <pt x="411" y="90" on="0"/>
+        <pt x="367" y="25" on="0"/>
+        <pt x="279" y="-10" on="0"/>
+        <pt x="213" y="-10" on="1"/>
+        <pt x="158" y="-10" on="0"/>
+        <pt x="68" y="11" on="0"/>
+        <pt x="39" y="24" on="1"/>
+        <pt x="39" y="54" on="1"/>
+        <pt x="79" y="34" on="0"/>
+        <pt x="166" y="15" on="0"/>
+        <pt x="213" y="15" on="1"/>
+        <pt x="304" y="15" on="0"/>
+        <pt x="384" y="78" on="0"/>
+        <pt x="384" y="134" on="1"/>
+        <pt x="384" y="173" on="0"/>
+        <pt x="341" y="220" on="0"/>
+        <pt x="268" y="249" on="0"/>
+        <pt x="224" y="262" on="1"/>
+        <pt x="178" y="276" on="0"/>
+        <pt x="101" y="305" on="0"/>
+        <pt x="56" y="358" on="0"/>
+        <pt x="56" y="407" on="1"/>
+        <pt x="56" y="468" on="0"/>
+        <pt x="154" y="538" on="0"/>
+        <pt x="238" y="538" on="1"/>
+        <pt x="285" y="538" on="0"/>
+        <pt x="366" y="521" on="0"/>
+        <pt x="398" y="508" on="1"/>
+        <pt x="387" y="483" on="1"/>
+        <pt x="359" y="496" on="0"/>
+        <pt x="278" y="513" on="0"/>
+        <pt x="238" y="513" on="1"/>
+        <pt x="166" y="513" on="0"/>
+        <pt x="83" y="460" on="0"/>
+        <pt x="83" y="407" on="1"/>
+        <pt x="83" y="366" on="0"/>
+        <pt x="124" y="323" on="0"/>
+        <pt x="192" y="299" on="0"/>
+        <pt x="233" y="286" on="1"/>
+        <pt x="277" y="272" on="0"/>
+        <pt x="359" y="240" on="0"/>
+        <pt x="411" y="184" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="t" xMin="10" yMin="-10" xMax="291" yMax="659">
+      <contour>
+        <pt x="212" y="15" on="1"/>
+        <pt x="237" y="15" on="0"/>
+        <pt x="274" y="22" on="0"/>
+        <pt x="291" y="28" on="1"/>
+        <pt x="291" y="3" on="1"/>
+        <pt x="274" y="-2" on="0"/>
+        <pt x="238" y="-10" on="0"/>
+        <pt x="212" y="-10" on="1"/>
+        <pt x="166" y="-10" on="0"/>
+        <pt x="113" y="26" on="0"/>
+        <pt x="91" y="94" on="0"/>
+        <pt x="91" y="140" on="1"/>
+        <pt x="91" y="503" on="1"/>
+        <pt x="10" y="503" on="1"/>
+        <pt x="10" y="525" on="1"/>
+        <pt x="90" y="528" on="1"/>
+        <pt x="96" y="659" on="1"/>
+        <pt x="117" y="659" on="1"/>
+        <pt x="117" y="528" on="1"/>
+        <pt x="289" y="528" on="1"/>
+        <pt x="289" y="503" on="1"/>
+        <pt x="117" y="503" on="1"/>
+        <pt x="117" y="143" on="1"/>
+        <pt x="117" y="82" on="0"/>
+        <pt x="156" y="15" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2015 Google Inc. All Rights Reserved.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Light
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.902;GOOG;TestFamily3-Light
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Light
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.902
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      TestFamily3-Light
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Noto is a trademark of Google Inc.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Monotype Imaging Inc.
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Monotype Design Team
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Designed by Monotype design team.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.google.com/get/noto/
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://www.monotype.com/studio
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="16" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="T"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1 Format="2">
+          </ClassDef1>
+          <ClassDef2 Format="1">
+            <ClassDef glyph="T" class="4"/>
+            <ClassDef glyph="n" class="3"/>
+            <ClassDef glyph="o" class="2"/>
+            <ClassDef glyph="s" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=1 -->
+          <!-- Class2Count=5 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+              <Value1 XAdvance="0"/>
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-60"/>
+            </Class2Record>
+            <Class2Record index="2">
+              <Value1 XAdvance="-70"/>
+            </Class2Record>
+            <Class2Record index="3">
+              <Value1 XAdvance="-50"/>
+            </Class2Record>
+            <Class2Record index="4">
+              <Value1 XAdvance="20"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Regular.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Regular.ttx
@@ -1,0 +1,520 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.14">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="F"/>
+    <GlyphID id="2" name="T"/>
+    <GlyphID id="3" name="l"/>
+    <GlyphID id="4" name="n"/>
+    <GlyphID id="5" name="o"/>
+    <GlyphID id="6" name="s"/>
+    <GlyphID id="7" name="t"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.902"/>
+    <checkSumAdjustment value="0x216f5a4a"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Tue Mar 15 19:50:39 2016"/>
+    <modified value="Wed Aug 16 14:03:23 2017"/>
+    <xMin value="10"/>
+    <yMin value="-240"/>
+    <xMax value="551"/>
+    <yMax value="760"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1069"/>
+    <descent value="-293"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="618"/>
+    <minLeftSideBearing value="10"/>
+    <minRightSideBearing value="11"/>
+    <xMaxExtent value="551"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="43"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="487"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="322"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="5"/>
+      <bProportion value="2"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="4"/>
+      <bLetterForm value="2"/>
+      <bMidline value="2"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="11100000 00000000 00000010 11111111"/>
+    <ulUnicodeRange2 value="01000000 00000000 00000000 00011111"/>
+    <ulUnicodeRange3 value="00001000 00000000 00000000 00101001"/>
+    <ulUnicodeRange4 value="00000000 00010000 00000000 00000000"/>
+    <achVendID value="GOOG"/>
+    <fsSelection value="00000001 01000000"/>
+    <usFirstCharIndex value="70"/>
+    <usLastCharIndex value="116"/>
+    <sTypoAscender value="1069"/>
+    <sTypoDescender value="-293"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1069"/>
+    <usWinDescent value="293"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="536"/>
+    <sCapHeight value="714"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="F" width="519" lsb="97"/>
+    <mtx name="T" width="556" lsb="10"/>
+    <mtx name="l" width="258" lsb="85"/>
+    <mtx name="n" width="618" lsb="85"/>
+    <mtx name="o" width="605" lsb="55"/>
+    <mtx name="s" width="479" lsb="51"/>
+    <mtx name="t" width="361" lsb="16"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-240" xMax="450" yMax="760">
+      <contour>
+        <pt x="50" y="-240" on="1"/>
+        <pt x="450" y="-240" on="1"/>
+        <pt x="450" y="760" on="1"/>
+        <pt x="50" y="760" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-190" on="1"/>
+        <pt x="100" y="710" on="1"/>
+        <pt x="400" y="710" on="1"/>
+        <pt x="400" y="-190" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="97" yMin="0" xMax="496" yMax="714">
+      <contour>
+        <pt x="187" y="0" on="1"/>
+        <pt x="97" y="0" on="1"/>
+        <pt x="97" y="714" on="1"/>
+        <pt x="496" y="714" on="1"/>
+        <pt x="496" y="635" on="1"/>
+        <pt x="187" y="635" on="1"/>
+        <pt x="187" y="382" on="1"/>
+        <pt x="477" y="382" on="1"/>
+        <pt x="477" y="303" on="1"/>
+        <pt x="187" y="303" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="T" xMin="10" yMin="0" xMax="545" yMax="714">
+      <contour>
+        <pt x="323" y="0" on="1"/>
+        <pt x="233" y="0" on="1"/>
+        <pt x="233" y="635" on="1"/>
+        <pt x="10" y="635" on="1"/>
+        <pt x="10" y="714" on="1"/>
+        <pt x="545" y="714" on="1"/>
+        <pt x="545" y="635" on="1"/>
+        <pt x="323" y="635" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="l" xMin="85" yMin="0" xMax="173" yMax="760">
+      <contour>
+        <pt x="173" y="0" on="1"/>
+        <pt x="85" y="0" on="1"/>
+        <pt x="85" y="760" on="1"/>
+        <pt x="173" y="760" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="n" xMin="85" yMin="0" xMax="537" yMax="546">
+      <contour>
+        <pt x="343" y="546" on="1"/>
+        <pt x="439" y="546" on="0"/>
+        <pt x="537" y="452" on="0"/>
+        <pt x="537" y="349" on="1"/>
+        <pt x="537" y="0" on="1"/>
+        <pt x="450" y="0" on="1"/>
+        <pt x="450" y="343" on="1"/>
+        <pt x="450" y="408" on="0"/>
+        <pt x="392" y="472" on="0"/>
+        <pt x="330" y="472" on="1"/>
+        <pt x="241" y="472" on="0"/>
+        <pt x="173" y="372" on="0"/>
+        <pt x="173" y="278" on="1"/>
+        <pt x="173" y="0" on="1"/>
+        <pt x="85" y="0" on="1"/>
+        <pt x="85" y="536" on="1"/>
+        <pt x="156" y="536" on="1"/>
+        <pt x="169" y="463" on="1"/>
+        <pt x="174" y="463" on="1"/>
+        <pt x="192" y="491" on="0"/>
+        <pt x="245" y="528" on="0"/>
+        <pt x="309" y="546" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="o" xMin="55" yMin="-10" xMax="551" yMax="546">
+      <contour>
+        <pt x="551" y="269" on="1"/>
+        <pt x="551" y="202" on="0"/>
+        <pt x="516" y="98" on="0"/>
+        <pt x="451" y="27" on="0"/>
+        <pt x="358" y="-10" on="0"/>
+        <pt x="301" y="-10" on="1"/>
+        <pt x="248" y="-10" on="0"/>
+        <pt x="158" y="27" on="0"/>
+        <pt x="92" y="98" on="0"/>
+        <pt x="55" y="202" on="0"/>
+        <pt x="55" y="269" on="1"/>
+        <pt x="55" y="358" on="0"/>
+        <pt x="115" y="481" on="0"/>
+        <pt x="227" y="546" on="0"/>
+        <pt x="304" y="546" on="1"/>
+        <pt x="376" y="546" on="0"/>
+        <pt x="488" y="481" on="0"/>
+        <pt x="551" y="358" on="0"/>
+      </contour>
+      <contour>
+        <pt x="146" y="269" on="1"/>
+        <pt x="146" y="206" on="0"/>
+        <pt x="179" y="113" on="0"/>
+        <pt x="249" y="63" on="0"/>
+        <pt x="303" y="63" on="1"/>
+        <pt x="357" y="63" on="0"/>
+        <pt x="426" y="113" on="0"/>
+        <pt x="460" y="206" on="0"/>
+        <pt x="460" y="269" on="1"/>
+        <pt x="460" y="332" on="0"/>
+        <pt x="426" y="423" on="0"/>
+        <pt x="356" y="472" on="0"/>
+        <pt x="302" y="472" on="1"/>
+        <pt x="220" y="472" on="0"/>
+        <pt x="146" y="364" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="s" xMin="51" yMin="-10" xMax="434" yMax="546">
+      <contour>
+        <pt x="434" y="148" on="1"/>
+        <pt x="434" y="96" on="0"/>
+        <pt x="382" y="26" on="0"/>
+        <pt x="286" y="-10" on="0"/>
+        <pt x="220" y="-10" on="1"/>
+        <pt x="164" y="-10" on="0"/>
+        <pt x="83" y="8" on="0"/>
+        <pt x="52" y="24" on="1"/>
+        <pt x="52" y="104" on="1"/>
+        <pt x="84" y="88" on="0"/>
+        <pt x="175" y="61" on="0"/>
+        <pt x="222" y="61" on="1"/>
+        <pt x="289" y="61" on="0"/>
+        <pt x="349" y="104" on="0"/>
+        <pt x="349" y="140" on="1"/>
+        <pt x="349" y="160" on="0"/>
+        <pt x="327" y="192" on="0"/>
+        <pt x="270" y="224" on="0"/>
+        <pt x="217" y="244" on="1"/>
+        <pt x="165" y="264" on="0"/>
+        <pt x="91" y="304" on="0"/>
+        <pt x="51" y="360" on="0"/>
+        <pt x="51" y="404" on="1"/>
+        <pt x="51" y="472" on="0"/>
+        <pt x="162" y="546" on="0"/>
+        <pt x="252" y="546" on="1"/>
+        <pt x="301" y="546" on="0"/>
+        <pt x="386" y="526" on="0"/>
+        <pt x="423" y="510" on="1"/>
+        <pt x="393" y="440" on="1"/>
+        <pt x="359" y="454" on="0"/>
+        <pt x="285" y="474" on="0"/>
+        <pt x="246" y="474" on="1"/>
+        <pt x="192" y="474" on="0"/>
+        <pt x="135" y="439" on="0"/>
+        <pt x="135" y="409" on="1"/>
+        <pt x="135" y="386" on="0"/>
+        <pt x="161" y="356" on="0"/>
+        <pt x="222" y="326" on="0"/>
+        <pt x="273" y="307" on="1"/>
+        <pt x="324" y="288" on="0"/>
+        <pt x="396" y="248" on="0"/>
+        <pt x="434" y="191" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="t" xMin="16" yMin="-10" xMax="339" yMax="659">
+      <contour>
+        <pt x="264" y="62" on="1"/>
+        <pt x="284" y="62" on="0"/>
+        <pt x="326" y="68" on="0"/>
+        <pt x="339" y="73" on="1"/>
+        <pt x="339" y="6" on="1"/>
+        <pt x="325" y="-1" on="0"/>
+        <pt x="273" y="-10" on="0"/>
+        <pt x="249" y="-10" on="1"/>
+        <pt x="207" y="-10" on="0"/>
+        <pt x="136" y="19" on="0"/>
+        <pt x="92" y="91" on="0"/>
+        <pt x="92" y="156" on="1"/>
+        <pt x="92" y="468" on="1"/>
+        <pt x="16" y="468" on="1"/>
+        <pt x="16" y="510" on="1"/>
+        <pt x="93" y="545" on="1"/>
+        <pt x="128" y="659" on="1"/>
+        <pt x="180" y="659" on="1"/>
+        <pt x="180" y="536" on="1"/>
+        <pt x="335" y="536" on="1"/>
+        <pt x="335" y="468" on="1"/>
+        <pt x="180" y="468" on="1"/>
+        <pt x="180" y="158" on="1"/>
+        <pt x="180" y="109" on="0"/>
+        <pt x="227" y="62" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2015 Google Inc. All Rights Reserved.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.902;GOOG;TestFamily3-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.902
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      TestFamily3-Regular
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Noto is a trademark of Google Inc.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Monotype Imaging Inc.
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Monotype Design Team
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Designed by Monotype design team.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.google.com/get/noto/
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://www.monotype.com/studio
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="T"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1 Format="2">
+          </ClassDef1>
+          <ClassDef2 Format="1">
+            <ClassDef glyph="T" class="4"/>
+            <ClassDef glyph="n" class="3"/>
+            <ClassDef glyph="o" class="2"/>
+            <ClassDef glyph="s" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=1 -->
+          <!-- Class2Count=5 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+              <Value1 XAdvance="0"/>
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-60"/>
+            </Class2Record>
+            <Class2Record index="2">
+              <Value1 XAdvance="-70"/>
+            </Class2Record>
+            <Class2Record index="3">
+              <Value1 XAdvance="-50"/>
+            </Class2Record>
+            <Class2Record index="4">
+              <Value1 XAdvance="20"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-SemiBold.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-SemiBold.ttx
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.14">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="F"/>
+    <GlyphID id="2" name="T"/>
+    <GlyphID id="3" name="l"/>
+    <GlyphID id="4" name="n"/>
+    <GlyphID id="5" name="o"/>
+    <GlyphID id="6" name="s"/>
+    <GlyphID id="7" name="t"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.902"/>
+    <checkSumAdjustment value="0x9fcb5370"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Tue Mar 15 19:50:39 2016"/>
+    <modified value="Wed Aug 16 14:03:23 2017"/>
+    <xMin value="20"/>
+    <yMin value="-240"/>
+    <xMax value="582"/>
+    <yMax value="760"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1069"/>
+    <descent value="-293"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="657"/>
+    <minLeftSideBearing value="20"/>
+    <minRightSideBearing value="20"/>
+    <xMaxExtent value="582"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="43"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="518"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="328"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="8"/>
+      <bProportion value="2"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="4"/>
+      <bLetterForm value="2"/>
+      <bMidline value="2"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="11100000 00000000 00000010 11111111"/>
+    <ulUnicodeRange2 value="01000000 00000000 00000000 00011111"/>
+    <ulUnicodeRange3 value="00001000 00000000 00000000 00101001"/>
+    <ulUnicodeRange4 value="00000000 00010000 00000000 00000000"/>
+    <achVendID value="GOOG"/>
+    <fsSelection value="00000001 01000000"/>
+    <usFirstCharIndex value="70"/>
+    <usLastCharIndex value="116"/>
+    <sTypoAscender value="1069"/>
+    <sTypoDescender value="-293"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1069"/>
+    <usWinDescent value="293"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="546"/>
+    <sCapHeight value="714"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="F" width="549" lsb="90"/>
+    <mtx name="T" width="579" lsb="20"/>
+    <mtx name="l" width="305" lsb="78"/>
+    <mtx name="n" width="657" lsb="78"/>
+    <mtx name="o" width="619" lsb="45"/>
+    <mtx name="s" width="497" lsb="45"/>
+    <mtx name="t" width="434" lsb="23"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+      <map code="0x54" name="T"/><!-- LATIN CAPITAL LETTER T -->
+      <map code="0x6c" name="l"/><!-- LATIN SMALL LETTER L -->
+      <map code="0x6e" name="n"/><!-- LATIN SMALL LETTER N -->
+      <map code="0x6f" name="o"/><!-- LATIN SMALL LETTER O -->
+      <map code="0x73" name="s"/><!-- LATIN SMALL LETTER S -->
+      <map code="0x74" name="t"/><!-- LATIN SMALL LETTER T -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-240" xMax="450" yMax="760">
+      <contour>
+        <pt x="50" y="-240" on="1"/>
+        <pt x="450" y="-240" on="1"/>
+        <pt x="450" y="760" on="1"/>
+        <pt x="50" y="760" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-190" on="1"/>
+        <pt x="100" y="710" on="1"/>
+        <pt x="400" y="710" on="1"/>
+        <pt x="400" y="-190" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="90" yMin="0" xMax="499" yMax="714">
+      <contour>
+        <pt x="239" y="0" on="1"/>
+        <pt x="90" y="0" on="1"/>
+        <pt x="90" y="714" on="1"/>
+        <pt x="499" y="714" on="1"/>
+        <pt x="499" y="590" on="1"/>
+        <pt x="239" y="590" on="1"/>
+        <pt x="239" y="406" on="1"/>
+        <pt x="481" y="406" on="1"/>
+        <pt x="481" y="282" on="1"/>
+        <pt x="239" y="282" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="T" xMin="20" yMin="0" xMax="559" yMax="714">
+      <contour>
+        <pt x="365" y="0" on="1"/>
+        <pt x="214" y="0" on="1"/>
+        <pt x="214" y="588" on="1"/>
+        <pt x="20" y="588" on="1"/>
+        <pt x="20" y="714" on="1"/>
+        <pt x="559" y="714" on="1"/>
+        <pt x="559" y="588" on="1"/>
+        <pt x="365" y="588" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="l" xMin="78" yMin="0" xMax="227" yMax="760">
+      <contour>
+        <pt x="227" y="0" on="1"/>
+        <pt x="78" y="0" on="1"/>
+        <pt x="78" y="760" on="1"/>
+        <pt x="227" y="760" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="n" xMin="78" yMin="0" xMax="582" yMax="556">
+      <contour>
+        <pt x="388" y="556" on="1"/>
+        <pt x="476" y="556" on="0"/>
+        <pt x="582" y="461" on="0"/>
+        <pt x="582" y="356" on="1"/>
+        <pt x="582" y="0" on="1"/>
+        <pt x="433" y="0" on="1"/>
+        <pt x="433" y="319" on="1"/>
+        <pt x="433" y="378" on="0"/>
+        <pt x="391" y="437" on="0"/>
+        <pt x="345" y="437" on="1"/>
+        <pt x="277" y="437" on="0"/>
+        <pt x="227" y="344" on="0"/>
+        <pt x="227" y="257" on="1"/>
+        <pt x="227" y="0" on="1"/>
+        <pt x="78" y="0" on="1"/>
+        <pt x="78" y="546" on="1"/>
+        <pt x="192" y="546" on="1"/>
+        <pt x="212" y="476" on="1"/>
+        <pt x="220" y="476" on="1"/>
+        <pt x="238" y="504" on="0"/>
+        <pt x="290" y="539" on="0"/>
+        <pt x="354" y="556" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="o" xMin="45" yMin="-10" xMax="574" yMax="556">
+      <contour>
+        <pt x="574" y="274" on="1"/>
+        <pt x="574" y="206" on="0"/>
+        <pt x="537" y="100" on="0"/>
+        <pt x="468" y="27" on="0"/>
+        <pt x="370" y="-10" on="0"/>
+        <pt x="308" y="-10" on="1"/>
+        <pt x="251" y="-10" on="0"/>
+        <pt x="154" y="27" on="0"/>
+        <pt x="84" y="100" on="0"/>
+        <pt x="45" y="206" on="0"/>
+        <pt x="45" y="274" on="1"/>
+        <pt x="45" y="364" on="0"/>
+        <pt x="109" y="490" on="0"/>
+        <pt x="228" y="556" on="0"/>
+        <pt x="311" y="556" on="1"/>
+        <pt x="388" y="556" on="0"/>
+        <pt x="506" y="490" on="0"/>
+        <pt x="574" y="364" on="0"/>
+      </contour>
+      <contour>
+        <pt x="197" y="274" on="1"/>
+        <pt x="197" y="220" on="0"/>
+        <pt x="220" y="147" on="0"/>
+        <pt x="270" y="110" on="0"/>
+        <pt x="310" y="110" on="1"/>
+        <pt x="350" y="110" on="0"/>
+        <pt x="399" y="147" on="0"/>
+        <pt x="422" y="220" on="0"/>
+        <pt x="422" y="274" on="1"/>
+        <pt x="422" y="328" on="0"/>
+        <pt x="399" y="400" on="0"/>
+        <pt x="349" y="436" on="0"/>
+        <pt x="309" y="436" on="1"/>
+        <pt x="250" y="436" on="0"/>
+        <pt x="197" y="355" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="s" xMin="45" yMin="-10" xMax="459" yMax="556">
+      <contour>
+        <pt x="459" y="162" on="1"/>
+        <pt x="459" y="106" on="0"/>
+        <pt x="407" y="30" on="0"/>
+        <pt x="303" y="-10" on="0"/>
+        <pt x="226" y="-10" on="1"/>
+        <pt x="169" y="-10" on="0"/>
+        <pt x="87" y="5" on="0"/>
+        <pt x="46" y="22" on="1"/>
+        <pt x="46" y="145" on="1"/>
+        <pt x="90" y="125" on="0"/>
+        <pt x="192" y="99" on="0"/>
+        <pt x="231" y="99" on="1"/>
+        <pt x="274" y="99" on="0"/>
+        <pt x="312" y="125" on="0"/>
+        <pt x="312" y="146" on="1"/>
+        <pt x="312" y="160" on="0"/>
+        <pt x="297" y="182" on="0"/>
+        <pt x="247" y="210" on="0"/>
+        <pt x="194" y="232" on="1"/>
+        <pt x="142" y="254" on="0"/>
+        <pt x="77" y="297" on="0"/>
+        <pt x="45" y="358" on="0"/>
+        <pt x="45" y="404" on="1"/>
+        <pt x="45" y="480" on="0"/>
+        <pt x="163" y="556" on="0"/>
+        <pt x="261" y="556" on="1"/>
+        <pt x="312" y="556" on="0"/>
+        <pt x="404" y="536" on="0"/>
+        <pt x="453" y="513" on="1"/>
+        <pt x="408" y="406" on="1"/>
+        <pt x="368" y="423" on="0"/>
+        <pt x="296" y="446" on="0"/>
+        <pt x="259" y="446" on="1"/>
+        <pt x="226" y="446" on="0"/>
+        <pt x="193" y="428" on="0"/>
+        <pt x="193" y="410" on="1"/>
+        <pt x="193" y="397" on="0"/>
+        <pt x="210" y="376" on="0"/>
+        <pt x="259" y="352" on="0"/>
+        <pt x="307" y="332" on="1"/>
+        <pt x="354" y="313" on="0"/>
+        <pt x="422" y="272" on="0"/>
+        <pt x="459" y="210" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="t" xMin="23" yMin="-10" xMax="402" yMax="662">
+      <contour>
+        <pt x="308" y="109" on="1"/>
+        <pt x="333" y="109" on="0"/>
+        <pt x="379" y="118" on="0"/>
+        <pt x="402" y="126" on="1"/>
+        <pt x="402" y="15" on="1"/>
+        <pt x="378" y="4" on="0"/>
+        <pt x="307" y="-10" on="0"/>
+        <pt x="265" y="-10" on="1"/>
+        <pt x="216" y="-10" on="0"/>
+        <pt x="139" y="22" on="0"/>
+        <pt x="94" y="100" on="0"/>
+        <pt x="94" y="171" on="1"/>
+        <pt x="94" y="434" on="1"/>
+        <pt x="23" y="434" on="1"/>
+        <pt x="23" y="497" on="1"/>
+        <pt x="105" y="547" on="1"/>
+        <pt x="148" y="662" on="1"/>
+        <pt x="243" y="662" on="1"/>
+        <pt x="243" y="546" on="1"/>
+        <pt x="396" y="546" on="1"/>
+        <pt x="396" y="434" on="1"/>
+        <pt x="243" y="434" on="1"/>
+        <pt x="243" y="171" on="1"/>
+        <pt x="243" y="140" on="0"/>
+        <pt x="279" y="109" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2015 Google Inc. All Rights Reserved.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 SemiBold
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.902;GOOG;TestFamily3-SemiBold
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3 SemiBold
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.902
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      TestFamily3-SemiBold
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Noto is a trademark of Google Inc.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Monotype Imaging Inc.
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Monotype Design Team
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Designed by Monotype design team.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.google.com/get/noto/
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://www.monotype.com/studio
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="16" platformID="3" platEncID="1" langID="0x409">
+      Test Family 3
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      SemiBold
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="T"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1 Format="2">
+          </ClassDef1>
+          <ClassDef2 Format="1">
+            <ClassDef glyph="T" class="4"/>
+            <ClassDef glyph="n" class="3"/>
+            <ClassDef glyph="o" class="2"/>
+            <ClassDef glyph="s" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=1 -->
+          <!-- Class2Count=5 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+              <Value1 XAdvance="0"/>
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-60"/>
+            </Class2Record>
+            <Class2Record index="2">
+              <Value1 XAdvance="-70"/>
+            </Class2Record>
+            <Class2Record index="3">
+              <Value1 XAdvance="-50"/>
+            </Class2Record>
+            <Class2Record index="4">
+              <Value1 XAdvance="20"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/fontinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/fontinfo.plist
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>760</integer>
+	<key>capHeight</key>
+	<integer>714</integer>
+	<key>copyright</key>
+	<string>Copyright 2015 Google Inc. All Rights Reserved.</string>
+	<key>descender</key>
+	<integer>-240</integer>
+	<key>familyName</key>
+	<string>Test Family 3</string>
+	<key>guidelines</key>
+	<array/>
+	<key>openTypeHeadCreated</key>
+	<string>2016/03/15 19:50:39</string>
+	<key>openTypeHheaAscender</key>
+	<integer>1069</integer>
+	<key>openTypeHheaDescender</key>
+	<integer>-293</integer>
+	<key>openTypeHheaLineGap</key>
+	<integer>0</integer>
+	<key>openTypeNameDescription</key>
+	<string>Designed by Monotype design team.</string>
+	<key>openTypeNameDesigner</key>
+	<string>Monotype Design Team</string>
+	<key>openTypeNameDesignerURL</key>
+	<string>http://www.monotype.com/studio</string>
+	<key>openTypeNameLicense</key>
+	<string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.</string>
+	<key>openTypeNameLicenseURL</key>
+	<string>http://scripts.sil.org/OFL</string>
+	<key>openTypeNameManufacturer</key>
+	<string>Monotype Imaging Inc.</string>
+	<key>openTypeNameManufacturerURL</key>
+	<string>http://www.google.com/get/noto/</string>
+	<key>openTypeNameVersion</key>
+	<string>Version 1.902</string>
+	<key>openTypeOS2Panose</key>
+	<array>
+		<integer>2</integer>
+		<integer>11</integer>
+		<integer>10</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>4</integer>
+		<integer>2</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+	</array>
+	<key>openTypeOS2Selection</key>
+	<array>
+		<integer>8</integer>
+	</array>
+	<key>openTypeOS2Type</key>
+	<array/>
+	<key>openTypeOS2TypoAscender</key>
+	<integer>1069</integer>
+	<key>openTypeOS2TypoDescender</key>
+	<integer>-293</integer>
+	<key>openTypeOS2TypoLineGap</key>
+	<integer>0</integer>
+	<key>openTypeOS2UnicodeRanges</key>
+	<array>
+		<integer>0</integer>
+		<integer>1</integer>
+		<integer>2</integer>
+		<integer>3</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>6</integer>
+		<integer>7</integer>
+		<integer>9</integer>
+		<integer>29</integer>
+		<integer>30</integer>
+		<integer>31</integer>
+		<integer>32</integer>
+		<integer>33</integer>
+		<integer>34</integer>
+		<integer>35</integer>
+		<integer>36</integer>
+		<integer>62</integer>
+		<integer>64</integer>
+		<integer>67</integer>
+		<integer>69</integer>
+		<integer>91</integer>
+		<integer>116</integer>
+	</array>
+	<key>openTypeOS2VendorID</key>
+	<string>GOOG</string>
+	<key>openTypeOS2WinAscent</key>
+	<integer>1069</integer>
+	<key>openTypeOS2WinDescent</key>
+	<integer>293</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<integer>-15</integer>
+		<integer>0</integer>
+		<integer>553</integer>
+		<integer>563</integer>
+		<integer>591</integer>
+		<integer>601</integer>
+		<integer>714</integer>
+		<integer>725</integer>
+		<integer>760</integer>
+		<integer>766</integer>
+	</array>
+	<key>postscriptFamilyBlues</key>
+	<array/>
+	<key>postscriptFamilyOtherBlues</key>
+	<array/>
+	<key>postscriptOtherBlues</key>
+	<array>
+		<integer>-256</integer>
+		<integer>-240</integer>
+	</array>
+	<key>postscriptStemSnapH</key>
+	<array>
+		<integer>115</integer>
+		<integer>143</integer>
+		<integer>158</integer>
+	</array>
+	<key>postscriptStemSnapV</key>
+	<array>
+		<integer>132</integer>
+		<integer>176</integer>
+		<integer>194</integer>
+	</array>
+	<key>postscriptUnderlinePosition</key>
+	<integer>-100</integer>
+	<key>postscriptUnderlineThickness</key>
+	<integer>50</integer>
+	<key>styleMapFamilyName</key>
+	<string>Test Family 3</string>
+	<key>styleMapStyleName</key>
+	<string>bold</string>
+	<key>styleName</key>
+	<string>Bold</string>
+	<key>trademark</key>
+	<string>Noto is a trademark of Google Inc.</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>902</integer>
+	<key>xHeight</key>
+	<integer>553</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/F_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/F_.glif
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="F" format="2">
+  <advance width="539"/>
+  <unicode hex="0046"/>
+  <anchor x="270" y="0" name="bottom"/>
+  <anchor x="288" y="714" name="top"/>
+  <anchor x="519" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="267" y="0" type="line"/>
+      <point x="267" y="268" type="line"/>
+      <point x="481" y="268" type="line"/>
+      <point x="481" y="423" type="line"/>
+      <point x="267" y="423" type="line"/>
+      <point x="267" y="559" type="line"/>
+      <point x="499" y="559" type="line"/>
+      <point x="499" y="714" type="line"/>
+      <point x="77" y="714" type="line"/>
+      <point x="77" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/T_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/T_.glif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="T" format="2">
+  <advance width="591"/>
+  <unicode hex="0054"/>
+  <anchor x="296" y="0" name="bottom"/>
+  <anchor x="296" y="357" name="center"/>
+  <anchor x="296" y="714" name="top"/>
+  <anchor x="571" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="392" y="0" type="line"/>
+      <point x="392" y="556" type="line"/>
+      <point x="566" y="556" type="line"/>
+      <point x="566" y="714" type="line"/>
+      <point x="25" y="714" type="line"/>
+      <point x="25" y="556" type="line"/>
+      <point x="199" y="556" type="line"/>
+      <point x="199" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/contents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/contents.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>F</key>
+	<string>F_.glif</string>
+	<key>T</key>
+	<string>T_.glif</string>
+	<key>l</key>
+	<string>l.glif</string>
+	<key>n</key>
+	<string>n.glif</string>
+	<key>o</key>
+	<string>o.glif</string>
+	<key>s</key>
+	<string>s.glif</string>
+	<key>t</key>
+	<string>t.glif</string>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/l.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/l.glif
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="l" format="2">
+  <advance width="323"/>
+  <unicode hex="006C"/>
+  <anchor x="162" y="0" name="bottom"/>
+  <anchor x="162" y="277" name="center"/>
+  <anchor x="162" y="760" name="top"/>
+  <anchor x="278" y="760" name="topright"/>
+  <outline>
+    <contour>
+      <point x="257" y="0" type="line"/>
+      <point x="257" y="760" type="line"/>
+      <point x="66" y="760" type="line"/>
+      <point x="66" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/layerinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/n.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/n.glif
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="n" format="2">
+  <advance width="670"/>
+  <unicode hex="006E"/>
+  <anchor x="335" y="0" name="bottom"/>
+  <anchor x="335" y="553" name="top"/>
+  <anchor x="636" y="553" name="topright"/>
+  <outline>
+    <contour>
+      <point x="412" y="563" type="curve" smooth="yes"/>
+      <point x="334" y="563"/>
+      <point x="278" y="532"/>
+      <point x="243" y="480" type="curve"/>
+      <point x="236" y="480" type="line"/>
+      <point x="210" y="553" type="line"/>
+      <point x="66" y="553" type="line"/>
+      <point x="66" y="0" type="line"/>
+      <point x="257" y="0" type="line"/>
+      <point x="257" y="242" type="line" smooth="yes"/>
+      <point x="257" y="352"/>
+      <point x="276" y="413"/>
+      <point x="348" y="413" type="curve" smooth="yes"/>
+      <point x="395" y="413"/>
+      <point x="415" y="375"/>
+      <point x="415" y="302" type="curve" smooth="yes"/>
+      <point x="415" y="0" type="line"/>
+      <point x="606" y="0" type="line"/>
+      <point x="606" y="360" type="line" smooth="yes"/>
+      <point x="606" y="502"/>
+      <point x="526" y="563"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/o.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/o.glif
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="o" format="2">
+  <advance width="637"/>
+  <unicode hex="006F"/>
+  <anchor x="317" y="0" name="bottom"/>
+  <anchor x="319" y="277" name="center"/>
+  <anchor x="319" y="553" name="top"/>
+  <anchor x="617" y="553" name="topright"/>
+  <outline>
+    <contour>
+      <point x="594" y="278" type="curve" smooth="yes"/>
+      <point x="594" y="461"/>
+      <point x="479" y="563"/>
+      <point x="320" y="563" type="curve" smooth="yes"/>
+      <point x="147" y="563"/>
+      <point x="42" y="461"/>
+      <point x="42" y="278" type="curve" smooth="yes"/>
+      <point x="42" y="93"/>
+      <point x="157" y="-10"/>
+      <point x="317" y="-10" type="curve" smooth="yes"/>
+      <point x="489" y="-10"/>
+      <point x="594" y="93"/>
+    </contour>
+    <contour>
+      <point x="236" y="278" type="curve" smooth="yes"/>
+      <point x="236" y="372"/>
+      <point x="260" y="421"/>
+      <point x="318" y="421" type="curve" smooth="yes"/>
+      <point x="378" y="421"/>
+      <point x="400" y="372"/>
+      <point x="400" y="278" type="curve" smooth="yes"/>
+      <point x="400" y="183"/>
+      <point x="378" y="132"/>
+      <point x="319" y="132" type="curve" smooth="yes"/>
+      <point x="259" y="132"/>
+      <point x="236" y="183"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/s.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/s.glif
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="s" format="2">
+  <advance width="517"/>
+  <unicode hex="0073"/>
+  <anchor x="251" y="0" name="bottom"/>
+  <anchor x="251" y="553" name="top"/>
+  <anchor x="497" y="553" name="topright"/>
+  <outline>
+    <contour>
+      <point x="477" y="170" type="curve" smooth="yes"/>
+      <point x="477" y="267"/>
+      <point x="431" y="307"/>
+      <point x="335" y="346" type="curve" smooth="yes"/>
+      <point x="243" y="383"/>
+      <point x="224" y="390"/>
+      <point x="224" y="411" type="curve" smooth="yes"/>
+      <point x="224" y="426"/>
+      <point x="241" y="434"/>
+      <point x="271" y="434" type="curve" smooth="yes"/>
+      <point x="304" y="434"/>
+      <point x="366" y="418"/>
+      <point x="421" y="393" type="curve"/>
+      <point x="473" y="516" type="line"/>
+      <point x="404" y="547"/>
+      <point x="343" y="563"/>
+      <point x="270" y="563" type="curve" smooth="yes"/>
+      <point x="133" y="563"/>
+      <point x="42" y="508"/>
+      <point x="42" y="400" type="curve" smooth="yes"/>
+      <point x="42" y="309"/>
+      <point x="87" y="266"/>
+      <point x="179" y="228" type="curve" smooth="yes"/>
+      <point x="272" y="190"/>
+      <point x="297" y="181"/>
+      <point x="297" y="157" type="curve" smooth="yes"/>
+      <point x="297" y="138"/>
+      <point x="278" y="129"/>
+      <point x="235" y="129" type="curve" smooth="yes"/>
+      <point x="193" y="129"/>
+      <point x="113" y="142"/>
+      <point x="43" y="174" type="curve"/>
+      <point x="43" y="21" type="line"/>
+      <point x="107" y="-3"/>
+      <point x="164" y="-10"/>
+      <point x="243" y="-10" type="curve" smooth="yes"/>
+      <point x="411" y="-10"/>
+      <point x="477" y="65"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/t.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/glyphs/t.glif
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="t" format="2">
+  <advance width="460"/>
+  <unicode hex="0074"/>
+  <anchor x="264" y="0" name="bottom"/>
+  <anchor x="230" y="277" name="center"/>
+  <anchor x="219" y="664" name="top"/>
+  <anchor x="421" y="664" name="topright"/>
+  <outline>
+    <contour>
+      <point x="337" y="141" type="curve" smooth="yes"/>
+      <point x="304" y="141"/>
+      <point x="285" y="159"/>
+      <point x="285" y="195" type="curve" smooth="yes"/>
+      <point x="285" y="410" type="line"/>
+      <point x="421" y="410" type="line"/>
+      <point x="421" y="553" type="line"/>
+      <point x="285" y="553" type="line"/>
+      <point x="285" y="664" type="line"/>
+      <point x="160" y="664" type="line"/>
+      <point x="111" y="548" type="line"/>
+      <point x="26" y="488" type="line"/>
+      <point x="26" y="410" type="line"/>
+      <point x="93" y="410" type="line"/>
+      <point x="93" y="182" type="line" smooth="yes"/>
+      <point x="93" y="32"/>
+      <point x="166" y="-10"/>
+      <point x="274" y="-10" type="curve" smooth="yes"/>
+      <point x="346" y="-10"/>
+      <point x="387" y="3"/>
+      <point x="429" y="21" type="curve"/>
+      <point x="429" y="160" type="line"/>
+      <point x="398" y="149"/>
+      <point x="371" y="141"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/groups.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/groups.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern1.d</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern1.n.left</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern1.o.left</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern1.t.left</key>
+	<array>
+		<string>t</string>
+	</array>
+	<key>public.kern2.T.right</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern2.b</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern2.n.right</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern2.o.right</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern2.s.right</key>
+	<array>
+		<string>s</string>
+	</array>
+	<key>public.kern2.t.right</key>
+	<array>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/kerning.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/kerning.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<dict>
+		<key>public.kern2.T.right</key>
+		<integer>20</integer>
+		<key>public.kern2.n.right</key>
+		<integer>-50</integer>
+		<key>public.kern2.o.right</key>
+		<integer>-70</integer>
+		<key>public.kern2.s.right</key>
+		<integer>-60</integer>
+	</dict>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/layercontents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/lib.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/lib.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>F</string>
+		<string>T</string>
+		<string>l</string>
+		<string>n</string>
+		<string>o</string>
+		<string>s</string>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/metainfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Bold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/fontinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/fontinfo.plist
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>760</integer>
+	<key>capHeight</key>
+	<integer>714</integer>
+	<key>copyright</key>
+	<string>Copyright 2015 Google Inc. All Rights Reserved.</string>
+	<key>descender</key>
+	<integer>-240</integer>
+	<key>familyName</key>
+	<string>Test Family 3</string>
+	<key>guidelines</key>
+	<array/>
+	<key>openTypeHeadCreated</key>
+	<string>2016/03/15 19:50:39</string>
+	<key>openTypeHheaAscender</key>
+	<integer>1069</integer>
+	<key>openTypeHheaDescender</key>
+	<integer>-293</integer>
+	<key>openTypeHheaLineGap</key>
+	<integer>0</integer>
+	<key>openTypeNameDescription</key>
+	<string>Designed by Monotype design team.</string>
+	<key>openTypeNameDesigner</key>
+	<string>Monotype Design Team</string>
+	<key>openTypeNameDesignerURL</key>
+	<string>http://www.monotype.com/studio</string>
+	<key>openTypeNameLicense</key>
+	<string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.</string>
+	<key>openTypeNameLicenseURL</key>
+	<string>http://scripts.sil.org/OFL</string>
+	<key>openTypeNameManufacturer</key>
+	<string>Monotype Imaging Inc.</string>
+	<key>openTypeNameManufacturerURL</key>
+	<string>http://www.google.com/get/noto/</string>
+	<key>openTypeNameVersion</key>
+	<string>Version 1.902</string>
+	<key>openTypeOS2Panose</key>
+	<array>
+		<integer>2</integer>
+		<integer>11</integer>
+		<integer>5</integer>
+		<integer>6</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>4</integer>
+		<integer>2</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+	</array>
+	<key>openTypeOS2Selection</key>
+	<array>
+		<integer>8</integer>
+	</array>
+	<key>openTypeOS2Type</key>
+	<array/>
+	<key>openTypeOS2TypoAscender</key>
+	<integer>1069</integer>
+	<key>openTypeOS2TypoDescender</key>
+	<integer>-293</integer>
+	<key>openTypeOS2TypoLineGap</key>
+	<integer>0</integer>
+	<key>openTypeOS2UnicodeRanges</key>
+	<array>
+		<integer>0</integer>
+		<integer>1</integer>
+		<integer>2</integer>
+		<integer>3</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>6</integer>
+		<integer>7</integer>
+		<integer>9</integer>
+		<integer>29</integer>
+		<integer>30</integer>
+		<integer>31</integer>
+		<integer>32</integer>
+		<integer>33</integer>
+		<integer>34</integer>
+		<integer>35</integer>
+		<integer>36</integer>
+		<integer>62</integer>
+		<integer>64</integer>
+		<integer>67</integer>
+		<integer>69</integer>
+		<integer>91</integer>
+		<integer>116</integer>
+	</array>
+	<key>openTypeOS2VendorID</key>
+	<string>GOOG</string>
+	<key>openTypeOS2WinAscent</key>
+	<integer>1069</integer>
+	<key>openTypeOS2WinDescent</key>
+	<integer>293</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<integer>-15</integer>
+		<integer>0</integer>
+		<integer>537</integer>
+		<integer>548</integer>
+		<integer>571</integer>
+		<integer>581</integer>
+		<integer>714</integer>
+		<integer>725</integer>
+		<integer>760</integer>
+		<integer>766</integer>
+	</array>
+	<key>postscriptFamilyBlues</key>
+	<array/>
+	<key>postscriptFamilyOtherBlues</key>
+	<array/>
+	<key>postscriptOtherBlues</key>
+	<array>
+		<integer>-256</integer>
+		<integer>-240</integer>
+	</array>
+	<key>postscriptStemSnapH</key>
+	<array>
+		<integer>60</integer>
+		<integer>68</integer>
+		<integer>76</integer>
+	</array>
+	<key>postscriptStemSnapV</key>
+	<array>
+		<integer>64</integer>
+		<integer>75</integer>
+		<integer>84</integer>
+	</array>
+	<key>postscriptUnderlinePosition</key>
+	<integer>-100</integer>
+	<key>postscriptUnderlineThickness</key>
+	<integer>50</integer>
+	<key>styleMapFamilyName</key>
+	<string>Test Family 3 Condensed</string>
+	<key>styleMapStyleName</key>
+	<string>regular</string>
+	<key>styleName</key>
+	<string>Condensed</string>
+	<key>trademark</key>
+	<string>Noto is a trademark of Google Inc.</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>902</integer>
+	<key>xHeight</key>
+	<integer>537</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/F_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/F_.glif
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="F" format="2">
+  <advance width="380"/>
+  <unicode hex="0046"/>
+  <anchor x="190" y="0" name="bottom"/>
+  <anchor x="220" y="714" name="top"/>
+  <anchor x="360" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="157" y="0" type="line"/>
+      <point x="157" y="305" type="line"/>
+      <point x="345" y="305" type="line"/>
+      <point x="345" y="381" type="line"/>
+      <point x="157" y="381" type="line"/>
+      <point x="157" y="639" type="line"/>
+      <point x="357" y="639" type="line"/>
+      <point x="357" y="714" type="line"/>
+      <point x="73" y="714" type="line"/>
+      <point x="73" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/T_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/T_.glif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="T" format="2">
+  <advance width="381"/>
+  <unicode hex="0054"/>
+  <anchor x="191" y="0" name="bottom"/>
+  <anchor x="191" y="357" name="center"/>
+  <anchor x="191" y="714" name="top"/>
+  <anchor x="361" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="232" y="0" type="line"/>
+      <point x="232" y="638" type="line"/>
+      <point x="370" y="638" type="line"/>
+      <point x="370" y="714" type="line"/>
+      <point x="10" y="714" type="line"/>
+      <point x="10" y="638" type="line"/>
+      <point x="148" y="638" type="line"/>
+      <point x="148" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/contents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/contents.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>F</key>
+	<string>F_.glif</string>
+	<key>T</key>
+	<string>T_.glif</string>
+	<key>l</key>
+	<string>l.glif</string>
+	<key>n</key>
+	<string>n.glif</string>
+	<key>o</key>
+	<string>o.glif</string>
+	<key>s</key>
+	<string>s.glif</string>
+	<key>t</key>
+	<string>t.glif</string>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/l.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/l.glif
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="l" format="2">
+  <advance width="210"/>
+  <unicode hex="006C"/>
+  <anchor x="106" y="0" name="bottom"/>
+  <anchor x="105" y="269" name="center"/>
+  <anchor x="106" y="760" name="top"/>
+  <anchor x="167" y="760" name="topright"/>
+  <outline>
+    <contour>
+      <point x="146" y="0" type="line"/>
+      <point x="146" y="760" type="line"/>
+      <point x="65" y="760" type="line"/>
+      <point x="65" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/layerinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/n.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/n.glif
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="n" format="2">
+  <advance width="456"/>
+  <unicode hex="006E"/>
+  <anchor x="229" y="0" name="bottom"/>
+  <anchor x="236" y="537" name="top"/>
+  <anchor x="418" y="537" name="topright"/>
+  <outline>
+    <contour>
+      <point x="262" y="547" type="curve" smooth="yes"/>
+      <point x="211" y="547"/>
+      <point x="167" y="517"/>
+      <point x="144" y="464" type="curve"/>
+      <point x="139" y="464" type="line"/>
+      <point x="130" y="537" type="line"/>
+      <point x="65" y="537" type="line"/>
+      <point x="65" y="0" type="line"/>
+      <point x="146" y="0" type="line"/>
+      <point x="146" y="279" type="line" smooth="yes"/>
+      <point x="146" y="417"/>
+      <point x="174" y="475"/>
+      <point x="244" y="475" type="curve" smooth="yes"/>
+      <point x="292" y="475"/>
+      <point x="312" y="432"/>
+      <point x="312" y="348" type="curve" smooth="yes"/>
+      <point x="312" y="0" type="line"/>
+      <point x="393" y="0" type="line"/>
+      <point x="393" y="364" type="line" smooth="yes"/>
+      <point x="393" y="488"/>
+      <point x="348" y="547"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/o.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/o.glif
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="o" format="2">
+  <advance width="445"/>
+  <unicode hex="006F"/>
+  <anchor x="223" y="0" name="bottom"/>
+  <anchor x="223" y="269" name="center"/>
+  <anchor x="222" y="537" name="top"/>
+  <anchor x="425" y="537" name="topright"/>
+  <outline>
+    <contour>
+      <point x="403" y="269" type="curve" smooth="yes"/>
+      <point x="403" y="452"/>
+      <point x="337" y="547"/>
+      <point x="223" y="547" type="curve" smooth="yes"/>
+      <point x="99" y="547"/>
+      <point x="42" y="446"/>
+      <point x="42" y="269" type="curve" smooth="yes"/>
+      <point x="42" y="101"/>
+      <point x="102" y="-10"/>
+      <point x="221" y="-10" type="curve" smooth="yes"/>
+      <point x="346" y="-10"/>
+      <point x="403" y="102"/>
+    </contour>
+    <contour>
+      <point x="125" y="269" type="curve" smooth="yes"/>
+      <point x="125" y="407"/>
+      <point x="154" y="476"/>
+      <point x="223" y="476" type="curve" smooth="yes"/>
+      <point x="290" y="476"/>
+      <point x="321" y="407"/>
+      <point x="321" y="269" type="curve" smooth="yes"/>
+      <point x="321" y="130"/>
+      <point x="290" y="61"/>
+      <point x="223" y="61" type="curve" smooth="yes"/>
+      <point x="155" y="61"/>
+      <point x="125" y="132"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/s.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/s.glif
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="s" format="2">
+  <advance width="339"/>
+  <unicode hex="0073"/>
+  <anchor x="158" y="0" name="bottom"/>
+  <anchor x="179" y="537" name="top"/>
+  <anchor x="309" y="537" name="topright"/>
+  <outline>
+    <contour>
+      <point x="307" y="144" type="curve" smooth="yes"/>
+      <point x="307" y="226"/>
+      <point x="262" y="265"/>
+      <point x="196" y="307" type="curve" smooth="yes"/>
+      <point x="133" y="345"/>
+      <point x="111" y="365"/>
+      <point x="111" y="408" type="curve" smooth="yes"/>
+      <point x="111" y="450"/>
+      <point x="139" y="478"/>
+      <point x="184" y="478" type="curve" smooth="yes"/>
+      <point x="217" y="478"/>
+      <point x="248" y="466"/>
+      <point x="276" y="447" type="curve"/>
+      <point x="306" y="512" type="line"/>
+      <point x="269" y="535"/>
+      <point x="229" y="547"/>
+      <point x="183" y="547" type="curve" smooth="yes"/>
+      <point x="94" y="547"/>
+      <point x="33" y="491"/>
+      <point x="33" y="406" type="curve" smooth="yes"/>
+      <point x="33" y="323"/>
+      <point x="78" y="283"/>
+      <point x="145" y="242" type="curve" smooth="yes"/>
+      <point x="205" y="208"/>
+      <point x="227" y="183"/>
+      <point x="227" y="141" type="curve" smooth="yes"/>
+      <point x="227" y="92"/>
+      <point x="199" y="63"/>
+      <point x="152" y="63" type="curve" smooth="yes"/>
+      <point x="108" y="63"/>
+      <point x="62" y="80"/>
+      <point x="33" y="104" type="curve"/>
+      <point x="33" y="20" type="line"/>
+      <point x="63" y="3"/>
+      <point x="105" y="-10"/>
+      <point x="155" y="-10" type="curve" smooth="yes"/>
+      <point x="251" y="-10"/>
+      <point x="307" y="45"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/t.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/glyphs/t.glif
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="t" format="2">
+  <advance width="259"/>
+  <unicode hex="0074"/>
+  <anchor x="159" y="0" name="bottom"/>
+  <anchor x="130" y="268" name="center"/>
+  <anchor x="119" y="658" name="top"/>
+  <anchor x="238" y="658" name="topright"/>
+  <outline>
+    <contour>
+      <point x="197" y="62" type="curve" smooth="yes"/>
+      <point x="158" y="62"/>
+      <point x="148" y="89"/>
+      <point x="148" y="143" type="curve" smooth="yes"/>
+      <point x="148" y="469" type="line"/>
+      <point x="238" y="469" type="line"/>
+      <point x="238" y="537" type="line"/>
+      <point x="148" y="537" type="line"/>
+      <point x="148" y="658" type="line"/>
+      <point x="93" y="658" type="line"/>
+      <point x="71" y="535" type="line"/>
+      <point x="17" y="513" type="line"/>
+      <point x="17" y="469" type="line"/>
+      <point x="67" y="469" type="line"/>
+      <point x="67" y="133" type="line" smooth="yes"/>
+      <point x="67" y="37"/>
+      <point x="99" y="-10"/>
+      <point x="170" y="-10" type="curve" smooth="yes"/>
+      <point x="200" y="-10"/>
+      <point x="224" y="-4"/>
+      <point x="245" y="6" type="curve"/>
+      <point x="245" y="72" type="line"/>
+      <point x="229" y="66"/>
+      <point x="213" y="62"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/groups.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/groups.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern1.d</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern1.n.left</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern1.o.left</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern1.t.left</key>
+	<array>
+		<string>t</string>
+	</array>
+	<key>public.kern2.T.right</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern2.b</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern2.n.right</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern2.o.right</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern2.s.right</key>
+	<array>
+		<string>s</string>
+	</array>
+	<key>public.kern2.t.right</key>
+	<array>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/kerning.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/kerning.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<dict>
+		<key>public.kern2.T.right</key>
+		<integer>12</integer>
+		<key>public.kern2.n.right</key>
+		<integer>-30</integer>
+		<key>public.kern2.o.right</key>
+		<integer>-42</integer>
+		<key>public.kern2.s.right</key>
+		<integer>-36</integer>
+	</dict>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/layercontents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/lib.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/lib.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>F</string>
+		<string>T</string>
+		<string>l</string>
+		<string>n</string>
+		<string>o</string>
+		<string>s</string>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/metainfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Condensed.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/fontinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/fontinfo.plist
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>760</integer>
+	<key>capHeight</key>
+	<integer>714</integer>
+	<key>copyright</key>
+	<string>Copyright 2015 Google Inc. All Rights Reserved.</string>
+	<key>descender</key>
+	<integer>-240</integer>
+	<key>familyName</key>
+	<string>Test Family 3</string>
+	<key>guidelines</key>
+	<array/>
+	<key>openTypeHeadCreated</key>
+	<string>2016/03/15 19:50:39</string>
+	<key>openTypeHheaAscender</key>
+	<integer>1069</integer>
+	<key>openTypeHheaDescender</key>
+	<integer>-293</integer>
+	<key>openTypeHheaLineGap</key>
+	<integer>0</integer>
+	<key>openTypeNameDescription</key>
+	<string>Designed by Monotype design team.</string>
+	<key>openTypeNameDesigner</key>
+	<string>Monotype Design Team</string>
+	<key>openTypeNameDesignerURL</key>
+	<string>http://www.monotype.com/studio</string>
+	<key>openTypeNameLicense</key>
+	<string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.</string>
+	<key>openTypeNameLicenseURL</key>
+	<string>http://scripts.sil.org/OFL</string>
+	<key>openTypeNameManufacturer</key>
+	<string>Monotype Imaging Inc.</string>
+	<key>openTypeNameManufacturerURL</key>
+	<string>http://www.google.com/get/noto/</string>
+	<key>openTypeNameVersion</key>
+	<string>Version 1.902</string>
+	<key>openTypeOS2Panose</key>
+	<array>
+		<integer>2</integer>
+		<integer>11</integer>
+		<integer>10</integer>
+		<integer>6</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>4</integer>
+		<integer>2</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+	</array>
+	<key>openTypeOS2Selection</key>
+	<array>
+		<integer>8</integer>
+	</array>
+	<key>openTypeOS2Type</key>
+	<array/>
+	<key>openTypeOS2TypoAscender</key>
+	<integer>1069</integer>
+	<key>openTypeOS2TypoDescender</key>
+	<integer>-293</integer>
+	<key>openTypeOS2TypoLineGap</key>
+	<integer>0</integer>
+	<key>openTypeOS2UnicodeRanges</key>
+	<array>
+		<integer>0</integer>
+		<integer>1</integer>
+		<integer>2</integer>
+		<integer>3</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>6</integer>
+		<integer>7</integer>
+		<integer>9</integer>
+		<integer>29</integer>
+		<integer>30</integer>
+		<integer>31</integer>
+		<integer>32</integer>
+		<integer>33</integer>
+		<integer>34</integer>
+		<integer>35</integer>
+		<integer>36</integer>
+		<integer>62</integer>
+		<integer>64</integer>
+		<integer>67</integer>
+		<integer>69</integer>
+		<integer>91</integer>
+		<integer>116</integer>
+	</array>
+	<key>openTypeOS2VendorID</key>
+	<string>GOOG</string>
+	<key>openTypeOS2WinAscent</key>
+	<integer>1069</integer>
+	<key>openTypeOS2WinDescent</key>
+	<integer>293</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<integer>-15</integer>
+		<integer>0</integer>
+		<integer>553</integer>
+		<integer>564</integer>
+		<integer>589</integer>
+		<integer>599</integer>
+		<integer>714</integer>
+		<integer>726</integer>
+		<integer>760</integer>
+		<integer>766</integer>
+	</array>
+	<key>postscriptFamilyBlues</key>
+	<array/>
+	<key>postscriptFamilyOtherBlues</key>
+	<array/>
+	<key>postscriptOtherBlues</key>
+	<array>
+		<integer>-256</integer>
+		<integer>-240</integer>
+	</array>
+	<key>postscriptStemSnapH</key>
+	<array>
+		<integer>115</integer>
+		<integer>133</integer>
+		<integer>146</integer>
+	</array>
+	<key>postscriptStemSnapV</key>
+	<array>
+		<integer>117</integer>
+		<integer>150</integer>
+		<integer>170</integer>
+	</array>
+	<key>postscriptUnderlinePosition</key>
+	<integer>-100</integer>
+	<key>postscriptUnderlineThickness</key>
+	<integer>50</integer>
+	<key>styleMapFamilyName</key>
+	<string>Test Family 3 Condensed Bold</string>
+	<key>styleMapStyleName</key>
+	<string>regular</string>
+	<key>styleName</key>
+	<string>Condensed Bold</string>
+	<key>trademark</key>
+	<string>Noto is a trademark of Google Inc.</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>902</integer>
+	<key>xHeight</key>
+	<integer>553</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/F_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/F_.glif
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="F" format="2">
+  <advance width="436"/>
+  <unicode hex="0046"/>
+  <anchor x="218" y="0" name="bottom"/>
+  <anchor x="231" y="714" name="top"/>
+  <anchor x="416" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="229" y="0" type="line"/>
+      <point x="229" y="273" type="line"/>
+      <point x="388" y="273" type="line"/>
+      <point x="388" y="417" type="line"/>
+      <point x="229" y="417" type="line"/>
+      <point x="229" y="570" type="line"/>
+      <point x="401" y="570" type="line"/>
+      <point x="401" y="714" type="line"/>
+      <point x="59" y="714" type="line"/>
+      <point x="59" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/T_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/T_.glif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="T" format="2">
+  <advance width="460"/>
+  <unicode hex="0054"/>
+  <anchor x="230" y="0" name="bottom"/>
+  <anchor x="230" y="357" name="center"/>
+  <anchor x="230" y="714" name="top"/>
+  <anchor x="440" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="315" y="0" type="line"/>
+      <point x="315" y="567" type="line"/>
+      <point x="443" y="567" type="line"/>
+      <point x="443" y="714" type="line"/>
+      <point x="17" y="714" type="line"/>
+      <point x="17" y="567" type="line"/>
+      <point x="146" y="567" type="line"/>
+      <point x="146" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/contents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/contents.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>F</key>
+	<string>F_.glif</string>
+	<key>T</key>
+	<string>T_.glif</string>
+	<key>l</key>
+	<string>l.glif</string>
+	<key>n</key>
+	<string>n.glif</string>
+	<key>o</key>
+	<string>o.glif</string>
+	<key>s</key>
+	<string>s.glif</string>
+	<key>t</key>
+	<string>t.glif</string>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/l.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/l.glif
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="l" format="2">
+  <advance width="263"/>
+  <unicode hex="006C"/>
+  <anchor x="132" y="0" name="bottom"/>
+  <anchor x="132" y="277" name="center"/>
+  <anchor x="132" y="760" name="top"/>
+  <anchor x="232" y="760" name="topright"/>
+  <outline>
+    <contour>
+      <point x="212" y="0" type="line"/>
+      <point x="212" y="760" type="line"/>
+      <point x="50" y="760" type="line"/>
+      <point x="50" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/layerinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/n.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/n.glif
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="n" format="2">
+  <advance width="529"/>
+  <unicode hex="006E"/>
+  <anchor x="265" y="0" name="bottom"/>
+  <anchor x="275" y="553" name="top"/>
+  <anchor x="500" y="553" name="topright"/>
+  <outline>
+    <contour>
+      <point x="328" y="563" type="curve" smooth="yes"/>
+      <point x="269" y="563"/>
+      <point x="229" y="537"/>
+      <point x="204" y="485" type="curve"/>
+      <point x="195" y="485" type="line"/>
+      <point x="177" y="553" type="line"/>
+      <point x="50" y="553" type="line"/>
+      <point x="50" y="0" type="line"/>
+      <point x="212" y="0" type="line"/>
+      <point x="212" y="253" type="line" smooth="yes"/>
+      <point x="212" y="378"/>
+      <point x="224" y="419"/>
+      <point x="270" y="419" type="curve" smooth="yes"/>
+      <point x="310" y="419"/>
+      <point x="318" y="381"/>
+      <point x="318" y="308" type="curve" smooth="yes"/>
+      <point x="318" y="0" type="line"/>
+      <point x="480" y="0" type="line"/>
+      <point x="480" y="360" type="line" smooth="yes"/>
+      <point x="480" y="489"/>
+      <point x="424" y="563"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/o.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/o.glif
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="o" format="2">
+  <advance width="516"/>
+  <unicode hex="006F"/>
+  <anchor x="257" y="0" name="bottom"/>
+  <anchor x="258" y="277" name="center"/>
+  <anchor x="258" y="553" name="top"/>
+  <anchor x="496" y="553" name="topright"/>
+  <outline>
+    <contour>
+      <point x="483" y="278" type="curve" smooth="yes"/>
+      <point x="483" y="460"/>
+      <point x="393" y="563"/>
+      <point x="259" y="563" type="curve" smooth="yes"/>
+      <point x="97" y="563"/>
+      <point x="32" y="437"/>
+      <point x="32" y="278" type="curve" smooth="yes"/>
+      <point x="32" y="132"/>
+      <point x="100" y="-10"/>
+      <point x="257" y="-10" type="curve" smooth="yes"/>
+      <point x="427" y="-10"/>
+      <point x="483" y="136"/>
+    </contour>
+    <contour>
+      <point x="196" y="276" type="curve" smooth="yes"/>
+      <point x="196" y="380"/>
+      <point x="215" y="428"/>
+      <point x="258" y="428" type="curve" smooth="yes"/>
+      <point x="303" y="428"/>
+      <point x="319" y="379"/>
+      <point x="319" y="278" type="curve" smooth="yes"/>
+      <point x="319" y="176"/>
+      <point x="303" y="125"/>
+      <point x="258" y="125" type="curve" smooth="yes"/>
+      <point x="215" y="125"/>
+      <point x="196" y="177"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/s.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/s.glif
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="s" format="2">
+  <advance width="396"/>
+  <unicode hex="0073"/>
+  <anchor x="184" y="0" name="bottom"/>
+  <anchor x="204" y="553" name="top"/>
+  <anchor x="376" y="553" name="topright"/>
+  <outline>
+    <contour>
+      <point x="372" y="170" type="curve" smooth="yes"/>
+      <point x="372" y="255"/>
+      <point x="326" y="304"/>
+      <point x="259" y="342" type="curve" smooth="yes"/>
+      <point x="188" y="384"/>
+      <point x="181" y="390"/>
+      <point x="181" y="408" type="curve" smooth="yes"/>
+      <point x="181" y="426"/>
+      <point x="192" y="434"/>
+      <point x="215" y="434" type="curve" smooth="yes"/>
+      <point x="253" y="434"/>
+      <point x="291" y="415"/>
+      <point x="324" y="393" type="curve"/>
+      <point x="364" y="516" type="line"/>
+      <point x="311" y="547"/>
+      <point x="262" y="563"/>
+      <point x="205" y="563" type="curve" smooth="yes"/>
+      <point x="90" y="563"/>
+      <point x="25" y="503"/>
+      <point x="25" y="400" type="curve" smooth="yes"/>
+      <point x="25" y="322"/>
+      <point x="60" y="265"/>
+      <point x="128" y="231" type="curve" smooth="yes"/>
+      <point x="205" y="193"/>
+      <point x="211" y="179"/>
+      <point x="211" y="161" type="curve" smooth="yes"/>
+      <point x="211" y="138"/>
+      <point x="196" y="129"/>
+      <point x="166" y="129" type="curve" smooth="yes"/>
+      <point x="116" y="129"/>
+      <point x="66" y="150"/>
+      <point x="26" y="174" type="curve"/>
+      <point x="26" y="21" type="line"/>
+      <point x="77" y="-2"/>
+      <point x="129" y="-10"/>
+      <point x="183" y="-10" type="curve" smooth="yes"/>
+      <point x="302" y="-10"/>
+      <point x="372" y="51"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/t.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/glyphs/t.glif
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="t" format="2">
+  <advance width="354"/>
+  <unicode hex="0074"/>
+  <anchor x="208" y="0" name="bottom"/>
+  <anchor x="177" y="277" name="center"/>
+  <anchor x="163" y="664" name="top"/>
+  <anchor x="329" y="664" name="topright"/>
+  <outline>
+    <contour>
+      <point x="265" y="130" type="curve" smooth="yes"/>
+      <point x="238" y="130"/>
+      <point x="225" y="148"/>
+      <point x="225" y="184" type="curve" smooth="yes"/>
+      <point x="225" y="420" type="line"/>
+      <point x="329" y="420" type="line"/>
+      <point x="329" y="553" type="line"/>
+      <point x="225" y="553" type="line"/>
+      <point x="225" y="664" type="line"/>
+      <point x="115" y="664" type="line"/>
+      <point x="77" y="548" type="line"/>
+      <point x="7" y="506" type="line"/>
+      <point x="7" y="420" type="line"/>
+      <point x="63" y="420" type="line"/>
+      <point x="63" y="182" type="line" smooth="yes"/>
+      <point x="63" y="52"/>
+      <point x="107" y="-10"/>
+      <point x="216" y="-10" type="curve" smooth="yes"/>
+      <point x="261" y="-10"/>
+      <point x="300" y="1"/>
+      <point x="336" y="21" type="curve"/>
+      <point x="336" y="149" type="line"/>
+      <point x="309" y="137"/>
+      <point x="285" y="130"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/groups.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/groups.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern1.d</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern1.n.left</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern1.o.left</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern1.t.left</key>
+	<array>
+		<string>t</string>
+	</array>
+	<key>public.kern2.T.right</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern2.b</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern2.n.right</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern2.o.right</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern2.s.right</key>
+	<array>
+		<string>s</string>
+	</array>
+	<key>public.kern2.t.right</key>
+	<array>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/kerning.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/kerning.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<dict>
+		<key>public.kern2.T.right</key>
+		<integer>12</integer>
+		<key>public.kern2.n.right</key>
+		<integer>-30</integer>
+		<key>public.kern2.o.right</key>
+		<integer>-42</integer>
+		<key>public.kern2.s.right</key>
+		<integer>-36</integer>
+	</dict>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/layercontents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/lib.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/lib.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>F</string>
+		<string>T</string>
+		<string>l</string>
+		<string>n</string>
+		<string>o</string>
+		<string>s</string>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/metainfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedBold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/fontinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/fontinfo.plist
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>760</integer>
+	<key>capHeight</key>
+	<integer>714</integer>
+	<key>copyright</key>
+	<string>Copyright 2015 Google Inc. All Rights Reserved.</string>
+	<key>descender</key>
+	<integer>-232</integer>
+	<key>familyName</key>
+	<string>Test Family 3</string>
+	<key>guidelines</key>
+	<array/>
+	<key>openTypeHeadCreated</key>
+	<string>2016/03/15 19:50:39</string>
+	<key>openTypeHheaAscender</key>
+	<integer>1069</integer>
+	<key>openTypeHheaDescender</key>
+	<integer>-293</integer>
+	<key>openTypeHheaLineGap</key>
+	<integer>0</integer>
+	<key>openTypeNameDescription</key>
+	<string>Designed by Monotype design team.</string>
+	<key>openTypeNameDesigner</key>
+	<string>Monotype Design Team</string>
+	<key>openTypeNameDesignerURL</key>
+	<string>http://www.monotype.com/studio</string>
+	<key>openTypeNameLicense</key>
+	<string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.</string>
+	<key>openTypeNameLicenseURL</key>
+	<string>http://scripts.sil.org/OFL</string>
+	<key>openTypeNameManufacturer</key>
+	<string>Monotype Imaging Inc.</string>
+	<key>openTypeNameManufacturerURL</key>
+	<string>http://www.google.com/get/noto/</string>
+	<key>openTypeNameVersion</key>
+	<string>Version 1.902</string>
+	<key>openTypeOS2Panose</key>
+	<array>
+		<integer>2</integer>
+		<integer>11</integer>
+		<integer>2</integer>
+		<integer>6</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>4</integer>
+		<integer>2</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+	</array>
+	<key>openTypeOS2Selection</key>
+	<array>
+		<integer>8</integer>
+	</array>
+	<key>openTypeOS2Type</key>
+	<array/>
+	<key>openTypeOS2TypoAscender</key>
+	<integer>1069</integer>
+	<key>openTypeOS2TypoDescender</key>
+	<integer>-293</integer>
+	<key>openTypeOS2TypoLineGap</key>
+	<integer>0</integer>
+	<key>openTypeOS2UnicodeRanges</key>
+	<array>
+		<integer>0</integer>
+		<integer>1</integer>
+		<integer>2</integer>
+		<integer>3</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>6</integer>
+		<integer>7</integer>
+		<integer>9</integer>
+		<integer>29</integer>
+		<integer>30</integer>
+		<integer>31</integer>
+		<integer>32</integer>
+		<integer>33</integer>
+		<integer>34</integer>
+		<integer>35</integer>
+		<integer>36</integer>
+		<integer>62</integer>
+		<integer>64</integer>
+		<integer>67</integer>
+		<integer>69</integer>
+		<integer>91</integer>
+		<integer>116</integer>
+	</array>
+	<key>openTypeOS2VendorID</key>
+	<string>GOOG</string>
+	<key>openTypeOS2WinAscent</key>
+	<integer>1069</integer>
+	<key>openTypeOS2WinDescent</key>
+	<integer>293</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<integer>-15</integer>
+		<integer>0</integer>
+		<integer>527</integer>
+		<integer>537</integer>
+		<integer>559</integer>
+		<integer>569</integer>
+		<integer>714</integer>
+		<integer>724</integer>
+		<integer>760</integer>
+		<integer>765</integer>
+	</array>
+	<key>postscriptFamilyBlues</key>
+	<array/>
+	<key>postscriptFamilyOtherBlues</key>
+	<array/>
+	<key>postscriptOtherBlues</key>
+	<array>
+		<integer>-242</integer>
+		<integer>-232</integer>
+	</array>
+	<key>postscriptStemSnapH</key>
+	<array>
+		<integer>26</integer>
+	</array>
+	<key>postscriptStemSnapV</key>
+	<array>
+		<integer>26</integer>
+	</array>
+	<key>postscriptUnderlinePosition</key>
+	<integer>-100</integer>
+	<key>postscriptUnderlineThickness</key>
+	<integer>50</integer>
+	<key>styleMapFamilyName</key>
+	<string>Test Family 3 Condensed Light</string>
+	<key>styleMapStyleName</key>
+	<string>regular</string>
+	<key>styleName</key>
+	<string>Condensed Light</string>
+	<key>trademark</key>
+	<string>Noto is a trademark of Google Inc.</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>902</integer>
+	<key>xHeight</key>
+	<integer>527</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/F_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/F_.glif
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="F" format="2">
+  <advance width="352"/>
+  <unicode hex="0046"/>
+  <anchor x="176" y="0" name="bottom"/>
+  <anchor x="206" y="714" name="top"/>
+  <anchor x="332" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="104" y="0" type="line"/>
+      <point x="104" y="329" type="line"/>
+      <point x="322" y="329" type="line"/>
+      <point x="322" y="354" type="line"/>
+      <point x="104" y="354" type="line"/>
+      <point x="104" y="689" type="line"/>
+      <point x="334" y="689" type="line"/>
+      <point x="334" y="714" type="line"/>
+      <point x="78" y="714" type="line"/>
+      <point x="78" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/T_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/T_.glif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="T" format="2">
+  <advance width="336"/>
+  <unicode hex="0054"/>
+  <anchor x="168" y="0" name="bottom"/>
+  <anchor x="168" y="357" name="center"/>
+  <anchor x="168" y="714" name="top"/>
+  <anchor x="316" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="180" y="0" type="line"/>
+      <point x="180" y="689" type="line"/>
+      <point x="328" y="689" type="line"/>
+      <point x="328" y="714" type="line"/>
+      <point x="7" y="714" type="line"/>
+      <point x="7" y="689" type="line"/>
+      <point x="154" y="689" type="line"/>
+      <point x="154" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/contents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/contents.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>F</key>
+	<string>F_.glif</string>
+	<key>T</key>
+	<string>T_.glif</string>
+	<key>l</key>
+	<string>l.glif</string>
+	<key>n</key>
+	<string>n.glif</string>
+	<key>o</key>
+	<string>o.glif</string>
+	<key>s</key>
+	<string>s.glif</string>
+	<key>t</key>
+	<string>t.glif</string>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/l.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/l.glif
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="l" format="2">
+  <advance width="167"/>
+  <unicode hex="006C"/>
+  <anchor x="84" y="0" name="bottom"/>
+  <anchor x="84" y="264" name="center"/>
+  <anchor x="84" y="760" name="top"/>
+  <anchor x="118" y="760" name="topright"/>
+  <outline>
+    <contour>
+      <point x="97" y="0" type="line"/>
+      <point x="97" y="760" type="line"/>
+      <point x="71" y="760" type="line"/>
+      <point x="71" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/layerinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/n.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/n.glif
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="n" format="2">
+  <advance width="408"/>
+  <unicode hex="006E"/>
+  <anchor x="204" y="0" name="bottom"/>
+  <anchor x="204" y="527" name="top"/>
+  <anchor x="388" y="527" name="topright"/>
+  <outline>
+    <contour>
+      <point x="225" y="537" type="curve" smooth="yes"/>
+      <point x="145" y="537"/>
+      <point x="108" y="474"/>
+      <point x="94" y="415" type="curve"/>
+      <point x="92" y="415" type="line"/>
+      <point x="91" y="527" type="line"/>
+      <point x="71" y="527" type="line"/>
+      <point x="71" y="0" type="line"/>
+      <point x="97" y="0" type="line"/>
+      <point x="97" y="311" type="line" smooth="yes"/>
+      <point x="97" y="445"/>
+      <point x="156" y="513"/>
+      <point x="225" y="513" type="curve" smooth="yes"/>
+      <point x="279" y="513"/>
+      <point x="313" y="471"/>
+      <point x="313" y="365" type="curve" smooth="yes"/>
+      <point x="313" y="0" type="line"/>
+      <point x="339" y="0" type="line"/>
+      <point x="339" y="375" type="line" smooth="yes"/>
+      <point x="339" y="488"/>
+      <point x="298" y="537"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/o.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/o.glif
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="o" format="2">
+  <advance width="403"/>
+  <unicode hex="006F"/>
+  <anchor x="202" y="0" name="bottom"/>
+  <anchor x="202" y="264" name="center"/>
+  <anchor x="202" y="527" name="top"/>
+  <anchor x="383" y="527" name="topright"/>
+  <outline>
+    <contour>
+      <point x="357" y="264" type="curve" smooth="yes"/>
+      <point x="357" y="433"/>
+      <point x="315" y="537"/>
+      <point x="202" y="537" type="curve" smooth="yes"/>
+      <point x="96" y="537"/>
+      <point x="46" y="444"/>
+      <point x="46" y="266" type="curve" smooth="yes"/>
+      <point x="46" y="80"/>
+      <point x="100" y="-10"/>
+      <point x="204" y="-10" type="curve" smooth="yes"/>
+      <point x="306" y="-10"/>
+      <point x="357" y="77"/>
+    </contour>
+    <contour>
+      <point x="72" y="266" type="curve" smooth="yes"/>
+      <point x="72" y="424"/>
+      <point x="110" y="512"/>
+      <point x="202" y="512" type="curve" smooth="yes"/>
+      <point x="298" y="512"/>
+      <point x="331" y="418"/>
+      <point x="331" y="265" type="curve" smooth="yes"/>
+      <point x="331" y="94"/>
+      <point x="291" y="15"/>
+      <point x="203" y="15" type="curve" smooth="yes"/>
+      <point x="113" y="15"/>
+      <point x="72" y="102"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/s.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/s.glif
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="s" format="2">
+  <advance width="312"/>
+  <unicode hex="0073"/>
+  <anchor x="156" y="0" name="bottom"/>
+  <anchor x="156" y="527" name="top"/>
+  <anchor x="292" y="527" name="topright"/>
+  <outline>
+    <contour>
+      <point x="278" y="123" type="curve" smooth="yes"/>
+      <point x="278" y="210"/>
+      <point x="228" y="239"/>
+      <point x="162" y="280" type="curve" smooth="yes"/>
+      <point x="98" y="320"/>
+      <point x="65" y="349"/>
+      <point x="65" y="407" type="curve" smooth="yes"/>
+      <point x="65" y="475"/>
+      <point x="109" y="512"/>
+      <point x="174" y="512" type="curve" smooth="yes"/>
+      <point x="206" y="512"/>
+      <point x="240" y="503"/>
+      <point x="262" y="487" type="curve"/>
+      <point x="275" y="510" type="line"/>
+      <point x="249" y="527"/>
+      <point x="213" y="537"/>
+      <point x="175" y="537" type="curve" smooth="yes"/>
+      <point x="82" y="537"/>
+      <point x="39" y="479"/>
+      <point x="39" y="408" type="curve" smooth="yes"/>
+      <point x="39" y="330"/>
+      <point x="90" y="296"/>
+      <point x="157" y="254" type="curve" smooth="yes"/>
+      <point x="216" y="217"/>
+      <point x="251" y="195"/>
+      <point x="251" y="125" type="curve" smooth="yes"/>
+      <point x="251" y="56"/>
+      <point x="217" y="16"/>
+      <point x="147" y="16" type="curve" smooth="yes"/>
+      <point x="105" y="16"/>
+      <point x="65" y="31"/>
+      <point x="36" y="52" type="curve"/>
+      <point x="36" y="21" type="line"/>
+      <point x="59" y="6"/>
+      <point x="98" y="-10"/>
+      <point x="147" y="-10" type="curve" smooth="yes"/>
+      <point x="235" y="-10"/>
+      <point x="278" y="43"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/t.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/glyphs/t.glif
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="t" format="2">
+  <advance width="209"/>
+  <unicode hex="0074"/>
+  <anchor x="134" y="0" name="bottom"/>
+  <anchor x="105" y="264" name="center"/>
+  <anchor x="85" y="656" name="top"/>
+  <anchor x="189" y="656" name="topright"/>
+  <outline>
+    <contour>
+      <point x="147" y="14" type="curve" smooth="yes"/>
+      <point x="107" y="14"/>
+      <point x="97" y="44"/>
+      <point x="97" y="108" type="curve" smooth="yes"/>
+      <point x="97" y="503" type="line"/>
+      <point x="196" y="503" type="line"/>
+      <point x="196" y="527" type="line"/>
+      <point x="97" y="527" type="line"/>
+      <point x="97" y="656" type="line"/>
+      <point x="76" y="656" type="line"/>
+      <point x="69" y="528" type="line"/>
+      <point x="21" y="521" type="line"/>
+      <point x="21" y="503" type="line"/>
+      <point x="71" y="503" type="line"/>
+      <point x="71" y="112" type="line" smooth="yes"/>
+      <point x="71" y="32"/>
+      <point x="85" y="-10"/>
+      <point x="146" y="-10" type="curve" smooth="yes"/>
+      <point x="165" y="-10"/>
+      <point x="179" y="-6"/>
+      <point x="192" y="0" type="curve"/>
+      <point x="192" y="25" type="line"/>
+      <point x="182" y="19"/>
+      <point x="164" y="14"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/groups.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/groups.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern1.d</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern1.n.left</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern1.o.left</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern1.t.left</key>
+	<array>
+		<string>t</string>
+	</array>
+	<key>public.kern2.T.right</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern2.b</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern2.n.right</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern2.o.right</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern2.s.right</key>
+	<array>
+		<string>s</string>
+	</array>
+	<key>public.kern2.t.right</key>
+	<array>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/kerning.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/kerning.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<dict>
+		<key>public.kern2.T.right</key>
+		<integer>12</integer>
+		<key>public.kern2.n.right</key>
+		<integer>-30</integer>
+		<key>public.kern2.o.right</key>
+		<integer>-42</integer>
+		<key>public.kern2.s.right</key>
+		<integer>-36</integer>
+	</dict>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/layercontents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/lib.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/lib.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>F</string>
+		<string>T</string>
+		<string>l</string>
+		<string>n</string>
+		<string>o</string>
+		<string>s</string>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/metainfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedLight.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/fontinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/fontinfo.plist
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>760</integer>
+	<key>capHeight</key>
+	<integer>714</integer>
+	<key>copyright</key>
+	<string>Copyright 2015 Google Inc. All Rights Reserved.</string>
+	<key>descender</key>
+	<integer>-240</integer>
+	<key>familyName</key>
+	<string>Test Family 3</string>
+	<key>guidelines</key>
+	<array/>
+	<key>openTypeHeadCreated</key>
+	<string>2016/03/15 19:50:39</string>
+	<key>openTypeHheaAscender</key>
+	<integer>1069</integer>
+	<key>openTypeHheaDescender</key>
+	<integer>-293</integer>
+	<key>openTypeHheaLineGap</key>
+	<integer>0</integer>
+	<key>openTypeNameDescription</key>
+	<string>Designed by Monotype design team.</string>
+	<key>openTypeNameDesigner</key>
+	<string>Monotype Design Team</string>
+	<key>openTypeNameDesignerURL</key>
+	<string>http://www.monotype.com/studio</string>
+	<key>openTypeNameLicense</key>
+	<string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.</string>
+	<key>openTypeNameLicenseURL</key>
+	<string>http://scripts.sil.org/OFL</string>
+	<key>openTypeNameManufacturer</key>
+	<string>Monotype Imaging Inc.</string>
+	<key>openTypeNameManufacturerURL</key>
+	<string>http://www.google.com/get/noto/</string>
+	<key>openTypeNameVersion</key>
+	<string>Version 1.902</string>
+	<key>openTypeOS2Panose</key>
+	<array>
+		<integer>2</integer>
+		<integer>11</integer>
+		<integer>8</integer>
+		<integer>6</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>4</integer>
+		<integer>2</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+	</array>
+	<key>openTypeOS2Selection</key>
+	<array>
+		<integer>8</integer>
+	</array>
+	<key>openTypeOS2Type</key>
+	<array/>
+	<key>openTypeOS2TypoAscender</key>
+	<integer>1069</integer>
+	<key>openTypeOS2TypoDescender</key>
+	<integer>-293</integer>
+	<key>openTypeOS2TypoLineGap</key>
+	<integer>0</integer>
+	<key>openTypeOS2UnicodeRanges</key>
+	<array>
+		<integer>0</integer>
+		<integer>1</integer>
+		<integer>2</integer>
+		<integer>3</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>6</integer>
+		<integer>7</integer>
+		<integer>9</integer>
+		<integer>29</integer>
+		<integer>30</integer>
+		<integer>31</integer>
+		<integer>32</integer>
+		<integer>33</integer>
+		<integer>34</integer>
+		<integer>35</integer>
+		<integer>36</integer>
+		<integer>62</integer>
+		<integer>64</integer>
+		<integer>67</integer>
+		<integer>69</integer>
+		<integer>91</integer>
+		<integer>116</integer>
+	</array>
+	<key>openTypeOS2VendorID</key>
+	<string>GOOG</string>
+	<key>openTypeOS2WinAscent</key>
+	<integer>1069</integer>
+	<key>openTypeOS2WinDescent</key>
+	<integer>293</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<integer>-15</integer>
+		<integer>0</integer>
+		<integer>547</integer>
+		<integer>558</integer>
+		<integer>582</integer>
+		<integer>592</integer>
+		<integer>714</integer>
+		<integer>726</integer>
+		<integer>760</integer>
+		<integer>766</integer>
+	</array>
+	<key>postscriptFamilyBlues</key>
+	<array/>
+	<key>postscriptFamilyOtherBlues</key>
+	<array/>
+	<key>postscriptOtherBlues</key>
+	<array>
+		<integer>-256</integer>
+		<integer>-240</integer>
+	</array>
+	<key>postscriptStemSnapH</key>
+	<array>
+		<integer>95</integer>
+		<integer>108</integer>
+		<integer>119</integer>
+	</array>
+	<key>postscriptStemSnapV</key>
+	<array>
+		<integer>97</integer>
+		<integer>121</integer>
+		<integer>137</integer>
+	</array>
+	<key>postscriptUnderlinePosition</key>
+	<integer>-100</integer>
+	<key>postscriptUnderlineThickness</key>
+	<integer>50</integer>
+	<key>styleMapFamilyName</key>
+	<string>Test Family 3 Condensed SemiBold</string>
+	<key>styleMapStyleName</key>
+	<string>regular</string>
+	<key>styleName</key>
+	<string>Condensed SemiBold</string>
+	<key>trademark</key>
+	<string>Noto is a trademark of Google Inc.</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>902</integer>
+	<key>xHeight</key>
+	<integer>547</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/F_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/F_.glif
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="F" format="2">
+  <advance width="414"/>
+  <unicode hex="0046"/>
+  <anchor x="207" y="0" name="bottom"/>
+  <anchor x="227" y="714" name="top"/>
+  <anchor x="394" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="201" y="0" type="line"/>
+      <point x="201" y="286" type="line"/>
+      <point x="371" y="286" type="line"/>
+      <point x="371" y="403" type="line"/>
+      <point x="201" y="403" type="line"/>
+      <point x="201" y="597" type="line"/>
+      <point x="383" y="597" type="line"/>
+      <point x="383" y="714" type="line"/>
+      <point x="64" y="714" type="line"/>
+      <point x="64" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/T_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/T_.glif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="T" format="2">
+  <advance width="429"/>
+  <unicode hex="0054"/>
+  <anchor x="215" y="0" name="bottom"/>
+  <anchor x="215" y="357" name="center"/>
+  <anchor x="215" y="714" name="top"/>
+  <anchor x="409" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="282" y="0" type="line"/>
+      <point x="282" y="595" type="line"/>
+      <point x="414" y="595" type="line"/>
+      <point x="414" y="714" type="line"/>
+      <point x="14" y="714" type="line"/>
+      <point x="14" y="595" type="line"/>
+      <point x="147" y="595" type="line"/>
+      <point x="147" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/contents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/contents.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>F</key>
+	<string>F_.glif</string>
+	<key>T</key>
+	<string>T_.glif</string>
+	<key>l</key>
+	<string>l.glif</string>
+	<key>n</key>
+	<string>n.glif</string>
+	<key>o</key>
+	<string>o.glif</string>
+	<key>s</key>
+	<string>s.glif</string>
+	<key>t</key>
+	<string>t.glif</string>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/l.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/l.glif
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="l" format="2">
+  <advance width="242"/>
+  <unicode hex="006C"/>
+  <anchor x="122" y="0" name="bottom"/>
+  <anchor x="121" y="274" name="center"/>
+  <anchor x="122" y="760" name="top"/>
+  <anchor x="210" y="760" name="topright"/>
+  <outline>
+    <contour>
+      <point x="186" y="0" type="line"/>
+      <point x="186" y="760" type="line"/>
+      <point x="56" y="760" type="line"/>
+      <point x="56" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/layerinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/n.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/n.glif
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="n" format="2">
+  <advance width="501"/>
+  <unicode hex="006E"/>
+  <anchor x="251" y="0" name="bottom"/>
+  <anchor x="260" y="547" name="top"/>
+  <anchor x="468" y="547" name="topright"/>
+  <outline>
+    <contour>
+      <point x="302" y="557" type="curve" smooth="yes"/>
+      <point x="247" y="557"/>
+      <point x="205" y="529"/>
+      <point x="181" y="477" type="curve"/>
+      <point x="173" y="477" type="line"/>
+      <point x="159" y="547" type="line"/>
+      <point x="56" y="547" type="line"/>
+      <point x="56" y="0" type="line"/>
+      <point x="186" y="0" type="line"/>
+      <point x="186" y="263" type="line" smooth="yes"/>
+      <point x="186" y="393"/>
+      <point x="205" y="441"/>
+      <point x="260" y="441" type="curve" smooth="yes"/>
+      <point x="303" y="441"/>
+      <point x="316" y="401"/>
+      <point x="316" y="324" type="curve" smooth="yes"/>
+      <point x="316" y="0" type="line"/>
+      <point x="446" y="0" type="line"/>
+      <point x="446" y="362" type="line" smooth="yes"/>
+      <point x="446" y="489"/>
+      <point x="394" y="557"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/o.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/o.glif
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="o" format="2">
+  <advance width="488"/>
+  <unicode hex="006F"/>
+  <anchor x="244" y="0" name="bottom"/>
+  <anchor x="244" y="274" name="center"/>
+  <anchor x="244" y="547" name="top"/>
+  <anchor x="468" y="547" name="topright"/>
+  <outline>
+    <contour>
+      <point x="452" y="275" type="curve" smooth="yes"/>
+      <point x="452" y="457"/>
+      <point x="371" y="557"/>
+      <point x="245" y="557" type="curve" smooth="yes"/>
+      <point x="98" y="557"/>
+      <point x="36" y="440"/>
+      <point x="36" y="275" type="curve" smooth="yes"/>
+      <point x="36" y="120"/>
+      <point x="101" y="-10"/>
+      <point x="243" y="-10" type="curve" smooth="yes"/>
+      <point x="395" y="-10"/>
+      <point x="452" y="123"/>
+    </contour>
+    <contour>
+      <point x="168" y="273" type="curve" smooth="yes"/>
+      <point x="168" y="391"/>
+      <point x="191" y="447"/>
+      <point x="244" y="447" type="curve" smooth="yes"/>
+      <point x="298" y="447"/>
+      <point x="319" y="390"/>
+      <point x="319" y="275" type="curve" smooth="yes"/>
+      <point x="319" y="158"/>
+      <point x="298" y="100"/>
+      <point x="244" y="100" type="curve" smooth="yes"/>
+      <point x="191" y="100"/>
+      <point x="168" y="159"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/s.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/s.glif
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="s" format="2">
+  <advance width="374"/>
+  <unicode hex="0073"/>
+  <anchor x="174" y="0" name="bottom"/>
+  <anchor x="194" y="547" name="top"/>
+  <anchor x="336" y="547" name="topright"/>
+  <outline>
+    <contour>
+      <point x="347" y="160" type="curve" smooth="yes"/>
+      <point x="347" y="244"/>
+      <point x="301" y="289"/>
+      <point x="234" y="328" type="curve" smooth="yes"/>
+      <point x="166" y="369"/>
+      <point x="154" y="380"/>
+      <point x="154" y="408" type="curve" smooth="yes"/>
+      <point x="154" y="435"/>
+      <point x="171" y="451"/>
+      <point x="203" y="451" type="curve" smooth="yes"/>
+      <point x="239" y="451"/>
+      <point x="274" y="435"/>
+      <point x="305" y="414" type="curve"/>
+      <point x="341" y="514" type="line"/>
+      <point x="295" y="542"/>
+      <point x="249" y="557"/>
+      <point x="196" y="557" type="curve" smooth="yes"/>
+      <point x="92" y="557"/>
+      <point x="28" y="498"/>
+      <point x="28" y="402" type="curve" smooth="yes"/>
+      <point x="28" y="323"/>
+      <point x="67" y="272"/>
+      <point x="135" y="235" type="curve" smooth="yes"/>
+      <point x="205" y="199"/>
+      <point x="217" y="180"/>
+      <point x="217" y="153" type="curve" smooth="yes"/>
+      <point x="217" y="120"/>
+      <point x="197" y="103"/>
+      <point x="160" y="103" type="curve" smooth="yes"/>
+      <point x="113" y="103"/>
+      <point x="64" y="123"/>
+      <point x="29" y="147" type="curve"/>
+      <point x="29" y="21" type="line"/>
+      <point x="71" y="0"/>
+      <point x="119" y="-10"/>
+      <point x="172" y="-10" type="curve" smooth="yes"/>
+      <point x="282" y="-10"/>
+      <point x="347" y="49"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/t.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/glyphs/t.glif
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="t" format="2">
+  <advance width="317"/>
+  <unicode hex="0074"/>
+  <anchor x="189" y="0" name="bottom"/>
+  <anchor x="159" y="274" name="center"/>
+  <anchor x="138" y="662" name="top"/>
+  <anchor x="293" y="662" name="topright"/>
+  <outline>
+    <contour>
+      <point x="239" y="104" type="curve" smooth="yes"/>
+      <point x="207" y="104"/>
+      <point x="195" y="125"/>
+      <point x="195" y="168" type="curve" smooth="yes"/>
+      <point x="195" y="439" type="line"/>
+      <point x="293" y="439" type="line"/>
+      <point x="293" y="547" type="line"/>
+      <point x="195" y="547" type="line"/>
+      <point x="195" y="662" type="line"/>
+      <point x="106" y="662" type="line"/>
+      <point x="75" y="543" type="line"/>
+      <point x="11" y="509" type="line"/>
+      <point x="11" y="439" type="line"/>
+      <point x="65" y="439" type="line"/>
+      <point x="65" y="163" type="line" smooth="yes"/>
+      <point x="65" y="46"/>
+      <point x="104" y="-10"/>
+      <point x="198" y="-10" type="curve" smooth="yes"/>
+      <point x="237" y="-10"/>
+      <point x="271" y="-1"/>
+      <point x="300" y="15" type="curve"/>
+      <point x="300" y="119" type="line"/>
+      <point x="278" y="109"/>
+      <point x="257" y="104"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/groups.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/groups.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern1.d</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern1.n.left</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern1.o.left</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern1.t.left</key>
+	<array>
+		<string>t</string>
+	</array>
+	<key>public.kern2.T.right</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern2.b</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern2.n.right</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern2.o.right</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern2.s.right</key>
+	<array>
+		<string>s</string>
+	</array>
+	<key>public.kern2.t.right</key>
+	<array>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/kerning.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/kerning.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<dict>
+		<key>public.kern2.T.right</key>
+		<integer>12</integer>
+		<key>public.kern2.n.right</key>
+		<integer>-30</integer>
+		<key>public.kern2.o.right</key>
+		<integer>-42</integer>
+		<key>public.kern2.s.right</key>
+		<integer>-36</integer>
+	</dict>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/layercontents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/lib.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/lib.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>F</string>
+		<string>T</string>
+		<string>l</string>
+		<string>n</string>
+		<string>o</string>
+		<string>s</string>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/metainfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-CondensedSemiBold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/fontinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/fontinfo.plist
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>760</integer>
+	<key>capHeight</key>
+	<integer>714</integer>
+	<key>copyright</key>
+	<string>Copyright 2015 Google Inc. All Rights Reserved.</string>
+	<key>descender</key>
+	<integer>-240</integer>
+	<key>familyName</key>
+	<string>Test Family 3</string>
+	<key>guidelines</key>
+	<array/>
+	<key>openTypeHeadCreated</key>
+	<string>2016/03/15 19:50:39</string>
+	<key>openTypeHheaAscender</key>
+	<integer>1069</integer>
+	<key>openTypeHheaDescender</key>
+	<integer>-293</integer>
+	<key>openTypeHheaLineGap</key>
+	<integer>0</integer>
+	<key>openTypeNameDescription</key>
+	<string>Designed by Monotype design team.</string>
+	<key>openTypeNameDesigner</key>
+	<string>Monotype Design Team</string>
+	<key>openTypeNameDesignerURL</key>
+	<string>http://www.monotype.com/studio</string>
+	<key>openTypeNameLicense</key>
+	<string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.</string>
+	<key>openTypeNameLicenseURL</key>
+	<string>http://scripts.sil.org/OFL</string>
+	<key>openTypeNameManufacturer</key>
+	<string>Monotype Imaging Inc.</string>
+	<key>openTypeNameManufacturerURL</key>
+	<string>http://www.google.com/get/noto/</string>
+	<key>openTypeNameVersion</key>
+	<string>Version 1.902</string>
+	<key>openTypeOS2Panose</key>
+	<array>
+		<integer>2</integer>
+		<integer>11</integer>
+		<integer>2</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>4</integer>
+		<integer>2</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+	</array>
+	<key>openTypeOS2Selection</key>
+	<array>
+		<integer>8</integer>
+	</array>
+	<key>openTypeOS2Type</key>
+	<array/>
+	<key>openTypeOS2TypoAscender</key>
+	<integer>1069</integer>
+	<key>openTypeOS2TypoDescender</key>
+	<integer>-293</integer>
+	<key>openTypeOS2TypoLineGap</key>
+	<integer>0</integer>
+	<key>openTypeOS2UnicodeRanges</key>
+	<array>
+		<integer>0</integer>
+		<integer>1</integer>
+		<integer>2</integer>
+		<integer>3</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>6</integer>
+		<integer>7</integer>
+		<integer>9</integer>
+		<integer>29</integer>
+		<integer>30</integer>
+		<integer>31</integer>
+		<integer>32</integer>
+		<integer>33</integer>
+		<integer>34</integer>
+		<integer>35</integer>
+		<integer>36</integer>
+		<integer>62</integer>
+		<integer>64</integer>
+		<integer>67</integer>
+		<integer>69</integer>
+		<integer>91</integer>
+		<integer>116</integer>
+	</array>
+	<key>openTypeOS2VendorID</key>
+	<string>GOOG</string>
+	<key>openTypeOS2WinAscent</key>
+	<integer>1069</integer>
+	<key>openTypeOS2WinDescent</key>
+	<integer>293</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<integer>-15</integer>
+		<integer>0</integer>
+		<integer>528</integer>
+		<integer>537</integer>
+		<integer>559</integer>
+		<integer>569</integer>
+		<integer>714</integer>
+		<integer>724</integer>
+		<integer>760</integer>
+		<integer>766</integer>
+	</array>
+	<key>postscriptFamilyBlues</key>
+	<array/>
+	<key>postscriptFamilyOtherBlues</key>
+	<array/>
+	<key>postscriptOtherBlues</key>
+	<array>
+		<integer>-256</integer>
+		<integer>-240</integer>
+	</array>
+	<key>postscriptStemSnapH</key>
+	<array>
+		<integer>25</integer>
+	</array>
+	<key>postscriptStemSnapV</key>
+	<array>
+		<integer>26</integer>
+	</array>
+	<key>postscriptUnderlinePosition</key>
+	<integer>-100</integer>
+	<key>postscriptUnderlineThickness</key>
+	<integer>50</integer>
+	<key>styleMapFamilyName</key>
+	<string>Test Family 3 Light</string>
+	<key>styleMapStyleName</key>
+	<string>regular</string>
+	<key>styleName</key>
+	<string>Light</string>
+	<key>trademark</key>
+	<string>Noto is a trademark of Google Inc.</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>902</integer>
+	<key>xHeight</key>
+	<integer>528</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/F_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/F_.glif
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="F" format="2">
+  <advance width="492"/>
+  <unicode hex="0046"/>
+  <anchor x="246" y="0" name="bottom"/>
+  <anchor x="296" y="714" name="top"/>
+  <anchor x="472" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="129" y="0" type="line"/>
+      <point x="129" y="329" type="line"/>
+      <point x="470" y="329" type="line"/>
+      <point x="470" y="354" type="line"/>
+      <point x="129" y="354" type="line"/>
+      <point x="129" y="689" type="line"/>
+      <point x="489" y="689" type="line"/>
+      <point x="489" y="714" type="line"/>
+      <point x="103" y="714" type="line"/>
+      <point x="103" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/T_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/T_.glif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="T" format="2">
+  <advance width="505"/>
+  <unicode hex="0054"/>
+  <anchor x="253" y="0" name="bottom"/>
+  <anchor x="253" y="357" name="center"/>
+  <anchor x="253" y="714" name="top"/>
+  <anchor x="485" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="265" y="0" type="line"/>
+      <point x="265" y="689" type="line"/>
+      <point x="503" y="689" type="line"/>
+      <point x="503" y="714" type="line"/>
+      <point x="2" y="714" type="line"/>
+      <point x="2" y="689" type="line"/>
+      <point x="239" y="689" type="line"/>
+      <point x="239" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/contents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/contents.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>F</key>
+	<string>F_.glif</string>
+	<key>T</key>
+	<string>T_.glif</string>
+	<key>l</key>
+	<string>l.glif</string>
+	<key>n</key>
+	<string>n.glif</string>
+	<key>o</key>
+	<string>o.glif</string>
+	<key>s</key>
+	<string>s.glif</string>
+	<key>t</key>
+	<string>t.glif</string>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/l.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/l.glif
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="l" format="2">
+  <advance width="207"/>
+  <unicode hex="006C"/>
+  <anchor x="104" y="0" name="bottom"/>
+  <anchor x="104" y="264" name="center"/>
+  <anchor x="104" y="760" name="top"/>
+  <anchor x="187" y="760" name="topright"/>
+  <outline>
+    <contour>
+      <point x="117" y="0" type="line"/>
+      <point x="117" y="760" type="line"/>
+      <point x="91" y="760" type="line"/>
+      <point x="91" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/layerinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/n.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/n.glif
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="n" format="2">
+  <advance width="573"/>
+  <unicode hex="006E"/>
+  <anchor x="287" y="0" name="bottom"/>
+  <anchor x="287" y="528" name="top"/>
+  <anchor x="553" y="528" name="topright"/>
+  <outline>
+    <contour>
+      <point x="309" y="538" type="curve" smooth="yes"/>
+      <point x="197" y="538"/>
+      <point x="140" y="478"/>
+      <point x="117" y="417" type="curve"/>
+      <point x="115" y="417" type="line"/>
+      <point x="111" y="528" type="line"/>
+      <point x="90" y="528" type="line"/>
+      <point x="90" y="0" type="line"/>
+      <point x="116" y="0" type="line"/>
+      <point x="116" y="302" type="line" smooth="yes"/>
+      <point x="116" y="446"/>
+      <point x="194" y="513"/>
+      <point x="309" y="513" type="curve" smooth="yes"/>
+      <point x="406" y="513"/>
+      <point x="463" y="462"/>
+      <point x="463" y="345" type="curve" smooth="yes"/>
+      <point x="463" y="0" type="line"/>
+      <point x="489" y="0" type="line"/>
+      <point x="489" y="346" type="line" smooth="yes"/>
+      <point x="489" y="477"/>
+      <point x="423" y="538"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/o.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/o.glif
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="o" format="2">
+  <advance width="575"/>
+  <unicode hex="006F"/>
+  <anchor x="288" y="0" name="bottom"/>
+  <anchor x="288" y="264" name="center"/>
+  <anchor x="288" y="528" name="top"/>
+  <anchor x="555" y="528" name="topright"/>
+  <outline>
+    <contour>
+      <point x="515" y="264" type="curve" smooth="yes"/>
+      <point x="515" y="417"/>
+      <point x="451" y="538"/>
+      <point x="292" y="538" type="curve" smooth="yes"/>
+      <point x="145" y="538"/>
+      <point x="59" y="432"/>
+      <point x="59" y="264" type="curve" smooth="yes"/>
+      <point x="59" y="107"/>
+      <point x="134" y="-10"/>
+      <point x="286" y="-10" type="curve" smooth="yes"/>
+      <point x="443" y="-10"/>
+      <point x="515" y="109"/>
+    </contour>
+    <contour>
+      <point x="86" y="264" type="curve" smooth="yes"/>
+      <point x="86" y="420"/>
+      <point x="160" y="513"/>
+      <point x="292" y="513" type="curve" smooth="yes"/>
+      <point x="433" y="513"/>
+      <point x="488" y="402"/>
+      <point x="488" y="264" type="curve" smooth="yes"/>
+      <point x="488" y="119"/>
+      <point x="426" y="15"/>
+      <point x="286" y="15" type="curve" smooth="yes"/>
+      <point x="151" y="15"/>
+      <point x="86" y="117"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/s.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/s.glif
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="s" format="2">
+  <advance width="458"/>
+  <unicode hex="0073"/>
+  <anchor x="229" y="0" name="bottom"/>
+  <anchor x="229" y="528" name="top"/>
+  <anchor x="438" y="528" name="topright"/>
+  <outline>
+    <contour>
+      <point x="411" y="134" type="curve" smooth="yes"/>
+      <point x="411" y="235"/>
+      <point x="321" y="258"/>
+      <point x="233" y="286" type="curve" smooth="yes"/>
+      <point x="152" y="312"/>
+      <point x="83" y="325"/>
+      <point x="83" y="407" type="curve" smooth="yes"/>
+      <point x="83" y="478"/>
+      <point x="142" y="513"/>
+      <point x="238" y="513" type="curve" smooth="yes"/>
+      <point x="291" y="513"/>
+      <point x="350" y="501"/>
+      <point x="387" y="483" type="curve"/>
+      <point x="398" y="508" type="line"/>
+      <point x="356" y="525"/>
+      <point x="301" y="538"/>
+      <point x="238" y="538" type="curve" smooth="yes"/>
+      <point x="126" y="538"/>
+      <point x="56" y="489"/>
+      <point x="56" y="407" type="curve" smooth="yes"/>
+      <point x="56" y="309"/>
+      <point x="131" y="290"/>
+      <point x="224" y="262" type="curve" smooth="yes"/>
+      <point x="312" y="236"/>
+      <point x="384" y="212"/>
+      <point x="384" y="134" type="curve" smooth="yes"/>
+      <point x="384" y="60"/>
+      <point x="334" y="15"/>
+      <point x="213" y="15" type="curve" smooth="yes"/>
+      <point x="151" y="15"/>
+      <point x="92" y="28"/>
+      <point x="39" y="54" type="curve"/>
+      <point x="39" y="24" type="line"/>
+      <point x="77" y="7"/>
+      <point x="140" y="-10"/>
+      <point x="213" y="-10" type="curve" smooth="yes"/>
+      <point x="345" y="-10"/>
+      <point x="411" y="45"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/t.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/glyphs/t.glif
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="t" format="2">
+  <advance width="319"/>
+  <unicode hex="0074"/>
+  <anchor x="191" y="0" name="bottom"/>
+  <anchor x="160" y="264" name="center"/>
+  <anchor x="109" y="659" name="top"/>
+  <anchor x="299" y="659" name="topright"/>
+  <outline>
+    <contour>
+      <point x="212" y="15" type="curve" smooth="yes"/>
+      <point x="138" y="15"/>
+      <point x="117" y="61"/>
+      <point x="117" y="143" type="curve" smooth="yes"/>
+      <point x="117" y="503" type="line"/>
+      <point x="289" y="503" type="line"/>
+      <point x="289" y="528" type="line"/>
+      <point x="117" y="528" type="line"/>
+      <point x="117" y="659" type="line"/>
+      <point x="96" y="659" type="line"/>
+      <point x="90" y="528" type="line"/>
+      <point x="10" y="525" type="line"/>
+      <point x="10" y="503" type="line"/>
+      <point x="91" y="503" type="line"/>
+      <point x="91" y="140" type="line" smooth="yes"/>
+      <point x="91" y="47"/>
+      <point x="119" y="-10"/>
+      <point x="212" y="-10" type="curve" smooth="yes"/>
+      <point x="247" y="-10"/>
+      <point x="269" y="-4"/>
+      <point x="291" y="3" type="curve"/>
+      <point x="291" y="28" type="line"/>
+      <point x="269" y="20"/>
+      <point x="245" y="15"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/groups.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/groups.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern1.d</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern1.n.left</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern1.o.left</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern1.t.left</key>
+	<array>
+		<string>t</string>
+	</array>
+	<key>public.kern2.T.right</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern2.b</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern2.n.right</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern2.o.right</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern2.s.right</key>
+	<array>
+		<string>s</string>
+	</array>
+	<key>public.kern2.t.right</key>
+	<array>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/kerning.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/kerning.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<dict>
+		<key>public.kern2.T.right</key>
+		<integer>20</integer>
+		<key>public.kern2.n.right</key>
+		<integer>-50</integer>
+		<key>public.kern2.o.right</key>
+		<integer>-70</integer>
+		<key>public.kern2.s.right</key>
+		<integer>-60</integer>
+	</dict>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/layercontents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/lib.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/lib.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>F</string>
+		<string>T</string>
+		<string>l</string>
+		<string>n</string>
+		<string>o</string>
+		<string>s</string>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/metainfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Light.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/fontinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/fontinfo.plist
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>760</integer>
+	<key>capHeight</key>
+	<integer>714</integer>
+	<key>copyright</key>
+	<string>Copyright 2015 Google Inc. All Rights Reserved.</string>
+	<key>descender</key>
+	<integer>-240</integer>
+	<key>familyName</key>
+	<string>Test Family 3</string>
+	<key>guidelines</key>
+	<array/>
+	<key>openTypeHeadCreated</key>
+	<string>2016/03/15 19:50:39</string>
+	<key>openTypeHheaAscender</key>
+	<integer>1069</integer>
+	<key>openTypeHheaDescender</key>
+	<integer>-293</integer>
+	<key>openTypeHheaLineGap</key>
+	<integer>0</integer>
+	<key>openTypeNameDescription</key>
+	<string>Designed by Monotype design team.</string>
+	<key>openTypeNameDesigner</key>
+	<string>Monotype Design Team</string>
+	<key>openTypeNameDesignerURL</key>
+	<string>http://www.monotype.com/studio</string>
+	<key>openTypeNameLicense</key>
+	<string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.</string>
+	<key>openTypeNameLicenseURL</key>
+	<string>http://scripts.sil.org/OFL</string>
+	<key>openTypeNameManufacturer</key>
+	<string>Monotype Imaging Inc.</string>
+	<key>openTypeNameManufacturerURL</key>
+	<string>http://www.google.com/get/noto/</string>
+	<key>openTypeNameVersion</key>
+	<string>Version 1.902</string>
+	<key>openTypeOS2Panose</key>
+	<array>
+		<integer>2</integer>
+		<integer>11</integer>
+		<integer>5</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>4</integer>
+		<integer>2</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+	</array>
+	<key>openTypeOS2Selection</key>
+	<array>
+		<integer>8</integer>
+	</array>
+	<key>openTypeOS2Type</key>
+	<array/>
+	<key>openTypeOS2TypoAscender</key>
+	<integer>1069</integer>
+	<key>openTypeOS2TypoDescender</key>
+	<integer>-293</integer>
+	<key>openTypeOS2TypoLineGap</key>
+	<integer>0</integer>
+	<key>openTypeOS2UnicodeRanges</key>
+	<array>
+		<integer>0</integer>
+		<integer>1</integer>
+		<integer>2</integer>
+		<integer>3</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>6</integer>
+		<integer>7</integer>
+		<integer>9</integer>
+		<integer>29</integer>
+		<integer>30</integer>
+		<integer>31</integer>
+		<integer>32</integer>
+		<integer>33</integer>
+		<integer>34</integer>
+		<integer>35</integer>
+		<integer>36</integer>
+		<integer>62</integer>
+		<integer>64</integer>
+		<integer>67</integer>
+		<integer>69</integer>
+		<integer>91</integer>
+		<integer>116</integer>
+	</array>
+	<key>openTypeOS2VendorID</key>
+	<string>GOOG</string>
+	<key>openTypeOS2WinAscent</key>
+	<integer>1069</integer>
+	<key>openTypeOS2WinDescent</key>
+	<integer>293</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<integer>-15</integer>
+		<integer>0</integer>
+		<integer>536</integer>
+		<integer>547</integer>
+		<integer>572</integer>
+		<integer>582</integer>
+		<integer>714</integer>
+		<integer>726</integer>
+		<integer>760</integer>
+		<integer>766</integer>
+	</array>
+	<key>postscriptFamilyBlues</key>
+	<array/>
+	<key>postscriptFamilyOtherBlues</key>
+	<array/>
+	<key>postscriptOtherBlues</key>
+	<array>
+		<integer>-256</integer>
+		<integer>-240</integer>
+	</array>
+	<key>postscriptStemSnapH</key>
+	<array>
+		<integer>60</integer>
+		<integer>68</integer>
+		<integer>79</integer>
+	</array>
+	<key>postscriptStemSnapV</key>
+	<array>
+		<integer>64</integer>
+		<integer>75</integer>
+		<integer>90</integer>
+	</array>
+	<key>postscriptUnderlinePosition</key>
+	<integer>-100</integer>
+	<key>postscriptUnderlineThickness</key>
+	<integer>50</integer>
+	<key>styleMapFamilyName</key>
+	<string>Test Family 3</string>
+	<key>styleMapStyleName</key>
+	<string>regular</string>
+	<key>styleName</key>
+	<string>Regular</string>
+	<key>trademark</key>
+	<string>Noto is a trademark of Google Inc.</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>902</integer>
+	<key>xHeight</key>
+	<integer>536</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/F_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/F_.glif
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="F" format="2">
+  <advance width="519"/>
+  <unicode hex="0046"/>
+  <anchor x="260" y="0" name="bottom"/>
+  <anchor x="298" y="714" name="top"/>
+  <anchor x="499" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="187" y="0" type="line"/>
+      <point x="187" y="303" type="line"/>
+      <point x="477" y="303" type="line"/>
+      <point x="477" y="382" type="line"/>
+      <point x="187" y="382" type="line"/>
+      <point x="187" y="635" type="line"/>
+      <point x="496" y="635" type="line"/>
+      <point x="496" y="714" type="line"/>
+      <point x="97" y="714" type="line"/>
+      <point x="97" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/T_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/T_.glif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="T" format="2">
+  <advance width="556"/>
+  <unicode hex="0054"/>
+  <anchor x="278" y="0" name="bottom"/>
+  <anchor x="278" y="357" name="center"/>
+  <anchor x="278" y="714" name="top"/>
+  <anchor x="536" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="323" y="0" type="line"/>
+      <point x="323" y="635" type="line"/>
+      <point x="545" y="635" type="line"/>
+      <point x="545" y="714" type="line"/>
+      <point x="10" y="714" type="line"/>
+      <point x="10" y="635" type="line"/>
+      <point x="233" y="635" type="line"/>
+      <point x="233" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/contents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>F</key>
+	<string>F_.glif</string>
+	<key>T</key>
+	<string>T_.glif</string>
+	<key>l</key>
+	<string>l.glif</string>
+	<key>n</key>
+	<string>n.glif</string>
+	<key>o</key>
+	<string>o.glif</string>
+	<key>s</key>
+	<string>s.glif</string>
+	<key>t</key>
+	<string>t.glif</string>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/l.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/l.glif
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="l" format="2">
+  <advance width="258"/>
+  <unicode hex="006C"/>
+  <anchor x="129" y="0" name="bottom"/>
+  <anchor x="129" y="268" name="center"/>
+  <anchor x="129" y="760" name="top"/>
+  <anchor x="202" y="760" name="topright"/>
+  <outline>
+    <contour>
+      <point x="173" y="0" type="line"/>
+      <point x="173" y="760" type="line"/>
+      <point x="85" y="760" type="line"/>
+      <point x="85" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/layerinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/n.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/n.glif
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="n" format="2">
+  <advance width="618"/>
+  <unicode hex="006E"/>
+  <anchor x="309" y="0" name="bottom"/>
+  <anchor x="309" y="536" name="top"/>
+  <anchor x="562" y="536" name="topright"/>
+  <outline>
+    <contour>
+      <point x="343" y="546" type="curve" smooth="yes"/>
+      <point x="275" y="546"/>
+      <point x="209" y="519"/>
+      <point x="174" y="463" type="curve"/>
+      <point x="169" y="463" type="line"/>
+      <point x="156" y="536" type="line"/>
+      <point x="85" y="536" type="line"/>
+      <point x="85" y="0" type="line"/>
+      <point x="173" y="0" type="line"/>
+      <point x="173" y="278" type="line" smooth="yes"/>
+      <point x="173" y="403"/>
+      <point x="211" y="472"/>
+      <point x="330" y="472" type="curve" smooth="yes"/>
+      <point x="412" y="472"/>
+      <point x="450" y="429"/>
+      <point x="450" y="343" type="curve" smooth="yes"/>
+      <point x="450" y="0" type="line"/>
+      <point x="537" y="0" type="line"/>
+      <point x="537" y="349" type="line" smooth="yes"/>
+      <point x="537" y="487"/>
+      <point x="471" y="546"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/o.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/o.glif
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="o" format="2">
+  <advance width="605"/>
+  <unicode hex="006F"/>
+  <anchor x="301" y="0" name="bottom"/>
+  <anchor x="303" y="268" name="center"/>
+  <anchor x="303" y="536" name="top"/>
+  <anchor x="575" y="536" name="topright"/>
+  <outline>
+    <contour>
+      <point x="551" y="269" type="curve" smooth="yes"/>
+      <point x="551" y="446"/>
+      <point x="449" y="546"/>
+      <point x="304" y="546" type="curve" smooth="yes"/>
+      <point x="150" y="546"/>
+      <point x="55" y="446"/>
+      <point x="55" y="269" type="curve" smooth="yes"/>
+      <point x="55" y="91"/>
+      <point x="159" y="-10"/>
+      <point x="301" y="-10" type="curve" smooth="yes"/>
+      <point x="454" y="-10"/>
+      <point x="551" y="91"/>
+    </contour>
+    <contour>
+      <point x="146" y="269" type="curve" smooth="yes"/>
+      <point x="146" y="396"/>
+      <point x="193" y="472"/>
+      <point x="302" y="472" type="curve" smooth="yes"/>
+      <point x="411" y="472"/>
+      <point x="460" y="396"/>
+      <point x="460" y="269" type="curve" smooth="yes"/>
+      <point x="460" y="142"/>
+      <point x="411" y="63"/>
+      <point x="303" y="63" type="curve" smooth="yes"/>
+      <point x="194" y="63"/>
+      <point x="146" y="142"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/s.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/s.glif
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="s" format="2">
+  <advance width="479"/>
+  <unicode hex="0073"/>
+  <anchor x="240" y="0" name="bottom"/>
+  <anchor x="240" y="536" name="top"/>
+  <anchor x="439" y="536" name="topright"/>
+  <outline>
+    <contour>
+      <point x="434" y="148" type="curve" smooth="yes"/>
+      <point x="434" y="234"/>
+      <point x="375" y="269"/>
+      <point x="273" y="307" type="curve" smooth="yes"/>
+      <point x="170" y="346"/>
+      <point x="135" y="364"/>
+      <point x="135" y="409" type="curve" smooth="yes"/>
+      <point x="135" y="449"/>
+      <point x="174" y="474"/>
+      <point x="246" y="474" type="curve" smooth="yes"/>
+      <point x="298" y="474"/>
+      <point x="348" y="459"/>
+      <point x="393" y="440" type="curve"/>
+      <point x="423" y="510" type="line"/>
+      <point x="373" y="532"/>
+      <point x="317" y="546"/>
+      <point x="252" y="546" type="curve" smooth="yes"/>
+      <point x="132" y="546"/>
+      <point x="51" y="495"/>
+      <point x="51" y="404" type="curve" smooth="yes"/>
+      <point x="51" y="316"/>
+      <point x="113" y="284"/>
+      <point x="217" y="244" type="curve" smooth="yes"/>
+      <point x="322" y="204"/>
+      <point x="349" y="180"/>
+      <point x="349" y="140" type="curve" smooth="yes"/>
+      <point x="349" y="92"/>
+      <point x="311" y="61"/>
+      <point x="222" y="61" type="curve" smooth="yes"/>
+      <point x="159" y="61"/>
+      <point x="94" y="83"/>
+      <point x="52" y="104" type="curve"/>
+      <point x="52" y="24" type="line"/>
+      <point x="93" y="2"/>
+      <point x="145" y="-10"/>
+      <point x="220" y="-10" type="curve" smooth="yes"/>
+      <point x="351" y="-10"/>
+      <point x="434" y="44"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/t.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/glyphs/t.glif
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="t" format="2">
+  <advance width="361"/>
+  <unicode hex="0074"/>
+  <anchor x="214" y="0" name="bottom"/>
+  <anchor x="181" y="268" name="center"/>
+  <anchor x="154" y="659" name="top"/>
+  <anchor x="335" y="659" name="topright"/>
+  <outline>
+    <contour>
+      <point x="264" y="62" type="curve" smooth="yes"/>
+      <point x="215" y="62"/>
+      <point x="180" y="93"/>
+      <point x="180" y="158" type="curve" smooth="yes"/>
+      <point x="180" y="468" type="line"/>
+      <point x="335" y="468" type="line"/>
+      <point x="335" y="536" type="line"/>
+      <point x="180" y="536" type="line"/>
+      <point x="180" y="659" type="line"/>
+      <point x="128" y="659" type="line"/>
+      <point x="93" y="545" type="line"/>
+      <point x="16" y="510" type="line"/>
+      <point x="16" y="468" type="line"/>
+      <point x="92" y="468" type="line"/>
+      <point x="92" y="156" type="line" smooth="yes"/>
+      <point x="92" y="26"/>
+      <point x="165" y="-10"/>
+      <point x="249" y="-10" type="curve" smooth="yes"/>
+      <point x="281" y="-10"/>
+      <point x="320" y="-3"/>
+      <point x="339" y="6" type="curve"/>
+      <point x="339" y="73" type="line"/>
+      <point x="322" y="67"/>
+      <point x="290" y="62"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/groups.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/groups.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern1.d</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern1.n.left</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern1.o.left</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern1.t.left</key>
+	<array>
+		<string>t</string>
+	</array>
+	<key>public.kern2.T.right</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern2.b</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern2.n.right</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern2.o.right</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern2.s.right</key>
+	<array>
+		<string>s</string>
+	</array>
+	<key>public.kern2.t.right</key>
+	<array>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/kerning.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/kerning.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<dict>
+		<key>public.kern2.T.right</key>
+		<integer>20</integer>
+		<key>public.kern2.n.right</key>
+		<integer>-50</integer>
+		<key>public.kern2.o.right</key>
+		<integer>-70</integer>
+		<key>public.kern2.s.right</key>
+		<integer>-60</integer>
+	</dict>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/layercontents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/lib.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/lib.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>F</string>
+		<string>T</string>
+		<string>l</string>
+		<string>n</string>
+		<string>o</string>
+		<string>s</string>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/metainfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/fontinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/fontinfo.plist
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>760</integer>
+	<key>capHeight</key>
+	<integer>714</integer>
+	<key>copyright</key>
+	<string>Copyright 2015 Google Inc. All Rights Reserved.</string>
+	<key>descender</key>
+	<integer>-240</integer>
+	<key>familyName</key>
+	<string>Test Family 3</string>
+	<key>guidelines</key>
+	<array/>
+	<key>openTypeHeadCreated</key>
+	<string>2016/03/15 19:50:39</string>
+	<key>openTypeHheaAscender</key>
+	<integer>1069</integer>
+	<key>openTypeHheaDescender</key>
+	<integer>-293</integer>
+	<key>openTypeHheaLineGap</key>
+	<integer>0</integer>
+	<key>openTypeNameDescription</key>
+	<string>Designed by Monotype design team.</string>
+	<key>openTypeNameDesigner</key>
+	<string>Monotype Design Team</string>
+	<key>openTypeNameDesignerURL</key>
+	<string>http://www.monotype.com/studio</string>
+	<key>openTypeNameLicense</key>
+	<string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.</string>
+	<key>openTypeNameLicenseURL</key>
+	<string>http://scripts.sil.org/OFL</string>
+	<key>openTypeNameManufacturer</key>
+	<string>Monotype Imaging Inc.</string>
+	<key>openTypeNameManufacturerURL</key>
+	<string>http://www.google.com/get/noto/</string>
+	<key>openTypeNameVersion</key>
+	<string>Version 1.902</string>
+	<key>openTypeOS2Panose</key>
+	<array>
+		<integer>2</integer>
+		<integer>11</integer>
+		<integer>8</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>4</integer>
+		<integer>2</integer>
+		<integer>2</integer>
+		<integer>4</integer>
+	</array>
+	<key>openTypeOS2Selection</key>
+	<array>
+		<integer>8</integer>
+	</array>
+	<key>openTypeOS2Type</key>
+	<array/>
+	<key>openTypeOS2TypoAscender</key>
+	<integer>1069</integer>
+	<key>openTypeOS2TypoDescender</key>
+	<integer>-293</integer>
+	<key>openTypeOS2TypoLineGap</key>
+	<integer>0</integer>
+	<key>openTypeOS2UnicodeRanges</key>
+	<array>
+		<integer>0</integer>
+		<integer>1</integer>
+		<integer>2</integer>
+		<integer>3</integer>
+		<integer>4</integer>
+		<integer>5</integer>
+		<integer>6</integer>
+		<integer>7</integer>
+		<integer>9</integer>
+		<integer>29</integer>
+		<integer>30</integer>
+		<integer>31</integer>
+		<integer>32</integer>
+		<integer>33</integer>
+		<integer>34</integer>
+		<integer>35</integer>
+		<integer>36</integer>
+		<integer>62</integer>
+		<integer>64</integer>
+		<integer>67</integer>
+		<integer>69</integer>
+		<integer>91</integer>
+		<integer>116</integer>
+	</array>
+	<key>openTypeOS2VendorID</key>
+	<string>GOOG</string>
+	<key>openTypeOS2WinAscent</key>
+	<integer>1069</integer>
+	<key>openTypeOS2WinDescent</key>
+	<integer>293</integer>
+	<key>postscriptBlueValues</key>
+	<array>
+		<integer>-15</integer>
+		<integer>0</integer>
+		<integer>546</integer>
+		<integer>557</integer>
+		<integer>582</integer>
+		<integer>593</integer>
+		<integer>714</integer>
+		<integer>726</integer>
+		<integer>760</integer>
+		<integer>766</integer>
+	</array>
+	<key>postscriptFamilyBlues</key>
+	<array/>
+	<key>postscriptFamilyOtherBlues</key>
+	<array/>
+	<key>postscriptOtherBlues</key>
+	<array>
+		<integer>-256</integer>
+		<integer>-240</integer>
+	</array>
+	<key>postscriptStemSnapH</key>
+	<array>
+		<integer>103</integer>
+		<integer>112</integer>
+		<integer>124</integer>
+	</array>
+	<key>postscriptStemSnapV</key>
+	<array>
+		<integer>117</integer>
+		<integer>144</integer>
+		<integer>151</integer>
+	</array>
+	<key>postscriptUnderlinePosition</key>
+	<integer>-100</integer>
+	<key>postscriptUnderlineThickness</key>
+	<integer>50</integer>
+	<key>styleMapFamilyName</key>
+	<string>Test Family 3 SemiBold</string>
+	<key>styleMapStyleName</key>
+	<string>regular</string>
+	<key>styleName</key>
+	<string>SemiBold</string>
+	<key>trademark</key>
+	<string>Noto is a trademark of Google Inc.</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>902</integer>
+	<key>xHeight</key>
+	<integer>546</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/F_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/F_.glif
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="F" format="2">
+  <advance width="549"/>
+  <unicode hex="0046"/>
+  <anchor x="275" y="0" name="bottom"/>
+  <anchor x="298" y="714" name="top"/>
+  <anchor x="529" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="239" y="0" type="line"/>
+      <point x="239" y="282" type="line"/>
+      <point x="481" y="282" type="line"/>
+      <point x="481" y="406" type="line"/>
+      <point x="239" y="406" type="line"/>
+      <point x="239" y="590" type="line"/>
+      <point x="499" y="590" type="line"/>
+      <point x="499" y="714" type="line"/>
+      <point x="90" y="714" type="line"/>
+      <point x="90" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/T_.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/T_.glif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="T" format="2">
+  <advance width="579"/>
+  <unicode hex="0054"/>
+  <anchor x="290" y="0" name="bottom"/>
+  <anchor x="290" y="357" name="center"/>
+  <anchor x="290" y="714" name="top"/>
+  <anchor x="559" y="714" name="topright"/>
+  <outline>
+    <contour>
+      <point x="365" y="0" type="line"/>
+      <point x="365" y="588" type="line"/>
+      <point x="559" y="588" type="line"/>
+      <point x="559" y="714" type="line"/>
+      <point x="20" y="714" type="line"/>
+      <point x="20" y="588" type="line"/>
+      <point x="214" y="588" type="line"/>
+      <point x="214" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/contents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/contents.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>F</key>
+	<string>F_.glif</string>
+	<key>T</key>
+	<string>T_.glif</string>
+	<key>l</key>
+	<string>l.glif</string>
+	<key>n</key>
+	<string>n.glif</string>
+	<key>o</key>
+	<string>o.glif</string>
+	<key>s</key>
+	<string>s.glif</string>
+	<key>t</key>
+	<string>t.glif</string>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/l.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/l.glif
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="l" format="2">
+  <advance width="305"/>
+  <unicode hex="006C"/>
+  <anchor x="153" y="0" name="bottom"/>
+  <anchor x="153" y="273" name="center"/>
+  <anchor x="153" y="760" name="top"/>
+  <anchor x="248" y="760" name="topright"/>
+  <outline>
+    <contour>
+      <point x="227" y="0" type="line"/>
+      <point x="227" y="760" type="line"/>
+      <point x="78" y="760" type="line"/>
+      <point x="78" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/layerinfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/layerinfo.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/n.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/n.glif
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="n" format="2">
+  <advance width="657"/>
+  <unicode hex="006E"/>
+  <anchor x="329" y="0" name="bottom"/>
+  <anchor x="329" y="546" name="top"/>
+  <anchor x="607" y="546" name="topright"/>
+  <outline>
+    <contour>
+      <point x="388" y="556" type="curve" smooth="yes"/>
+      <point x="320" y="556"/>
+      <point x="255" y="532"/>
+      <point x="220" y="476" type="curve"/>
+      <point x="212" y="476" type="line"/>
+      <point x="192" y="546" type="line"/>
+      <point x="78" y="546" type="line"/>
+      <point x="78" y="0" type="line"/>
+      <point x="227" y="0" type="line"/>
+      <point x="227" y="257" type="line" smooth="yes"/>
+      <point x="227" y="373"/>
+      <point x="254" y="437"/>
+      <point x="345" y="437" type="curve" smooth="yes"/>
+      <point x="406" y="437"/>
+      <point x="433" y="397"/>
+      <point x="433" y="319" type="curve" smooth="yes"/>
+      <point x="433" y="0" type="line"/>
+      <point x="582" y="0" type="line"/>
+      <point x="582" y="356" type="line"/>
+      <point x="582" y="496"/>
+      <point x="505" y="556"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/o.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/o.glif
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="o" format="2">
+  <advance width="619"/>
+  <unicode hex="006F"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="273" name="center"/>
+  <anchor x="310" y="546" name="top"/>
+  <anchor x="599" y="546" name="topright"/>
+  <outline>
+    <contour>
+      <point x="574" y="274" type="curve"/>
+      <point x="574" y="455"/>
+      <point x="464" y="556"/>
+      <point x="311" y="556" type="curve" smooth="yes"/>
+      <point x="146" y="556"/>
+      <point x="45" y="455"/>
+      <point x="45" y="274" type="curve" smooth="yes"/>
+      <point x="45" y="92"/>
+      <point x="155" y="-10"/>
+      <point x="308" y="-10" type="curve" smooth="yes"/>
+      <point x="472" y="-10"/>
+      <point x="574" y="92"/>
+    </contour>
+    <contour>
+      <point x="197" y="274" type="curve"/>
+      <point x="197" y="382"/>
+      <point x="230" y="436"/>
+      <point x="309" y="436" type="curve" smooth="yes"/>
+      <point x="389" y="436"/>
+      <point x="422" y="382"/>
+      <point x="422" y="274" type="curve" smooth="yes"/>
+      <point x="422" y="166"/>
+      <point x="389" y="110"/>
+      <point x="310" y="110" type="curve" smooth="yes"/>
+      <point x="230" y="110"/>
+      <point x="197" y="166"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/s.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/s.glif
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="s" format="2">
+  <advance width="497"/>
+  <unicode hex="0073"/>
+  <anchor x="249" y="0" name="bottom"/>
+  <anchor x="249" y="546" name="top"/>
+  <anchor x="457" y="546" name="topright"/>
+  <outline>
+    <contour>
+      <point x="459" y="162" type="curve" smooth="yes"/>
+      <point x="459" y="259"/>
+      <point x="400" y="294"/>
+      <point x="307" y="332" type="curve" smooth="yes"/>
+      <point x="211" y="371"/>
+      <point x="193" y="384"/>
+      <point x="193" y="410" type="curve" smooth="yes"/>
+      <point x="193" y="434"/>
+      <point x="215" y="446"/>
+      <point x="259" y="446" type="curve" smooth="yes"/>
+      <point x="308" y="446"/>
+      <point x="354" y="429"/>
+      <point x="408" y="406" type="curve"/>
+      <point x="453" y="513" type="line"/>
+      <point x="388" y="543"/>
+      <point x="329" y="556"/>
+      <point x="261" y="556" type="curve" smooth="yes"/>
+      <point x="130" y="556"/>
+      <point x="45" y="505"/>
+      <point x="45" y="404" type="curve" smooth="yes"/>
+      <point x="45" y="311"/>
+      <point x="91" y="275"/>
+      <point x="194" y="232" type="curve" smooth="yes"/>
+      <point x="300" y="187"/>
+      <point x="312" y="173"/>
+      <point x="312" y="146" type="curve" smooth="yes"/>
+      <point x="312" y="118"/>
+      <point x="289" y="99"/>
+      <point x="231" y="99" type="curve" smooth="yes"/>
+      <point x="179" y="99"/>
+      <point x="105" y="118"/>
+      <point x="46" y="145" type="curve"/>
+      <point x="46" y="22" type="line"/>
+      <point x="101" y="-1"/>
+      <point x="150" y="-10"/>
+      <point x="226" y="-10" type="curve" smooth="yes"/>
+      <point x="380" y="-10"/>
+      <point x="459" y="51"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/t.glif
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/glyphs/t.glif
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="t" format="2">
+  <advance width="434"/>
+  <unicode hex="0074"/>
+  <anchor x="241" y="0" name="bottom"/>
+  <anchor x="217" y="273" name="center"/>
+  <anchor x="198" y="662" name="top"/>
+  <anchor x="396" y="662" name="topright"/>
+  <outline>
+    <contour>
+      <point x="308" y="109" type="curve" smooth="yes"/>
+      <point x="269" y="109"/>
+      <point x="243" y="129"/>
+      <point x="243" y="171" type="curve" smooth="yes"/>
+      <point x="243" y="434" type="line"/>
+      <point x="396" y="434" type="line"/>
+      <point x="396" y="546" type="line"/>
+      <point x="243" y="546" type="line"/>
+      <point x="243" y="662" type="line"/>
+      <point x="148" y="662" type="line"/>
+      <point x="105" y="547" type="line"/>
+      <point x="23" y="497" type="line"/>
+      <point x="23" y="434" type="line"/>
+      <point x="94" y="434" type="line"/>
+      <point x="94" y="171" type="line" smooth="yes"/>
+      <point x="94" y="30"/>
+      <point x="167" y="-10"/>
+      <point x="265" y="-10" type="curve" smooth="yes"/>
+      <point x="321" y="-10"/>
+      <point x="370" y="1"/>
+      <point x="402" y="15" type="curve"/>
+      <point x="402" y="126" type="line"/>
+      <point x="371" y="116"/>
+      <point x="341" y="109"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/groups.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/groups.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern1.d</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern1.n.left</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern1.o.left</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern1.t.left</key>
+	<array>
+		<string>t</string>
+	</array>
+	<key>public.kern2.T.right</key>
+	<array>
+		<string>T</string>
+	</array>
+	<key>public.kern2.b</key>
+	<array>
+		<string>l</string>
+	</array>
+	<key>public.kern2.n.right</key>
+	<array>
+		<string>n</string>
+	</array>
+	<key>public.kern2.o.right</key>
+	<array>
+		<string>o</string>
+	</array>
+	<key>public.kern2.s.right</key>
+	<array>
+		<string>s</string>
+	</array>
+	<key>public.kern2.t.right</key>
+	<array>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/kerning.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/kerning.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.kern1.T.left</key>
+	<dict>
+		<key>public.kern2.T.right</key>
+		<integer>20</integer>
+		<key>public.kern2.n.right</key>
+		<integer>-50</integer>
+		<key>public.kern2.o.right</key>
+		<integer>-70</integer>
+		<key>public.kern2.s.right</key>
+		<integer>-60</integer>
+	</dict>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/layercontents.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<array>
+		<string>public.default</string>
+		<string>glyphs</string>
+	</array>
+</array>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/lib.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/lib.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>public.glyphOrder</key>
+	<array>
+		<string>F</string>
+		<string>T</string>
+		<string>l</string>
+		<string>n</string>
+		<string>o</string>
+		<string>s</string>
+		<string>t</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/metainfo.plist
+++ b/Tests/varLib/data/master_ufo/TestFamily3-SemiBold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>3</integer>
+</dict>
+</plist>

--- a/Tests/varLib/data/test_results/BuildAvarEmptyAxis.ttx
+++ b/Tests/varLib/data/test_results/BuildAvarEmptyAxis.ttx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.14">
+
+  <avar>
+    <segment axis="wght">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.6" to="0.61"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+    <segment axis="wdth">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+</ttFont>

--- a/Tests/varLib/data/test_results/BuildAvarIdentityMaps.ttx
+++ b/Tests/varLib/data/test_results/BuildAvarIdentityMaps.ttx
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.14">
+
+  <avar>
+    <segment axis="wght">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="-0.6667" to="-0.7969"/>
+      <mapping from="-0.3333" to="-0.5"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.2" to="0.18"/>
+      <mapping from="0.4" to="0.38"/>
+      <mapping from="0.6" to="0.61"/>
+      <mapping from="0.8" to="0.79"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+    <segment axis="wdth">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+</ttFont>

--- a/Tests/varLib/data/test_results/BuildAvarSingleAxis.ttx
+++ b/Tests/varLib/data/test_results/BuildAvarSingleAxis.ttx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.14">
+
+  <avar>
+    <segment axis="wght">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="-0.6667" to="-0.7969"/>
+      <mapping from="-0.3333" to="-0.5"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.2" to="0.18"/>
+      <mapping from="0.4" to="0.38"/>
+      <mapping from="0.6" to="0.61"/>
+      <mapping from="0.8" to="0.79"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+</ttFont>

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -93,51 +93,97 @@ class BuildTest(unittest.TestCase):
         font.save(savepath, reorderTables=None)
         return font, savepath
 
+    def _run_varlib_build_test(self, designspace_name, font_name, tables,
+                               expected_ttx_name):
+        suffix = '.ttf'
+        ds_path = self.get_test_input(designspace_name + '.designspace')
+        ufo_dir = self.get_test_input('master_ufo')
+        ttx_dir = self.get_test_input('master_ttx_interpolatable_ttf')
+
+        self.temp_dir()
+        ttx_paths = self.get_file_list(ttx_dir, '.ttx', font_name + '-')
+        for path in ttx_paths:
+            self.compile_font(path, suffix, self.tempdir)
+
+        finder = lambda s: s.replace(ufo_dir, self.tempdir).replace('.ufo', suffix)
+        varfont, model, _ = build(ds_path, finder)
+
+        expected_ttx_path = self.get_test_output(expected_ttx_name + '.ttx')
+        self.expect_ttx(varfont, expected_ttx_path, tables)
+        self.check_ttx_dump(varfont, expected_ttx_path, tables, suffix)
 # -----
 # Tests
 # -----
 
     def test_varlib_build_ttf(self):
         """Designspace file contains <axes> element."""
-        suffix = '.ttf'
-        ds_path = self.get_test_input('Build.designspace')
-        ufo_dir = self.get_test_input('master_ufo')
-        ttx_dir = self.get_test_input('master_ttx_interpolatable_ttf')
+        self._run_varlib_build_test(
+            designspace_name='Build',
+            font_name='TestFamily',
+            tables=['GDEF', 'HVAR', 'MVAR', 'fvar', 'gvar'],
+            expected_ttx_name='Build'
+        )
 
-        self.temp_dir()
-        ttx_paths = self.get_file_list(ttx_dir, '.ttx', 'TestFamily-')
-        for path in ttx_paths:
-            self.compile_font(path, suffix, self.tempdir)
-
-        finder = lambda s: s.replace(ufo_dir, self.tempdir).replace('.ufo', suffix)
-        varfont, model, _ = build(ds_path, finder)
-
-        tables = ['GDEF', 'HVAR', 'MVAR', 'fvar', 'gvar']
-        expected_ttx_path = self.get_test_output('Build.ttx')
-        self.expect_ttx(varfont, expected_ttx_path, tables)
-        self.check_ttx_dump(varfont, expected_ttx_path, tables, suffix)
-
-
-    def test_varlib_build3_ttf(self):
+    def test_varlib_build_no_axes_ttf(self):
         """Designspace file does not contain an <axes> element."""
-        suffix = '.ttf'
-        ds_path = self.get_test_input('InterpolateLayout3.designspace')
-        ufo_dir = self.get_test_input('master_ufo')
-        ttx_dir = self.get_test_input('master_ttx_interpolatable_ttf')
+        self._run_varlib_build_test(
+            designspace_name='InterpolateLayout3',
+            font_name='TestFamily2',
+            tables=['GDEF', 'HVAR', 'MVAR', 'fvar', 'gvar'],
+            expected_ttx_name='Build3'
+        )
 
-        self.temp_dir()
-        ttx_paths = self.get_file_list(ttx_dir, '.ttx', 'TestFamily2-')
-        for path in ttx_paths:
-            self.compile_font(path, suffix, self.tempdir)
+    def test_varlib_avar_single_axis(self):
+        """Designspace file contains a 'weight' axis with <map> elements
+        modifying the normalization mapping. An 'avar' table is generated.
+        """
+        test_name = 'BuildAvarSingleAxis'
+        self._run_varlib_build_test(
+            designspace_name=test_name,
+            font_name='TestFamily3',
+            tables=['avar'],
+            expected_ttx_name=test_name
+        )
 
-        finder = lambda s: s.replace(ufo_dir, self.tempdir).replace('.ufo', suffix)
-        varfont, model, _ = build(ds_path, finder)
+    def test_varlib_avar_with_identity_maps(self):
+        """Designspace file contains two 'weight' and 'width' axes both with
+        <map> elements.
 
-        tables = ['GDEF', 'HVAR', 'MVAR', 'fvar', 'gvar']
-        expected_ttx_path = self.get_test_output('Build3.ttx')
-        self.expect_ttx(varfont, expected_ttx_path, tables)
-        self.check_ttx_dump(varfont, expected_ttx_path, tables, suffix)
+        The 'width' axis only contains identity mappings, however the resulting
+        avar segment will not be empty but will contain the default axis value
+        maps: {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}.
 
+        This is to to work around an issue with some rasterizers:
+        https://github.com/googlei18n/fontmake/issues/295
+        https://github.com/fonttools/fonttools/issues/1011
+        """
+        test_name = 'BuildAvarIdentityMaps'
+        self._run_varlib_build_test(
+            designspace_name=test_name,
+            font_name='TestFamily3',
+            tables=['avar'],
+            expected_ttx_name=test_name
+        )
+
+    def test_varlib_avar_empty_axis(self):
+        """Designspace file contains two 'weight' and 'width' axes, but
+        only one axis ('weight') has some <map> elements.
+
+        Even if no <map> elements are defined for the 'width' axis, the
+        resulting avar segment still contains the default axis value maps:
+        {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}.
+
+        This is again to to work around an issue with some rasterizers:
+        https://github.com/googlei18n/fontmake/issues/295
+        https://github.com/fonttools/fonttools/issues/1011
+        """
+        test_name = 'BuildAvarEmptyAxis'
+        self._run_varlib_build_test(
+            designspace_name=test_name,
+            font_name='TestFamily3',
+            tables=['avar'],
+            expected_ttx_name=test_name
+        )
 
     def test_varlib_main_ttf(self):
         """Mostly for testing varLib.main()

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -149,7 +149,7 @@ class BuildTest(unittest.TestCase):
         """Designspace file contains two 'weight' and 'width' axes both with
         <map> elements.
 
-        The 'width' axis only contains identity mappings, however the resulting
+        The 'width' axis only contains identity mappings, however the resulting
         avar segment will not be empty but will contain the default axis value
         maps: {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}.
 
@@ -170,7 +170,7 @@ class BuildTest(unittest.TestCase):
         only one axis ('weight') has some <map> elements.
 
         Even if no <map> elements are defined for the 'width' axis, the
-        resulting avar segment still contains the default axis value maps:
+        resulting avar segment still contains the default axis value maps:
         {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}.
 
         This is again to to work around an issue with some rasterizers:


### PR DESCRIPTION
The patch looks huge because I also included the UFO sources used to generate the master interpolatable ttx used in the tests.
To review the actual code changes it's better to check the single commits' diff and messages, excluding the last big one that contains the UFOs.

Besides the avar tests, the only library change follows a comment by @jenskutilek (19c4b37#commitcomment-23458151) about making sure that all the axes (even those which don't have any `<map>` elements defined in a designspace) end up with a non-empty segment maps array containing all the three default maps {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}.

The latest OT spec says that axis value maps "are required only if the normalization mapping for an axis is being modified. "  However, when default maps are missing for an axis' segment, both CoreText and DirectWrite display no modification to that axis coordinates, hence the current workaround.