### PR TITLE
[ttx] add option to dump glyf table's glyphs as individual ttx 

### DIFF
--- a/Lib/fontTools/misc/filenames.py
+++ b/Lib/fontTools/misc/filenames.py
@@ -1,0 +1,207 @@
+"""
+User name to file name conversion.
+This was taken form the UFO 3 spec.
+"""
+from __future__ import unicode_literals
+from fontTools.misc.py23 import basestring, unicode
+
+
+illegalCharacters = "\" * + / : < > ? [ \ ] | \0".split(" ")
+illegalCharacters += [chr(i) for i in range(1, 32)]
+illegalCharacters += [chr(0x7F)]
+reservedFileNames = "CON PRN AUX CLOCK$ NUL A:-Z: COM1".lower().split(" ")
+reservedFileNames += "LPT1 LPT2 LPT3 COM2 COM3 COM4".lower().split(" ")
+maxFileNameLength = 255
+
+
+class NameTranslationError(Exception):
+	pass
+
+# ----------------------
+# User Name to File Name
+# ----------------------
+# This code was taken directly from the ufoNormalizer script in the unified-font-object repositry
+# (https://github.com/unified-font-object/)
+# ...which algorithm was taken directly from the UFO 3 specification
+
+def userNameToFileName(userName, existing=[], prefix="", suffix=""):
+	"""
+	existing should be a case-insensitive list
+	of all existing file names.
+	>>> userNameToFileName("a") == "a"
+	True
+	>>> userNameToFileName("A") == "A_"
+	True
+	>>> userNameToFileName("AE") == "A_E_"
+	True
+	>>> userNameToFileName("Ae") == "A_e"
+	True
+	>>> userNameToFileName("ae") == "ae"
+	True
+	>>> userNameToFileName("aE") == "aE_"
+	True
+	>>> userNameToFileName("a.alt") == "a.alt"
+	True
+	>>> userNameToFileName("A.alt") == "A_.alt"
+	True
+	>>> userNameToFileName("A.Alt") == "A_.A_lt"
+	True
+	>>> userNameToFileName("A.aLt") == "A_.aL_t"
+	True
+	>>> userNameToFileName(u"A.alT") == "A_.alT_"
+	True
+	>>> userNameToFileName("T_H") == "T__H_"
+	True
+	>>> userNameToFileName("T_h") == "T__h"
+	True
+	>>> userNameToFileName("t_h") == "t_h"
+	True
+	>>> userNameToFileName("F_F_I") == "F__F__I_"
+	True
+	>>> userNameToFileName("f_f_i") == "f_f_i"
+	True
+	>>> userNameToFileName("Aacute_V.swash") == "A_acute_V_.swash"
+	True
+	>>> userNameToFileName(".notdef") == "_notdef"
+	True
+	>>> userNameToFileName("con") == "_con"
+	True
+	>>> userNameToFileName("CON") == "C_O_N_"
+	True
+	>>> userNameToFileName("con.alt") == "_con.alt"
+	True
+	>>> userNameToFileName("alt.con") == "alt._con"
+	True
+	"""
+	# the incoming name must be a unicode string
+	if not isinstance(userName, unicode):
+		raise ValueError("The value for userName must be a unicode string.")
+	# establish the prefix and suffix lengths
+	prefixLength = len(prefix)
+	suffixLength = len(suffix)
+	# replace an initial period with an _
+	# if no prefix is to be added
+	if not prefix and userName[0] == ".":
+		userName = "_" + userName[1:]
+	# filter the user name
+	filteredUserName = []
+	for character in userName:
+		# replace illegal characters with _
+		if character in illegalCharacters:
+			character = "_"
+		# add _ to all non-lower characters
+		elif character != character.lower():
+			character += "_"
+		filteredUserName.append(character)
+	userName = "".join(filteredUserName)
+	# clip to 255
+	sliceLength = maxFileNameLength - prefixLength - suffixLength
+	userName = userName[:sliceLength]
+	# test for illegal files names
+	parts = []
+	for part in userName.split("."):
+		if part.lower() in reservedFileNames:
+			part = "_" + part
+		parts.append(part)
+	userName = ".".join(parts)
+	# test for clash
+	fullName = prefix + userName + suffix
+	if fullName.lower() in existing:
+		fullName = handleClash1(userName, existing, prefix, suffix)
+	# finished
+	return fullName
+
+def handleClash1(userName, existing=[], prefix="", suffix=""):
+	"""
+	existing should be a case-insensitive list
+	of all existing file names.
+	>>> prefix = ("0" * 5) + "."
+	>>> suffix = "." + ("0" * 10)
+	>>> existing = ["a" * 5]
+	>>> e = list(existing)
+	>>> handleClash1(userName="A" * 5, existing=e,
+	...		prefix=prefix, suffix=suffix) == (
+	... 	'00000.AAAAA000000000000001.0000000000')
+	True
+	>>> e = list(existing)
+	>>> e.append(prefix + "aaaaa" + "1".zfill(15) + suffix)
+	>>> handleClash1(userName="A" * 5, existing=e,
+	...		prefix=prefix, suffix=suffix) == (
+	... 	'00000.AAAAA000000000000002.0000000000')
+	True
+	>>> e = list(existing)
+	>>> e.append(prefix + "AAAAA" + "2".zfill(15) + suffix)
+	>>> handleClash1(userName="A" * 5, existing=e,
+	...		prefix=prefix, suffix=suffix) == (
+	... 	'00000.AAAAA000000000000001.0000000000')
+	True
+	"""
+	# if the prefix length + user name length + suffix length + 15 is at
+	# or past the maximum length, silce 15 characters off of the user name
+	prefixLength = len(prefix)
+	suffixLength = len(suffix)
+	if prefixLength + len(userName) + suffixLength + 15 > maxFileNameLength:
+		l = (prefixLength + len(userName) + suffixLength + 15)
+		sliceLength = maxFileNameLength - l
+		userName = userName[:sliceLength]
+	finalName = None
+	# try to add numbers to create a unique name
+	counter = 1
+	while finalName is None:
+		name = userName + str(counter).zfill(15)
+		fullName = prefix + name + suffix
+		if fullName.lower() not in existing:
+			finalName = fullName
+			break
+		else:
+			counter += 1
+		if counter >= 999999999999999:
+			break
+	# if there is a clash, go to the next fallback
+	if finalName is None:
+		finalName = handleClash2(existing, prefix, suffix)
+	# finished
+	return finalName
+
+def handleClash2(existing=[], prefix="", suffix=""):
+	"""
+	existing should be a case-insensitive list
+	of all existing file names.
+	>>> prefix = ("0" * 5) + "."
+	>>> suffix = "." + ("0" * 10)
+	>>> existing = [prefix + str(i) + suffix for i in range(100)]
+	>>> e = list(existing)
+	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix) == (
+	... 	'00000.100.0000000000')
+	True
+	>>> e = list(existing)
+	>>> e.remove(prefix + "1" + suffix)
+	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix) == (
+	... 	'00000.1.0000000000')
+	True
+	>>> e = list(existing)
+	>>> e.remove(prefix + "2" + suffix)
+	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix) == (
+	... 	'00000.2.0000000000')
+	True
+	"""
+	# calculate the longest possible string
+	maxLength = maxFileNameLength - len(prefix) - len(suffix)
+	maxValue = int("9" * maxLength)
+	# try to find a number
+	finalName = None
+	counter = 1
+	while finalName is None:
+		fullName = prefix + str(counter) + suffix
+		if fullName.lower() not in existing:
+			finalName = fullName
+			break
+		else:
+			counter += 1
+		if counter >= maxValue:
+			break
+	# raise an error if nothing has been found
+	if finalName is None:
+		raise NameTranslationError("No unique name could be found.")
+	# finished
+	return finalName

