### PR TITLE
[feaLib] Support params in character variant features (cvXX)

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1171,7 +1171,7 @@ class CVParametersNameStatement(NameRecord):
         if self.block_name == "ParamUILabelNameID":
             item = "_{}".format(builder.cv_num_named_params_.get(self.nameID, 0))
         builder.add_cv_parameter(self.nameID)
-        self.nameID = '{}.{}{}'.format(self.nameID, self.block_name, item)
+        self.nameID = (self.nameID, self.block_name + item)
         NameRecord.build(self, builder)
 
     def asFea(self, indent=""):

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1174,6 +1174,13 @@ class CVParametersNameStatement(NameRecord):
         self.nameID = '{}.{}{}'.format(self.nameID, self.block_name, item)
         NameRecord.build(self, builder)
 
+    def asFea(self, indent=""):
+        plat = simplify_name_attributes(self.platformID, self.platEncID,
+                                        self.langID)
+        if plat != "":
+            plat += " "
+        return "name {}\"{}\";".format(plat, self.string)
+
 
 class CharacterStatement(Statement):
     """
@@ -1189,6 +1196,9 @@ class CharacterStatement(Statement):
 
     def build(self, builder):
         builder.add_cv_character(self.character, self.tag)
+
+    def asFea(self, indent=""):
+        return "Character {:#x};".format(self.character)
 
 
 class BaseAxis(Statement):

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1120,7 +1120,7 @@ class NameRecord(Statement):
 class FeatureNameStatement(NameRecord):
     def build(self, builder):
         NameRecord.build(self, builder)
-        builder.add_featureName(self.location, self.nameID)
+        builder.add_featureName(self.nameID)
 
     def asFea(self, indent=""):
         if self.nameID == "size":

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1153,6 +1153,14 @@ class SizeParameters(Statement):
         return res + ";"
 
 
+class CVParametersNameStatement(NameRecord):
+    def __init__(self, location, nameID, platformID,
+                 platEncID, langID, string, block_name):
+        NameRecord.__init__(self, location, nameID, platformID,
+                            platEncID, langID, string)
+        self.block_name = block_name
+
+
 class CharacterStatement(Statement):
     """
     Statement used in cvParameters blocks of Character Variant features (cvXX).

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -230,9 +230,15 @@ class FeatureBlock(Block):
 
 
 class NestedBlock(Block):
-    def __init__(self, block_name, location=None):
+    def __init__(self, tag, block_name, location=None):
         Block.__init__(self, location)
+        self.tag = tag
         self.block_name = block_name
+
+    def build(self, builder):
+        Block.build(self, builder)
+        if self.block_name == "ParamUILabelNameID":
+            builder.add_to_cv_num_named_params(self.tag)
 
     def asFea(self, indent=""):
         res = "{}{} {{\n".format(indent, self.block_name)
@@ -1160,6 +1166,14 @@ class CVParametersNameStatement(NameRecord):
                             platEncID, langID, string)
         self.block_name = block_name
 
+    def build(self, builder):
+        item = ""
+        if self.block_name == "ParamUILabelNameID":
+            item = "_{}".format(builder.cv_num_named_params_.get(self.nameID, 0))
+        builder.add_cv_parameter(self.nameID)
+        self.nameID = '{}.{}{}'.format(self.nameID, self.block_name, item)
+        NameRecord.build(self, builder)
+
 
 class CharacterStatement(Statement):
     """
@@ -1172,6 +1186,9 @@ class CharacterStatement(Statement):
         Statement.__init__(self, location)
         self.character = character
         self.tag = tag
+
+    def build(self, builder):
+        builder.add_cv_character(self.character, self.tag)
 
 
 class BaseAxis(Statement):

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1160,10 +1160,10 @@ class SizeParameters(Statement):
 
 
 class CVParametersNameStatement(NameRecord):
-    def __init__(self, location, nameID, platformID,
-                 platEncID, langID, string, block_name):
-        NameRecord.__init__(self, location, nameID, platformID,
-                            platEncID, langID, string)
+    def __init__(self, nameID, platformID, platEncID, langID, string,
+                 block_name, location=None):
+        NameRecord.__init__(self, nameID, platformID, platEncID, langID,
+                            string, location=location)
         self.block_name = block_name
 
     def build(self, builder):
@@ -1189,7 +1189,7 @@ class CharacterStatement(Statement):
     notation. The value must be preceded by '0x' if it is a hexadecimal value.
     The largest Unicode value allowed is 0xFFFFFF.
     """
