### PR TITLE
textTools: use ast.literal_eval for safeEval

### DIFF
--- a/Lib/fontTools/misc/textTools.py
+++ b/Lib/fontTools/misc/textTools.py
@@ -7,14 +7,14 @@ import ast
 import string
 
 
-def safeEval(data):
-	"""A (kindof) safe replacement for eval."""
-	return ast.literal_eval(data)
+# alias kept for backward compatibility
+safeEval = ast.literal_eval
 
 
 def readHex(content):
 	"""Convert a list of hex strings to binary data."""
 	return deHexStr(strjoin(chunk for chunk in content if isinstance(chunk, basestring)))
+
 
 def deHexStr(hexdata):
 	"""Convert a hex string to binary data."""

--- a/Lib/fontTools/misc/textTools.py
+++ b/Lib/fontTools/misc/textTools.py
@@ -3,12 +3,13 @@
 
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+import ast
 import string
 
 
-def safeEval(data, eval=eval):
+def safeEval(data):
 	"""A (kindof) safe replacement for eval."""
-	return eval(data, {"__builtins__":{"True":True,"False":False}})
+	return ast.literal_eval(data)
 
 
 def readHex(content):


### PR DESCRIPTION
go back to using `literal_eval`, as nobody does complex expressions in TTX files, and eval is evil.

Fixes https://github.com/fonttools/fonttools/issues/164