### PR TITLE
[ttGlyphPen] decompose components if transform overflows F2Dot14

### DIFF
--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -86,7 +86,7 @@ class TTGlyphPen(AbstractPen):
         eps = .5 / (1 << 14)
 
         def closeTo2(value):
-            return True if abs(value - 2) <= eps else False
+            return abs(value - 2) <= eps
 
         for i, (glyphName, transformation) in enumerate(self.components):
             if any(s > 2 or s < -2 for s in transformation[:3]):

--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -83,21 +83,24 @@ class TTGlyphPen(AbstractPen):
         assert self._isClosed(), "Didn't close last contour."
 
         almost2 = 1.99993896484375  # F2Dot14 0b1.11111111111111
+        eps = .5 / (1 << 14)
+
+        def closeTo2(value):
+            return True if abs(value - 2) <= eps else False
+
         for i, (glyphName, transformation) in enumerate(self.components):
-            if any(s > 2 or s < -2 for s in transformation[0::3]):
+            if any(s > 2 or s < -2 for s in transformation[:3]):
                 # can't have scale >= 2 or scale < -2:
                 tpen = TransformPen(self, transformation)
                 self.glyphSet[glyphName].draw(tpen)
                 self.components.remove((glyphName, transformation))
-            elif any(almost2 < s <= 2 for s in transformation[0::3]):
+            elif any(closeTo2(s) for s in transformation[:3]):
                 # use closest F2Dot14 value to 2 when possible
                 transformation = (
-                    (almost2 if almost2 < transformation[0] <= 2 else
-                     transformation[0]),
-                    transformation[1],
-                    transformation[2],
-                    (almost2 if almost2 < transformation[3] <= 2 else
-                     transformation[3]),
+                    almost2 if closeTo2(transformation[0]) else transformation[0],
+                    almost2 if closeTo2(transformation[1]) else transformation[1],
+                    almost2 if closeTo2(transformation[2]) else transformation[2],
+                    almost2 if closeTo2(transformation[3]) else transformation[3],
                     transformation[4],
                     transformation[5]
                 )

--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -12,6 +12,14 @@ from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 __all__ = ["TTGlyphPen"]
 
 
+ALMOST2 = 1.99993896484375  # F2Dot14 0b1.11111111111111
+EPSILON= .5 / (1 << 14)
+
+
+def _closeTo2(value):
+    return abs(value - 2) <= EPSILON
+
+
 class TTGlyphPen(AbstractPen):
     """Pen used for drawing to a TrueType glyph."""
 
@@ -82,20 +90,14 @@ class TTGlyphPen(AbstractPen):
     def glyph(self, componentFlags=0x4):
         assert self._isClosed(), "Didn't close last contour."
 
-        almost2 = 1.99993896484375  # F2Dot14 0b1.11111111111111
-        eps = .5 / (1 << 14)
-
-        def closeTo2(value):
-            return abs(value - 2) <= eps
-
         for i, (glyphName, transformation) in enumerate(self.components):
-            if any(closeTo2(s) for s in transformation[:4]):
+            if any(_closeTo2(s) for s in transformation[:4]):
                 # use closest F2Dot14 value to 2 when possible
                 transformation = (
-                    almost2 if closeTo2(transformation[0]) else transformation[0],
-                    almost2 if closeTo2(transformation[1]) else transformation[1],
-                    almost2 if closeTo2(transformation[2]) else transformation[2],
-                    almost2 if closeTo2(transformation[3]) else transformation[3],
+                    ALMOST2 if _closeTo2(transformation[0]) else transformation[0],
+                    ALMOST2 if _closeTo2(transformation[1]) else transformation[1],
+                    ALMOST2 if _closeTo2(transformation[2]) else transformation[2],
+                    ALMOST2 if _closeTo2(transformation[3]) else transformation[3],
                     transformation[4],
                     transformation[5]
                 )

--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -89,7 +89,7 @@ class TTGlyphPen(AbstractPen):
             return abs(value - 2) <= eps
 
         for i, (glyphName, transformation) in enumerate(self.components):
-            if any(closeTo2(s) for s in transformation[:3]):
+            if any(closeTo2(s) for s in transformation[:4]):
                 # use closest F2Dot14 value to 2 when possible
                 transformation = (
                     almost2 if closeTo2(transformation[0]) else transformation[0],
@@ -100,7 +100,7 @@ class TTGlyphPen(AbstractPen):
                     transformation[5]
                 )
                 self.components[i] = (glyphName, transformation)
-            elif any(s > 2 or s < -2 for s in transformation[:3]):
+            elif any(s > 2 or s < -2 for s in transformation[:4]):
                 # can't have scale >= 2 or scale < -2:
                 tpen = TransformPen(self, transformation)
                 self.glyphSet[glyphName].draw(tpen)

--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -89,12 +89,7 @@ class TTGlyphPen(AbstractPen):
             return abs(value - 2) <= eps
 
         for i, (glyphName, transformation) in enumerate(self.components):
-            if any(s > 2 or s < -2 for s in transformation[:3]):
-                # can't have scale >= 2 or scale < -2:
-                tpen = TransformPen(self, transformation)
-                self.glyphSet[glyphName].draw(tpen)
-                self.components.remove((glyphName, transformation))
-            elif any(closeTo2(s) for s in transformation[:3]):
+            if any(closeTo2(s) for s in transformation[:3]):
                 # use closest F2Dot14 value to 2 when possible
                 transformation = (
                     almost2 if closeTo2(transformation[0]) else transformation[0],
@@ -105,6 +100,11 @@ class TTGlyphPen(AbstractPen):
                     transformation[5]
                 )
                 self.components[i] = (glyphName, transformation)
