### PR TITLE
[cffLib] save file position against lazy-load of charset

### DIFF
--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -1027,20 +1027,16 @@ def buildConverters(table):
 	return d
 
 
-class BaseConverter(object):
+class SimpleConverter(object):
 
 	def read(self, parent, value):
+		if not hasattr(parent, "file"):
+			return self._read(parent, value)
 		file = parent.file
 		pos = file.tell()
-		try:
-			return self._read(parent, value)
-		finally:
-			file.seek(pos)
-
-	def _read(self, parent, value):
-		raise NotImplementedError
-
-class SimpleConverter(BaseConverter):
+		value = self._read(parent, value)
+		file.seek(pos)
+		return value
 
 	def _read(self, parent, value):
 		return value
@@ -1271,7 +1267,7 @@ class CharStringsConverter(TableConverter):
 		return charStrings
 
 
-class CharsetConverter(BaseConverter):
+class CharsetConverter(SimpleConverter):
 	def _read(self, parent, value):
 		isCID = hasattr(parent, "ROS")
 		if value > 2:
@@ -1646,7 +1642,7 @@ class FDArrayConverter(TableConverter):
 		return fdArray
 
 
-class FDSelectConverter(BaseConverter):
+class FDSelectConverter(SimpleConverter):
 
 	def _read(self, parent, value):
 		file = parent.file

--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -1034,9 +1034,10 @@ class SimpleConverter(object):
 			return self._read(parent, value)
 		file = parent.file
 		pos = file.tell()
-		value = self._read(parent, value)
-		file.seek(pos)
-		return value
+		try:
+			return self._read(parent, value)
+		finally:
+			file.seek(pos)
 
 	def _read(self, parent, value):
 		return value


### PR DESCRIPTION
This PR is related to #1177.

As is discussed, parseEncoding0 may receive unexpected file position due to lazy-load of 'charset'.
So I save file position before calling parseEncoding0 and restore the position at the beginning of parseEncoding0.

Similar modification is applied to parseCharset0 because of symmetry. Actually it may not be needed since 'strings' which has possibility of lazy-load seems to be always loaded before calling parseCharset0.