### PR TITLE
Drop glyph names for CFF fonts, promote to CID

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2466,7 +2466,8 @@ def prune_post_subset(self, options):
 		for subrs in all_subrs:
 			del subrs._used, subrs._old_bias, subrs._new_bias
 
-	if not options.glyph_names:
+	is_name_keyed = not hasattr(cff.topDictIndex[0], 'ROS')
+	if is_name_keyed and not options.glyph_names:
 		# Drop PostScript names, promote the font to being CID-keyed.
 		topDict0 = cff.topDictIndex[0]
 		topDict0.ROS = ('Adobe', 'Identity', 0)

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2466,6 +2466,21 @@ def prune_post_subset(self, options):
 		for subrs in all_subrs:
 			del subrs._used, subrs._old_bias, subrs._new_bias
 
+	if not options.glyph_names:
+		# Drop PostScript names, promote the font to being CID-keyed.
+		topDict0 = cff.topDictIndex[0]
+		topDict0.ROS = ('Adobe', 'Identity', 0)
+		mapping = {
+			name: ("cid" + str(n) if n else ".notdef")
+			for n, name in enumerate(topDict0.charset)}
+		charstrings = topDict0.CharStrings
+		charstrings.charStrings = {
+			mapping[name]: v
+			for name, v in charstrings.charStrings.items()}
+		topDict0.charset = [
+			"cid" + str(n) if n else ".notdef"
+			for n in range(len(topDict0.charset))]
+
 	return True
 
 

--- a/Tests/subset/data/expect_desubroutinize_CFF.ttx
+++ b/Tests/subset/data/expect_desubroutinize_CFF.ttx
@@ -5,6 +5,7 @@
     <major value="1"/>
     <minor value="0"/>
     <CFFFont name="Lobster1.4">
+      <ROS Registry="Adobe" Order="Identity" Supplement="0"/>
       <version value="001.001"/>
       <Notice value="Copyright (c) 2010 by Pablo Impallari. www.impallari.com. All rights reserved."/>
       <Copyright value="Copyright (c) 2010 by Pablo Impallari. All rights reserved."/>
@@ -20,8 +21,11 @@
       <FontMatrix value="0.001 0 0 0.001 0 0"/>
       <FontBBox value="-209 -250 1186 1000"/>
       <StrokeWidth value="0"/>
+      <CIDFontVersion value="0"/>
+      <CIDFontRevision value="0"/>
+      <CIDFontType value="0"/>
+      <CIDCount value="8720"/>
       <!-- charset is dumped separately as the 'GlyphOrder' element -->
-      <Encoding name="StandardEncoding"/>
       <Private>
         <BlueValues value="0 0"/>
         <BlueScale value="0.039625"/>
@@ -38,7 +42,7 @@
         <CharString name=".notdef">
           -63 endchar
         </CharString>
-        <CharString name="A">
+        <CharString name="cid00001">
           220 -93 -21 114 -20 297 181 -59 59 292 -20 hstemhm
           9 118 -43 120 hintmask 11101100
           535 hmoveto
@@ -58,7 +62,7 @@
           -39 16 -43 11 -40 8 56 112 64 93 60 32 rrcurveto
           endchar
         </CharString>
-        <CharString name="A.salt">
+        <CharString name="cid00002">
           142 -92 -21 113 -20 386 52 333 -20 hstem
           8 120 vstem
           459 hmoveto
@@ -73,7 +77,7 @@
           58 126 72 106 73 32 -56 -264 rcurveline
           endchar
         </CharString>
-        <CharString name="B">
+        <CharString name="cid00003">
           187 -17 96 -79 -20 406 48 270 46 hstemhm
           6 93 362 139 -119 101 -101 119 hintmask 01111100
           230 636 rmoveto
@@ -95,7 +99,7 @@
           47 222 rlineto
           endchar
         </CharString>
-        <CharString name="B.salt">
+        <CharString name="cid00004">
           185 -28 92 -64 -20 413 41 270 46 hstemhm
           6 93 350 149 -119 105 -105 119 hintmask 01111100
           230 636 rmoveto
@@ -120,7 +124,7 @@
           63 21 -49 -57 -96 -58 -120 -72 hvcurveto
           endchar
         </CharString>
-        <CharString name="I">
+        <CharString name="cid00005">
           -73 21 -21 750 -20 hstem
           6 93 vstem
           397 748 rmoveto
@@ -132,7 +136,7 @@
           144 hlineto
           endchar
         </CharString>