-    def __init__(self, location, character, tag):
+    def __init__(self, character, tag, location=None):
         Statement.__init__(self, location)
         self.character = character
         self.tag = tag

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -229,14 +229,15 @@ class FeatureBlock(Block):
         return res
 
 
-class FeatureNamesBlock(Block):
-    def __init__(self, location=None):
+class NestedBlock(Block):
+    def __init__(self, block_name, location=None):
         Block.__init__(self, location)
+        self.block_name = block_name
 
     def asFea(self, indent=""):
-        res = indent + "featureNames {\n"
+        res = "{}{} {{\n".format(indent, self.block_name)
         res += Block.asFea(self, indent=indent)
-        res += indent + "};\n"
+        res += "{}}};\n".format(indent)
         return res
 
 

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1153,6 +1153,19 @@ class SizeParameters(Statement):
         return res + ";"
 
 
+class CharacterStatement(Statement):
+    """
+    Statement used in cvParameters blocks of Character Variant features (cvXX).
+    The Unicode value may be written with either decimal or hexadecimal
+    notation. The value must be preceded by '0x' if it is a hexadecimal value.
+    The largest Unicode value allowed is 0xFFFFFF.
+    """
+    def __init__(self, location, character, tag):
+        Statement.__init__(self, location)
+        self.character = character
+        self.tag = tag
+
+
 class BaseAxis(Statement):
     def __init__(self, bases, scripts, vertical, location=None):
         Statement.__init__(self, location)

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -70,7 +70,7 @@ class Builder(object):
         self.aalt_location_ = None
         self.aalt_alternates_ = {}
         # for 'featureNames'
-        self.featureNames_ = []
+        self.featureNames_ = set()
         self.featureNames_ids_ = {}
         # for feature 'size'
         self.size_parameters_ = None
@@ -804,8 +804,8 @@ class Builder(object):
                 location)
         self.aalt_features_.append((location, featureName))
 
-    def add_featureName(self, location, tag):
-        self.featureNames_.append(tag)
+    def add_featureName(self, tag):
+        self.featureNames_.add(tag)
 
     def set_base_axis(self, bases, scripts, vertical):
         if vertical:

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -297,14 +297,14 @@ class Builder(object):
             params = otTables.FeatureParamsCharacterVariants()
             params.Format = 0
             params.FeatUILabelNameID = self.cv_parameters_ids_.get(
-                '{}.{}'.format(tag, 'FeatUILabelNameID'), 0)
+                (tag, 'FeatUILabelNameID'), 0)
             params.FeatUITooltipTextNameID = self.cv_parameters_ids_.get(
-                '{}.{}'.format(tag, 'FeatUITooltipTextNameID'), 0)
+                (tag, 'FeatUITooltipTextNameID'), 0)
             params.SampleTextNameID = self.cv_parameters_ids_.get(
-                '{}.{}'.format(tag, 'SampleTextNameID'), 0)
+                (tag, 'SampleTextNameID'), 0)
             params.NumNamedParameters = self.cv_num_named_params_.get(tag, 0)
             params.FirstParamUILabelNameID = self.cv_parameters_ids_.get(
-                '{}.{}'.format(tag, 'ParamUILabelNameID_0'), 0)
+                (tag, 'ParamUILabelNameID_0'), 0)
             params.CharCount = len(self.cv_characters_[tag])
             params.Character = self.cv_characters_[tag]
         return params
@@ -319,7 +319,7 @@ class Builder(object):
         for name in self.names_:
             nameID, platformID, platEncID, langID, string = name
             # For featureNames block, nameID is 'feature tag'
