### PR TITLE
[Snippets] SHA1 hash checksum list generation and testing script for font binaries and select OpenType table data

### DIFF
--- a/Snippets/checksum.py
+++ b/Snippets/checksum.py
@@ -16,6 +16,9 @@
 #
 # Usage: checksum.py (options) [file path 1]...[file path n]
 #
+#   `file path` should be defined as a path to a font file for all use cases except with use of -c/--check.
+#   With the -c/--check option, use one or more file paths to checksum files
+#
 # Options:
 #   -h, --help          Help
 #   -t, --ttx           Calculate SHA1 hash values from ttx dump of XML (default = font binary)

--- a/Snippets/checksum.py
+++ b/Snippets/checksum.py
@@ -71,7 +71,7 @@ def check_checksum(filepaths):
     check_failed = False
     for path in filepaths:
         if not os.path.exists(path):
-            sys.stderr.write("[checksum.py] ERROR: " + filepath + " is not a valid filepath" + os.linesep)
+            sys.stderr.write("[checksum.py] ERROR: " + path + " is not a valid filepath" + os.linesep)
             sys.exit(1)
 
         with open(path, mode='r') as file:

--- a/Snippets/checksum.py
+++ b/Snippets/checksum.py
@@ -114,12 +114,13 @@ def _read_binary(filepath):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(prog="checksum.py")
+    parser = argparse.ArgumentParser(prog="checksum.py", description="A SHA1 hash checksum list generator and checksum testing script")
     parser.add_argument("-t", "--ttx", help="Calculate from ttx file", action="store_true")
     parser.add_argument("-s", "--stdout", help="Write output to stdout stream", action="store_true")
     parser.add_argument("-n", "--noclean", help="Do not discard *.ttx files used to calculate SHA1 hashes", action="store_true")
     parser.add_argument("-c", "--check", help="Verify checksum values vs. files", action="store_true")
-    parser.add_argument("filepaths", nargs="+", help="One or more file paths to font binary files")
+    parser.add_argument("filepaths", nargs="+", help="One or more file paths.  Use checksum file path for -c/--check.  Use paths\
+        to font files for all other commands.")
 
     parser.add_argument("-i", "--include", action="append", help="Included OpenType tables for ttx data dump")
     parser.add_argument("-e", "--exclude", action="append", help="Excluded OpenType tables for ttx data dump")

--- a/Snippets/checksum.py
+++ b/Snippets/checksum.py
@@ -1,36 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-#----------------------------------------------------------------------------------------------------------
-# checksum.py
-#  A SHA1 hash checksum list generator for fonts and fontTools
-#  XML dumps of font OpenType table data + checksum testing
-#  script
-#
-# Copyright 2018 Christopher Simpkins
-# MIT License
-#
-# Dependencies:
-#   - Python fontTools library
-#   - Python 3 interpreter
-#
-# Usage: checksum.py (options) [file path 1]...[file path n]
-#
-#   `file path` should be defined as a path to a font file for all use cases except with use of -c/--check.
-#   With the -c/--check option, use one or more file paths to checksum files
-#
-# Options:
-#   -h, --help          Help
-#   -t, --ttx           Calculate SHA1 hash values from ttx dump of XML (default = font binary)
-#   -s, --stdout        Stream to standard output stream (default = write to working dir as 'checksum.txt')
-#   -c, --check         Test SHA1 checksum values against a valid checksum file
-#
-# Options, --ttx only:
-#   -e, --exclude       Excluded OpenType table (may be used more than once, mutually exclusive with -i)
-#   -i, --include       Included OpenType table (may be used more than once, mutually exclusive with -e)
-#   -n, --noclean       Do not discard .ttx files that are used to calculate SHA1 hashes
-#-----------------------------------------------------------------------------------------------------------
-
 import argparse
 import hashlib
 import os

