### PR TITLE
Split context

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -328,6 +328,9 @@ class Parser(object):
                 self.expect_symbol_("'")
                 hasMarks = marked = True
             if marked:
+                glyphs.extend(suffix)
+                lookups.extend([None] * len(suffix))
+                suffix = []
                 glyphs.append(gc)
             elif glyphs:
                 suffix.append(gc)

--- a/Lib/fontTools/ttLib/tables/F__e_a_t.py
+++ b/Lib/fontTools/ttLib/tables/F__e_a_t.py
@@ -99,7 +99,7 @@ class table_F__e_a_t(DefaultTable.DefaultTable):
             fobj = Feature()
             fobj.flags = int(safeEval(attrs['flags']))
             fobj.label = int(safeEval(attrs['label']))
-            fobj.default = int(safeEval(attrs['default']))
+            fobj.default = int(safeEval(attrs.get('default','0')))
             fobj.index = len(self.features)
             self.features[fid] = fobj
             fobj.settings = {}

--- a/Lib/fontTools/ttLib/tables/F__e_a_t.py
+++ b/Lib/fontTools/ttLib/tables/F__e_a_t.py
@@ -41,23 +41,27 @@ class table_F__e_a_t(DefaultTable.DefaultTable):
             if len(data) >= 4 * (i + 1):
                 (val, lid) = struct.unpack(">HH", data[4*i:4*(i+1)])
                 allsettings.append((val, lid))
-        for f in allfeats:
+        for i,f in enumerate(allfeats):
             (fid, nums, offset, flags, lid) = f
             fobj = Feature()
             fobj.flags = flags
             fobj.label = lid
             self.features[grUtils.num2tag(fid)] = fobj
             fobj.settings = {}
+            fobj.default = None
+            fobj.index = i
             for i in range(offset, offset + nums):
                 if i >= len(allsettings): continue
                 (vid, vlid) = allsettings[i]
                 fobj.settings[vid] = vlid
+                if fobj.default is None:
+                    fobj.default = vid
 
     def compile(self, ttFont):
         fdat = ""
         vdat = ""
         offset = 0
