### PR TITLE
add ReverseContourPen

### DIFF
--- a/Lib/fontTools/misc/arrayTools.py
+++ b/Lib/fontTools/misc/arrayTools.py
@@ -213,6 +213,46 @@ class Vector(object):
 		assert len(a) == len(b)
 		return sum([a[i] * b[i] for i in range(len(a))])
 
+
+def pairwise(iterable, reverse=False):
+    """Iterate over current and next items in iterable, optionally in
+    reverse order.
+
+    >>> tuple(pairwise([]))
+    ()
+    >>> tuple(pairwise([], reverse=True))
+    ()
+    >>> tuple(pairwise([0]))
+    ((0, 0),)
+    >>> tuple(pairwise([0], reverse=True))
+    ((0, 0),)
+    >>> tuple(pairwise([0, 1]))
+    ((0, 1), (1, 0))
+    >>> tuple(pairwise([0, 1], reverse=True))
+    ((1, 0), (0, 1))
+    >>> tuple(pairwise([0, 1, 2]))
+    ((0, 1), (1, 2), (2, 0))
+    >>> tuple(pairwise([0, 1, 2], reverse=True))
+    ((2, 1), (1, 0), (0, 2))
+    >>> tuple(pairwise(['a', 'b', 'c', 'd']))
+    (('a', 'b'), ('b', 'c'), ('c', 'd'), ('d', 'a'))
+    >>> tuple(pairwise(['a', 'b', 'c', 'd'], reverse=True))
+    (('d', 'c'), ('c', 'b'), ('b', 'a'), ('a', 'd'))
+    """
+    if not iterable:
+        return
+    if reverse:
+        it = reversed(iterable)
+    else:
+        it = iter(iterable)
+    first = next(it, None)
+    a = first
+    for b in it:
+        yield (a, b)
+        a = b
+    yield (a, first)
+
+
 def _test():
     """
     >>> import math

--- a/Lib/fontTools/misc/arrayTools.py
+++ b/Lib/fontTools/misc/arrayTools.py
@@ -121,97 +121,98 @@ def intRect(rect1):
     yMax = int(math.ceil(yMax))
     return (xMin, yMin, xMax, yMax)
 
+
 class Vector(object):
-	"""A math-like vector."""
+    """A math-like vector."""
 
-	def __init__(self, values, keep=False):
-		self.values = values if keep else list(values)
+    def __init__(self, values, keep=False):
+        self.values = values if keep else list(values)
 
-	def __getitem__(self, index):
-		return self.values[index]
+    def __getitem__(self, index):
+        return self.values[index]
 
-	def __len__(self):
-		return len(self.values)
+    def __len__(self):
+        return len(self.values)
 
-	def __repr__(self):
-		return "Vector(%s)" % self.values
+    def __repr__(self):
+        return "Vector(%s)" % self.values
 
-	def _vectorOp(self, other, op):
-		if isinstance(other, Vector):
-			assert len(self.values) == len(other.values)
-			a = self.values
-			b = other.values
-			return [op(a[i], b[i]) for i in range(len(self.values))]
-		if isinstance(other, Number):
-			return [op(v, other) for v in self.values]
-		raise NotImplementedError
+    def _vectorOp(self, other, op):
+        if isinstance(other, Vector):
+            assert len(self.values) == len(other.values)
+            a = self.values
+            b = other.values
+            return [op(a[i], b[i]) for i in range(len(self.values))]
+        if isinstance(other, Number):
+            return [op(v, other) for v in self.values]
+        raise NotImplementedError
 
-	def _scalarOp(self, other, op):
-		if isinstance(other, Number):
-			return [op(v, other) for v in self.values]
-		raise NotImplementedError
+    def _scalarOp(self, other, op):
+        if isinstance(other, Number):
+            return [op(v, other) for v in self.values]
+        raise NotImplementedError
 
-	def _unaryOp(self, op):
-		if isinstance(other, Number):
-			return [op(v) for v in self.values]
-		raise NotImplementedError
+    def _unaryOp(self, op):
+        if isinstance(other, Number):
+            return [op(v) for v in self.values]
+        raise NotImplementedError
 
-	def __add__(self, other):
-		return Vector(self._vectorOp(other, operator.add), keep=True)
-	def __iadd__(self, other):
-		self.values = self._vectorOp(other, operator.add)
-		return self
-	__radd__ = __add__
+    def __add__(self, other):
+        return Vector(self._vectorOp(other, operator.add), keep=True)
+    def __iadd__(self, other):
+        self.values = self._vectorOp(other, operator.add)
+        return self
+    __radd__ = __add__
 
-	def __sub__(self, other):
-		return Vector(self._vectorOp(other, operator.sub), keep=True)
-	def __isub__(self, other):
-		self.values = self._vectorOp(other, operator.sub)
-		return self
-	def __rsub__(self, other):
-		return other + (-self)
+    def __sub__(self, other):
+        return Vector(self._vectorOp(other, operator.sub), keep=True)
+    def __isub__(self, other):
+        self.values = self._vectorOp(other, operator.sub)
+        return self
+    def __rsub__(self, other):
+        return other + (-self)
 
-	def __mul__(self, other):
-		return Vector(self._scalarOp(other, operator.mul), keep=True)
-	def __imul__(self, other):
-		self.values = self._scalarOp(other, operator.mul)
-		return self
-	__rmul__ = __mul__
+    def __mul__(self, other):
+        return Vector(self._scalarOp(other, operator.mul), keep=True)
+    def __imul__(self, other):
+        self.values = self._scalarOp(other, operator.mul)
+        return self
+    __rmul__ = __mul__
 
-	def __truediv__(self, other):
-		return Vector(self._scalarOp(other, operator.div), keep=True)
-	def __itruediv__(self, other):
-		self.values = self._scalarOp(other, operator.div)
-		return self
+    def __truediv__(self, other):
+        return Vector(self._scalarOp(other, operator.div), keep=True)
+    def __itruediv__(self, other):
+        self.values = self._scalarOp(other, operator.div)
+        return self
 
-	def __pos__(self):
-		return Vector(self._unaryOp(other, operator.pos), keep=True)
-	def __neg__(self):
-		return Vector(self._unaryOp(other, operator.neg), keep=True)
-	def __round__(self):
-		return Vector(self._unaryOp(other, round), keep=True)
-	def toInt(self):
-		return self.__round__()
+    def __pos__(self):
+        return Vector(self._unaryOp(other, operator.pos), keep=True)
+    def __neg__(self):
+        return Vector(self._unaryOp(other, operator.neg), keep=True)
+    def __round__(self):
+        return Vector(self._unaryOp(other, round), keep=True)
+    def toInt(self):
+        return self.__round__()
 
-	def __eq__(self, other):
-		if type(other) == Vector:
-			return self.values == other.values
-		else:
-			return self.values == other
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def __eq__(self, other):
+        if type(other) == Vector:
+            return self.values == other.values
+        else:
+            return self.values == other
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
-	def __bool__(self):
-		return any(self.values)
-	__nonzero__ = __bool__
+    def __bool__(self):
+        return any(self.values)
+    __nonzero__ = __bool__
 
-	def __abs__(self):
-		return math.sqrt(sum([x*x for x in self.values]))
-	def dot(self, other):
-		a = self.values
-		b = other.values if type(other) == Vector else b
-		assert len(a) == len(b)
-		return sum([a[i] * b[i] for i in range(len(a))])
+    def __abs__(self):
+        return math.sqrt(sum([x*x for x in self.values]))
+    def dot(self, other):
+        a = self.values
+        b = other.values if type(other) == Vector else b
+        assert len(a) == len(b)
+        return sum([a[i] * b[i] for i in range(len(a))])
 
 
 def pairwise(iterable, reverse=False):

--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -82,6 +82,8 @@ class ContourFilterPen(_PassThruComponentsMixin, RecordingPen):
     """A "buffered" filter pen that accumulates contour data, passes
     it through a ``filterContour`` method when the contour is closed or ended,
     and finally draws the result with the output pen.