-        <CharString name="IJ">
+        <CharString name="cid00006">
           215 -207 50 157 -20 770 -20 hstemhm
           6 93 13 84 -84 205 hintmask 11111000
           397 748 rmoveto
@@ -152,7 +156,7 @@
           34 -26 24 -41 6 vhcurveto
           endchar
         </CharString>
-        <CharString name="J">
+        <CharString name="cid00007">
           88 -207 50 144 81 682 -20 hstemhm
           17 84 -84 220 -50 93 hintmask 11110100
           538 750 rmoveto
@@ -168,7 +172,7 @@
           150 710 rlineto
           endchar
         </CharString>
-        <CharString name="one">
+        <CharString name="cid00008">
           -131 21 -21 624 46 78 -20 hstem
           324 748 rmoveto
           -72 -121 -78 -6 -55 hhcurveto
@@ -178,7 +182,7 @@
           144 hlineto
           endchar
         </CharString>
-        <CharString name="three">
+        <CharString name="cid00009">
           66 -5 65 197 51 204 237 -54 54 hstemhm
           6 111 -12 110 117 155 -117 117 hintmask 11101001
           205 257 rmoveto
@@ -196,7 +200,7 @@
           -87 -53 -82 -86 -37 -39 13 76 40 10 62 78 6 vhcurveto
           endchar
         </CharString>
-        <CharString name="two">
+        <CharString name="cid00010">
           44 -11 125 -89 89 -89 107 380 237 -54 54 hstemhm
           66 110 142 119 -119 144 hintmask 00110101
           111 132 rmoveto
@@ -217,7 +221,7 @@
           -75 -57 18 -59 hhcurveto
           endchar
         </CharString>
-        <CharString name="zero">
+        <CharString name="cid00011">
           98 -9 84 623 52 hstem
           30 158 236 131 vstem
           377 750 rmoveto

--- a/Tests/subset/data/expect_keep_math.ttx
+++ b/Tests/subset/data/expect_keep_math.ttx
@@ -4,29 +4,30 @@
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
     <GlyphID id="0" name=".notdef"/>
-    <GlyphID id="1" name="parenleft"/>
-    <GlyphID id="2" name="A"/>
-    <GlyphID id="3" name="uni0302"/>
-    <GlyphID id="4" name="uni239B"/>
-    <GlyphID id="5" name="uni239C"/>
-    <GlyphID id="6" name="uni239D"/>
-    <GlyphID id="7" name="u1D400"/>
-    <GlyphID id="8" name="u1D435"/>
-    <GlyphID id="9" name="parenleft.size1"/>
-    <GlyphID id="10" name="uni0302.size1"/>
-    <GlyphID id="11" name="parenleft.size2"/>
-    <GlyphID id="12" name="uni0302.size2"/>
-    <GlyphID id="13" name="parenleft.size3"/>
-    <GlyphID id="14" name="uni0302.size3"/>
-    <GlyphID id="15" name="parenleft.size4"/>
-    <GlyphID id="16" name="uni0302.size4"/>
-    <GlyphID id="17" name="uni0302.size5"/>
+    <GlyphID id="1" name="cid00001"/>
+    <GlyphID id="2" name="cid00002"/>
+    <GlyphID id="3" name="cid00003"/>
+    <GlyphID id="4" name="cid00004"/>
+    <GlyphID id="5" name="cid00005"/>
+    <GlyphID id="6" name="cid00006"/>
+    <GlyphID id="7" name="cid00007"/>
+    <GlyphID id="8" name="cid00008"/>
+    <GlyphID id="9" name="cid00009"/>
+    <GlyphID id="10" name="cid00010"/>
+    <GlyphID id="11" name="cid00011"/>
+    <GlyphID id="12" name="cid00012"/>
+    <GlyphID id="13" name="cid00013"/>
+    <GlyphID id="14" name="cid00014"/>
+    <GlyphID id="15" name="cid00015"/>
+    <GlyphID id="16" name="cid00016"/>
+    <GlyphID id="17" name="cid00017"/>
   </GlyphOrder>
 
   <CFF>
     <major value="1"/>
     <minor value="0"/>
     <CFFFont name="XITSMath">
+      <ROS Registry="Adobe" Order="Identity" Supplement="0"/>
       <version value="1.108"/>
       <Notice value="Copyright (c) 2001-2011 by the STI Pub Companies, consisting of the American Chemical Society, the American Institute of Physics, the American Mathematical Society, the American Physical Society, Elsevier, Inc., and The Institute of Electrical and Electronic Engineers, Inc.  Portions copyright (c) 1998-2003 by MicroPress, Inc.  Portions copyright (c) 1990 by Elsevier, Inc.  Portions copyright (c) 2009-2012 by Khaled Hosny.  All rights reserved. "/>
       <FullName value="XITS Math"/>