-            # For cvParameters blocks, nameID is 'feature tag.block name'
+            # For cvParameters blocks, nameID is ('feature tag', 'block name')
             if not isinstance(nameID, int):
                 tag = nameID
                 if tag in self.featureNames_:
@@ -327,7 +327,7 @@ class Builder(object):
                         self.featureNames_ids_[tag] = self.get_user_name_id(table)
                         assert self.featureNames_ids_[tag] is not None
                     nameID = self.featureNames_ids_[tag]
-                elif tag.split('.')[0] in self.cv_parameters_:
+                elif tag[0] in self.cv_parameters_:
                     if tag not in self.cv_parameters_ids_:
                         self.cv_parameters_ids_[tag] = self.get_user_name_id(table)
                         assert self.cv_parameters_ids_[tag] is not None

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1549,6 +1549,7 @@ class Parser(object):
             return self.cur_token_
         raise FeatureLibError("Expected a name", self.cur_token_location_)
 
+    # TODO: Don't allow this method to accept hexadecimal values
     def expect_number_(self):
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.NUMBER:
@@ -1562,6 +1563,7 @@ class Parser(object):
         raise FeatureLibError("Expected a floating-point number",
                               self.cur_token_location_)
 
+    # TODO: Don't allow this method to accept hexadecimal values
     def expect_decipoint_(self):
         if self.next_token_type_ == Lexer.FLOAT:
             return self.expect_float_()
@@ -1571,6 +1573,7 @@ class Parser(object):
             raise FeatureLibError("Expected an integer or floating-point number",
                                   self.cur_token_location_)
 
+    # TODO: Don't allow this method to accept negative numbers
     def expect_decimal_or_hexadecimal_(self):
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.NUMBER:

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1237,7 +1237,7 @@ class Parser(object):
 
         block = self.ast.FeatureBlock(tag, use_extension=use_extension,
                                       location=location)
-        self.parse_block_(block, vertical, stylisticset, size_feature
+        self.parse_block_(block, vertical, stylisticset, size_feature,
                           cv_feature)
         return block
 
@@ -1251,8 +1251,8 @@ class Parser(object):
 
     def parse_featureNames_(self, tag):
         assert self.cur_token_ == "featureNames", self.cur_token_
-        block = self.ast.NestedBlock(self.cur_token_location_, tag,
-                                     self.cur_token_)
+        block = self.ast.NestedBlock(tag, self.cur_token_,
+                                     location=self.cur_token_location_)
         self.expect_symbol_("{")
         for symtab in self.symbol_tables_:
             symtab.enter_scope()
@@ -1281,8 +1281,8 @@ class Parser(object):
 
     def parse_cvParameters_(self, tag):
         assert self.cur_token_ == "cvParameters", self.cur_token_
-        block = self.ast.NestedBlock(self.cur_token_location_, tag,
-                                     self.cur_token_)
+        block = self.ast.NestedBlock(tag, self.cur_token_,
+                                     location=self.cur_token_location_)
         self.expect_symbol_("{")
         for symtab in self.symbol_tables_:
             symtab.enter_scope()
@@ -1291,8 +1291,8 @@ class Parser(object):
         while self.next_token_ != "}" or self.cur_comments_:
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
-                statements.append(self.ast.Comment(self.cur_token_location_,
-                                                   self.cur_token_))
+                statements.append(self.ast.Comment(
+                    self.cur_token_, location=self.cur_token_location_))
             elif self.is_cur_keyword_({"FeatUILabelNameID",
                                        "FeatUITooltipTextNameID",
                                        "SampleTextNameID",
@@ -1316,7 +1316,8 @@ class Parser(object):
 
     def parse_cvNameIDs_(self, tag, block_name):
         assert self.cur_token_ == block_name, self.cur_token_
-        block = self.ast.NestedBlock(self.cur_token_location_, tag, block_name)
+        block = self.ast.NestedBlock(tag, block_name,
+                                     location=self.cur_token_location_)
         self.expect_symbol_("{")
         for symtab in self.symbol_tables_:
             symtab.enter_scope()
@@ -1324,14 +1325,14 @@ class Parser(object):
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
                 block.statements.append(self.ast.Comment(
-                    self.cur_token_location_, self.cur_token_))
+                    self.cur_token_, location=self.cur_token_location_))
             elif self.is_cur_keyword_("name"):
                 location = self.cur_token_location_
                 platformID, platEncID, langID, string = self.parse_name_()
                 block.statements.append(
                     self.ast.CVParametersNameStatement(
-                        location, tag, platformID, platEncID, langID, string,
-                        block_name))
+                        tag, platformID, platEncID, langID, string,
+                        block_name, location=location))
             elif self.cur_token_ == ";":
                 continue
             else:
