### PR TITLE
Add option to parse one feature file without resolving included files

### DIFF
--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -411,7 +411,7 @@ class BaseDocWriter(object):
         axisElement.attrib['default'] = self.intOrFloat(axisObject.default)
         if axisObject.hidden:
             axisElement.attrib['hidden'] = "1"
-        for languageCode, labelName in axisObject.labelNames.items():
+        for languageCode, labelName in sorted(axisObject.labelNames.items()):
             languageElement = ET.Element('labelname')
             languageElement.attrib[u'xml:lang'] = languageCode
             languageElement.text = labelName
@@ -486,7 +486,7 @@ class BaseDocWriter(object):
                 glyphsElement = ET.Element('glyphs')
                 instanceElement.append(glyphsElement)
             glyphsElement = instanceElement.findall('.glyphs')[0]
-            for glyphName, data in instanceObject.glyphs.items():
+            for glyphName, data in sorted(instanceObject.glyphs.items()):
                 glyphElement = self._writeGlyphElement(instanceElement, instanceObject, glyphName, data)
                 glyphsElement.append(glyphElement)
         if instanceObject.kerning:

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -591,6 +591,22 @@ class IgnoreSubstStatement(Statement):
         return "ignore sub " + ", ".join(contexts) + ";"
 
 
+class IncludeStatement(Statement):
+    def __init__(self, location, filename):
+        super(IncludeStatement, self).__init__(location)
+        self.filename = filename
+
+    def build(self):
+        # TODO: consider lazy-loading the including parser/lexer?
+        raise FeatureLibError(
+            "Building an include statement is not implemented yet. "
+            "Instead, use Parser(..., followIncludes=True) for building.",
+            self.location)
+
+    def asFea(self, indent=""):
+        return indent + "include(%s);" % self.filename
+
+
 class LanguageStatement(Statement):
     def __init__(self, location, language, include_default, required):
         Statement.__init__(self, location)

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -240,3 +240,9 @@ class IncludingLexer(object):
 
     def scan_anonymous_block(self, tag):
         return self.lexers_[-1].scan_anonymous_block(tag)
+
+
+class NonIncludingLexer(IncludingLexer):
+    """Lexer that does not follow `include` statements, emits them as-is."""
+    def __next__(self):  # Python 3
+        return next(self.lexers_[0])

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -47,7 +47,7 @@ class Parser(object):
 
     def parse(self):
         statements = self.doc_.statements
-        while self.next_token_type_ is not None:
+        while self.next_token_type_ is not None or self.cur_comments_:
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(self.ast.Comment(self.cur_token_location_, self.cur_token_))

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 from __future__ import unicode_literals
 from fontTools.feaLib.error import FeatureLibError
-from fontTools.feaLib.lexer import Lexer, IncludingLexer
+from fontTools.feaLib.lexer import Lexer, IncludingLexer, NonIncludingLexer
 from fontTools.misc.encodingTools import getEncoding
 from fontTools.misc.py23 import *
 import fontTools.feaLib.ast as ast
@@ -17,7 +17,8 @@ class Parser(object):
     extensions = {}
     ast = ast
 
-    def __init__(self, featurefile, glyphNames=(), **kwargs):
+    def __init__(self, featurefile, glyphNames=(), followIncludes=True,
+                 **kwargs):
         if "glyphMap" in kwargs:
             from fontTools.misc.loggingTools import deprecateArgument
             deprecateArgument("glyphMap", "use 'glyphNames' (iterable) instead")
@@ -42,7 +43,8 @@ class Parser(object):
         self.next_token_type_, self.next_token_ = (None, None)
         self.cur_comments_ = []
         self.next_token_location_ = None
-        self.lexer_ = IncludingLexer(featurefile)
+        lexerClass = IncludingLexer if followIncludes else NonIncludingLexer
+        self.lexer_ = lexerClass(featurefile)
         self.advance_lexer_(comments=True)
 
     def parse(self):
@@ -51,6 +53,8 @@ class Parser(object):
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(self.ast.Comment(self.cur_token_location_, self.cur_token_))
+            elif self.is_cur_keyword_("include"):
+                statements.append(self.parse_include_())
             elif self.cur_token_type_ is Lexer.GLYPHCLASS:
                 statements.append(self.parse_glyphclass_definition_())
             elif self.is_cur_keyword_(("anon", "anonymous")):
@@ -419,6 +423,13 @@ class Parser(object):
         raise FeatureLibError(
             "Expected \"substitute\" or \"position\"",
             self.cur_token_location_)
+
+    def parse_include_(self):
+        assert self.cur_token_ == "include"
+        location = self.cur_token_location_
+        filename = self.expect_filename_()
+        # self.expect_symbol_(";")
+        return ast.IncludeStatement(location, filename)
 
     def parse_language_(self):
         assert self.is_cur_keyword_("language")
@@ -1318,6 +1329,13 @@ class Parser(object):
             return self.cur_token_
         raise FeatureLibError("Expected a CID", self.cur_token_location_)
 
+    def expect_filename_(self):
+        self.advance_lexer_()
+        if self.cur_token_type_ is not Lexer.FILENAME:
+            raise FeatureLibError("Expected file name",
+                                  self.cur_token_location_)
+        return self.cur_token_
+
     def expect_glyph_(self):
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.NAME:
@@ -1424,7 +1442,6 @@ class Parser(object):
         else:
             self.cur_token_type_, self.cur_token_, self.cur_token_location_ = (
                 self.next_token_type_, self.next_token_, self.next_token_location_)
-            self.cur_comments_ = []
         while True:
             try:
                 (self.next_token_type_, self.next_token_,

--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -9,6 +9,7 @@ import unittest
 def lex(s):
     return [(typ, tok) for (typ, tok, _) in Lexer(s, "test.fea")]
 
+
 class LexerTest(unittest.TestCase):
     def __init__(self, methodName):
         unittest.TestCase.__init__(self, methodName)

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -86,6 +86,15 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(c2.text, "# simple")
         self.assertEqual(doc.statements[1].name, "test")
 
+    def test_only_comments(self):
+        doc = self.parse("""\
+            # Initial
+        """)
+        c1 = doc.statements[0]
+        self.assertEqual(type(c1), ast.Comment)
+        self.assertEqual(c1.text, "# Initial")
+        self.assertEqual(str(c1), "# Initial")
+
     def test_anchor_format_a(self):
         doc = self.parse(
             "feature test {"


### PR DESCRIPTION
* [x] Have an option to not follow includes (get ast.IncludeStatement instead)
* ~~Compute `end_location` as well as location to be able to get the original text of any statement/block~~