@@ -41,8 +42,11 @@
       <FontMatrix value="0.001 0 0 0.001 0 0"/>
       <FontBBox value="-970 -906 3238 2566"/>
       <StrokeWidth value="0"/>
+      <CIDFontVersion value="0"/>
+      <CIDFontRevision value="0"/>
+      <CIDFontType value="0"/>
+      <CIDCount value="8720"/>
       <!-- charset is dumped separately as the 'GlyphOrder' element -->
-      <Encoding name="StandardEncoding"/>
       <Private>
         <BlueValues value="-14 0 450 460 662 676"/>
         <BlueScale value="0.039625"/>
@@ -125,15 +129,7 @@
         <CharString name=".notdef">
           -351 endchar
         </CharString>
-        <CharString name="A">
-          121 0 20 196 41 397 20 hstem
-          707 hmoveto
-          -107 callsubr
-          -5 257 rmoveto
-          -106 callsubr
-          endchar
-        </CharString>
-        <CharString name="parenleft">
+        <CharString name="cid00001">
           -268 656 20 hstem
           48 86 vstem
           304 -161 rmoveto
@@ -142,39 +138,43 @@
           -160 -95 -87 -144 0 -185 0 -170 86 -169 158 -90 rrcurveto
           endchar
         </CharString>
-        <CharString name="parenleft.size1">
-          -133 139 81 vstem
-          382 -134 rmoveto
-          -90 110 -72 169 0 306 0 303 72 172 90 110 rrcurveto
-          30 vlineto
-          -142 -134 -101 -214 0 -267 0 -272 101 -209 142 -134 rrcurveto
+        <CharString name="cid00002">
+          121 0 20 196 41 397 20 hstem
+          707 hmoveto
+          -107 callsubr
+          -5 257 rmoveto
+          -106 callsubr
           endchar
         </CharString>
-        <CharString name="parenleft.size2">
-          -12 139 95 vstem
-          503 -243 rmoveto
-          -134 165 -135 265 0 456 0 458 135 294 134 138 rrcurveto
-          33 vlineto
-          -213 -171 -151 -352 0 -400 0 -409 151 -313 213 -200 rrcurveto
+        <CharString name="cid00003">
+          -601 654 20 hstem
+          -75 507 rmoveto
+          -105 callsubr
           endchar
         </CharString>
-        <CharString name="parenleft.size3">
-          149 182 110 vstem
-          667 -346 rmoveto
-          -178 220 -197 349 0 613 0 606 197 396 178 184 rrcurveto
-          44 vlineto
-          -284 -228 -201 -464 0 -538 0 -541 201 -422 284 -267 rrcurveto
+        <CharString name="cid00004">
+          -151 50 124 vstem
+          400 1005 rmoveto
+          -261 -184 -89 -359 0 -303 rrcurveto
+          -159 124 239 vlineto
+          0 254 54 285 172 197 rrcurveto
           endchar
         </CharString>
-        <CharString name="parenleft.size4">
-          207 124 130 vstem
-          732 -453 rmoveto
-          -224 232 -254 504 0 746 0 777 254 473 224 231 rrcurveto
-          56 vlineto
-          -355 -286 -253 -578 0 -673 0 -675 253 -577 355 -286 rrcurveto
+        <CharString name="cid00005">
+          -151 50 124 vstem
+          174 hmoveto
+          1010 -124 -1010 vlineto
           endchar
         </CharString>
-        <CharString name="u1D400">
+        <CharString name="cid00006">
+          -151 50 124 vstem
+          400 30 rmoveto
+          -172 197 -54 285 0 254 rrcurveto
+          239 -124 -159 vlineto
+          0 -303 89 -359 261 -184 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="cid00007">
           121 0 20 177 39 hstem
           689 hmoveto
           -104 callsubr
@@ -182,7 +182,7 @@
           -195 0 94 243 rlineto
           endchar
         </CharString>
-        <CharString name="u1D435">
+        <CharString name="cid00008">
           95 0 38 280 35 261 39 hstem
           198 653 rmoveto
           -103 callsubr
@@ -192,57 +192,61 @@
           -101 callsubr
           endchar
         </CharString>
-        <CharString name="uni0302">
-          -601 654 20 hstem
-          -75 507 rmoveto
-          -105 callsubr
+        <CharString name="cid00009">
+          -133 139 81 vstem
+          382 -134 rmoveto
+          -90 110 -72 169 0 306 0 303 72 172 90 110 rrcurveto
+          30 vlineto
+          -142 -134 -101 -214 0 -267 0 -272 101 -209 142 -134 rrcurveto
           endchar
         </CharString>
