### PR TITLE
run tests on Python 2.7.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,19 @@ matrix:
       env:
         - TOXENV=py35-cov
         - HOMEBREW_NO_AUTO_UPDATE=1
+    - env:
+        - TOXENV=py27-cov
+        - PYENV_VERSION='2.7.6'
+        - PYENV_VERSION_STRING='Python 2.7.6'
+        - TRAVIS_PYENV_VERSION='0.4.0'
+
+cache:
+  - pip
+  - directories:
+    - $HOME/.pyenv_cache
+
+before_install:
+  - source ./.travis/before_install.sh
 
 install:
   - ./.travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
         - TOXENV=py27-cov
         - PYENV_VERSION='2.7.6'
         - PYENV_VERSION_STRING='Python 2.7.6'
+        - PYENV_ROOT=$HOME/.travis-pyenv
         - TRAVIS_PYENV_VERSION='0.4.0'
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
         - TOXENV=py35-cov
         - HOMEBREW_NO_AUTO_UPDATE=1
     - env:
-        - TOXENV=py27-cov
+        - TOXENV=py27-nocov
         - PYENV_VERSION='2.7.6'
         - PYENV_VERSION_STRING='Python 2.7.6'
         - PYENV_ROOT=$HOME/.travis-pyenv

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -e
 set -x
 
 if [[ -n "$PYENV_VERSION" ]]; then

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 if [[ -n "$PYENV_VERSION" ]]; then
     wget https://github.com/praekeltfoundation/travis-pyenv/releases/download/${TRAVIS_PYENV_VERSION}/setup-pyenv.sh
     source setup-pyenv.sh

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ -n "$PYENV_VERSION" ]]; then
+    wget https://github.com/praekeltfoundation/travis-pyenv/releases/download/${TRAVIS_PYENV_VERSION}/setup-pyenv.sh
+    source setup-pyenv.sh
+fi


### PR DESCRIPTION
We use this helper script (https://github.com/praekeltfoundation/travis-pyenv) to install the latest [pyenv](https://github.com/pyenv/pyenv) and use that to compile and install Python 2.7.6 on linux.

Travis already have pyenv installed but is not always up to date, so we install it ourselves.

This will hopefully help us catch issues like #993 a bit earlier.

Note that this doesn't increase the overall Travis build time, as the osx builds still finish much later than the 6 linux builds combined, and adding another linux one doesn't change this.