--- a/Lib/fontTools/misc/filenames.py
+++ b/Lib/fontTools/misc/filenames.py
@@ -1,6 +1,15 @@
 """
-User name to file name conversion.
-This was taken form the UFO 3 spec.
+User name to file name conversion based on the UFO 3 spec:
+http://unifiedfontobject.org/versions/ufo3/conventions/
+
+The code was copied from:
+https://github.com/unified-font-object/ufoLib/blob/8747da7/Lib/ufoLib/filenames.py
+
+Author: Tal Leming
+Copyright (c) 2005-2016, The RoboFab Developers:
+	Erik van Blokland
+	Tal Leming
+	Just van Rossum
 """
 from __future__ import unicode_literals
 from fontTools.misc.py23 import basestring, unicode
@@ -17,17 +26,12 @@ maxFileNameLength = 255
 class NameTranslationError(Exception):
 	pass
 
-# ----------------------
-# User Name to File Name
-# ----------------------
-# This code was taken directly from the ufoNormalizer script in the unified-font-object repositry
-# (https://github.com/unified-font-object/)
-# ...which algorithm was taken directly from the UFO 3 specification
 
 def userNameToFileName(userName, existing=[], prefix="", suffix=""):
 	"""
 	existing should be a case-insensitive list
 	of all existing file names.
+
 	>>> userNameToFileName("a") == "a"
 	True
 	>>> userNameToFileName("A") == "A_"
@@ -115,20 +119,24 @@ def handleClash1(userName, existing=[], prefix="", suffix=""):
 	"""
 	existing should be a case-insensitive list
 	of all existing file names.
