### PR TITLE
Respect SOURCE_DATE_EPOCH for time stamp

### DIFF
--- a/Lib/fontTools/misc/timeTools.py
+++ b/Lib/fontTools/misc/timeTools.py
@@ -3,6 +3,7 @@
 
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+import os
 import time
 import calendar
 
@@ -47,6 +48,10 @@ def timestampFromString(value):
 	return calendar.timegm(time.strptime(value)) - epoch_diff
 
 def timestampNow():
+	# https://reproducible-builds.org/specs/source-date-epoch/
+	source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH")
+	if source_date_epoch is not None:
+		return int(source_date_epoch) - epoch_diff
 	return int(time.time() - epoch_diff)
 
 def timestampSinceEpoch(value):

--- a/Tests/misc/timeTools_test.py
+++ b/Tests/misc/timeTools_test.py
@@ -1,9 +1,25 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
-from fontTools.misc.timeTools import asctime
+from fontTools.misc.timeTools import asctime, timestampNow, epoch_diff
+import os
 import time
 
 
 def test_asctime():
     assert isinstance(asctime(), basestring)
     assert asctime(time.gmtime(0)) == 'Thu Jan  1 00:00:00 1970'
+
+def test_source_date_epoch():
+    os.environ["SOURCE_DATE_EPOCH"] = "150687315"
+    assert timestampNow() + epoch_diff == 150687315
+
+    # Check that malformed value fail, any better way?
+    os.environ["SOURCE_DATE_EPOCH"] = "ABCDEFGHI"
+    try:
+        timestampNow()
+        assert False
+    except ValueError:
+        assert True
+
+    del os.environ["SOURCE_DATE_EPOCH"]
+    assert timestampNow() + epoch_diff != 150687315


### PR DESCRIPTION
For reproducible builds, check the presence of SOURCE_DATE_EPOCH
environment variable and use it for the time stamp. This affects the
head.modified (and head.created in merge.py).

See https://reproducible-builds.org/specs/source-date-epoch/