@@ -1351,7 +1352,7 @@ class Parser(object):
             raise FeatureLibError("Character value must be between "
                                   "{:#x} and {:#x}".format(0, 0xFFFFFF),
                                   location)
-        return self.ast.CharacterStatement(location, character, tag)
+        return self.ast.CharacterStatement(character, tag, location=location)
 
     def parse_FontRevision_(self):
         assert self.cur_token_ == "FontRevision", self.cur_token_

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1243,7 +1243,7 @@ class Parser(object):
 
     def parse_featureNames_(self, tag):
         assert self.cur_token_ == "featureNames", self.cur_token_
-        block = self.ast.FeatureNamesBlock(self.cur_token_location_)
+        block = self.ast.NestedBlock(self.cur_token_location_, self.cur_token_)
         self.expect_symbol_("{")
         for symtab in self.symbol_tables_:
             symtab.enter_scope()

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1310,6 +1310,16 @@ class Parser(object):
         self.expect_symbol_(";")
         return block
 
+    def parse_cvCharacter_(self, tag):
+        assert self.cur_token_ == "Character", self.cur_token_
+        location, character = self.cur_token_location_, self.expect_decimal_or_hexadecimal_()
+        self.expect_symbol_(";")
+        if not (0xFFFFFF >= character >= 0):
+            raise FeatureLibError("Character value must be between "
+                                  "{:#x} and {:#x}".format(0, 0xFFFFFF),
+                                  location)
+        return self.ast.CharacterStatement(location, character, tag)
+
     def parse_FontRevision_(self):
         assert self.cur_token_ == "FontRevision", self.cur_token_
         location, version = self.cur_token_location_, self.expect_float_()
@@ -1529,6 +1539,13 @@ class Parser(object):
         else:
             raise FeatureLibError("Expected an integer or floating-point number",
                                   self.cur_token_location_)
+
+    def expect_decimal_or_hexadecimal_(self):
+        self.advance_lexer_()
+        if self.cur_token_type_ is Lexer.NUMBER:
+            return self.cur_token_
+        raise FeatureLibError("Expected a decimal or hexadecimal number",
+                              self.cur_token_location_)
 
     def expect_string_(self):
         self.advance_lexer_()

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1217,9 +1217,14 @@ class Parser(object):
         location = self.cur_token_location_
         tag = self.expect_tag_()
         vertical = (tag in {"vkrn", "vpal", "vhal", "valt"})
+
         stylisticset = None
         if tag in ["ss%02d" % i for i in range(1, 20+1)]:
             stylisticset = tag
+
+        cv_feature = None
+        if tag in ["cv%02d" % i for i in range(1, 99+1)]:
+            cv_feature = tag
 
         size_feature = (tag == "size")
 
@@ -1230,7 +1235,8 @@ class Parser(object):
 
         block = self.ast.FeatureBlock(tag, use_extension=use_extension,
                                       location=location)
-        self.parse_block_(block, vertical, stylisticset, size_feature)
+        self.parse_block_(block, vertical, stylisticset, size_feature
+                          cv_feature)
         return block
 
     def parse_feature_reference_(self):
@@ -1280,7 +1286,7 @@ class Parser(object):
         return self.ast.FontRevisionStatement(version, location=location)
 
     def parse_block_(self, block, vertical, stylisticset=None,
-                     size_feature=False):
+                     size_feature=False, cv_feature=None):
         self.expect_symbol_("{")
         for symtab in self.symbol_tables_:
             symtab.enter_scope()
