### PR TITLE
feaLib: add IncludedFeaNotFound error

### DIFF
--- a/Lib/fontTools/feaLib/error.py
+++ b/Lib/fontTools/feaLib/error.py
@@ -14,3 +14,7 @@ class FeatureLibError(Exception):
             return "%s:%d:%d: %s" % (path, line, column, message)
         else:
             return message
+
+
+class IncludedFeaNotFound(FeatureLibError):
+    pass

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 from __future__ import unicode_literals
 from fontTools.misc.py23 import *
-from fontTools.feaLib.error import FeatureLibError
+from fontTools.feaLib.error import FeatureLibError, IncludedFeaNotFound
 import re
 import os
 
@@ -231,7 +231,11 @@ class IncludingLexer(object):
             try:
                 fileobj = open(filename, "r", encoding="utf-8")
             except IOError as err:
-                raise FeatureLibError(str(err), location)
+                # FileNotFoundError does not exist on Python < 3.3
+                import errno
+                if err.errno == errno.ENOENT:
+                    raise IncludedFeaNotFound(str(err), location)
+                raise  # pragma: no cover
         data = fileobj.read()
         filename = fileobj.name if hasattr(fileobj, "name") else "<features>"
         if closing:


### PR DESCRIPTION
subclass of FeatureLibError, only raised if IOError.errno == ENOENT (i.e. FileNotFoundError)

https://github.com/googlei18n/fontmake/issues/157#issuecomment-367380471

Will be useful in ufo2ft to detect when an included feature file doesn't exist and print a nicer error message explaining that includes must be relative to the UFO itself, and not relative to the embedded features.fea file.

https://github.com/unified-font-object/ufo-spec/issues/55