### PR TITLE
[travis] fast_finish + allow_failures for OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 
 language: python
+python: 3.5
 
 # empty "env:" is needed for 'allow_failures'
 # https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail
@@ -8,6 +9,9 @@ env:
 
 matrix:
   fast_finish: true
+  exclude:
+    # Exclude the default Python 3.5 build
+    - python: 3.5
   include:
     - python: 2.7
       env: TOXENV=py27-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 
 language: python
 
+# empty "env:" is needed for 'allow_failures'
+# https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail
+env:
+
 matrix:
   fast_finish: true
   include:
@@ -32,6 +36,17 @@ matrix:
         - PYENV_VERSION_STRING='Python 2.7.6'
         - PYENV_ROOT=$HOME/.travis-pyenv
         - TRAVIS_PYENV_VERSION='0.4.0'
+  allow_failures:
+    # We use fast_finish + allow_failures because OSX builds take forever
+    # https://blog.travis-ci.com/2013-11-27-fast-finishing-builds
+    - language: generic
+      os: osx
+      env: TOXENV=py27-cov
+    - language: generic
+      os: osx
+      env:
+        - TOXENV=py36-cov
+        - HOMEBREW_NO_AUTO_UPDATE=1
 
 cache:
   - pip


### PR DESCRIPTION
Travis CI has been experiencing maintainance problems with the macOS infrastructure, and in fact it has become too slow to be useable. It's better we temporarily enable `allow_failures` in combination with `fast_finish` for the OSX builds, so that the CI goes green as soon as the other builds have completed.

https://blog.travis-ci.com/2013-11-27-fast-finishing-builds