+
+    Components are passed through unchanged.
     """
 
     def __init__(self, outPen):
@@ -108,9 +110,9 @@ class ContourFilterPen(_PassThruComponentsMixin, RecordingPen):
 
         The contour is a list of pen (operator, operands) tuples.
         Operators are strings corresponding to the AbstractPen methods:
-        "moveTo", "lineTo", "curveTo", "qCurveTo", "closePath",
-        "endPath", and "addComponent". The operands are the positional
-        arguments that are passed to each method.
+        "moveTo", "lineTo", "curveTo", "qCurveTo", "closePath" and
+        "endPath". The operands are the positional arguments that are
+        passed to each method.
 
         If the method doesn't return a value (i.e. returns None), it's
         assumed that the argument was modified in-place.

--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -1,9 +1,16 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools.pens.basePen import AbstractPen
+from fontTools.pens.recordingPen import RecordingPen
 
 
-class FilterPen(AbstractPen):
+class _PassThruComponentsMixin(object):
+
+    def addComponent(self, glyphName, transformation):
+        self._outPen.addComponent(glyphName, transformation)
+
+
+class FilterPen(_PassThruComponentsMixin, AbstractPen):
 
     """ Base class for pens that apply some transformation to the coordinates
     they receive and pass them to another pen.
@@ -70,5 +77,43 @@ class FilterPen(AbstractPen):
     def endPath(self):
         self._outPen.endPath()
 
