### PR TITLE
[subset] delete empty SubrsIndex after subsetting CFF

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2407,11 +2407,26 @@ def prune_post_subset(self, options):
             for subr in subrs.items:
                 subr.subset_subroutines (local_subrs, font.GlobalSubrs)
 
+        # Delete local SubrsIndex if empty
+        if hasattr(font, 'FDSelect'):
+            for fd in font.FDArray:
+                _delete_empty_subrs(fd)
+        else:
+            _delete_empty_subrs(font)
+
         # Cleanup
         for subrs in all_subrs:
             del subrs._used, subrs._old_bias, subrs._new_bias
 
     return True
+
+
+def _delete_empty_subrs(font):
+    if hasattr(font.Private, 'Subrs') and not font.Private.Subrs:
+        if 'Subrs' in font.Private.rawDict:
+            del font.Private.rawDict['Subrs']
+        delattr(font.Private, 'Subrs')
+
 
 @_add_method(ttLib.getTableClass('cmap'))
 def closure_glyphs(self, s):

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2425,7 +2425,7 @@ def _delete_empty_subrs(font):
     if hasattr(font.Private, 'Subrs') and not font.Private.Subrs:
         if 'Subrs' in font.Private.rawDict:
             del font.Private.rawDict['Subrs']
-        delattr(font.Private, 'Subrs')
+        del font.Private.Subrs
 
 
 @_add_method(ttLib.getTableClass('cmap'))

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2410,9 +2410,9 @@ def prune_post_subset(self, options):
         # Delete local SubrsIndex if empty
         if hasattr(font, 'FDSelect'):
             for fd in font.FDArray:
-                _delete_empty_subrs(fd)
+                _delete_empty_subrs(fd.Private)
         else:
-            _delete_empty_subrs(font)
+            _delete_empty_subrs(font.Private)
 
         # Cleanup
         for subrs in all_subrs:
@@ -2421,11 +2421,11 @@ def prune_post_subset(self, options):
     return True
 
 
-def _delete_empty_subrs(font):
-    if hasattr(font.Private, 'Subrs') and not font.Private.Subrs:
-        if 'Subrs' in font.Private.rawDict:
-            del font.Private.rawDict['Subrs']
-        del font.Private.Subrs
+def _delete_empty_subrs(private_dict):
+    if hasattr(private_dict, 'Subrs') and not private_dict.Subrs:
+        if 'Subrs' in private_dict.rawDict:
+            del private_dict.rawDict['Subrs']
+        del private_dict.Subrs
 
 
 @_add_method(ttLib.getTableClass('cmap'))

--- a/Tests/subset/data/expect_desubroutinize_CFF.ttx
+++ b/Tests/subset/data/expect_desubroutinize_CFF.ttx
@@ -33,9 +33,6 @@
         <initialRandomSeed value="0"/>
         <defaultWidthX value="267"/>
         <nominalWidthX value="448"/>
-        <Subrs>
-          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
-        </Subrs>
       </Private>
       <CharStrings>
         <CharString name=".notdef">

--- a/Tests/subset/data/expect_no_hinting_desubroutinize_CFF.ttx
+++ b/Tests/subset/data/expect_no_hinting_desubroutinize_CFF.ttx
@@ -32,9 +32,6 @@
         <initialRandomSeed value="0"/>
         <defaultWidthX value="267"/>
         <nominalWidthX value="448"/>
-        <Subrs>
-          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
-        </Subrs>
       </Private>
       <CharStrings>
         <CharString name=".notdef">

--- a/Tests/subset/data/expect_no_notdef_outline_cid.ttx
+++ b/Tests/subset/data/expect_no_notdef_outline_cid.ttx
@@ -43,9 +43,6 @@
             <initialRandomSeed value="0"/>
             <defaultWidthX value="1000"/>
             <nominalWidthX value="107"/>
-            <Subrs>
-              <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
-            </Subrs>
           </Private>
         </FontDict>
       </FDArray>

--- a/Tests/subset/data/expect_no_notdef_outline_otf.ttx
+++ b/Tests/subset/data/expect_no_notdef_outline_otf.ttx
@@ -33,9 +33,6 @@
         <initialRandomSeed value="0"/>
         <defaultWidthX value="500"/>
         <nominalWidthX value="300"/>
-        <Subrs>
-          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
-        </Subrs>
       </Private>
       <CharStrings>
         <CharString name=".notdef">

--- a/Tests/subset/data/expect_notdef_width_cid.ttx
+++ b/Tests/subset/data/expect_notdef_width_cid.ttx
@@ -38,9 +38,6 @@
             <initialRandomSeed value="0"/>
             <defaultWidthX value="602"/>
             <nominalWidthX value="630"/>
-            <Subrs>
-              <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
-            </Subrs>
           </Private>
         </FontDict>
         <FontDict index="1">
@@ -56,9 +53,6 @@
             <initialRandomSeed value="0"/>
             <defaultWidthX value="1000"/>
             <nominalWidthX value="107"/>
-            <Subrs>
-              <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
-            </Subrs>
           </Private>
         </FontDict>
       </FDArray>


### PR DESCRIPTION
Fixes #994 

According to @benkiel, when a CFF PrivateDict contains an empty SubrsIndex (one with no local subroutines), Windows rejects the font.

If the SubrsIndex is left empty by the subsetting operation, we delete it from the PrivateDict.