### PR TITLE
[varLib] make STAT 1.2, and reuse fvar nameIDs

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -169,22 +169,26 @@ def _add_avar(font, axes):
 	return avar
 
 def _add_stat(font, axes):
+	# for now we just get the axis tags and nameIDs from the fvar,
+	# so we can reuse the same nameIDs which were defined in there.
+	# TODO make use of 'axes' once it adds style attributes info:
+	# https://github.com/LettError/designSpaceDocument/issues/8
 
 	if "STAT" in font:
             return
 
 	nameTable = font['name']
+	fvarTable = font['fvar']
 
 	STAT = font["STAT"] = newTable('STAT')
 	stat = STAT.table = ot.STAT()
-	stat.Version = 0x00010000
+	stat.Version = 0x00010002
 
 	axisRecords = []
-	for i,a in enumerate(axes.values()):
+	for i, a in enumerate(fvarTable.axes):
 		axis = ot.AxisRecord()
-		axis.AxisTag = Tag(a.tag)
-		# Meh. Reuse fvar nameID!
-		axis.AxisNameID = nameTable.addName(tounicode(a.labelname['en']))
+		axis.AxisTag = Tag(a.axisTag)
+		axis.AxisNameID = a.axisNameID
 		axis.AxisOrdering = i
 		axisRecords.append(axis)
 
@@ -194,6 +198,10 @@ def _add_stat(font, axes):
 	stat.DesignAxisRecordSize = 8
 	stat.DesignAxisCount = len(axisRecords)
 	stat.DesignAxisRecord = axisRecordArray
+
+	# for the elided fallback name, we default to the base style name.
+	# TODO make this user-configurable via designspace document
+	stat.ElidedFallbackNameID = 2
 
 # TODO Move to glyf or gvar table proper
 def _GetCoordinates(font, glyphName):

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -177,7 +177,6 @@ def _add_stat(font, axes):
 	if "STAT" in font:
             return
 
-	nameTable = font['name']
 	fvarTable = font['fvar']
 
 	STAT = font["STAT"] = newTable('STAT')

--- a/Tests/varLib/data/test_results/BuildMain.ttx
+++ b/Tests/varLib/data/test_results/BuildMain.ttx
@@ -494,12 +494,6 @@
     <namerecord nameID="273" platformID="1" platEncID="0" langID="0x0" unicode="True">
       TestFamily-BlackHighContrast
     </namerecord>
-    <namerecord nameID="274" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Weight
-    </namerecord>
-    <namerecord nameID="275" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Contrast
-    </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
       Test Family
     </namerecord>
@@ -577,12 +571,6 @@
     </namerecord>
     <namerecord nameID="273" platformID="3" platEncID="1" langID="0x409">
       TestFamily-BlackHighContrast
-    </namerecord>
-    <namerecord nameID="274" platformID="3" platEncID="1" langID="0x409">
-      Weight
-    </namerecord>
-    <namerecord nameID="275" platformID="3" platEncID="1" langID="0x409">
-      Contrast
     </namerecord>
   </name>
 
@@ -794,22 +782,23 @@
   </MVAR>
 
   <STAT>
-    <Version value="0x00010000"/>
+    <Version value="0x00010002"/>
     <DesignAxisRecordSize value="8"/>
     <!-- DesignAxisCount=2 -->
     <DesignAxisRecord>
       <Axis index="0">
         <AxisTag value="wght"/>
-        <AxisNameID value="274"/>  <!-- Weight -->
+        <AxisNameID value="256"/>  <!-- Weight -->
         <AxisOrdering value="0"/>
       </Axis>
       <Axis index="1">
         <AxisTag value="cntr"/>
-        <AxisNameID value="275"/>  <!-- Contrast -->
+        <AxisNameID value="257"/>  <!-- Contrast -->
         <AxisOrdering value="1"/>
       </Axis>
     </DesignAxisRecord>
     <!-- AxisValueCount=0 -->
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
   </STAT>
 
   <cvar>

--- a/Tests/varLib/data/test_results/Mutator.ttx
+++ b/Tests/varLib/data/test_results/Mutator.ttx
@@ -494,12 +494,6 @@
     <namerecord nameID="273" platformID="1" platEncID="0" langID="0x0" unicode="True">
       TestFamily-BlackHighContrast
     </namerecord>
-    <namerecord nameID="274" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Weight
-    </namerecord>
-    <namerecord nameID="275" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Contrast
-    </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
       Test Family
     </namerecord>
@@ -577,12 +571,6 @@
     </namerecord>
     <namerecord nameID="273" platformID="3" platEncID="1" langID="0x409">
       TestFamily-BlackHighContrast
-    </namerecord>
-    <namerecord nameID="274" platformID="3" platEncID="1" langID="0x409">
-      Weight
-    </namerecord>
-    <namerecord nameID="275" platformID="3" platEncID="1" langID="0x409">
-      Contrast
     </namerecord>
   </name>
 


### PR DESCRIPTION
STAT 1.0 is deprecated
See https://github.com/googlei18n/fontmake/issues/417

also we should use the same nameIDs that were defined for the fvar, not add additional ones.