-        <CharString name="uni0302.size1">
+        <CharString name="cid00010">
           -41 560 554 rmoveto
           -256 213 -48 0 -256 -213 64 0 216 146 216 -146 rlineto
           endchar
         </CharString>
-        <CharString name="uni0302.size2">
+        <CharString name="cid00011">
+          -12 139 95 vstem
+          503 -243 rmoveto
+          -134 165 -135 265 0 456 0 458 135 294 134 138 rrcurveto
+          33 vlineto
+          -213 -171 -151 -352 0 -400 0 -409 151 -313 213 -200 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="cid00012">
           378 979 564 rmoveto
           -465 213 -48 0 -466 -213 99 0 391 145 390 -145 rlineto
           endchar
         </CharString>
-        <CharString name="uni0302.size3">
+        <CharString name="cid00013">
+          149 182 110 vstem
+          667 -346 rmoveto
+          -178 220 -197 349 0 613 0 606 197 396 178 184 rrcurveto
+          44 vlineto
+          -284 -228 -201 -464 0 -538 0 -541 201 -422 284 -267 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="cid00014">
           859 1460 564 rmoveto
           -706 213 -48 0 -706 -213 153 0 577 145 577 -145 rlineto
           endchar
         </CharString>
-        <CharString name="uni0302.size4">
+        <CharString name="cid00015">
+          207 124 130 vstem
+          732 -453 rmoveto
+          -224 232 -254 504 0 746 0 777 254 473 224 231 rrcurveto
+          56 vlineto
+          -355 -286 -253 -578 0 -673 0 -675 253 -577 355 -286 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="cid00016">
           1285 1886 599 rmoveto
           -943 197 -943 -197 5 -26 937 161 939 -161 rlineto
           endchar
         </CharString>
-        <CharString name="uni0302.size5">
+        <CharString name="cid00017">
           1727 2328 603 rmoveto
           -1164 213 -1164 -213 5 -31 1158 182 1160 -182 rlineto
-          endchar
-        </CharString>
-        <CharString name="uni239B">
-          -151 50 124 vstem
-          400 1005 rmoveto
-          -261 -184 -89 -359 0 -303 rrcurveto
-          -159 124 239 vlineto
-          0 254 54 285 172 197 rrcurveto
-          endchar
-        </CharString>
-        <CharString name="uni239C">
-          -151 50 124 vstem
-          174 hmoveto
-          1010 -124 -1010 vlineto
-          endchar
-        </CharString>
-        <CharString name="uni239D">
-          -151 50 124 vstem
-          400 30 rmoveto
-          -172 197 -54 285 0 254 rrcurveto
-          239 -124 -159 vlineto
-          0 -303 89 -359 261 -184 rrcurveto
           endchar
         </CharString>
       </CharStrings>
@@ -418,7 +422,7 @@
     <MathGlyphInfo>
       <MathItalicsCorrectionInfo>
         <Coverage Format="1">
-          <Glyph value="u1D435"/>
+          <Glyph value="cid00008"/>
         </Coverage>
         <!-- ItalicsCorrectionCount=1 -->
         <ItalicsCorrection index="0">
@@ -427,15 +431,15 @@
       </MathItalicsCorrectionInfo>
       <MathTopAccentAttachment>
         <TopAccentCoverage Format="1">
-          <Glyph value="A"/>
-          <Glyph value="uni0302"/>
-          <Glyph value="u1D400"/>
-          <Glyph value="u1D435"/>
-          <Glyph value="uni0302.size1"/>
-          <Glyph value="uni0302.size2"/>
-          <Glyph value="uni0302.size3"/>
-          <Glyph value="uni0302.size4"/>
-          <Glyph value="uni0302.size5"/>
+          <Glyph value="cid00002"/>
+          <Glyph value="cid00003"/>
+          <Glyph value="cid00007"/>
+          <Glyph value="cid00008"/>
+          <Glyph value="cid00010"/>
+          <Glyph value="cid00012"/>
+          <Glyph value="cid00014"/>
+          <Glyph value="cid00016"/>
+          <Glyph value="cid00017"/>
         </TopAccentCoverage>
         <!-- TopAccentAttachmentCount=9 -->
         <TopAccentAttachment index="0">
@@ -467,15 +471,15 @@
         </TopAccentAttachment>
       </MathTopAccentAttachment>
       <ExtendedShapeCoverage Format="1">