@@ -1323,6 +1329,8 @@ class Parser(object):
                 statements.append(self.parse_valuerecord_definition_(vertical))
             elif stylisticset and self.is_cur_keyword_("featureNames"):
                 statements.append(self.parse_featureNames_(stylisticset))
+            elif cv_feature and self.is_cur_keyword_("cvParameters"):
+                statements.append(self.parse_cvParameters_(cv_feature))
             elif size_feature and self.is_cur_keyword_("parameters"):
                 statements.append(self.parse_size_parameters_())
             elif size_feature and self.is_cur_keyword_("sizemenuname"):

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1249,7 +1249,8 @@ class Parser(object):
 
     def parse_featureNames_(self, tag):
         assert self.cur_token_ == "featureNames", self.cur_token_
-        block = self.ast.NestedBlock(self.cur_token_location_, self.cur_token_)
+        block = self.ast.NestedBlock(self.cur_token_location_, tag,
+                                     self.cur_token_)
         self.expect_symbol_("{")
         for symtab in self.symbol_tables_:
             symtab.enter_scope()
@@ -1278,7 +1279,8 @@ class Parser(object):
 
     def parse_cvParameters_(self, tag):
         assert self.cur_token_ == "cvParameters", self.cur_token_
-        block = self.ast.NestedBlock(self.cur_token_location_, self.cur_token_)
+        block = self.ast.NestedBlock(self.cur_token_location_, tag,
+                                     self.cur_token_)
         self.expect_symbol_("{")
         for symtab in self.symbol_tables_:
             symtab.enter_scope()
@@ -1312,7 +1314,7 @@ class Parser(object):
 
     def parse_cvNameIDs_(self, tag, block_name):
         assert self.cur_token_ == block_name, self.cur_token_
-        block = self.ast.NestedBlock(self.cur_token_location_, block_name)
+        block = self.ast.NestedBlock(self.cur_token_location_, tag, block_name)
         self.expect_symbol_("{")
         for symtab in self.symbol_tables_:
             symtab.enter_scope()

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -46,6 +46,8 @@ class Parser(object):
         lexerClass = IncludingLexer if followIncludes else NonIncludingLexer
         self.lexer_ = lexerClass(featurefile)
         self.advance_lexer_(comments=True)
+        self.SS_FEATURE_TAGS = ["ss%02d" % i for i in range(1, 20+1)]
+        self.CV_FEATURE_TAGS = ["cv%02d" % i for i in range(1, 99+1)]
 
     def parse(self):
         statements = self.doc_.statements
@@ -1219,14 +1221,14 @@ class Parser(object):
         vertical = (tag in {"vkrn", "vpal", "vhal", "valt"})
 
         stylisticset = None
-        if tag in ["ss%02d" % i for i in range(1, 20+1)]:
-            stylisticset = tag
-
         cv_feature = None
-        if tag in ["cv%02d" % i for i in range(1, 99+1)]:
+        size_feature = False
+        if tag in self.SS_FEATURE_TAGS:
+            stylisticset = tag
+        elif tag in self.CV_FEATURE_TAGS:
             cv_feature = tag
-
-        size_feature = (tag == "size")
+        elif tag == "size":
+            size_feature = True
 
         use_extension = False
         if self.next_token_ == "useExtension":

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -16,6 +16,8 @@ log = logging.getLogger(__name__)
 class Parser(object):
     extensions = {}
     ast = ast
+    SS_FEATURE_TAGS = ["ss%02d" % i for i in range(1, 20+1)]
+    CV_FEATURE_TAGS = ["cv%02d" % i for i in range(1, 99+1)]
 
     def __init__(self, featurefile, glyphNames=(), followIncludes=True,
                  **kwargs):
@@ -46,8 +48,6 @@ class Parser(object):
         lexerClass = IncludingLexer if followIncludes else NonIncludingLexer
         self.lexer_ = lexerClass(featurefile)
         self.advance_lexer_(comments=True)
-        self.SS_FEATURE_TAGS = ["ss%02d" % i for i in range(1, 20+1)]
-        self.CV_FEATURE_TAGS = ["cv%02d" % i for i in range(1, 99+1)]
 
     def parse(self):
         statements = self.doc_.statements
