### PR TITLE
Fixes the eq comparison of the Tag object to work in a comparison with None type

### DIFF
--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -157,7 +157,7 @@ else:
 		def __ne__(self, other):
 			return not self.__eq__(other)
 		def __eq__(self, other):
-			return str.__eq__(self, self.transcode(other))
+			return str.__eq__(self, other)
 
 		def __hash__(self):
 			return str.__hash__(self)

--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -148,7 +148,7 @@ else:
 
 		@staticmethod
 		def transcode(blob):
-			if not isinstance(blob, str):
+			if isinstance(blob, bytes):
 				blob = blob.decode('latin-1')
 			return blob
 
@@ -157,7 +157,7 @@ else:
 		def __ne__(self, other):
 			return not self.__eq__(other)
 		def __eq__(self, other):
-			return str.__eq__(self, other)
+			return str.__eq__(self, self.transcode(other))
 
 		def __hash__(self):
 			return str.__hash__(self)


### PR DESCRIPTION
I'm not sure if it was intentional to make the Tag type so strict for Python 3, but it breaks when trying to compare the Tag to a None type. 

Even though a tag couldn't/shouldn't be set to None, the expectation is still that it would work like a string.