-        <Glyph value="parenleft.size1"/>
-        <Glyph value="parenleft.size2"/>
-        <Glyph value="parenleft.size3"/>
-        <Glyph value="parenleft.size4"/>
+        <Glyph value="cid00009"/>
+        <Glyph value="cid00011"/>
+        <Glyph value="cid00013"/>
+        <Glyph value="cid00015"/>
       </ExtendedShapeCoverage>
       <MathKernInfo>
         <MathKernCoverage Format="1">
-          <Glyph value="A"/>
-          <Glyph value="u1D400"/>
+          <Glyph value="cid00002"/>
+          <Glyph value="cid00007"/>
         </MathKernCoverage>
         <!-- MathKernCount=2 -->
         <MathKernInfoRecords index="0">
@@ -523,10 +527,10 @@
     <MathVariants>
       <MinConnectorOverlap value="50"/>
       <VertGlyphCoverage Format="1">
-        <Glyph value="parenleft"/>
+        <Glyph value="cid00001"/>
       </VertGlyphCoverage>
       <HorizGlyphCoverage Format="1">
-        <Glyph value="uni0302"/>
+        <Glyph value="cid00003"/>
       </HorizGlyphCoverage>
       <!-- VertGlyphCount=1 -->
       <!-- HorizGlyphCount=1 -->
@@ -537,21 +541,21 @@
           </ItalicsCorrection>
           <!-- PartCount=3 -->
           <PartRecords index="0">
-            <glyph value="uni239D"/>
+            <glyph value="cid00006"/>
             <StartConnectorLength value="0"/>
             <EndConnectorLength value="150"/>
             <FullAdvance value="1005"/>
             <PartFlags value="0"/>
           </PartRecords>
           <PartRecords index="1">
-            <glyph value="uni239C"/>
+            <glyph value="cid00005"/>
             <StartConnectorLength value="150"/>
             <EndConnectorLength value="150"/>
             <FullAdvance value="1010"/>
             <PartFlags value="1"/>
           </PartRecords>
           <PartRecords index="2">
-            <glyph value="uni239B"/>
+            <glyph value="cid00004"/>
             <StartConnectorLength value="150"/>
             <EndConnectorLength value="0"/>
             <FullAdvance value="1005"/>
@@ -560,50 +564,50 @@
         </GlyphAssembly>
         <!-- VariantCount=5 -->
         <MathGlyphVariantRecord index="0">
-          <VariantGlyph value="parenleft"/>
+          <VariantGlyph value="cid00001"/>
           <AdvanceMeasurement value="854"/>
         </MathGlyphVariantRecord>
         <MathGlyphVariantRecord index="1">
-          <VariantGlyph value="parenleft.size1"/>
+          <VariantGlyph value="cid00009"/>
           <AdvanceMeasurement value="1231"/>
         </MathGlyphVariantRecord>
         <MathGlyphVariantRecord index="2">
-          <VariantGlyph value="parenleft.size2"/>
+          <VariantGlyph value="cid00011"/>
           <AdvanceMeasurement value="1846"/>
         </MathGlyphVariantRecord>
         <MathGlyphVariantRecord index="3">
-          <VariantGlyph value="parenleft.size3"/>
+          <VariantGlyph value="cid00013"/>
           <AdvanceMeasurement value="2461"/>
         </MathGlyphVariantRecord>
         <MathGlyphVariantRecord index="4">
-          <VariantGlyph value="parenleft.size4"/>
+          <VariantGlyph value="cid00015"/>
           <AdvanceMeasurement value="3076"/>
         </MathGlyphVariantRecord>
       </VertGlyphConstruction>
       <HorizGlyphConstruction index="0">
         <!-- VariantCount=6 -->
         <MathGlyphVariantRecord index="0">
-          <VariantGlyph value="uni0302"/>
+          <VariantGlyph value="cid00003"/>
           <AdvanceMeasurement value="312"/>
         </MathGlyphVariantRecord>
         <MathGlyphVariantRecord index="1">
-          <VariantGlyph value="uni0302.size1"/>
+          <VariantGlyph value="cid00010"/>
           <AdvanceMeasurement value="561"/>
         </MathGlyphVariantRecord>
         <MathGlyphVariantRecord index="2">
-          <VariantGlyph value="uni0302.size2"/>
+          <VariantGlyph value="cid00012"/>
           <AdvanceMeasurement value="980"/>
         </MathGlyphVariantRecord>
         <MathGlyphVariantRecord index="3">