@@ -1576,8 +1576,12 @@ class Parser(object):
             raise FeatureLibError("Expected an integer or floating-point number",
                                   self.cur_token_location_)
 
-    # TODO: Don't allow this method to accept negative numbers
     def expect_decimal_or_hexadecimal_(self):
+        # the lexer returns the same token type 'NUMBER' for either decimal or
+        # hexadecimal integers, and casts them both to a `int` type, so it's
+        # impossible to distinguish the two here. This method is implemented
+        # the same as `expect_number_`, only it gives a more informative
+        # error message
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.NUMBER:
             return self.cur_token_

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -61,7 +61,7 @@ class BuilderTest(unittest.TestCase):
         spec4h1 spec4h2 spec5d1 spec5d2 spec5fi1 spec5fi2 spec5fi3 spec5fi4
         spec5f_ii_1 spec5f_ii_2 spec5f_ii_3 spec5f_ii_4
         spec5h1 spec6b_ii spec6d2 spec6e spec6f
-        spec6h_ii spec6h_iii_1 spec6h_iii_3d spec8a spec8b spec8c
+        spec6h_ii spec6h_iii_1 spec6h_iii_3d spec8a spec8b spec8c spec8d
         spec9a spec9b spec9c1 spec9c2 spec9c3 spec9d spec9e spec9f spec9g
         spec10
         bug453 bug457 bug463 bug501 bug502 bug504 bug505 bug506 bug509

--- a/Tests/feaLib/data/spec8d.fea
+++ b/Tests/feaLib/data/spec8d.fea
@@ -1,0 +1,45 @@
+# The cvParameters block must precede any of the rules in the feature.
+# The ParamUILabelNameID entry may be omitted or repeated as often as needed.
+# The other NameID types may be omitted, or defined only once.
+# The NameID entries must be specified in the order listed below.
+
+# Following the set of NameID entries, a series of 24-bit Unicode values may be specified.
+# These provide Unicode values for the base glyphs referenced by the feature.
+# The developer may specify none, some, or all of the Unicode values for the base glyphs.
+# The Unicode value may be written with either decimal or hexadecimal notation.
+# The value must be preceded by '0x' if it is a hexadecimal value.
+
+# NOTE: The ParamUILabelNameID entries are used when one base glyph is mapped to more than
+# one variant; the font designer may then specify one ParamUILabelNameID for each variant, in
+# order to uniquely describe that variant. If any ParamUILabelNameID entries are specified,
+# the number of ParamUILabelNameID entries must match the number of variants for each base
+# glyph. If the Character Variant feature specifies more than one base glyph, then the set
+# of NameID entries in the parameter block will be used for each base glyph and its variants.
+feature cv01 {
+	cvParameters {
+		FeatUILabelNameID {
+			name 3 1 0x0409 "uilabel simple a"; # English US
+			name 1 0 0 "uilabel simple a"; # Mac English
+		};
+		FeatUITooltipTextNameID {
+			name 3 1 0x0409 "tool tip simple a"; # English US
+			name 1 0 0 "tool tip simple a"; # Mac English
+		};
+		SampleTextNameID {
+			name 3 1 0x0409 "sample text simple a"; # English US
+			name 1 0 0 "sample text simple a"; # Mac English
+		};
+		ParamUILabelNameID {
+			name 3 1 0x0409 "param1 text simple a"; # English US
+			name 1 0 0 "param1 text simple a"; # Mac English
+		};
+		ParamUILabelNameID {
+			name 3 1 0x0409 "param2 text simple a"; # English US
+			name 1 0 0 "param2 text simple a"; # Mac English
+		};
+		Character 10;
+		Character 0x5DDE;
+	};
+# --- rules for this feature ---
+    sub A by B;
+} cv01;

