### PR TITLE
[feaLib] Fix writing back nested glyph classes

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -293,6 +293,10 @@ class Parser(object):
                     raise FeatureLibError(
                         "Unknown glyph class @%s" % self.cur_token_,
                         self.cur_token_location_)
+                if isinstance(gc, self.ast.MarkClass):
+                    gc = self.ast.MarkClassName(self.cur_token_location_, gc)
+                else:
+                    gc = self.ast.GlyphClassName(self.cur_token_location_, gc)
                 glyphs.add_class(gc)
             else:
                 raise FeatureLibError(

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -363,6 +363,8 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(vowels_lc.glyphSet(), tuple("aeiou"))
         self.assertEqual(vowels_uc.glyphSet(), tuple("AEIOU"))
         self.assertEqual(vowels.glyphSet(), tuple("aeiouAEIOUyY"))
+        self.assertEqual(vowels.asFea(),
+            "@Vowels = [@Vowels.lc @Vowels.uc y Y];")
         self.assertRaisesRegex(
             FeatureLibError, "Unknown glyph class @unknown",
             self.parse, "@bad = [@unknown];")


### PR DESCRIPTION
Before this change, the following glyph class:

    @Vowels = [@Vowels.lc @Vowels.uc y Y];

Would be written back as:

    @Vowels = [@Vowels.lc = [a e i o u]; @Vowels.uc = [A E I O U]; y Y];

Which is clearly invalid. It seems for `GlyphClass.asFea()` to work correctly here we should be using `GlyphClassName` not `GlyphClass` for the nested classes (similar to the code at the beginning of
`parse_glyphclass_()`).