### PR TITLE
otConverters: don't write XML comment if NameID value is 0 == NULL

### DIFF
--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -285,15 +285,16 @@ class GlyphID(SimpleValue):
 class NameID(UShort):
 	def xmlWrite(self, xmlWriter, font, value, name, attrs):
 		xmlWriter.simpletag(name, attrs + [("value", value)])
-		nameTable = font.get("name") if font else None
-		if nameTable:
-			name = nameTable.getDebugName(value)
-			xmlWriter.write("  ")
-			if name:
-				xmlWriter.comment(name)
-			else:
-				xmlWriter.comment("missing from name table")
-				log.warning("name id %d missing from name table" % value)
+		if font and value:
+			nameTable = font.get("name")
+			if nameTable:
+				name = nameTable.getDebugName(value)
+				xmlWriter.write("  ")
+				if name:
+					xmlWriter.comment(name)
+				else:
+					xmlWriter.comment("missing from name table")
+					log.warning("name id %d missing from name table" % value)
 		xmlWriter.newline()
 
 

--- a/Tests/ttLib/tables/otConverters_test.py
+++ b/Tests/ttLib/tables/otConverters_test.py
@@ -114,6 +114,7 @@ class NameIDTest(unittest.TestCase):
     def makeFont(self):
         nameTable = newTable('name')
         nameTable.setName(u"Demibold Condensed", 0x123, 3, 0, 0x409)
+        nameTable.setName(u"Copyright 2018", 0, 3, 0, 0x409)
         return {"name": nameTable}
 
     def test_read(self):
@@ -147,6 +148,14 @@ class NameIDTest(unittest.TestCase):
             xml,
             '<Entity attrib="val"'
             ' value="666"/>  <!-- missing from name table -->')
+
+    def test_xmlWrite_NULL(self):
+        writer = makeXMLWriter()
+        self.converter.xmlWrite(writer, self.makeFont(), 0,
+                                "FooNameID", [("attr", "val")])
+        xml = writer.file.getvalue().decode("utf-8").rstrip()
+        self.assertEqual(
+            xml, '<FooNameID attr="val" value="0"/>')
 
 
 class UInt8Test(unittest.TestCase):

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_size_feat_same.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_size_feat_same.ttx
@@ -25,7 +25,7 @@
           <FeatureParamsSize>
             <DesignSize value="10.0"/>
             <SubfamilyID value="0"/>
-            <SubfamilyNameID value="0"/>  <!-- missing from name table -->
+            <SubfamilyNameID value="0"/>
             <RangeStart value="0.0"/>
             <RangeEnd value="0.0"/>
           </FeatureParamsSize>


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/1151