### PR TITLE
[feaLib] Allow mixed single/multiple substitutions

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1295,8 +1295,8 @@ class Parser(object):
             for i, s in enumerate(statements):
                 if isinstance(s, self.ast.SingleSubstStatement):
                     statements[i] = self.ast.MultipleSubstStatement(s.location,
-                        s.prefix, tuple(s.glyphs[0].glyphSet())[0], s.suffix,
-                        tuple([list(r.glyphSet())[0] for r in s.replacements]))
+                        s.prefix, s.glyphs[0].glyphSet()[0], s.suffix,
+                        [r.glyphSet()[0] for r in s.replacements])
 
     def is_cur_keyword_(self, k):
         if self.cur_token_type_ is Lexer.NAME:

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1256,6 +1256,18 @@ class ParserTest(unittest.TestCase):
                         "    sub a' lookup upper x x A' lookup lower;"
                         "} test;")
 
+    def test_substitute_mix_single_multiple(self):
+        doc = self.parse("lookup Look {"
+                         "  sub f_f   by f f;"
+                         "  sub f     by f;"
+                         "  sub f_f_i by f f i;"
+                         "} Look;")
+        statements = doc.statements[0].statements
+        for sub in statements:
+            self.assertIsInstance(sub, ast.MultipleSubstStatement)
+        self.assertEqual(statements[1].glyph, "f")
+        self.assertEqual(statements[1].replacement, ["f"])
+
     def test_substitute_from(self):  # GSUB LookupType 3
         doc = self.parse("feature test {"
                          "  substitute a from [a.1 a.2 a.3];"


### PR DESCRIPTION
A multiple substitution may have a single destination, in which case it will look just like a single substitution. So if there are both multiple and single substitutions, upgrade all the single ones to multiple substitutions. Previously we would just give an error message in the builder and abort, which means certain valid OpenType lookups can’t be represented by feature files.

This is the same logic implemented by FontForge (actually the explanation above is almost copied verbatim from its source), makeotf does not do this AFAIK but I consider it a bug not a feature.

Fixes https://github.com/fonttools/fonttools/issues/612