### PR TITLE
Add context guard to ttfont

### DIFF
--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -141,6 +141,12 @@ class TTFont(object):
 		self.flavor = self.reader.flavor
 		self.flavorData = self.reader.flavorData
 
+	def __enter__(self):
+		return self
+
+	def __exit__(self, type, value, traceback):
+		self.close()
+
 	def close(self):
 		"""If we still have a reader object, close it."""
 		if self.reader is not None:


### PR DESCRIPTION
This implements the [`__enter__` and `__exit__` context guard](https://www.python.org/dev/peps/pep-0343/) methods in the `TTFont` class. With this you can do something like
```python
from fontTools.ttLib import TTFont
with TTFont('/path/to/font.ttf') as font:
     print(font.getGlyphNames())
```
and have the file auto closed when the block is exited. This seems pretty straight forward, but I'm happy for any feedback.