-        for f, v in sorted(self.features.items()):
+        for f, v in sorted(self.features.items(), key=lambda x:x[1].index):
             fnum = grUtils.tag2num(f)
             if self.version >= 2.0:
                 fdat += struct.pack(">LHHLHH", grUtils.tag2num(f), len(v.settings),
@@ -68,7 +72,7 @@ class table_F__e_a_t(DefaultTable.DefaultTable):
             else:
                 fdat += struct.pack(">HHLHH", grUtils.tag2num(f), len(v.settings),
                     offset * 4 + 12 + 12 * len(self.features), v.flags, v.label)
-            for s, l in sorted(v.settings.items()):
+            for s, l in sorted(v.settings.items(), key=lambda x:(-1, x[1]) if x[0] == v.default else x):
                 vdat += struct.pack(">HH", s, l)
             offset += len(v.settings)
         hdr = sstruct.pack(Feat_hdr_format, self)
@@ -77,8 +81,9 @@ class table_F__e_a_t(DefaultTable.DefaultTable):
     def toXML(self, writer, ttFont):
         writer.simpletag('version', version=self.version)
         writer.newline()
-        for f, v in sorted(self.features.items()):
-            writer.begintag('feature', fid=f, label=v.label, flags=v.flags)
+        for f, v in sorted(self.features.items(), key=lambda x:x[1].index):
+            writer.begintag('feature', fid=f, label=v.label, flags=v.flags,
+                            default=(v.default if v.default else 0))
             writer.newline()
             for s, l in sorted(v.settings.items()):
                 writer.simpletag('setting', value=s, label=l)
@@ -94,6 +99,8 @@ class table_F__e_a_t(DefaultTable.DefaultTable):
             fobj = Feature()
             fobj.flags = int(safeEval(attrs['flags']))
             fobj.label = int(safeEval(attrs['label']))
+            fobj.default = int(safeEval(attrs['default']))
+            fobj.index = len(self.features)
             self.features[fid] = fobj
             fobj.settings = {}
             for element in content:

--- a/Lib/fontTools/ttLib/tables/S__i_l_f.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_f.py
@@ -727,9 +727,9 @@ class Pass(object):
                 oConstraints[i] = oConstraints[i+1]
         self.ruleConstraints = [(data[s:e] if (e-s > 1) else "") for (s,e) in zip(oConstraints, oConstraints[1:])]
         data = data[oConstraints[-1]:]
-        for i in range(len(oActions)-2,-1,-1):
-            if oActions[i] == 0:
-                oActions[i] = oActions[i+1]
+#        for i in range(len(oActions)-2,-1,-1):
+#            if oActions[i] == 0:
+#                oActions[i] = oActions[i+1]
         self.actions = [(data[s:e] if (e-s > 1) else "") for (s,e) in zip(oActions, oActions[1:])]
         data = data[oActions[-1]:]
         # not using debug
@@ -737,8 +737,8 @@ class Pass(object):
     def compile(self, ttFont, base, version=2.0):
         # build it all up backwards
         oActions = reduce(lambda a, x: (a[0]+len(x), a[1]+[a[0]]), self.actions + [""], (0, []))[1]
-        oConstraints = reduce(lambda a, x: (a[0]+len(x), a[1]+[a[0]]), self.ruleConstraints + [""], (0, []))[1]
-        constraintCode = "".join(self.ruleConstraints)
+        oConstraints = reduce(lambda a, x: (a[0]+len(x), a[1]+[a[0]]), self.ruleConstraints + [""], (1, []))[1]
+        constraintCode = "\000" + "".join(self.ruleConstraints)
         transes = []
         for t in self.stateTrans:
             t.byteswap()

--- a/Lib/fontTools/ttLib/tables/S__i_l_f.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_f.py
@@ -195,7 +195,7 @@ def disassemble(aCode):
     pc = 0
     res = []
     while pc < codelen:
-        opcode = ord(aCode[pc:pc+1])
+        opcode = byteord(aCode[pc:pc+1])
         if opcode > len(aCode_info):
             instr = aCode_info[0]
         else:
@@ -203,7 +203,7 @@ def disassemble(aCode):
         pc += 1
         if instr[1] != 0 and pc >= codelen : return res
         if instr[1] == -1:
-            count = ord(aCode[pc])
+            count = byteord(aCode[pc])
             fmt = "%dB" % count
             pc += 1
         elif instr[1] == 0:
@@ -230,7 +230,7 @@ def assemble(instrs):
         if m.group(2):
             if parmfmt == 0:
                 continue
-            parms = map(int, re.split(",\s*", m.group(2)))
+            parms = [int(x) for x in re.split(",\s*", m.group(2))]
             if parmfmt == -1:
                 l = len(parms)
                 res.append(struct.pack(("%dB" % (l+1)), l, *parms))

--- a/Lib/fontTools/ttLib/tables/S__i_l_f.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_f.py
@@ -727,9 +727,6 @@ class Pass(object):
                 oConstraints[i] = oConstraints[i+1]
         self.ruleConstraints = [(data[s:e] if (e-s > 1) else "") for (s,e) in zip(oConstraints, oConstraints[1:])]
         data = data[oConstraints[-1]:]
-#        for i in range(len(oActions)-2,-1,-1):
-#            if oActions[i] == 0:
-#                oActions[i] = oActions[i+1]
         self.actions = [(data[s:e] if (e-s > 1) else "") for (s,e) in zip(oActions, oActions[1:])]
         data = data[oActions[-1]:]
         # not using debug

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -62,6 +62,7 @@ class BuilderTest(unittest.TestCase):
         spec6h_ii spec6h_iii_1 spec6h_iii_3d spec8a spec8b spec8c
         spec9a spec9b spec9c1 spec9c2 spec9c3 spec9d spec9e spec9f spec9g
         spec10
+        split_context
         bug453 bug457 bug463 bug501 bug502 bug504 bug505 bug506 bug509
         bug512 bug514 bug568 bug633
         name size size2 multiple_feature_blocks omitted_GlyphClassDef

--- a/Tests/feaLib/data/split_context.fea
+++ b/Tests/feaLib/data/split_context.fea
@@ -1,0 +1,12 @@
+lookup upper {
+    sub a by A;
+} upper;
+
+lookup lower {
+    sub A by a;
+} lower;
+
+feature test {
+#test-fea2fea: sub a' lookup upper x' x' A' lookup lower;
+    sub a'lookup upper x x A'lookup lower;
+} test;

--- a/Tests/feaLib/data/split_context.ttx
+++ b/Tests/feaLib/data/split_context.ttx
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="2"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=3 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="A"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="A" out="a"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="3">
+          <!-- BacktrackGlyphCount=0 -->
+          <!-- InputGlyphCount=4 -->
+          <InputCoverage index="0">
+            <Glyph value="a"/>
+          </InputCoverage>
+          <InputCoverage index="1">
+            <Glyph value="x"/>
+          </InputCoverage>
+          <InputCoverage index="2">
+            <Glyph value="x"/>
+          </InputCoverage>
+          <InputCoverage index="3">
+            <Glyph value="A"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=2 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="0"/>
+          </SubstLookupRecord>
+          <SubstLookupRecord index="1">
+            <SequenceIndex value="3"/>
+            <LookupListIndex value="1"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/Tests/ttLib/tables/data/graphite/graphite_tests.ttx.Feat
+++ b/Tests/ttLib/tables/data/graphite/graphite_tests.ttx.Feat
@@ -3,13 +3,13 @@
 
   <Feat>
     <version version="2.0"/>
-    <feature fid="1" flags="32768" label="258">
+    <feature default="0" fid="1" flags="32768" label="258">
     </feature>
-    <feature fid="nom " flags="32768" label="262">
+    <feature default="0" fid="nom " flags="32768" label="262">
       <setting label="261" value="0"/>
       <setting label="260" value="1"/>
     </feature>
-    <feature fid="yesm" flags="32768" label="259">
+    <feature default="0" fid="yesm" flags="32768" label="259">
       <setting label="261" value="0"/>
       <setting label="260" value="1"/>
     </feature>

--- a/Tests/ttLib/tables/data/graphite/graphite_tests.ttx.Silf
+++ b/Tests/ttLib/tables/data/graphite/graphite_tests.ttx.Silf
@@ -32,6 +32,12 @@
           <rules>
             <rule index="0" precontext="0" sortkey="2">
               <action>
+                PUT_GLYPH_8BIT_OBS(0)
+                ASSOC(0, 1)
+                NEXT
+                DELETE
+                NEXT
+                RET_ZERO
               </action>
             </rule>
             <rule index="1" precontext="1" sortkey="2">
@@ -63,6 +69,22 @@
           <rules>
             <rule index="0" precontext="0" sortkey="2">
               <action>
+                COPY_NEXT
+                PUT_COPY(0)
+                PUSH_BYTE(-1)
+                ATTR_SET_SLOT(2)
+                PUSH_BYTE(0)
+                ATTR_SET(17)
+                PUSH_GLYPH_ATTR_OBS(6, 0)
+                ATTR_SET(8)
+                PUSH_GLYPH_ATTR_OBS(7, 0)
+                ATTR_SET(9)
+                PUSH_ATT_TO_GATTR_OBS(6, 0)
+                ATTR_SET(3)
+                PUSH_ATT_TO_GATTR_OBS(7, 0)
+                ATTR_SET(4)
+                NEXT
+                RET_ZERO
               </action>
             </rule>
           </rules>


### PR DESCRIPTION
Given a split contextual lookup like:
```
sub a'lookup upper x x A'lookup lower;
```
Fonttools silently does the wrong thing in that it brings the two marked glyphs together resulting in a reordered rule that looks like:
```
sub a'lookup upper A' lookup lower x x;
```
Fontforge silently resolves this by inserting ' in all the intervening glyphs as in:
```
sub a'lookup upper x' x' A'lookup lower;
```
This PR does the same thing. The alternative is that an error should be reported and the user forced to insert the extra marks themselves. I leave that option as an open bug.