-          <VariantGlyph value="uni0302.size3"/>
+          <VariantGlyph value="cid00014"/>
           <AdvanceMeasurement value="1461"/>
         </MathGlyphVariantRecord>
         <MathGlyphVariantRecord index="4">
-          <VariantGlyph value="uni0302.size4"/>
+          <VariantGlyph value="cid00016"/>
           <AdvanceMeasurement value="1887"/>
         </MathGlyphVariantRecord>
         <MathGlyphVariantRecord index="5">
-          <VariantGlyph value="uni0302.size5"/>
+          <VariantGlyph value="cid00017"/>
           <AdvanceMeasurement value="2329"/>
         </MathGlyphVariantRecord>
       </HorizGlyphConstruction>
@@ -612,23 +616,23 @@
 
   <hmtx>
     <mtx name=".notdef" width="250" lsb="0"/>
-    <mtx name="A" width="722" lsb="15"/>
-    <mtx name="parenleft" width="333" lsb="48"/>
-    <mtx name="parenleft.size1" width="468" lsb="139"/>
-    <mtx name="parenleft.size2" width="589" lsb="139"/>
-    <mtx name="parenleft.size3" width="750" lsb="182"/>
-    <mtx name="parenleft.size4" width="808" lsb="124"/>
-    <mtx name="u1D400" width="722" lsb="9"/>
-    <mtx name="u1D435" width="696" lsb="38"/>
-    <mtx name="uni0302" width="0" lsb="-386"/>
-    <mtx name="uni0302.size1" width="560" lsb="0"/>
-    <mtx name="uni0302.size2" width="979" lsb="0"/>
-    <mtx name="uni0302.size3" width="1460" lsb="0"/>
-    <mtx name="uni0302.size4" width="1886" lsb="0"/>
-    <mtx name="uni0302.size5" width="2328" lsb="0"/>
-    <mtx name="uni239B" width="450" lsb="50"/>
-    <mtx name="uni239C" width="450" lsb="50"/>
-    <mtx name="uni239D" width="450" lsb="50"/>
+    <mtx name="cid00001" width="333" lsb="48"/>
+    <mtx name="cid00002" width="722" lsb="15"/>
+    <mtx name="cid00003" width="0" lsb="-386"/>
+    <mtx name="cid00004" width="450" lsb="50"/>
+    <mtx name="cid00005" width="450" lsb="50"/>
+    <mtx name="cid00006" width="450" lsb="50"/>
+    <mtx name="cid00007" width="722" lsb="9"/>
+    <mtx name="cid00008" width="696" lsb="38"/>
+    <mtx name="cid00009" width="468" lsb="139"/>
+    <mtx name="cid00010" width="560" lsb="0"/>
+    <mtx name="cid00011" width="589" lsb="139"/>
+    <mtx name="cid00012" width="979" lsb="0"/>
+    <mtx name="cid00013" width="750" lsb="182"/>
+    <mtx name="cid00014" width="1460" lsb="0"/>
+    <mtx name="cid00015" width="808" lsb="124"/>
+    <mtx name="cid00016" width="1886" lsb="0"/>
+    <mtx name="cid00017" width="2328" lsb="0"/>
   </hmtx>
 
 </ttFont>

--- a/Tests/subset/data/expect_no_hinting_CFF.ttx
+++ b/Tests/subset/data/expect_no_hinting_CFF.ttx
@@ -5,6 +5,7 @@
     <major value="1"/>
     <minor value="0"/>
     <CFFFont name="Lobster1.4">
+      <ROS Registry="Adobe" Order="Identity" Supplement="0"/>
       <version value="001.001"/>
       <Notice value="Copyright (c) 2010 by Pablo Impallari. www.impallari.com. All rights reserved."/>
       <Copyright value="Copyright (c) 2010 by Pablo Impallari. All rights reserved."/>
@@ -20,8 +21,11 @@
       <FontMatrix value="0.001 0 0 0.001 0 0"/>
       <FontBBox value="-209 -250 1186 1000"/>
       <StrokeWidth value="0"/>
+      <CIDFontVersion value="0"/>
+      <CIDFontRevision value="0"/>
+      <CIDFontType value="0"/>
+      <CIDCount value="8720"/>
       <!-- charset is dumped separately as the 'GlyphOrder' element -->
-      <Encoding name="StandardEncoding"/>
       <Private>
         <BlueScale value="0.039625"/>
         <BlueShift value="7"/>
@@ -64,7 +68,7 @@
         <CharString name=".notdef">
           -63 endchar
         </CharString>
-        <CharString name="A">
+        <CharString name="cid00001">
           220 535 hmoveto
           157 736 rlineto
           10 -24 -32 4 -23 hhcurveto
