### PR TITLE
feaLib.parser: raise meaningful error for substitution of multiple glyphs by multiple glyphs

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -749,6 +749,12 @@ class Parser(object):
             return self.ast.ReverseChainSingleSubstStatement(
                 location, old_prefix, old_suffix, old, new)
 
+        if len(old) > 1 and len(new) > 1:
+            raise FeatureLibError(
+                'Direct substitution of multiple glyphs by multiple glyphs '
+                'is not supported',
+                location)
+
         # GSUB lookup type 6: Chaining contextual substitution.
         assert len(new) == 0, new
         rule = self.ast.ChainContextSubstStatement(

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1220,6 +1220,14 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(sub.glyph, "f_f_i")
         self.assertEqual(sub.replacement, ("f", "f", "i"))
 
+    def test_substitute_multiple_by_mutliple(self):
+        self.assertRaisesRegex(
+            FeatureLibError,
+            "Direct substitution of multiple glyphs by multiple glyphs "
+            "is not supported",
+            self.parse,
+            "lookup MxM {sub a b c by d e f;} MxM;")
+
     def test_split_marked_glyphs_runs(self):
         self.assertRaisesRegex(
             FeatureLibError,


### PR DESCRIPTION
Raise a meaningful error instead of raising on `assert len(new) == 0, new`.