### PR TITLE
Don't share points in cvar by default

### DIFF
--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -465,7 +465,8 @@ def compileSharedTuples(axisTags, variations):
 
 
 def compileTupleVariationStore(variations, pointCount,
-                               axisTags, sharedTupleIndices):
+                               axisTags, sharedTupleIndices,
+                               useSharedPoints=True):
 	variations = [v for v in variations if v.hasImpact()]
 	if len(variations) == 0:
 		return (0, b"", b"")
@@ -515,7 +516,7 @@ def compileTupleVariationStore(variations, pointCount,
 			axisTags, sharedTupleIndices, sharedPoints=None)
 		sharedTuple, sharedData, usesSharedPoints = v.compile(
 			axisTags, sharedTupleIndices, sharedPoints=usedPoints)
-		if (len(sharedTuple) + len(sharedData)) < (len(privateTuple) + len(privateData)):
+		if useSharedPoints and (len(sharedTuple) + len(sharedData)) < (len(privateTuple) + len(privateData)):
 			tuples.append(sharedTuple)
 			data.append(sharedData)
 			someTuplesSharePoints |= usesSharedPoints

--- a/Lib/fontTools/ttLib/tables/_c_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_c_v_a_r.py
@@ -30,12 +30,13 @@ class table__c_v_a_r(DefaultTable.DefaultTable):
         self.majorVersion, self.minorVersion = 1, 0
         self.variations = []
 
-    def compile(self, ttFont):
+    def compile(self, ttFont, useSharedPoints=False):
         tupleVariationCount, tuples, data = compileTupleVariationStore(
             variations=[v for v in self.variations if v.hasImpact()],
             pointCount=len(ttFont["cvt "].values),
             axisTags=[axis.axisTag for axis in ttFont["fvar"].axes],
-            sharedTupleIndices={})
+            sharedTupleIndices={},
+            useSharedPoints=useSharedPoints)
         header = {
             "majorVersion": self.majorVersion,
             "minorVersion": self.minorVersion,

--- a/Tests/ttLib/tables/_c_v_a_r_test.py
+++ b/Tests/ttLib/tables/_c_v_a_r_test.py
@@ -18,31 +18,43 @@ CVAR_DATA = deHexStr(
     "0004 "           # 16: tvHeader[1].variationDataSize=4
     "8000 "           # 18: tvHeader[1].tupleIndex=EMBEDDED_PEAK
     "C000 3333 "      # 20: tvHeader[1].peakTuple=[-1.0, 0.8]
-    "00 "             # 24: shared values = 00, all values
+    "03 02 02 01 01"  # 24: shared_pointCount=03, run_count=2 cvt=[2, 3, 4]
     "02 03 01 04 "    # 25: deltas=[3, 1, 4]
     "02 09 07 08")    # 29: deltas=[9, 7, 8]
+
+CVAR_PRIVATE_POINT_DATA = deHexStr(
+    "0001 0000 "                    #  0: majorVersion=1 minorVersion=0
+    "0002 0018 "                    #  4: tupleVariationCount=2 offsetToData=24
+    "0009 "                         #  8: tvHeader[0].variationDataSize=9
+    "A000 "                         # 10: tvHeader[0].tupleIndex=EMBEDDED_PEAK|PRIVATE_POINT_NUMBERS
+    "4000 0000 "                    # 12: tvHeader[0].peakTuple=[1.0, 0.0]
+    "0009 "                         # 16: tvHeader[1].variationDataSize=9
+    "A000 "                         # 18: tvHeader[1].tupleIndex=EMBEDDED_PEAK|PRIVATE_POINT_NUMBERS
+    "C000 3333 "                    # 20: tvHeader[1].peakTuple=[-1.0, 0.8]
+    "03 02 02 01 01 02 03 01 04 "   # 24: pointCount=3 run_count=2 cvt=2 1 1 run_count=2 deltas=[3, 1, 4]
+    "03 02 02 01 01 02 09 07 08 ")  # 33: pointCount=3 run_count=2 cvt=2 1 1 run_count=2 deltas=[9, 7, 8]
 
 CVAR_XML = [
     '<version major="1" minor="0"/>',
     '<tuple>',
     '  <coord axis="wght" value="1.0"/>',
-    '  <delta cvt="0" value="3"/>',
-    '  <delta cvt="1" value="1"/>',
-    '  <delta cvt="2" value="4"/>',
+    '  <delta cvt="2" value="3"/>',
+    '  <delta cvt="3" value="1"/>',
+    '  <delta cvt="4" value="4"/>',
     '</tuple>',
     '<tuple>',
     '  <coord axis="wght" value="-1.0"/>',
     '  <coord axis="wdth" value="0.8"/>',
-    '  <delta cvt="0" value="9"/>',
-    '  <delta cvt="1" value="7"/>',
-    '  <delta cvt="2" value="8"/>',
+    '  <delta cvt="2" value="9"/>',
+    '  <delta cvt="3" value="7"/>',
+    '  <delta cvt="4" value="8"/>',
     '</tuple>',
 ]
 
 CVAR_VARIATIONS = [
-    TupleVariation({"wght": (0.0, 1.0, 1.0)}, [3, 1, 4]),
+    TupleVariation({"wght": (0.0, 1.0, 1.0)}, [None, None, 3, 1, 4]),
     TupleVariation({"wght": (-1, -1.0, 0.0), "wdth": (0.0, 0.8, 0.8)},
-                   [9, 7, 8]),
+                   [None, None, 9, 7, 8]),
 ]
 
 