@@ -81,7 +85,7 @@
           -39 16 -43 11 -40 8 56 112 64 93 60 32 rrcurveto
           endchar
         </CharString>
-        <CharString name="A.salt">
+        <CharString name="cid00002">
           142 459 hmoveto
           157 736 rlineto
           12 -30 -26 3 -24 hhcurveto
@@ -94,7 +98,7 @@
           58 126 72 106 73 32 -56 -264 rcurveline
           endchar
         </CharString>
-        <CharString name="B">
+        <CharString name="cid00003">
           187 -105 callsubr
           82 383 rlineto
           2 18 20 1 8 hhcurveto
@@ -109,7 +113,7 @@
           47 222 rlineto
           endchar
         </CharString>
-        <CharString name="B.salt">
+        <CharString name="cid00004">
           185 -105 callsubr
           6 30 rlineto
           -41 39 41 -17 39 hhcurveto
@@ -126,12 +130,12 @@
           63 21 -49 -57 -96 -58 -120 -72 hvcurveto
           endchar
         </CharString>
-        <CharString name="I">
+        <CharString name="cid00005">
           -73 -107 callsubr
           144 hlineto
           endchar
         </CharString>
-        <CharString name="IJ">
+        <CharString name="cid00006">
           215 -107 callsubr
           34 hlineto
           -11 -20 -5 -23 -27 vvcurveto
@@ -143,7 +147,7 @@
           34 -26 24 -41 6 vhcurveto
           endchar
         </CharString>
-        <CharString name="J">
+        <CharString name="cid00007">
           88 538 750 rmoveto
           -106 callsubr
           54 76 87 36 vhcurveto
@@ -155,7 +159,7 @@
           150 710 rlineto
           endchar
         </CharString>
-        <CharString name="one">
+        <CharString name="cid00008">
           -131 324 748 rmoveto
           -72 -121 -78 -6 -55 hhcurveto
           -12 -46 rlineto
@@ -164,7 +168,7 @@
           144 hlineto
           endchar
         </CharString>
-        <CharString name="three">
+        <CharString name="cid00009">
           66 205 257 rmoveto
           38 -8 -33 13 -37 hhcurveto
           -80 -41 -60 -83 -154 141 -16 58 171 111 136 121 71 -38 65 -88 29 hvcurveto
@@ -177,7 +181,7 @@
           -87 -53 -82 -86 -37 -39 13 76 40 10 62 78 6 vhcurveto
           endchar
         </CharString>
-        <CharString name="two">
+        <CharString name="cid00010">
           44 111 132 rmoveto
           -5 hlineto
           83 135 273 98 223 vvcurveto
@@ -193,7 +197,7 @@
           -75 -57 18 -59 hhcurveto
           endchar
         </CharString>
-        <CharString name="zero">
+        <CharString name="cid00011">
           98 377 750 rmoveto
           -215 -132 -223 -273 -166 35 -97 172 205 113 299 199 168 -53 93 -125 hvcurveto
           -189 -425 rmoveto

--- a/Tests/subset/data/expect_no_hinting_desubroutinize_CFF.ttx
+++ b/Tests/subset/data/expect_no_hinting_desubroutinize_CFF.ttx
@@ -5,6 +5,7 @@
     <major value="1"/>
     <minor value="0"/>
     <CFFFont name="Lobster1.4">
+      <ROS Registry="Adobe" Order="Identity" Supplement="0"/>
       <version value="001.001"/>
       <Notice value="Copyright (c) 2010 by Pablo Impallari. www.impallari.com. All rights reserved."/>
       <Copyright value="Copyright (c) 2010 by Pablo Impallari. All rights reserved."/>
@@ -20,8 +21,11 @@
       <FontMatrix value="0.001 0 0 0.001 0 0"/>
       <FontBBox value="-209 -250 1186 1000"/>
       <StrokeWidth value="0"/>
+      <CIDFontVersion value="0"/>
+      <CIDFontRevision value="0"/>
+      <CIDFontType value="0"/>
+      <CIDCount value="8720"/>
       <!-- charset is dumped separately as the 'GlyphOrder' element -->
-      <Encoding name="StandardEncoding"/>
       <Private>
         <BlueScale value="0.039625"/>
         <BlueShift value="7"/>
@@ -37,7 +41,7 @@
         <CharString name=".notdef">
           -63 endchar
         </CharString>
-        <CharString name="A">
+        <CharString name="cid00001">
           220 535 hmoveto
           157 736 rlineto
           10 -24 -32 4 -23 hhcurveto
