### PR TITLE
[feaLib] add `tables` argument to only build some tables (e.g. GSUB)

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -15,21 +15,34 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def addOpenTypeFeatures(font, featurefile):
+def addOpenTypeFeatures(font, featurefile, tables=None):
     builder = Builder(font, featurefile)
-    builder.build()
+    builder.build(tables=tables)
 
 
-def addOpenTypeFeaturesFromString(font, features, filename=None):
+def addOpenTypeFeaturesFromString(font, features, filename=None, tables=None):
     featurefile = UnicodeIO(tounicode(features))
     if filename:
         # the directory containing 'filename' is used as the root of relative
         # include paths; if None is provided, the current directory is assumed
         featurefile.name = filename
-    addOpenTypeFeatures(font, featurefile)
+    addOpenTypeFeatures(font, featurefile, tables=tables)
 
 
 class Builder(object):
+
+    supportedTables = frozenset(Tag(tag) for tag in [
+        "BASE",
+        "GDEF",
+        "GPOS",
+        "GSUB",
+        "OS/2",
+        "head",
+        "hhea",
+        "name",
+        "vhea",
+    ])
+
     def __init__(self, font, featurefile):
         self.font = font
         self.file = featurefile
@@ -78,16 +91,35 @@ class Builder(object):
         # for table 'vhea'
         self.vhea_ = {}
 
-    def build(self):
+    def build(self, tables=None):
         self.parseTree = Parser(self.file, self.glyphMap).parse()
         self.parseTree.build(self)
-        self.build_feature_aalt_()
-        self.build_head()
-        self.build_hhea()
-        self.build_vhea()
-        self.build_name()
-        self.build_OS_2()
+        # by default, build all the supported tables
+        if tables is None:
+            tables = self.supportedTables
+        else:
+            tables = frozenset(tables)
+            unsupported = tables - self.supportedTables
+            if unsupported:
+                log.warning(
+                    "skipped unsupported table%s: %s" % (
+                        "s" if len(unsupported) > 1 else "",
+                        ", ".join(sorted(repr(tag) for tag in unsupported))))
+        if "GSUB" in tables:
+            self.build_feature_aalt_()
+        if "head" in tables:
+            self.build_head()
+        if "hhea" in tables:
+            self.build_hhea()
+        if "vhea" in tables:
+            self.build_vhea()
+        if "name" in tables:
+            self.build_name()
+        if "OS/2" in tables:
+            self.build_OS_2()
         for tag in ('GPOS', 'GSUB'):
+            if tag not in tables:
+                continue
             table = self.makeTable(tag)
             if (table.ScriptList.ScriptCount > 0 or
                     table.FeatureList.FeatureCount > 0 or
@@ -96,16 +128,18 @@ class Builder(object):
                 fontTable.table = table
             elif tag in self.font:
                 del self.font[tag]
-        gdef = self.buildGDEF()
-        if gdef:
-            self.font["GDEF"] = gdef
-        elif "GDEF" in self.font:
-            del self.font["GDEF"]
-        base = self.buildBASE()
-        if base:
-            self.font["BASE"] = base
-        elif "BASE" in self.font:
-            del self.font["BASE"]
+        if "GDEF" in tables:
+            gdef = self.buildGDEF()
+            if gdef:
+                self.font["GDEF"] = gdef
+            elif "GDEF" in self.font:
+                del self.font["GDEF"]
+        if "BASE" in tables:
+            base = self.buildBASE()
+            if base:
+                self.font["BASE"] = base
+            elif "BASE" in self.font:
+                del self.font["BASE"]
 
     def get_chained_lookup_(self, location, builder_class):
         result = builder_class(self.font, location)

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -100,11 +100,7 @@ class Builder(object):
         else:
             tables = frozenset(tables)
             unsupported = tables - self.supportedTables
-            if unsupported:
-                log.warning(
-                    "skipped unsupported table%s: %s" % (
-                        "s" if len(unsupported) > 1 else "",
-                        ", ".join(sorted(repr(tag) for tag in unsupported))))
+            assert not unsupported, unsupported
         if "GSUB" in tables:
             self.build_feature_aalt_()
         if "head" in tables:

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -492,10 +492,8 @@ class BuilderTest(unittest.TestCase):
         font2 = self.build(features, tables=set())
         assert "GSUB" not in font2
 
-        logger = logging.getLogger("fontTools.feaLib.builder")
-        with CapturingLogHandler(logger, "WARNING") as captor:
-            font = self.build(features, tables=["FOOO", "BAAR"])
-        captor.assertRegex("skipped unsupported tables: 'BAAR', 'FOOO'")
+    def test_build_unsupported_tables(self):
+        self.assertRaises(AssertionError, self.build, "", tables={"FOO"})
 
 
 def generate_feature_file_test(name):

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -123,9 +123,9 @@ class BuilderTest(unittest.TestCase):
                 sys.stderr.write(line)
             self.fail("TTX output is different from expected")
 
-    def build(self, featureFile):
+    def build(self, featureFile, tables=None):
         font = makeTTFont()
-        addOpenTypeFeaturesFromString(font, featureFile)
+        addOpenTypeFeaturesFromString(font, featureFile, tables=tables)
         return font
 
     def check_feature_file(self, name):
@@ -483,6 +483,19 @@ class BuilderTest(unittest.TestCase):
             "    markClass [uni0327] <anchor 0 0> @cedilla;"
             "    pos base [a] <anchor 244 0> mark @cedilla;"
             "} mark;")
+
+    def test_build_specific_tables(self):
+        features = "feature liga {sub f i by f_i;} liga;"
+        font = self.build(features)
+        assert "GSUB" in font
+
+        font2 = self.build(features, tables=set())
+        assert "GSUB" not in font2
+
+        logger = logging.getLogger("fontTools.feaLib.builder")
+        with CapturingLogHandler(logger, "WARNING") as captor:
+            font = self.build(features, tables=["FOOO", "BAAR"])
+        captor.assertRegex("skipped unsupported tables: 'BAAR', 'FOOO'")
 
 
 def generate_feature_file_test(name):


### PR DESCRIPTION
This allows to build only some of the supported tables and ignore the others.
FYI, I need this for ufo2ft. 

(TL;DR I have to build the GSUB features before the GPOS ones, so I can use the subsetter's `closure_glyphs` logic to find all the glyphs that are "reachable", i.e. can be substituted from an initial list of characters, e.g. all the right-to-left glyphs, etc.)