-    def addComponent(self, glyphName, transformation):
-        self._outPen.addComponent(glyphName, transformation)
+
+class ContourFilterPen(_PassThruComponentsMixin, RecordingPen):
+    """A "buffered" filter pen that accumulates contour data, passes
+    it through a ``filterContour`` method when the contour is closed or ended,
+    and finally draws the result with the output pen.
+    """
+
+    def __init__(self, outPen):
+        super(ContourFilterPen, self).__init__()
+        self._outPen = outPen
+
+    def closePath(self):
+        super(ContourFilterPen, self).closePath()
+        self._flushContour()
+
+    def endPath(self):
+        super(ContourFilterPen, self).endPath()
+        self._flushContour()
+
+    def _flushContour(self):
+        result = self.filterContour(self.value)
+        if result is not None:
+            self.value = result
+        self.replay(self._outPen)
+        self.value = []
+
+    def filterContour(self, contour):
+        """Subclasses must override this to perform the filtering.
+
+        The contour is a list of pen (operator, operands) tuples.
+        Operators are strings corresponding to the AbstractPen methods:
+        "moveTo", "lineTo", "curveTo", "qCurveTo", "closePath",
+        "endPath", and "addComponent". The operands are the positional
+        arguments that are passed to each method.
+
+        If the method doesn't return a value (i.e. returns None), it's
+        assumed that the argument was modified in-place.
+        Otherwise, the return value is drawn with the output pen.
+        """
+        return  # or return contour

--- a/Lib/fontTools/pens/reverseContourPen.py
+++ b/Lib/fontTools/pens/reverseContourPen.py
@@ -1,0 +1,91 @@
+from __future__ import print_function, division, absolute_import
+from fontTools.misc.py23 import *
+from fontTools.misc.arrayTools import pairwise
+from fontTools.pens.filterPen import ContourFilterPen
+
+
+__all__ = ["reversedContour", "ReverseContourPen"]
+
+
+class ReverseContourPen(ContourFilterPen):
+    """Filter pen that passes outline data to another pen, but reversing
+    the winding direction of all contours. Components are simply passed
+    through unchanged.
+
+    Closed contours are reversed in such a way that the first point remains
+    the first point.
+    """
+
+    def filterContour(self, contour):
+        return reversedContour(contour)
+
+
+def reversedContour(contour):
+    """ Generator that takes a list of pen's (operator, operands) tuples,
+    and yields them with the winding direction reversed.
+    """
+    if not contour:
+        return  # nothing to do, stop iteration
+
+    # valid contours must have at least a starting and ending command,
+    # can't have one without the other
+    assert len(contour) > 1, "invalid contour"
+
+    # the type of the last command determines if the contour is closed
+    contourType = contour.pop()[0]
+    assert contourType in ("endPath", "closePath")
+    closed = contourType == "closePath"
+
+    firstType, firstPts = contour.pop(0)
+    assert firstType in ("moveTo", "qCurveTo"), (
+        "invalid initial segment type: %r" % firstType)
+    firstOnCurve = firstPts[-1]
+    if firstType == "qCurveTo":
+        # special case for TrueType paths contaning only off-curve points
+        assert firstOnCurve is None, (
+            "off-curve only paths must end with 'None'")
+        assert not contour, (
+            "only one qCurveTo allowed per off-curve path")
+        firstPts = ((firstPts[0],) + tuple(reversed(firstPts[1:-1])) +
+                    (None,))
+
+    if not contour:
+        # contour contains only one segment, nothing to reverse
+        if firstType == "moveTo":
+            closed = False  # single-point paths can't be closed
+        else:
+            closed = True  # off-curve paths are closed by definition
+        yield firstType, firstPts
+    else:
+        lastType, lastPts = contour[-1]
+        lastOnCurve = lastPts[-1]
+        if closed:
+            # for closed paths, we keep the starting point
+            yield firstType, firstPts
+            if firstOnCurve != lastOnCurve:
+                # emit an implied line between the last and first points
+                yield "lineTo", (lastOnCurve,)
+                contour[-1] = (lastType,
+                               tuple(lastPts[:-1]) + (firstOnCurve,))
+
+            # if a lineTo follows the initial moveTo, after reversing it
+            # will be implied by the closePath, so we don't emit one
+            secondType, secondPts = contour[0]
+            if secondType == "lineTo":
+                del contour[0]
+                if contour:
+                    contour[-1] = (lastType,
+                                   tuple(lastPts[:-1]) + secondPts)
+        else:
+            # for open paths, the last point will become the first
+            yield firstType, (lastOnCurve,)
+            contour[-1] = (lastType, tuple(lastPts[:-1]) + (firstOnCurve,))
+
+        # we iterate over all segment pairs in reverse order, and yield
+        # each one with the off-curve points reversed (if any), and
+        # with the on-curve point of the following segment
+        for (curType, curPts), (_, nextPts) in pairwise(
+                contour, reverse=True):
+            yield curType, tuple(reversed(curPts[:-1])) + (nextPts[-1],)
+
+    yield "closePath" if closed else "endPath", ()

