### PR TITLE
[ttFont] fixes xmlWriter import error in _saveXML method with ttx split tables request

### DIFF
--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division, absolute_import
+from fontTools.misc import xmlWriter
 from fontTools.misc.py23 import *
 from fontTools.misc.loggingTools import deprecateArgument
 from fontTools.ttLib.sfnt import SFNTReader, SFNTWriter
@@ -216,7 +217,6 @@ class TTFont(object):
 		to skip, but only when the 'tables' argument is false.
 		"""
 
-		from fontTools.misc import xmlWriter
 		writer = xmlWriter.XMLWriter(fileOrPath, newlinestr=newlinestr)
 		self._saveXML(writer, **kwargs)
 		writer.close()


### PR DESCRIPTION
Issue report: #1188 
Closes #1188 
Recognized in fontTools version 3.22.0 (PyPI release) with Python 3.6.4 interpreter

Problem: Attempt to dump split OT tables with ttx leads to NameError.  This PR moves the xmlWriter import from within the public `saveXML` method to the top of the ttFont module.

Replicated and confirmed test failure with this test: 

https://github.com/chrissimpkins/fonttools/blob/88b0446d066ee72ad70eb41b382d184875c2fcbd/Tests/xmlwriter_test.py#L1-L14

and left this in a separate branch because I don't know how you are testing your ttx dumps in testing to contribute it here. Can confirm that it fails before this change and does not fail after the change.

