### PR TITLE
Fix GlyphCoordinates overflow

### DIFF
--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -300,12 +300,7 @@ class VariationModel(object):
 		for i,weights in enumerate(self.deltaWeights):
 			delta = masterValues[mapping[i]]
 			for j,weight in weights.items():
-				try:
-					delta -= out[j] * weight
-				except OverflowError:
-					# if it doesn't fit signed shorts, retry with doubles
-					delta._ensureFloat()
-					delta -= out[j] * weight
+				delta -= out[j] * weight
 			out.append(delta)
 		return out
 

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 import sys
+import array
 import pytest
 
 
@@ -150,3 +151,9 @@ class GlyphCoordinatesTest(object):
         # since the Python float is truncated to a C float.
         # when using typecode 'd' it should return the correct value 243
         assert g[0][0] == round(afloat)
+
+    def test__checkFloat_overflow(self):
+        g = GlyphCoordinates([(1, 1)], typecode="h")
+        g.append((0x8000, 0))
+        assert g.array.typecode == "d"
+        assert g.array == array.array("d", [1.0, 1.0, 32768.0, 0.0])


### PR DESCRIPTION
Early on I pushed https://github.com/fonttools/fonttools/commit/0055f9414ca5094b0c9beb0176ac4998cdbbba70 to fix an OverflowError occurring while computing deltas in VariationModel.getDelta, when the values don't fit a signed short integer.
https://github.com/fonttools/fonttools/commit/0055f9414ca5094b0c9beb0176ac4998cdbbba70

However, I think a better fix is to change GlyphCoordinates so that whenever it is about to modify its inner array, it first checks that the value does not overflow, and if it does, upgrades it to an array of floats (doubles actually).

It might be a bit slower, but I think it's better than checking for overflow errors everywhere we use glyph coordinates. 