@@ -54,7 +58,7 @@
           -39 16 -43 11 -40 8 56 112 64 93 60 32 rrcurveto
           endchar
         </CharString>
-        <CharString name="A.salt">
+        <CharString name="cid00002">
           142 459 hmoveto
           157 736 rlineto
           12 -30 -26 3 -24 hhcurveto
@@ -67,7 +71,7 @@
           58 126 72 106 73 32 -56 -264 rcurveline
           endchar
         </CharString>
-        <CharString name="B">
+        <CharString name="cid00003">
           187 230 636 rmoveto
           -136 -636 rlineto
           144 hlineto
@@ -85,7 +89,7 @@
           47 222 rlineto
           endchar
         </CharString>
-        <CharString name="B.salt">
+        <CharString name="cid00004">
           185 230 636 rmoveto
           -136 -636 rlineto
           144 hlineto
@@ -105,7 +109,7 @@
           63 21 -49 -57 -96 -58 -120 -72 hvcurveto
           endchar
         </CharString>
-        <CharString name="I">
+        <CharString name="cid00005">
           -73 397 748 rmoveto
           1 -13 -13 1 -14 hhcurveto
           -167 -184 -127 -133 -72 38 -25 69 hvcurveto
@@ -115,7 +119,7 @@
           144 hlineto
           endchar
         </CharString>
-        <CharString name="IJ">
+        <CharString name="cid00006">
           215 397 748 rmoveto
           1 -13 -13 1 -14 hhcurveto
           -167 -184 -127 -133 -72 38 -25 69 hvcurveto
@@ -132,7 +136,7 @@
           34 -26 24 -41 6 vhcurveto
           endchar
         </CharString>
-        <CharString name="J">
+        <CharString name="cid00007">
           88 538 750 rmoveto
           -167 -184 -127 -133 -72 38 -25 69 hvcurveto
           -1 9 -13 8 51 vvcurveto
@@ -145,7 +149,7 @@
           150 710 rlineto
           endchar
         </CharString>
-        <CharString name="one">
+        <CharString name="cid00008">
           -131 324 748 rmoveto
           -72 -121 -78 -6 -55 hhcurveto
           -12 -46 rlineto
@@ -154,7 +158,7 @@
           144 hlineto
           endchar
         </CharString>
-        <CharString name="three">
+        <CharString name="cid00009">
           66 205 257 rmoveto
           38 -8 -33 13 -37 hhcurveto
           -80 -41 -60 -83 -154 141 -16 58 171 111 136 121 71 -38 65 -88 29 hvcurveto
@@ -167,7 +171,7 @@
           -87 -53 -82 -86 -37 -39 13 76 40 10 62 78 6 vhcurveto
           endchar
         </CharString>
-        <CharString name="two">
+        <CharString name="cid00010">
           44 111 132 rmoveto
           -5 hlineto
           83 135 273 98 223 vvcurveto
@@ -183,7 +187,7 @@
           -75 -57 18 -59 hhcurveto
           endchar
         </CharString>
-        <CharString name="zero">
+        <CharString name="cid00011">
           98 377 750 rmoveto
           -215 -132 -223 -273 -166 35 -97 172 205 113 299 199 168 -53 93 -125 hvcurveto
           -189 -425 rmoveto

--- a/Tests/subset/data/expect_no_notdef_outline_otf.ttx
+++ b/Tests/subset/data/expect_no_notdef_outline_otf.ttx
@@ -5,6 +5,7 @@
     <major value="1"/>
     <minor value="0"/>
     <CFFFont name="TestOTF-Regular">
+      <ROS Registry="Adobe" Order="Identity" Supplement="0"/>
       <version value="1.0"/>
       <FamilyName value="Test OTF"/>
       <isFixedPitch value="0"/>
@@ -16,8 +17,11 @@
       <FontMatrix value="0.001 0 0 0.001 0 0"/>
       <FontBBox value="0 0 486 660"/>
       <StrokeWidth value="0"/>
+      <CIDFontVersion value="0"/>
+      <CIDFontRevision value="0"/>
+      <CIDFontType value="0"/>
+      <CIDCount value="8720"/>
       <!-- charset is dumped separately as the 'GlyphOrder' element -->
-      <Encoding name="StandardEncoding"/>
       <Private>
         <BlueValues value="-10 0 500 510"/>
         <BlueScale value="0.039625"/>


### PR DESCRIPTION
Copy-pasting of Behdad's code in https://github.com/fonttools/fonttools/issues/147.

Replaces all glyph names with ones like "cid12345".

Why do we want to promote CFFs to being CID-keyed?