+
 	>>> prefix = ("0" * 5) + "."
 	>>> suffix = "." + ("0" * 10)
 	>>> existing = ["a" * 5]
+
 	>>> e = list(existing)
 	>>> handleClash1(userName="A" * 5, existing=e,
 	...		prefix=prefix, suffix=suffix) == (
 	... 	'00000.AAAAA000000000000001.0000000000')
 	True
+
 	>>> e = list(existing)
 	>>> e.append(prefix + "aaaaa" + "1".zfill(15) + suffix)
 	>>> handleClash1(userName="A" * 5, existing=e,
 	...		prefix=prefix, suffix=suffix) == (
 	... 	'00000.AAAAA000000000000002.0000000000')
 	True
+
 	>>> e = list(existing)
 	>>> e.append(prefix + "AAAAA" + "2".zfill(15) + suffix)
 	>>> handleClash1(userName="A" * 5, existing=e,
@@ -167,18 +175,22 @@ def handleClash2(existing=[], prefix="", suffix=""):
 	"""
 	existing should be a case-insensitive list
 	of all existing file names.
+
 	>>> prefix = ("0" * 5) + "."
 	>>> suffix = "." + ("0" * 10)
 	>>> existing = [prefix + str(i) + suffix for i in range(100)]
+
 	>>> e = list(existing)
 	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix) == (
 	... 	'00000.100.0000000000')
 	True
+
 	>>> e = list(existing)
 	>>> e.remove(prefix + "1" + suffix)
 	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix) == (
 	... 	'00000.1.0000000000')
 	True
+
 	>>> e = list(existing)
 	>>> e.remove(prefix + "2" + suffix)
 	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix) == (
@@ -205,3 +217,8 @@ def handleClash2(existing=[], prefix="", suffix=""):
 		raise NameTranslationError("No unique name could be found.")
 	# finished
 	return finalName
+
+if __name__ == "__main__":
+	import doctest
+	import sys
+	sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/misc/xmlReader.py
+++ b/Lib/fontTools/misc/xmlReader.py
@@ -18,7 +18,6 @@ BUFSIZE = 0x4000
 class XMLReader(object):
 
 	def __init__(self, fileOrPath, ttFont, progress=None, quiet=None, contentOnly=False):
-
 		if fileOrPath == '-':
 			fileOrPath = sys.stdin
 		if not hasattr(fileOrPath, "read"):

--- a/Lib/fontTools/misc/xmlReader.py
+++ b/Lib/fontTools/misc/xmlReader.py
@@ -17,7 +17,8 @@ BUFSIZE = 0x4000
 
 class XMLReader(object):
 
-	def __init__(self, fileOrPath, ttFont, progress=None, quiet=None):
+	def __init__(self, fileOrPath, ttFont, progress=None, quiet=None, contentOnly=False):
+
 		if fileOrPath == '-':
 			fileOrPath = sys.stdin
 		if not hasattr(fileOrPath, "read"):
@@ -35,6 +36,7 @@ class XMLReader(object):
 			self.quiet = quiet
 		self.root = None
 		self.contentStack = []
+		self.contentOnly = contentOnly
 		self.stackSize = 0
 
 	def read(self, rootless=False):
@@ -73,8 +75,24 @@ class XMLReader(object):
 			parser.Parse(chunk, 0)
 
 	def _startElementHandler(self, name, attrs):
+		if self.stackSize == 1 and self.contentOnly:
+			# We already know the table we're parsing, skip
+			# parsing the table tag and continue to
+			# stack '2' which begins parsing content
+			self.contentStack.append([])
+			self.stackSize = 2
+			return
 		stackSize = self.stackSize
 		self.stackSize = stackSize + 1
+		subFile = attrs.get("src")
+		if subFile is not None:
+			if hasattr(self.file, 'name'):
+				# if file has a name, get its parent directory
+				dirname = os.path.dirname(self.file.name)
+			else:
+				# else fall back to using the current working directory
+				dirname = os.getcwd()
+			subFile = os.path.join(dirname, subFile)
 		if not stackSize:
 			if name != "ttFont":
 				raise TTXParseError("illegal root tag: %s" % name)
@@ -85,15 +103,7 @@ class XMLReader(object):
 				self.ttFont.sfntVersion = sfntVersion
 			self.contentStack.append([])
 		elif stackSize == 1:
-			subFile = attrs.get("src")
 			if subFile is not None:
-				if hasattr(self.file, 'name'):
-					# if file has a name, get its parent directory
-					dirname = os.path.dirname(self.file.name)
-				else:
-					# else fall back to using the current working directory
-					dirname = os.getcwd()
-				subFile = os.path.join(dirname, subFile)
 				subReader = XMLReader(subFile, self.ttFont, self.progress)
 				subReader.read()
 				self.contentStack.append([])
@@ -119,6 +129,11 @@ class XMLReader(object):
 				self.currentTable = tableClass(tag)
 				self.ttFont[tag] = self.currentTable
 			self.contentStack.append([])
+		elif stackSize == 2 and subFile is not None:
+			subReader = XMLReader(subFile, self.ttFont, self.progress, contentOnly=True)
+			subReader.read()
+			self.contentStack.append([])
+			self.root = subReader.root
 		elif stackSize == 2:
 			self.contentStack.append([])
 			self.root = (name, attrs, self.contentStack[-1])
@@ -134,12 +149,13 @@ class XMLReader(object):
 	def _endElementHandler(self, name):
 		self.stackSize = self.stackSize - 1
 		del self.contentStack[-1]
-		if self.stackSize == 1:
-			self.root = None
-		elif self.stackSize == 2:
-			name, attrs, content = self.root
-			self.currentTable.fromXML(name, attrs, content, self.ttFont)
-			self.root = None
+		if not self.contentOnly:
+			if self.stackSize == 1:
+				self.root = None
+			elif self.stackSize == 2:
+				name, attrs, content = self.root
+				self.currentTable.fromXML(name, attrs, content, self.ttFont)
+				self.root = None
 
 
 class ProgressPrinter(object):

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -139,7 +139,7 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 					glyphPath = userNameToFileName(
 						tounicode(glyphName, 'utf-8'),
 						existingGlyphFiles,
-						prefix=("%s%s"%(path, "_")),
+						prefix=path + "_",
 						suffix=ext)
 					existingGlyphFiles.add(glyphPath.lower())
 					glyphWriter = xmlWriter.XMLWriter(

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -139,7 +139,7 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 					glyphPath = userNameToFileName(
 						tounicode(glyphName, 'utf-8'),
 						existingGlyphFiles,
-						prefix=path + "_",
+						prefix=path + ".",
 						suffix=ext)
 					existingGlyphFiles.add(glyphPath.lower())
 					glyphWriter = xmlWriter.XMLWriter(

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -224,8 +224,8 @@ class TTFont(object):
 	def _saveXML(self, writer,
 		     writeVersion=True,
 		     quiet=None, tables=None, skipTables=None, splitTables=False,
-		     disassembleInstructions=True, bitmapGlyphDataFormat='raw'):
-
+		     splitGlyphs=False, disassembleInstructions=True,
+			  bitmapGlyphDataFormat='raw'):
 
 		if quiet is not None:
 			deprecateArgument("quiet", "configure logging instead")
@@ -251,6 +251,9 @@ class TTFont(object):
 			writer.begintag("ttFont", sfntVersion=repr(tostr(self.sfntVersion))[1:-1])
 		writer.newline()
 
+		# always splitTables if splitGlyphs is enabled
+		splitTables = splitTables or splitGlyphs
+
 		if not splitTables:
 			writer.newline()
 		else:
@@ -270,7 +273,7 @@ class TTFont(object):
 				writer.newline()
 			else:
 				tableWriter = writer
-			self._tableToXML(tableWriter, tag)
+			self._tableToXML(tableWriter, tag, splitGlyphs=splitGlyphs)
 			if splitTables:
 				tableWriter.endtag("ttFont")
 				tableWriter.newline()
@@ -278,7 +281,7 @@ class TTFont(object):
 		writer.endtag("ttFont")
 		writer.newline()
 
-	def _tableToXML(self, writer, tag, quiet=None):
+	def _tableToXML(self, writer, tag, quiet=None, splitGlyphs=False):
 		if quiet is not None:
 			deprecateArgument("quiet", "configure logging instead")
 		if tag in self:
@@ -298,8 +301,8 @@ class TTFont(object):
 			attrs['raw'] = True
 		writer.begintag(xmlTag, **attrs)
 		writer.newline()
-		if tag in ("glyf", "CFF "):
-			table.toXML(writer, self)
+		if tag == "glyf":
+			table.toXML(writer, self, splitGlyphs=splitGlyphs)
 		else:
 			table.toXML(writer, self)
 		writer.endtag(xmlTag)

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -225,7 +225,7 @@ class TTFont(object):
 		     writeVersion=True,
 		     quiet=None, tables=None, skipTables=None, splitTables=False,
 		     splitGlyphs=False, disassembleInstructions=True,
-			  bitmapGlyphDataFormat='raw'):
+		     bitmapGlyphDataFormat='raw'):
 
 		if quiet is not None:
 			deprecateArgument("quiet", "configure logging instead")

--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -41,6 +41,7 @@ usage: ttx [options] inputfile1 [... inputfileN]
     -g Split glyf table: Save the glyf data into separate TTX files
        per glyph and write a small TTX for the glyf table which
        contains references to the individual TTGlyph elements.
+       NOTE: specifying -g implies -s (no need for -s together with -g)
     -i Do NOT disassemble TT instructions: when this option is given,
        all TrueType programs (glyph programs, the font program and the
        pre-program) will be written to the TTX file as hex data
@@ -165,7 +166,9 @@ class Options(object):
 			elif option == "-s":
 				self.splitTables = True
 			elif option == "-g":
+				# -g implies (and forces) splitTables
 				self.splitGlyphs = True
+				self.splitTables = True
 			elif option == "-i":
 				self.disassembleInstructions = False
 			elif option == "-z":

--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -38,6 +38,9 @@ usage: ttx [options] inputfile1 [... inputfileN]
        to the individual table dumps. This file can be used as
        input to ttx, as long as the table files are in the
        same directory.
+    -g Split glyf table: Save the glyf data into separate TTX files
+       per glyph and write a small TTX for the glyf table which
+       contains references to the individual TTGlyph elements.
     -i Do NOT disassemble TT instructions: when this option is given,
        all TrueType programs (glyph programs, the font program and the
        pre-program) will be written to the TTX file as hex data
@@ -110,6 +113,7 @@ class Options(object):
 	verbose = False
 	quiet = False
 	splitTables = False
+	splitGlyphs = False
 	disassembleInstructions = True
 	mergeFile = None
 	recalcBBoxes = True
@@ -160,6 +164,8 @@ class Options(object):
 				self.skipTables.append(value)
 			elif option == "-s":
 				self.splitTables = True
+			elif option == "-g":
+				self.splitGlyphs = True
 			elif option == "-i":
 				self.disassembleInstructions = False
 			elif option == "-z":
@@ -255,6 +261,7 @@ def ttDump(input, output, options):
 			tables=options.onlyTables,
 			skipTables=options.skipTables,
 			splitTables=options.splitTables,
+			splitGlyphs=options.splitGlyphs,
 			disassembleInstructions=options.disassembleInstructions,
 			bitmapGlyphDataFormat=options.bitmapGlyphDataFormat,
 			newlinestr=options.newlinestr)
@@ -318,7 +325,7 @@ def guessFileType(fileName):
 
 
 def parseOptions(args):
-	rawOptions, files = getopt.getopt(args, "ld:o:fvqht:x:sim:z:baey:",
+	rawOptions, files = getopt.getopt(args, "ld:o:fvqht:x:sgim:z:baey:",
 			['unicodedata=', "recalc-timestamp", 'flavor=', 'version',
 			 'with-zopfli', 'newline='])
 

--- a/Tests/misc/filenames_test.py
+++ b/Tests/misc/filenames_test.py
@@ -1,0 +1,57 @@
+from __future__ import unicode_literals
+import unittest
+from fontTools.misc.filenames import userNameToFileName
+
+class FilenamesTest(unittest.TestCase):
+
+	def test_names(self):
+		self.assertEqual(userNameToFileName("a"),"a")
+		self.assertEqual(userNameToFileName("A"), "A_")
+		self.assertEqual(userNameToFileName("AE"), "A_E_")
+		self.assertEqual(userNameToFileName("Ae"), "A_e")
+		self.assertEqual(userNameToFileName("ae"), "ae")
+		self.assertEqual(userNameToFileName("aE"), "aE_")
+		self.assertEqual(userNameToFileName("a.alt"), "a.alt")
+		self.assertEqual(userNameToFileName("A.alt"), "A_.alt")
+		self.assertEqual(userNameToFileName("A.Alt"), "A_.A_lt")
+		self.assertEqual(userNameToFileName("A.aLt"), "A_.aL_t")
+		self.assertEqual(userNameToFileName(u"A.alT"), "A_.alT_")
+		self.assertEqual(userNameToFileName("T_H"), "T__H_")
+		self.assertEqual(userNameToFileName("T_h"), "T__h")
+		self.assertEqual(userNameToFileName("t_h"), "t_h")
+		self.assertEqual(userNameToFileName("F_F_I"), "F__F__I_")
+		self.assertEqual(userNameToFileName("f_f_i"), "f_f_i")
+		self.assertEqual(userNameToFileName("Aacute_V.swash"), "A_acute_V_.swash")
+		self.assertEqual(userNameToFileName(".notdef"), "_notdef")
+		self.assertEqual(userNameToFileName("con"), "_con")
+		self.assertEqual(userNameToFileName("CON"), "C_O_N_")
+		self.assertEqual(userNameToFileName("con.alt"), "_con.alt")
+		self.assertEqual(userNameToFileName("alt.con"), "alt._con")
+
+	def test_prefix_suffix(self):
+		PREFIX="TEST_PREFIX"
+		SUFFIX="TEST_SUFFIX"
+		NAME="NAME"
+		NAME_FILE="N_A_M_E_"
+		self.assertEqual(userNameToFileName(NAME, prefix=PREFIX, suffix=SUFFIX), PREFIX + NAME_FILE + SUFFIX)
+
+	def test_collide(self):
+		PREFIX="TEST_PREFIX"
+		SUFFIX="TEST_SUFFIX"
+		NAME="NAME"
+		NAME_FILE="N_A_M_E_"
+		COLLISION_AVOIDANCE1="000000000000001"
+		COLLISION_AVOIDANCE2="000000000000002"
+		exist = set()
+		generated = userNameToFileName(NAME, exist, prefix=PREFIX, suffix=SUFFIX)
+		exist.add(generated.lower())
+		self.assertEqual(generated, PREFIX + NAME_FILE + SUFFIX)
+		generated = userNameToFileName(NAME, exist, prefix=PREFIX, suffix=SUFFIX)
+		exist.add(generated.lower())
+		self.assertEqual(generated, PREFIX + NAME_FILE + COLLISION_AVOIDANCE1 + SUFFIX)
+		generated = userNameToFileName(NAME, exist, prefix=PREFIX, suffix=SUFFIX)
+		self.assertEqual(generated, PREFIX + NAME_FILE + COLLISION_AVOIDANCE2+ SUFFIX)
+
+if __name__ == "__main__":
+	import sys
+	sys.exit(unittest.main())

--- a/Tests/misc/filenames_test.py
+++ b/Tests/misc/filenames_test.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
 import unittest
-from fontTools.misc.filenames import userNameToFileName
+from fontTools.misc.filenames import (
+	userNameToFileName, handleClash1, handleClash2)
 
-class FilenamesTest(unittest.TestCase):
+
+class UserNameToFilenameTest(unittest.TestCase):
 
 	def test_names(self):
 		self.assertEqual(userNameToFileName("a"),"a")
@@ -21,7 +23,9 @@ class FilenamesTest(unittest.TestCase):
 		self.assertEqual(userNameToFileName("t_h"), "t_h")
 		self.assertEqual(userNameToFileName("F_F_I"), "F__F__I_")
 		self.assertEqual(userNameToFileName("f_f_i"), "f_f_i")
-		self.assertEqual(userNameToFileName("Aacute_V.swash"), "A_acute_V_.swash")
+		self.assertEqual(
+			userNameToFileName("Aacute_V.swash"),
+			"A_acute_V_.swash")
 		self.assertEqual(userNameToFileName(".notdef"), "_notdef")
 		self.assertEqual(userNameToFileName("con"), "_con")
 		self.assertEqual(userNameToFileName("CON"), "C_O_N_")
@@ -29,28 +33,104 @@ class FilenamesTest(unittest.TestCase):
 		self.assertEqual(userNameToFileName("alt.con"), "alt._con")
 
 	def test_prefix_suffix(self):
-		PREFIX="TEST_PREFIX"
-		SUFFIX="TEST_SUFFIX"
-		NAME="NAME"
-		NAME_FILE="N_A_M_E_"
-		self.assertEqual(userNameToFileName(NAME, prefix=PREFIX, suffix=SUFFIX), PREFIX + NAME_FILE + SUFFIX)
+		prefix = "TEST_PREFIX"
+		suffix = "TEST_SUFFIX"
+		name = "NAME"
+		name_file = "N_A_M_E_"
+		self.assertEqual(
+			userNameToFileName(name, prefix=prefix, suffix=suffix),
+			prefix + name_file + suffix)
 
 	def test_collide(self):
-		PREFIX="TEST_PREFIX"
-		SUFFIX="TEST_SUFFIX"
-		NAME="NAME"
-		NAME_FILE="N_A_M_E_"
-		COLLISION_AVOIDANCE1="000000000000001"
-		COLLISION_AVOIDANCE2="000000000000002"
+		prefix = "TEST_PREFIX"
+		suffix = "TEST_SUFFIX"
+		name = "NAME"
+		name_file = "N_A_M_E_"
+		collision_avoidance1 = "000000000000001"
+		collision_avoidance2 = "000000000000002"
 		exist = set()
-		generated = userNameToFileName(NAME, exist, prefix=PREFIX, suffix=SUFFIX)
+		generated = userNameToFileName(
+			name, exist, prefix=prefix, suffix=suffix)
 		exist.add(generated.lower())
-		self.assertEqual(generated, PREFIX + NAME_FILE + SUFFIX)
-		generated = userNameToFileName(NAME, exist, prefix=PREFIX, suffix=SUFFIX)
+		self.assertEqual(generated, prefix + name_file + suffix)
+		generated = userNameToFileName(
+			name, exist, prefix=prefix, suffix=suffix)
 		exist.add(generated.lower())
-		self.assertEqual(generated, PREFIX + NAME_FILE + COLLISION_AVOIDANCE1 + SUFFIX)
-		generated = userNameToFileName(NAME, exist, prefix=PREFIX, suffix=SUFFIX)
-		self.assertEqual(generated, PREFIX + NAME_FILE + COLLISION_AVOIDANCE2+ SUFFIX)
+		self.assertEqual(
+			generated,
+			prefix + name_file + collision_avoidance1 + suffix)
+		generated = userNameToFileName(
+			name, exist, prefix=prefix, suffix=suffix)
+		self.assertEqual(
+			generated,
+			prefix + name_file + collision_avoidance2+ suffix)
+
+	def test_ValueError(self):
+		with self.assertRaises(ValueError):
+			userNameToFileName(b"a")
+		with self.assertRaises(ValueError):
+			userNameToFileName({"a"})
+		with self.assertRaises(ValueError):
+			userNameToFileName(("a",))
+		with self.assertRaises(ValueError):
+			userNameToFileName(["a"])
+		with self.assertRaises(ValueError):
+			userNameToFileName(["a"])
+		with self.assertRaises(ValueError):
+			userNameToFileName(b"\xd8\x00")
+
+	def test_handleClash1(self):
+		prefix = ("0" * 5) + "."
+		suffix = "." + ("0" * 10)
+		existing = ["a" * 5]
+
+		e = list(existing)
+		self.assertEqual(
+			handleClash1(userName="A" * 5, existing=e, prefix=prefix,
+						 suffix=suffix),
+			'00000.AAAAA000000000000001.0000000000'
+		)
+
+		e = list(existing)
+		e.append(prefix + "aaaaa" + "1".zfill(15) + suffix)
+		self.assertEqual(
+		handleClash1(userName="A" * 5, existing=e, prefix=prefix,
+					 suffix=suffix),
+		'00000.AAAAA000000000000002.0000000000'
+		)
+
+		e = list(existing)
+		e.append(prefix + "AAAAA" + "2".zfill(15) + suffix)
+		self.assertEqual(
+			handleClash1(userName="A" * 5, existing=e, prefix=prefix,
+						 suffix=suffix),
+			'00000.AAAAA000000000000001.0000000000'
+		)
+
+	def test_handleClash2(self):
+		prefix = ("0" * 5) + "."
+		suffix = "." + ("0" * 10)
+		existing = [prefix + str(i) + suffix for i in range(100)]
+
+		e = list(existing)
+		self.assertEqual(
+			handleClash2(existing=e, prefix=prefix, suffix=suffix),
+			'00000.100.0000000000'
+		)
+
+		e = list(existing)
+		e.remove(prefix + "1" + suffix)
+		self.assertEqual(
+			handleClash2(existing=e, prefix=prefix, suffix=suffix),
+			'00000.1.0000000000'
+		)
+
+		e = list(existing)
+		e.remove(prefix + "2" + suffix)
+		self.assertEqual(
+			handleClash2(existing=e, prefix=prefix, suffix=suffix),
+			'00000.2.0000000000'
+		)
 
 if __name__ == "__main__":
 	import sys

--- a/Tests/misc/xmlReader_test.py
+++ b/Tests/misc/xmlReader_test.py
@@ -144,7 +144,7 @@ class TestXMLReader(unittest.TestCase):
 
 	def test_read_sub_file(self):
 		# Verifies that sub-file content is able to be read to a table.
-		expectedContent = u'testContent'
+		expectedContent = 'testContent'
 		expectedNameID = '1'
 		expectedPlatform = '3'
 		expectedLangId = '0x409'

--- a/Tests/misc/xmlReader_test.py
+++ b/Tests/misc/xmlReader_test.py
@@ -142,7 +142,48 @@ class TestXMLReader(unittest.TestCase):
 		self.assertTrue(reader.file.closed)
 		os.remove(tmp.name)
 
+	def test_read_sub_file(self):
+		# Verifies that sub-file content is able to be read to a table.
+		expectedContent = u'testContent'
+		expectedNameID = '1'
+		expectedPlatform = '3'
+		expectedLangId = '0x409'
 
+		with tempfile.NamedTemporaryFile(delete=False) as tmp:
+			subFileData = (
+				'<ttFont ttLibVersion="3.15">'
+					'<name>'
+						'<namerecord nameID="%s" platformID="%s" platEncID="1" langID="%s">'
+							'%s'
+						'</namerecord>'
+					'</name>'
+				'</ttFont>'
+			) % (expectedNameID, expectedPlatform, expectedLangId, expectedContent)
+			tmp.write(subFileData.encode("utf-8"))
+
+		with tempfile.NamedTemporaryFile(delete=False) as tmp2:
+			fileData = (
+				'<ttFont ttLibVersion="3.15">'
+					'<name>'
+						'<namerecord src="%s"/>'
+					'</name>'
+				'</ttFont>'
+			) % tmp.name
+			tmp2.write(fileData.encode('utf-8'))
+
+		ttf = TTFont()
+		with open(tmp2.name, "rb") as f:
+			reader = XMLReader(f, ttf)
+			reader.read()
+			reader.close()
+			nameTable = ttf['name']
+			self.assertTrue(int(expectedNameID) == nameTable.names[0].nameID)
+			self.assertTrue(int(expectedLangId, 16) == nameTable.names[0].langID)
+			self.assertTrue(int(expectedPlatform) == nameTable.names[0].platformID)
+			self.assertEqual(expectedContent, nameTable.names[0].string.decode(nameTable.names[0].getEncoding()))
+
+		os.remove(tmp.name)
+		os.remove(tmp2.name)
 
 if __name__ == '__main__':
 	import sys


### PR DESCRIPTION
I rebased @bamidei original PRs (https://github.com/fonttools/fonttools/pull/1035 and https://github.com/fonttools/fonttools/pull/1132) on the current master branch.

With this `ttx` gets a new `-g` option that will dump each glyph from the glyf table as an individual ttx file, in the same directory as the parent ttx file, and with the latter's filename plus an `_` and the glyph name (and the ".ttx" file extension). For simplicity, the `-g` (split glyphs) option also implies the `-s` (spit tables) option, i.e. can't use split glyphs only without also splitting the tables.

The separator between the `_g_l_y_f` table tag and the glyph names in the ttx file name was chosen to be "_" instead of ".",  so that the glyf table's ttx file (containing the index of individual glyph's ttx files) doesn't get lost among hundreds of other ttx files, but appears _after_ all the glyphs ttx files when sorting a folder alphabetically.

The option currently only affects the glyf table, not yet the CFF (PRs are welcome).

Thanks @bamidei for your contribution, and apologies if I've kept your PRs lagging behind for so long.
(@ragingstorm apparently was his old nickname)

Related issue #153 