+            elif any(s > 2 or s < -2 for s in transformation[:3]):
+                # can't have scale >= 2 or scale < -2:
+                tpen = TransformPen(self, transformation)
+                self.glyphSet[glyphName].draw(tpen)
+                self.components.remove((glyphName, transformation))
 
         components = []
         for glyphName, transformation in self.components:

--- a/Tests/pens/ttGlyphPen_test.py
+++ b/Tests/pens/ttGlyphPen_test.py
@@ -135,6 +135,76 @@ class TTGlyphPenTest(unittest.TestCase):
         self.assertEqual(len(pen.points), 5)
         self.assertEqual(pen.points[0], (0, 0))
 
+    def test_within_range_of_scale_component(self):
+        componentName = 'a'
+        glyphSet = {}
+        pen = TTGlyphPen(glyphSet)
+
+        pen.moveTo((0, 0))
+        pen.lineTo((0, 1))
+        pen.lineTo((1, 0))
+        pen.closePath()
+        glyphSet[componentName] = _TestGlyph(pen.glyph())
+
+        pen.addComponent(componentName, (1.5, 0, 0, 1, 0, 0))
+        pen.addComponent(componentName, (1, 0, 0, -1.5, 0, 0))
+        compositeGlyph = pen.glyph()
+
+        pen.addComponent(componentName, (1.5, 0, 0, 1, 0, 0))
+        pen.addComponent(componentName, (1, 0, 0, -1.5, 0, 0))
+        expectedGlyph = pen.glyph()
+
+        self.assertEqual(expectedGlyph, compositeGlyph)
+
+    def test_limit_of_scale_component(self):
+        componentName = 'a'
+        glyphSet = {}
+        pen = TTGlyphPen(glyphSet)
+
+        pen.moveTo((0, 0))
+        pen.lineTo((0, 1))
+        pen.lineTo((1, 0))
+        pen.closePath()
+        glyphSet[componentName] = _TestGlyph(pen.glyph())
+
+        pen.addComponent(componentName, (1.999999, 0, 0, 2, 0, 0))
+        pen.addComponent(componentName, (-2, 0, 0, -2, 0, 0))
+        compositeGlyph = pen.glyph()
+
+        almost2 = 1.99993896484375  # 0b1.11111111111111
+        pen.addComponent(componentName, (almost2, 0, 0, almost2, 0, 0))
+        pen.addComponent(componentName, (-2, 0, 0, -2, 0, 0))
+        expectedGlyph = pen.glyph()
+
+        self.assertEqual(expectedGlyph, compositeGlyph)
+
+    def test_out_of_range_scale_component(self):
+        componentName = 'a'
+        glyphSet = {}
+        pen = TTGlyphPen(glyphSet)
+
+        pen.moveTo((0, 0))
+        pen.lineTo((0, 1))
+        pen.lineTo((1, 0))
+        pen.closePath()
+        glyphSet[componentName] = _TestGlyph(pen.glyph())
+
+        pen.addComponent(componentName, (3, 0, 0, 1, 0, 0))
+        pen.addComponent(componentName, (1, 0, 0, -3, 0, 0))
+        compositeGlyph = pen.glyph()
+
+        pen.moveTo((0, 0))
+        pen.lineTo((0, 1))
+        pen.lineTo((3, 0))
+        pen.closePath()
+        pen.moveTo((0, 0))
+        pen.lineTo((0, -3))
+        pen.lineTo((1, 0))
+        pen.closePath()
+        expectedGlyph = pen.glyph()
+
+        self.assertEqual(expectedGlyph, compositeGlyph)
+
 
 class _TestGlyph(object):
     def __init__(self, glyph):

--- a/Tests/pens/ttGlyphPen_test.py
+++ b/Tests/pens/ttGlyphPen_test.py
@@ -167,12 +167,18 @@ class TTGlyphPenTest(unittest.TestCase):
         pen.closePath()
         glyphSet[componentName] = _TestGlyph(pen.glyph())
 
-        pen.addComponent(componentName, (1.999999, 0, 0, 2, 0, 0))
+        pen.addComponent(componentName, (1.99999, 0, 0, 1, 0, 0))
+        pen.addComponent(componentName, (1, 2, 0, 1, 0, 0))
+        pen.addComponent(componentName, (1, 0, 2, 1, 0, 0))
+        pen.addComponent(componentName, (1, 0, 0, 2, 0, 0))
         pen.addComponent(componentName, (-2, 0, 0, -2, 0, 0))
         compositeGlyph = pen.glyph()
 
         almost2 = 1.99993896484375  # 0b1.11111111111111
-        pen.addComponent(componentName, (almost2, 0, 0, almost2, 0, 0))
+        pen.addComponent(componentName, (almost2, 0, 0, 1, 0, 0))
+        pen.addComponent(componentName, (1, almost2, 0, 1, 0, 0))
+        pen.addComponent(componentName, (1, 0, almost2, 1, 0, 0))
+        pen.addComponent(componentName, (1, 0, 0, almost2, 0, 0))
         pen.addComponent(componentName, (-2, 0, 0, -2, 0, 0))
         expectedGlyph = pen.glyph()
 


### PR DESCRIPTION
Fixes #1200, with little cheat when transform scale is close or equal to 2.