### PR TITLE
`*.afm` files are missing from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -31,3 +31,4 @@ recursive-include Tests *.glif *.plist
 recursive-include Tests *.txt README
 recursive-include Tests *.lwfn *.pfa *.pfb
 recursive-include Tests *.xml *.designspace *.bin
+recursive-include Tests *.afm


### PR DESCRIPTION
`*.afm` files are missing from MANIFEST.in causing `make check` to fail on pypi
releases. This PR adds the missing line.