### PR TITLE
varLib: don’t fail if STAT already in font

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -169,9 +169,11 @@ def _add_avar(font, axes):
 
 def _add_stat(font, axes):
 
+	if "STAT" in font:
+            return
+
 	nameTable = font['name']
 
-	assert "STAT" not in font
 	STAT = font["STAT"] = newTable('STAT')
 	stat = STAT.table = ot.STAT()
 	stat.Version = 0x00010000


### PR DESCRIPTION
The interpolatable TTFs used to generate the variable font may already contain a valid and more detailed STAT table.