### PR TITLE
[morx] Emit more meaningful subtable flags

### DIFF
--- a/Tests/ttLib/tables/_m_o_r_x_test.py
+++ b/Tests/ttLib/tables/_m_o_r_x_test.py
@@ -879,6 +879,25 @@ class MORXCoverageFlagsTest(unittest.TestCase):
         self.assertEqual(hexStr(table2.compile(self.font)[28:31]), "8abcde")
 
 
+class UnsupportedMorxLookupTest(unittest.TestCase):
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+        # Python 3 renamed assertRaisesRegexp to assertRaisesRegex,
+        # and fires deprecation warnings if a program uses the old name.
+        if not hasattr(self, "assertRaisesRegex"):
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
+    def test_unsupportedLookupType(self):
+        data = bytesjoin([
+            MORX_NONCONTEXTUAL_DATA[:67],
+            bytechr(66),
+            MORX_NONCONTEXTUAL_DATA[69:]])
+        with self.assertRaisesRegex(AssertionError,
+                                    r"unsupported 'morx' lookup type 66"):
+            morx = newTable('morx')
+            morx.decompile(data, FakeFont(['.notdef']))
+
+
 if __name__ == '__main__':
     import sys
     sys.exit(unittest.main())


### PR DESCRIPTION
Before this change, we were emitting XML with numeric values for `morx`
coverage flags. Now, we emit XML that makes more sense to human readers.
XML files from previous versions of fonttools can still be parsed.