--- a/Snippets/checksum.py
+++ b/Snippets/checksum.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#----------------------------------------------------------------------------------------------------------
+# checksum.py
+#  A SHA1 hash checksum list generator for fonts and fontTools
+#  XML dumps of font OpenType table data + checksum testing
+#  script
+#
+# Copyright 2018 Christopher Simpkins
+# MIT License
+#
+# Dependencies:
+#   - Python fontTools library
+#   - Python 3 interpreter
+#
+# Usage: checksum.py (options) [file path 1]...[file path n]
+#
+# Options:
+#   -h, --help          Help
+#   -t, --ttx           Calculate SHA1 hash values from ttx dump of XML (default = font binary)
+#   -s, --stdout        Stream to standard output stream (default = write to working dir as 'checksum.txt')
+#   -c, --check         Test SHA1 checksum values against a valid checksum file
+#
+# Options, --ttx only:
+#   -e, --exclude       Excluded OpenType table (may be used more than once, mutually exclusive with -i)
+#   -i, --include       Included OpenType table (may be used more than once, mutually exclusive with -e)
+#   -n, --noclean       Do not discard .ttx files that are used to calculate SHA1 hashes
+#-----------------------------------------------------------------------------------------------------------
+
+import argparse
+import hashlib
+import os
+import sys
+
+from os.path import basename
+
+from fontTools.ttLib import TTFont
+
+
+def write_checksum(filepaths, stdout_write=False, use_ttx=False, include_tables=None, exclude_tables=None, do_not_cleanup=False):
+    checksum_dict = {}
+    for path in filepaths:
+        if not os.path.exists(path):
+            sys.stderr.write("[checksum.py] ERROR: " + path + " is not a valid file path" + os.linesep)
+            sys.exit(1)
+
+        if use_ttx:
+            # append a .ttx extension to existing extension to maintain data about the binary that
+            # was used to generate the .ttx XML dump.  This creates unique checksum path values for
+            # paths that would otherwise not be unique with a file extension replacement with .ttx
+            # An example is woff and woff2 web font files that share the same base file name:
+            #
+            #  coolfont-regular.woff  ==> coolfont-regular.ttx
+            #  coolfont-regular.woff2 ==> coolfont-regular.ttx  (KAPOW! checksum data lost as this would overwrite dict value)
+            temp_ttx_path = path + ".ttx"
+
+            tt = TTFont(path)
+            # important to keep the newlinestr value defined here as hash values will change across platforms
+            # if platform specific newline values are assumed
+            tt.saveXML(temp_ttx_path, newlinestr="\n", skipTables=exclude_tables, tables=include_tables)
+            checksum_path = temp_ttx_path
+        else:
+            if include_tables is not None:
+                sys.stderr.write("[checksum.py] -i and --include are not supported for font binary filepaths. \
+                    Use these flags for checksums with the --ttx flag.")
+                sys.exit(1)
+            if exclude_tables is not None:
+                sys.stderr.write("[checksum.py] -e and --exclude are not supported for font binary filepaths. \
+                    Use these flags for checksums with the --ttx flag.")
+                sys.exit(1)
+            checksum_path = path
+
+        file_contents = _read_binary(checksum_path)
+
+        # store SHA1 hash data and associated file path basename in the checksum_dict dictionary
+        checksum_dict[basename(checksum_path)] = hashlib.sha1(file_contents).hexdigest()
+
+        # remove temp ttx files when present
+        if use_ttx and do_not_cleanup is False:
+            os.remove(temp_ttx_path)
+
+    # generate the checksum list string for writes
+    checksum_out_data = ""
+    for key in checksum_dict.keys():
+        checksum_out_data += checksum_dict[key] + "  " + key + "\n"
+
+    # write to stdout stream or file based upon user request (default = file write)
+    if stdout_write:
+        sys.stdout.write(checksum_out_data)
+    else:
+        checksum_report_filepath = "checksum.txt"
+        with open(checksum_report_filepath, "w") as file:
+            file.write(checksum_out_data)
+
+
+def check_checksum(filepaths):
+    check_failed = False
+    for path in filepaths:
+        if not os.path.exists(path):
+            sys.stderr.write("[checksum.py] ERROR: " + filepath + " is not a valid filepath" + os.linesep)
+            sys.exit(1)
+
+        with open(path, mode='r') as file:
+            for line in file.readlines():
+                cleaned_line = line.rstrip()
+                line_list = cleaned_line.split(" ")
+                # eliminate empty strings parsed from > 1 space characters
+                line_list = list(filter(None, line_list))
+                if len(line_list) == 2:
+                    expected_sha1 = line_list[0]
+                    test_path = line_list[1]
+                else:
+                    sys.stderr.write("[checksum.py] ERROR: failed to parse checksum file values" + os.linesep)
+                    sys.exit(1)
+
+                if not os.path.exists(test_path):
+                    print(test_path + ": Filepath is not valid, ignored")
+                else:
+                    file_contents = _read_binary(test_path)
+                    observed_sha1 = hashlib.sha1(file_contents).hexdigest()
+                    if observed_sha1 == expected_sha1:
+                        print(test_path + ": OK")
+                    else:
+                        print("-" * 80)
+                        print(test_path + ": === FAIL ===")
+                        print("Expected vs. Observed:")
+                        print(expected_sha1)
+                        print(observed_sha1)
+                        print("-" * 80)
+                        check_failed = True
+
+    # exit with status code 1 if any fails detected across all tests in the check
+    if check_failed is True:
+        sys.exit(1)
+
+
+def _read_binary(filepath):
+    with open(filepath, mode='rb') as file:
+        return file.read()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(prog="checksum.py")
+    parser.add_argument("-t", "--ttx", help="Calculate from ttx file", action="store_true")
+    parser.add_argument("-s", "--stdout", help="Write output to stdout stream", action="store_true")
+    parser.add_argument("-n", "--noclean", help="Do not discard *.ttx files used to calculate SHA1 hashes", action="store_true")
+    parser.add_argument("-c", "--check", help="Verify checksum values vs. files", action="store_true")
+    parser.add_argument("filepaths", nargs="+", help="One or more file paths to font binary files")
+
+    parser.add_argument("-i", "--include", action="append", help="Included OpenType tables for ttx data dump")
+    parser.add_argument("-e", "--exclude", action="append", help="Excluded OpenType tables for ttx data dump")
+
+    args = parser.parse_args(sys.argv[1:])
+
+    if args.check is True:
+        check_checksum(args.filepaths)
+    else:
+        write_checksum(args.filepaths, stdout_write=args.stdout, use_ttx=args.ttx, do_not_cleanup=args.noclean, include_tables=args.include, exclude_tables=args.exclude)


