### PR TITLE
allow an encoding to be specified when parsing a Type 1 font

### DIFF
--- a/Lib/fontTools/t1Lib/__init__.py
+++ b/Lib/fontTools/t1Lib/__init__.py
@@ -49,11 +49,12 @@ class T1Font(object):
 	Type 1 fonts.
 	"""
 
-	def __init__(self, path=None):
+	def __init__(self, path=None, encoding="ascii"):
 		if path is not None:
 			self.data, type = read(path)
 		else:
 			pass # XXX
+		self.encoding = encoding
 
 	def saveAs(self, path, type, dohex=False):
 		write(path, self.getData(), type, dohex)
@@ -82,7 +83,7 @@ class T1Font(object):
 	def parse(self):
 		from fontTools.misc import psLib
 		from fontTools.misc import psCharStrings
-		self.font = psLib.suckfont(self.data)
+		self.font = psLib.suckfont(self.data, self.encoding)
 		charStrings = self.font["CharStrings"]
 		lenIV = self.font["Private"].get("lenIV", 4)
 		assert lenIV >= 0


### PR DESCRIPTION
There are Type 1 fonts out there that use non-ascii characters in their copyright notice, and fonttools chokes on them. While I am not aware of how to determine the proper encoding, I'm happy with just guessing macroman. This doesn't change the default behavior.