### PR TITLE
[ttLib] Add a convenience method to the cmap table to return the best available cmap

### DIFF
--- a/Lib/fontTools/ttLib/__init__.py
+++ b/Lib/fontTools/ttLib/__init__.py
@@ -703,7 +703,8 @@ class TTFont(object):
 		return glyphs
 
 	def getBestCmap(self, cmapPreferences=((3, 10), (0, 4), (3, 1), (0, 3))):
-		"""Return the 'best' unicode cmap dictionary available in the font.
+		"""Return the 'best' unicode cmap dictionary available in the font,
+		or None, if no unicode cmap subtable is available.
 
 		By default it will search for the following (platformID, platEncID)
 		pairs:

--- a/Lib/fontTools/ttLib/__init__.py
+++ b/Lib/fontTools/ttLib/__init__.py
@@ -702,6 +702,16 @@ class TTFont(object):
 
 		return glyphs
 
+	def getBestCmap(self, cmapPreferences=((3, 10), (0, 4), (3, 1), (0, 3))):
+		"""Return the 'best' unicode cmap dictionary available in the font.
+
+		By default it will search for the following (platformID, platEncID)
+		pairs:
+			(3, 10), (0, 4), (3, 1), (0, 3)
+		But this can be customized via the cmapPreferences argument.
+		"""
+		return self["cmap"].getBestCmap(cmapPreferences=cmapPreferences)
+
 
 class _TTGlyphSet(object):
 

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -40,7 +40,9 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
 
 	def getBestCmap(self, cmapPreferences=((3, 10), (3, 1), (0, 3))):
 		"""Return the 'best' unicode cmap dictionary available in the font.
-		By default it will search for the following (platformID, platEncID) pairs:
+
+		By default it will search for the following (platformID, platEncID)
+		pairs:
 			(3, 10), (3, 1), (0, 3)
 		But this can be customized via the cmapPreferences argument.
 		"""

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -39,7 +39,8 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
 		return None # not found
 
 	def getBestCmap(self, cmapPreferences=((3, 10), (0, 4), (3, 1), (0, 3))):
-		"""Return the 'best' unicode cmap dictionary available in the font.
+		"""Return the 'best' unicode cmap dictionary available in the font,
+		or None, if no unicode cmap subtable is available.
 
 		By default it will search for the following (platformID, platEncID)
 		pairs:
@@ -50,7 +51,7 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
 			cmapSubtable = self.getcmap(platformID, platEncID)
 			if cmapSubtable is not None:
 				return cmapSubtable.cmap
-		raise ValueError("None of the requested cmap subtables were found")
+		return None  # None of the requested cmap subtables were found
 
 	def buildReversed(self):
 		"""Returns a reverse cmap such as {'one':{0x31}, 'A':{0x41,0x391}}.

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -38,12 +38,12 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
 				return subtable
 		return None # not found
 
-	def getBestCmap(self, cmapPreferences=((3, 10), (3, 1), (0, 3))):
+	def getBestCmap(self, cmapPreferences=((3, 10), (0, 4), (3, 1), (0, 3))):
 		"""Return the 'best' unicode cmap dictionary available in the font.
 
 		By default it will search for the following (platformID, platEncID)
 		pairs:
-			(3, 10), (3, 1), (0, 3)
+			(3, 10), (0, 4), (3, 1), (0, 3)
 		But this can be customized via the cmapPreferences argument.
 		"""
 		for platformID, platEncID in cmapPreferences:

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -38,6 +38,18 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
 				return subtable
 		return None # not found
 
+	def getBestCmap(self, cmapPreferences=((3, 10), (3, 1), (0, 3))):
+		"""Return the 'best' unicode cmap dictionary available in the font.
+		By default it will search for the following (platformID, platEncID) pairs:
+			(3, 10), (3, 1), (0, 3)
+		But this can be customized via the cmapPreferences argument.
+		"""
+		for platformID, platEncID in cmapPreferences:
+			cmapSubtable = self.getcmap(platformID, platEncID)
+			if cmapSubtable is not None:
+				return cmapSubtable.cmap
+		raise ValueError("None of the requested cmap subtables were found")
+
 	def buildReversed(self):
 		"""Returns a reverse cmap such as {'one':{0x31}, 'A':{0x41,0x391}}.
 