--- a/Tests/pens/reverseContourPen_test.py
+++ b/Tests/pens/reverseContourPen_test.py
@@ -1,0 +1,283 @@
+from fontTools.pens.recordingPen import RecordingPen
+from fontTools.pens.reverseContourPen import ReverseContourPen
+import pytest
+
+
+TEST_DATA = [
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((1, 1),)),
+            ('lineTo', ((2, 2),)),
+            ('lineTo', ((3, 3),)),  # last not on move, line is implied
+            ('closePath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((3, 3),)),
+            ('lineTo', ((2, 2),)),
+            ('lineTo', ((1, 1),)),
+            ('closePath', ()),
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((1, 1),)),
+            ('lineTo', ((2, 2),)),
+            ('lineTo', ((0, 0),)),  # last on move, no implied line
+            ('closePath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((2, 2),)),
+            ('lineTo', ((1, 1),)),
+            ('closePath', ()),
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((0, 0),)),
+            ('lineTo', ((1, 1),)),
+            ('lineTo', ((2, 2),)),
+            ('closePath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((2, 2),)),
+            ('lineTo', ((1, 1),)),
+            ('lineTo', ((0, 0),)),
+            ('closePath', ()),
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((1, 1),)),
+            ('closePath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((1, 1),)),
+            ('closePath', ()),
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('curveTo', ((1, 1), (2, 2), (3, 3))),
+            ('curveTo', ((4, 4), (5, 5), (0, 0))),
+            ('closePath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('curveTo', ((5, 5), (4, 4), (3, 3))),
+            ('curveTo', ((2, 2), (1, 1), (0, 0))),
+            ('closePath', ()),
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('curveTo', ((1, 1), (2, 2), (3, 3))),
+            ('curveTo', ((4, 4), (5, 5), (6, 6))),
+            ('closePath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((6, 6),)),  # implied line
+            ('curveTo', ((5, 5), (4, 4), (3, 3))),
+            ('curveTo', ((2, 2), (1, 1), (0, 0))),
+            ('closePath', ()),
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((1, 1),)),  # this line becomes implied
+            ('curveTo', ((2, 2), (3, 3), (4, 4))),
+            ('curveTo', ((5, 5), (6, 6), (7, 7))),
+            ('closePath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((7, 7),)),
+            ('curveTo', ((6, 6), (5, 5), (4, 4))),
+            ('curveTo', ((3, 3), (2, 2), (1, 1))),
+            ('closePath', ()),
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('qCurveTo', ((1, 1), (2, 2))),
+            ('qCurveTo', ((3, 3), (0, 0))),
+            ('closePath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('qCurveTo', ((3, 3), (2, 2))),
+            ('qCurveTo', ((1, 1), (0, 0))),
+            ('closePath', ()),
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('qCurveTo', ((1, 1), (2, 2))),
+            ('qCurveTo', ((3, 3), (4, 4))),
+            ('closePath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((4, 4),)),
+            ('qCurveTo', ((3, 3), (2, 2))),
+            ('qCurveTo', ((1, 1), (0, 0))),
+            ('closePath', ()),
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((1, 1),)),
+            ('qCurveTo', ((2, 2), (3, 3))),
+            ('closePath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((3, 3),)),
+            ('qCurveTo', ((2, 2), (1, 1))),
+            ('closePath', ()),
+        ]
+    ),
+    (
+        [
+            ('addComponent', ('a', (1, 0, 0, 1, 0, 0)))
+        ],
+        [
+            ('addComponent', ('a', (1, 0, 0, 1, 0, 0)))
+        ]
+    ),
+    (
+        [], []
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('endPath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('endPath', ()),
+        ],
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('closePath', ()),
+        ],
+        [
+            ('moveTo', ((0, 0),)),
+            ('endPath', ()),  # single-point paths is always open
+        ],
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((1, 1),)),
+            ('endPath', ())
+        ],
+        [
+            ('moveTo', ((1, 1),)),
+            ('lineTo', ((0, 0),)),
+            ('endPath', ())
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('curveTo', ((1, 1), (2, 2), (3, 3))),
+            ('endPath', ())
+        ],
+        [
+            ('moveTo', ((3, 3),)),
+            ('curveTo', ((2, 2), (1, 1), (0, 0))),
+            ('endPath', ())
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('curveTo', ((1, 1), (2, 2), (3, 3))),
+            ('lineTo', ((4, 4),)),
+            ('endPath', ())
+        ],
+        [
+            ('moveTo', ((4, 4),)),
+            ('lineTo', ((3, 3),)),
+            ('curveTo', ((2, 2), (1, 1), (0, 0))),
+            ('endPath', ())
+        ]
+    ),
+    (
+        [
+            ('moveTo', ((0, 0),)),
+            ('lineTo', ((1, 1),)),
+            ('curveTo', ((2, 2), (3, 3), (4, 4))),
+            ('endPath', ())
+        ],
+        [
+            ('moveTo', ((4, 4),)),
+            ('curveTo', ((3, 3), (2, 2), (1, 1))),
+            ('lineTo', ((0, 0),)),
+            ('endPath', ())
+        ]
+    ),
+    (
+        [
+            ('qCurveTo', ((0, 0), (1, 1), (2, 2), None)),
+            ('closePath', ())
+        ],
+        [
+            ('qCurveTo', ((0, 0), (2, 2), (1, 1), None)),
+            ('closePath', ())
+        ]
+    ),
+    (
+        [
+            ('qCurveTo', ((0, 0), (1, 1), (2, 2), None)),
+            ('endPath', ())
+        ],
+        [
+            ('qCurveTo', ((0, 0), (2, 2), (1, 1), None)),
+            ('closePath', ())  # this is always "closed"
+        ]
+    )
+]
+
+
+@pytest.mark.parametrize("contour, expected", TEST_DATA)
+def test_reverse_pen(contour, expected):
+    recpen = RecordingPen()
+    revpen = ReverseContourPen(recpen)
+    for operator, operands in contour:
+        getattr(revpen, operator)(*operands)
+    assert recpen.value == expected
+
+
+@pytest.mark.parametrize("contour, expected", TEST_DATA)
+def test_reverse_point_pen(contour, expected):
+    try:
+        from ufoLib.pointPen import (
+            ReverseContourPointPen, PointToSegmentPen, SegmentToPointPen)
+    except ImportError:
+        pytest.skip("ufoLib not installed")
+
+    recpen = RecordingPen()
+    pt2seg = PointToSegmentPen(recpen)
+    revpen = ReverseContourPointPen(pt2seg)
+    seg2pt = SegmentToPointPen(revpen)
+    for operator, operands in contour:
+        getattr(seg2pt, operator)(*operands)
+    assert recpen.value == expected


### PR DESCRIPTION
A filter pen to reverse the contour winding direction, similar to ufoLib's `ReverseContourPointPen`, but using segment pen API, so we don't need to use the segment/point pen converters.

