### PR TITLE
[AAT] Write AATLookups to XML in glyph order

### DIFF
--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -798,9 +798,9 @@ class AATLookup(BaseConverter):
 	def xmlWrite(self, xmlWriter, font, value, name, attrs):
 		xmlWriter.begintag(name, attrs)
 		xmlWriter.newline()
-		for glyph, value in sorted(value.items()):
+		for glyph in sorted(value, key=font.getGlyphID):
 			self.converter.xmlWrite(
-				xmlWriter, font, value=value,
+				xmlWriter, font, value=value[glyph],
 				name="Lookup", attrs=[("glyph", glyph)])
 		xmlWriter.endtag(name)
 		xmlWriter.newline()

--- a/Tests/ttLib/tables/_a_n_k_r_test.py
+++ b/Tests/ttLib/tables/_a_n_k_r_test.py
@@ -140,7 +140,7 @@ class ANKRTest(unittest.TestCase):
     def decompileToXML(self, data, xml):
         table = newTable('ankr')
         table.decompile(data, self.font)
-        self.assertEqual(getXML(table.toXML), xml)
+        self.assertEqual(getXML(table.toXML, self.font), xml)
 
     def compileFromXML(self, xml, data):
         table = newTable('ankr')

--- a/Tests/ttLib/tables/_b_s_l_n_test.py
+++ b/Tests/ttLib/tables/_b_s_l_n_test.py
@@ -281,7 +281,7 @@ class BSLNTest(unittest.TestCase):
     def decompileToXML(self, data, xml):
         table = newTable('bsln')
         table.decompile(data, self.font)
-        self.assertEqual(getXML(table.toXML), xml)
+        self.assertEqual(getXML(table.toXML, self.font), xml)
 
     def compileFromXML(self, xml, data):
         table = newTable('bsln')