--- a/Tests/ttLib/tables/_c_m_a_p_test.py
+++ b/Tests/ttLib/tables/_c_m_a_p_test.py
@@ -68,6 +68,18 @@ class CmapSubtableTest(unittest.TestCase):
 		self.assertEqual(cmap.getBestCmap(), {0x10314: 'u10314'})
 		self.assertEqual(cmap.getBestCmap(cmapPreferences=[(3, 1)]), {0x0041:'A', 0x0391:'A'})
 
+	def test_font_getBestCmap(self):
+		c4 = self.makeSubtable(4, 3, 1, 0)
+		c4.cmap = {0x0041:'A', 0x0391:'A'}
+		c12 = self.makeSubtable(12, 3, 10, 0)
+		c12.cmap = {0x10314: 'u10314'}
+		cmap = table__c_m_a_p()
+		cmap.tables = [c4, c12]
+		font = ttLib.TTFont()
+		font["cmap"] = cmap
+		self.assertEqual(font.getBestCmap(), {0x10314: 'u10314'})
+		self.assertEqual(font.getBestCmap(cmapPreferences=[(3, 1)]), {0x0041:'A', 0x0391:'A'})
+
 
 if __name__ == "__main__":
 	import sys

--- a/Tests/ttLib/tables/_c_m_a_p_test.py
+++ b/Tests/ttLib/tables/_c_m_a_p_test.py
@@ -58,6 +58,16 @@ class CmapSubtableTest(unittest.TestCase):
 		cmap.tables = [c4, c12]
 		self.assertEqual(cmap.buildReversed(), {'A':{0x0041, 0x0391}, 'u10314':{0x10314}})
 
+	def test_getBestCmap(self):
+		c4 = self.makeSubtable(4, 3, 1, 0)
+		c4.cmap = {0x0041:'A', 0x0391:'A'}
+		c12 = self.makeSubtable(12, 3, 10, 0)
+		c12.cmap = {0x10314: 'u10314'}
+		cmap = table__c_m_a_p()
+		cmap.tables = [c4, c12]
+		self.assertEqual(cmap.getBestCmap(), {0x10314: 'u10314'})
+		self.assertEqual(cmap.getBestCmap(cmapPreferences=[(3, 1)]), {0x0041:'A', 0x0391:'A'})
+
 
 if __name__ == "__main__":
 	import sys

--- a/Tests/ttLib/tables/_c_m_a_p_test.py
+++ b/Tests/ttLib/tables/_c_m_a_p_test.py
@@ -67,6 +67,7 @@ class CmapSubtableTest(unittest.TestCase):
 		cmap.tables = [c4, c12]
 		self.assertEqual(cmap.getBestCmap(), {0x10314: 'u10314'})
 		self.assertEqual(cmap.getBestCmap(cmapPreferences=[(3, 1)]), {0x0041:'A', 0x0391:'A'})
+		self.assertEqual(cmap.getBestCmap(cmapPreferences=[(0, 4)]), None)
 
 	def test_font_getBestCmap(self):
 		c4 = self.makeSubtable(4, 3, 1, 0)
@@ -79,6 +80,7 @@ class CmapSubtableTest(unittest.TestCase):
 		font["cmap"] = cmap
 		self.assertEqual(font.getBestCmap(), {0x10314: 'u10314'})
 		self.assertEqual(font.getBestCmap(cmapPreferences=[(3, 1)]), {0x0041:'A', 0x0391:'A'})
+		self.assertEqual(font.getBestCmap(cmapPreferences=[(0, 4)]), None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Often I just want to quickly access the best available cmap from a font, without being interested (or having to worry about) exactly which cmap subtables are in the font. I've used this functionality for while now in my own code as a separate function, and it's been so handy that I think it should just be in fonttools.