### PR TITLE
[reverseContourPen] don't imply closing lineTo if == moveTo

### DIFF
--- a/Lib/fontTools/pens/reverseContourPen.py
+++ b/Lib/fontTools/pens/reverseContourPen.py
@@ -68,10 +68,16 @@ def reversedContour(contour):
                 contour[-1] = (lastType,
                                tuple(lastPts[:-1]) + (firstOnCurve,))
 
+            if len(contour) > 1:
+                secondType, secondPts = contour[0]
+            else:
+                # contour has only two points, the second and last are the same
+                secondType, secondPts = lastType, lastPts
             # if a lineTo follows the initial moveTo, after reversing it
-            # will be implied by the closePath, so we don't emit one
-            secondType, secondPts = contour[0]
-            if secondType == "lineTo":
+            # will be implied by the closePath, so we don't emit one;
+            # unless the lineTo and moveTo overlap, in which case we keep the
+            # duplicate points
+            if secondType == "lineTo" and firstPts != secondPts:
                 del contour[0]
                 if contour:
                     contour[-1] = (lastType,

--- a/Tests/pens/reverseContourPen_test.py
+++ b/Tests/pens/reverseContourPen_test.py
@@ -254,6 +254,30 @@ TEST_DATA = [
             ('qCurveTo', ((0, 0), (2, 2), (1, 1), None)),
             ('closePath', ())  # this is always "closed"
         ]
+    ),
+    # Test case from:
+    # https://github.com/googlei18n/cu2qu/issues/51#issue-179370514
+    (
+        [
+            ('moveTo', ((848, 348),)),
+            ('lineTo', ((848, 348),)),  # duplicate lineTo point after moveTo
+            ('qCurveTo', ((848, 526), (649, 704), (449, 704))),
+            ('qCurveTo', ((449, 704), (248, 704), (50, 526), (50, 348))),
+            ('lineTo', ((50, 348),)),
+            ('qCurveTo', ((50, 348), (50, 171), (248, -3), (449, -3))),
+            ('qCurveTo', ((449, -3), (649, -3), (848, 171), (848, 348))),
+            ('closePath', ())
+        ],
+        [
+            ('moveTo', ((848, 348),)),
+            ('qCurveTo', ((848, 171), (649, -3), (449, -3), (449, -3))),
+            ('qCurveTo', ((248, -3), (50, 171), (50, 348), (50, 348))),
+            ('lineTo', ((50, 348),)),
+            ('qCurveTo', ((50, 526), (248, 704), (449, 704), (449, 704))),
+            ('qCurveTo', ((649, 704), (848, 526), (848, 348))),
+            ('lineTo', ((848, 348),)),  # the duplicate point is kept
+            ('closePath', ())
+        ]
     )
 ]
 

--- a/Tests/pens/reverseContourPen_test.py
+++ b/Tests/pens/reverseContourPen_test.py
@@ -300,7 +300,7 @@ def test_reverse_point_pen(contour, expected):
         pytest.skip("ufoLib not installed")
 
     recpen = RecordingPen()
-    pt2seg = PointToSegmentPen(recpen)
+    pt2seg = PointToSegmentPen(recpen, outputImpliedClosingLine=True)
     revpen = ReverseContourPointPen(pt2seg)
     seg2pt = SegmentToPointPen(revpen)
     for operator, operands in contour:

--- a/Tests/pens/reverseContourPen_test.py
+++ b/Tests/pens/reverseContourPen_test.py
@@ -48,6 +48,7 @@ TEST_DATA = [
             ('lineTo', ((2, 2),)),
             ('lineTo', ((1, 1),)),
             ('lineTo', ((0, 0),)),
+            ('lineTo', ((0, 0),)),
             ('closePath', ()),
         ]
     ),


### PR DESCRIPTION
Currently, for closed paths, we are always dropping a lineTo segment that follows moveTo, because after reversing the contour this lineTo becomes the last segment, and in the Pen protocol a closePath always implies a line to the fist point.

This is OK when in the original contour the move point and the following lineTo's oncurve point (which will become the last point after reversal) do not overlap.
However, if they do overlap, we end up dropping the duplicate point.

This cu2qu issue exemplifies the problem: googlei18n/cu2qu#51

(Note that cu2qu actually uses the `ReverseContourPointPen` wrapped by ufoLib's converter pens, but
fontTools' ReverseContourPen works the same)

Now, with this patch, the ReverseContourPen will emit the last lineTo when it is the same as moveTo, thus keeping the duplicate points in this case.