--- a/Tests/feaLib/data/spec8d.fea
+++ b/Tests/feaLib/data/spec8d.fea
@@ -18,26 +18,38 @@
 feature cv01 {
 	cvParameters {
 		FeatUILabelNameID {
+#test-fea2fea: name "uilabel simple a";
 			name 3 1 0x0409 "uilabel simple a"; # English US
+#test-fea2fea: name 1 "uilabel simple a";
 			name 1 0 0 "uilabel simple a"; # Mac English
 		};
 		FeatUITooltipTextNameID {
+#test-fea2fea: name "tool tip simple a";
 			name 3 1 0x0409 "tool tip simple a"; # English US
+#test-fea2fea: name 1 "tool tip simple a";
 			name 1 0 0 "tool tip simple a"; # Mac English
 		};
 		SampleTextNameID {
+#test-fea2fea: name "sample text simple a";
 			name 3 1 0x0409 "sample text simple a"; # English US
+#test-fea2fea: name 1 "sample text simple a";
 			name 1 0 0 "sample text simple a"; # Mac English
 		};
 		ParamUILabelNameID {
+#test-fea2fea: name "param1 text simple a";
 			name 3 1 0x0409 "param1 text simple a"; # English US
+#test-fea2fea: name 1 "param1 text simple a";
 			name 1 0 0 "param1 text simple a"; # Mac English
 		};
 		ParamUILabelNameID {
+#test-fea2fea: name "param2 text simple a";
 			name 3 1 0x0409 "param2 text simple a"; # English US
+#test-fea2fea: name 1 "param2 text simple a";
 			name 1 0 0 "param2 text simple a"; # Mac English
 		};
+#test-fea2fea: Character 0xa;
 		Character 10;
+#test-fea2fea: Character 0x5dde;
 		Character 0x5DDE;
 	};
 # --- rules for this feature ---

--- a/Tests/feaLib/data/spec8d.ttx
+++ b/Tests/feaLib/data/spec8d.ttx
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <name>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      uilabel simple a
+    </namerecord>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      uilabel simple a
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      tool tip simple a
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      tool tip simple a
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      sample text simple a
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      sample text simple a
+    </namerecord>
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      param1 text simple a
+    </namerecord>
+    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      param1 text simple a
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      param2 text simple a
+    </namerecord>
+    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      param2 text simple a
+    </namerecord>
+  </name>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="cv01"/>
+        <Feature>
+          <FeatureParamsCharacterVariants Format="0">
+            <Format value="0"/>
+            <FeatUILabelNameID value="256"/>  <!-- uilabel simple a -->
+            <FeatUITooltipTextNameID value="257"/>  <!-- tool tip simple a -->
+            <SampleTextNameID value="258"/>  <!-- sample text simple a -->
+            <NumNamedParameters value="2"/>
+            <FirstParamUILabelNameID value="259"/>  <!-- param1 text simple a -->
+            <!-- CharCount=2 -->
+            <Character index="0" value="10"/>
+            <Character index="1" value="24030"/>
+          </FeatureParamsCharacterVariants>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="A" out="B"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -237,7 +237,7 @@ class ParserTest(unittest.TestCase):
         [feature] = self.parse(
             "feature ss01 { featureNames { # Comment\n }; } ss01;").statements
         [featureNames] = feature.statements
-        self.assertIsInstance(featureNames, ast.FeatureNamesBlock)
+        self.assertIsInstance(featureNames, ast.NestedBlock)
         [comment] = featureNames.statements
         self.assertIsInstance(comment, ast.Comment)
         self.assertEqual(comment.text, "# Comment")
@@ -246,7 +246,7 @@ class ParserTest(unittest.TestCase):
         [feature] = self.parse(
             "feature ss01 { featureNames { ;;; }; } ss01;").statements
         [featureNames] = feature.statements
-        self.assertIsInstance(featureNames, ast.FeatureNamesBlock)
+        self.assertIsInstance(featureNames, ast.NestedBlock)
         self.assertEqual(featureNames.statements, [])
 
     def test_FontRevision(self):


### PR DESCRIPTION
AFAICT this is working. The expected TTX was compared with what makeotf produces.

The test is failing because FEA round tripping produces equivalent instead of exactly matching statements. Not sure what's the best way to address it.

The `cvParameters` block has a series of rules —see the header of *spec8d.fea* file— which the current code does not enforce.