@@ -50,7 +62,7 @@ class CVARTableTest(unittest.TestCase):
     def makeFont(self):
         cvt, cvar, fvar = newTable("cvt "), newTable("cvar"), newTable("fvar")
         font = {"cvt ": cvt, "cvar": cvar, "fvar": fvar}
-        cvt.values = [0, 1000, -2000]
+        cvt.values = [0, 0, 0, 1000, -2000]
         Axis = getTableModule("fvar").Axis
         fvar.axes = [Axis(), Axis()]
         fvar.axes[0].axisTag, fvar.axes[1].axisTag = "wght", "wdth"
@@ -59,9 +71,21 @@ class CVARTableTest(unittest.TestCase):
     def test_compile(self):
         font, cvar = self.makeFont()
         cvar.variations = CVAR_VARIATIONS
-        self.assertEqual(hexStr(cvar.compile(font)), hexStr(CVAR_DATA))
+        self.assertEqual(hexStr(cvar.compile(font)), hexStr(CVAR_PRIVATE_POINT_DATA))
+
+    def test_compile_shared_points(self):
+        font, cvar = self.makeFont()
+        cvar.variations = CVAR_VARIATIONS
+        self.assertEqual(hexStr(cvar.compile(font, useSharedPoints=True)), hexStr(CVAR_DATA))
 
     def test_decompile(self):
+        font, cvar = self.makeFont()
+        cvar.decompile(CVAR_PRIVATE_POINT_DATA, font)
+        self.assertEqual(cvar.majorVersion, 1)
+        self.assertEqual(cvar.minorVersion, 0)
+        self.assertEqual(cvar.variations, CVAR_VARIATIONS)
+
+    def test_decompile_shared_points(self):
         font, cvar = self.makeFont()
         cvar.decompile(CVAR_DATA, font)
         self.assertEqual(cvar.majorVersion, 1)


### PR DESCRIPTION
* Don't share points in cvar by default, font may fail to render properly in Chrome/WIndows (introduced in #1090)
* Adjust tests to test both shared and private points in cvar

TODO:
* Make `useSharedPoints` accessible to varLib (now only directly calling `cvar.compile()` or `TupleVariation.compileTupleVariationStore()` can take this argument)