--- a/Tests/ttLib/tables/_l_c_a_r_test.py
+++ b/Tests/ttLib/tables/_l_c_a_r_test.py
@@ -25,14 +25,14 @@ LCAR_FORMAT_0_XML = [
     '<Version value="0x00010000"/>',
     '<LigatureCarets Format="0">',
     '  <Carets>',
+    '    <Lookup glyph="f_r">',
+    '      <!-- DivsionPointCount=1 -->',
+    '      <DivisionPoint index="0" value="220"/>',
+    '    </Lookup>',
     '    <Lookup glyph="f_f_l">',
     '      <!-- DivsionPointCount=2 -->',
     '      <DivisionPoint index="0" value="239"/>',
     '      <DivisionPoint index="1" value="472"/>',
-    '    </Lookup>',
-    '    <Lookup glyph="f_r">',
-    '      <!-- DivsionPointCount=1 -->',
-    '      <DivisionPoint index="0" value="220"/>',
     '    </Lookup>',
     '  </Carets>',
     '</LigatureCarets>',
@@ -58,14 +58,14 @@ LCAR_FORMAT_1_XML = [
     '<Version value="0x00010000"/>',
     '<LigatureCarets Format="1">',
     '  <Carets>',
+    '    <Lookup glyph="f_r">',
+    '      <!-- DivsionPointCount=1 -->',
+    '      <DivisionPoint index="0" value="50"/>',
+    '    </Lookup>',
     '    <Lookup glyph="f_f_l">',
     '      <!-- DivsionPointCount=2 -->',
     '      <DivisionPoint index="0" value="55"/>',
     '      <DivisionPoint index="1" value="75"/>',
-    '    </Lookup>',
-    '    <Lookup glyph="f_r">',
-    '      <!-- DivsionPointCount=1 -->',
-    '      <DivisionPoint index="0" value="50"/>',
     '    </Lookup>',
     '  </Carets>',
     '</LigatureCarets>',
@@ -82,7 +82,7 @@ class LCARTest(unittest.TestCase):
     def test_decompile_toXML_format0(self):
         table = newTable('lcar')
         table.decompile(LCAR_FORMAT_0_DATA, self.font)
-        self.assertEqual(getXML(table.toXML), LCAR_FORMAT_0_XML)
+        self.assertEqual(getXML(table.toXML, self.font), LCAR_FORMAT_0_XML)
 
     def test_compile_fromXML_format0(self):
         table = newTable('lcar')
@@ -94,7 +94,7 @@ class LCARTest(unittest.TestCase):
     def test_decompile_toXML_format1(self):
         table = newTable('lcar')
         table.decompile(LCAR_FORMAT_1_DATA, self.font)
-        self.assertEqual(getXML(table.toXML), LCAR_FORMAT_1_XML)
+        self.assertEqual(getXML(table.toXML, self.font), LCAR_FORMAT_1_XML)
 
     def test_compile_fromXML_format1(self):
         table = newTable('lcar')

--- a/Tests/ttLib/tables/_m_o_r_t_test.py
+++ b/Tests/ttLib/tables/_m_o_r_t_test.py
@@ -100,7 +100,7 @@ class MORTNoncontextualGlyphSubstitutionTest(unittest.TestCase):
     def test_decompile_toXML(self):
         table = newTable('mort')
         table.decompile(MORT_NONCONTEXTUAL_DATA, self.font)
-        self.assertEqual(getXML(table.toXML), MORT_NONCONTEXTUAL_XML)
+        self.assertEqual(getXML(table.toXML, self.font), MORT_NONCONTEXTUAL_XML)
 
     def test_compile_fromXML(self):
         table = newTable('mort')

--- a/Tests/ttLib/tables/_m_o_r_x_test.py
+++ b/Tests/ttLib/tables/_m_o_r_x_test.py
@@ -98,7 +98,7 @@ class MORXNoncontextualGlyphSubstitutionTest(unittest.TestCase):
     def test_decompile_toXML(self):
         table = newTable('morx')
         table.decompile(MORX_NONCONTEXTUAL_DATA, self.font)
-        self.assertEqual(getXML(table.toXML), MORX_NONCONTEXTUAL_XML)
+        self.assertEqual(getXML(table.toXML, self.font), MORX_NONCONTEXTUAL_XML)
 
     def test_compile_fromXML(self):
         table = newTable('morx')

--- a/Tests/ttLib/tables/_o_p_b_d_test.py
+++ b/Tests/ttLib/tables/_o_p_b_d_test.py
@@ -25,17 +25,17 @@ OPBD_FORMAT_0_XML = [
     '<Version value="0x00010000"/>',
     '<OpticalBounds Format="0">',
     '  <OpticalBoundsDeltas>',
-    '    <Lookup glyph="A">',
-    '      <Left value="-10"/>',
-    '      <Top value="15"/>',
-    '      <Right value="0"/>',
-    '      <Bottom value="0"/>',
-    '    </Lookup>',
-    '    <Lookup glyph="C">',
+    '    <Lookup glyph="C">',  # GlyphID 10
     '      <Left value="-50"/>',
     '      <Top value="5"/>',
     '      <Right value="55"/>',
     '      <Bottom value="-5"/>',
+    '    </Lookup>',
+    '    <Lookup glyph="A">',  # GlyphID 43
+    '      <Left value="-10"/>',
+    '      <Top value="15"/>',
+    '      <Right value="0"/>',
+    '      <Bottom value="0"/>',
     '    </Lookup>',
     '  </OpticalBoundsDeltas>',
     '</OpticalBounds>',
@@ -61,17 +61,17 @@ OPBD_FORMAT_1_XML = [
     '<Version value="0x00010000"/>',
     '<OpticalBounds Format="1">',
     '  <OpticalBoundsPoints>',
-    '    <Lookup glyph="A">',
-    '      <Left value="32"/>',
-    '      <Top value="41"/>',
-    '      <Right value="-1"/>',
-    '      <Bottom value="-1"/>',
-    '    </Lookup>',
-    '    <Lookup glyph="C">',
+    '    <Lookup glyph="C">',  # GlyphID 10
     '      <Left value="36"/>',
     '      <Top value="37"/>',
     '      <Right value="38"/>',
     '      <Bottom value="39"/>',
+    '    </Lookup>',
+    '    <Lookup glyph="A">',  # GlyphID 43
+    '      <Left value="32"/>',
+    '      <Top value="41"/>',
+    '      <Right value="-1"/>',
+    '      <Bottom value="-1"/>',
     '    </Lookup>',
     '  </OpticalBoundsPoints>',
     '</OpticalBounds>',
@@ -149,7 +149,7 @@ class OPBDTest(unittest.TestCase):
     def test_decompile_toXML_format0(self):
         table = newTable('opbd')
         table.decompile(OPBD_FORMAT_0_DATA, self.font)
-        self.assertEqual(getXML(table.toXML), OPBD_FORMAT_0_XML)
+        self.assertEqual(getXML(table.toXML, self.font), OPBD_FORMAT_0_XML)
 
     def test_compile_fromXML_format0(self):
         table = newTable('opbd')
@@ -161,7 +161,7 @@ class OPBDTest(unittest.TestCase):
     def test_decompile_toXML_format1(self):
         table = newTable('opbd')
         table.decompile(OPBD_FORMAT_1_DATA, self.font)
-        self.assertEqual(getXML(table.toXML), OPBD_FORMAT_1_XML)
+        self.assertEqual(getXML(table.toXML, self.font), OPBD_FORMAT_1_XML)
 
     def test_compile_fromXML_format1(self):
         table = newTable('opbd')
@@ -174,8 +174,9 @@ class OPBDTest(unittest.TestCase):
         # Make sure we do not crash when decompiling the 'opbd' table of
         # AppleChancery.ttf. https://github.com/fonttools/fonttools/issues/1031
         table = newTable('opbd')
-        table.decompile(OPBD_APPLE_CHANCERY_DATA, self.font)
-        self.assertIn('<OpticalBounds Format="0">', getXML(table.toXML))
+        font = FakeFont([".notdef"] + ['G.alt%d' % i for i in range(1, 600)])
+        table.decompile(OPBD_APPLE_CHANCERY_DATA, font)
+        self.assertIn('<OpticalBounds Format="0">', getXML(table.toXML, font))
 
 
 if __name__ == '__main__':

--- a/Tests/ttLib/tables/_p_r_o_p_test.py
+++ b/Tests/ttLib/tables/_p_r_o_p_test.py
@@ -57,7 +57,7 @@ class PROPTest(unittest.TestCase):
     def test_decompile_toXML_format0(self):
         table = newTable('prop')
         table.decompile(PROP_FORMAT_0_DATA, self.font)
-        self.assertEqual(getXML(table.toXML), PROP_FORMAT_0_XML)
+        self.assertEqual(getXML(table.toXML, self.font), PROP_FORMAT_0_XML)
 
     def test_compile_fromXML_format0(self):
         table = newTable('prop')
@@ -69,7 +69,7 @@ class PROPTest(unittest.TestCase):
     def test_decompile_toXML_format1(self):
         table = newTable('prop')
         table.decompile(PROP_FORMAT_1_DATA, self.font)
-        self.assertEqual(getXML(table.toXML), PROP_FORMAT_1_XML)
+        self.assertEqual(getXML(table.toXML, self.font), PROP_FORMAT_1_XML)
 
     def test_compile_fromXML_format1(self):
         table = newTable('prop')


### PR DESCRIPTION
Before this change, the AAT lookups were alphabetically sorted by glyph name,
but it seems more natural to write XML in the usual glyph order. No changes to
the binary format (which already was in glyph order); this only affects how
XML output is produced.