### PR DESCRIPTION
We needed a concise (i.e., not ttx dumps + text diffs) way to describe, maintain the state of, and compare compiled OpenType tables across builds. This was driven by the need to provide an approach for Linux packagers to confirm that their font compiles from source do not differ meaningfully (read that as affecting renders) from upstream builds as their build dependency versions across our entire build toolchain (and dependency of dependency of dependency chain...) diverge from our own by nature of the way that most Linux distros package and release software.

This script represents my attempt at a solution to this issue since direct SHA1 hashes of the binary files will always differ when build times differ, as will diffs of full ttx dumps from the font files, unless we force the downstream projects to compile with environment variables that fix these time-dependent values to our own.  We could dump select tables with ttx and use text file diffs but maintaining these data upstream so that downstream projects have access to them requires files that are too large for our project and we only need to evaluate the XML when relevant differences occur.  Hashes of the XML dump from select, relevant OT tables appeared to be a reasonable solution that allows us to maintain the state of these tables in a very concise format as well as permit simple broadly supported checksum comparisons between builds.  I made this script a bit more broad to address other needs but this is how we intend to use it.

This script supports and demonstrates an approach to the following with Python 3 and fontTools library dependencies alone:

- generation of SHA1 hashes from fonts
- generation of ttx style XML dumps of OT tables with `ttLib.TTFont.saveXML` using include + exclude table options to achieve between one to full OT table data dumps from binaries
- generation of SHA1 hashes from the *OpenType XML text data derived from fonts with the `saveXML` method* including:
      - single OT table hash with `--include` option
      - multiple OT tables hash with `--include` or `--exclude` options
      - all OT tables hash by default
- generation of valid checksum files for any of the above hashes that can be used for testing with this script or with other platform-specific tools such as `shasum` (macOS) or `sha1sum` (Linux)
- writes of checksum files to disk (in working directory as `checksum.txt` by default) with optional writes to the stdout stream with `--stdout` flag
- cross platform support for automated testing of SHA1 hashes defined in one or more valid SHA1 checksum files created with this tool or other tools, eliminating the need for different platform dependent executables to perform these checks.  This is an attempt to replicate the `-c` option used in other checksum tools that will work with one approach across all platforms.

The source header contains all available options. I've performed local testing and can verify that the SHA1 hashes are valid for both font binaries and XML OT table dumps, it works interchangeably with `shasum` on macOS in terms of both tools using the other tool's checksum file to validate font and XML files, and that my machine is still running after execution of the script numerous times.  There is no comprehensive test suite at the moment, and this should be considered untested and intended for education as a Snippet if felt to be appropriate in that directory.  If not, I will maintain this in my downstream repository for anyone who might find it to be of use. 
