### PR TITLE
[varLib] Only recalculate horizontalAdvanceWidth if its not 0

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -233,6 +233,7 @@ def _GetCoordinates(font, glyphName):
 # TODO Move to glyf or gvar table proper
 def _SetCoordinates(font, glyphName, coord):
 	glyf = font["glyf"]
+	horizontalAdvanceWidth = font["hmtx"].metrics[glyphName][0]
 	assert glyphName in glyf.glyphs
 	glyph = glyf[glyphName]
 
@@ -261,7 +262,8 @@ def _SetCoordinates(font, glyphName, coord):
 
 	glyph.recalcBounds(glyf)
 
-	horizontalAdvanceWidth = round(rightSideX - leftSideX)
+	if horizontalAdvanceWidth != 0:
+		horizontalAdvanceWidth = round(rightSideX - leftSideX)
 	leftSideBearing = round(glyph.xMin - leftSideX)
 	# XXX Handle vertical
 	font["hmtx"].metrics[glyphName] = horizontalAdvanceWidth, leftSideBearing


### PR DESCRIPTION
Whilst trying to gen instances using varLib.mutator on [MarkaziText](https://github.com/BornaIz/markazitext). I got negative adv warnings for the following glyphs:

```
ERROR: Glyph 'uni0615' has negative advance width
ERROR: Glyph 'uniFBB4' has negative advance width
ERROR: Glyph 'uni0655' has negative advance width
```

These glyphs are Non-Spacing Marks so they should have 0 for their advance width.

When I inspect the glyphs, they have 0 but they're shifted to the right. Even when I center the outlines, the adv width still get recalculated to a negative integer in many cases.

![screen shot 2018-02-26 at 10 19 03](https://user-images.githubusercontent.com/7525512/36665176-c24140ec-1ade-11e8-8773-78d92d72ac72.png)


This pr will only recalc the horizontalAdvanceWidth if they're not 0 to start with.

I guess I may be missing some edge cases here. I'm more than happy to add them if needs be.