### PR TITLE
[varLib.mutator] prune fvar nameIDs from instance's name table

### DIFF
--- a/Lib/fontTools/varLib/mutator.py
+++ b/Lib/fontTools/varLib/mutator.py
@@ -112,6 +112,17 @@ def instantiateVariableFont(varfont, location, inplace=False):
 		log.info("Building interpolated tables")
 		merger.instantiate()
 
+	if 'name' in varfont:
+		log.info("Pruning name table")
+		exclude = {a.axisNameID for a in fvar.axes}
+		for i in fvar.instances:
+			exclude.add(i.subfamilyNameID)
+			exclude.add(i.postscriptNameID)
+		varfont['name'].names[:] = [
+			n for n in varfont['name'].names
+			if n.nameID not in exclude
+		]
+
 	log.info("Removing variable tables")
 	for tag in ('avar','cvar','fvar','gvar','HVAR','MVAR','VVAR','STAT'):
 		if tag in varfont:

--- a/Tests/varLib/data/test_results/Mutator.ttx
+++ b/Tests/varLib/data/test_results/Mutator.ttx
@@ -440,60 +440,6 @@
   </glyf>
 
   <name>
-    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Weight
-    </namerecord>
-    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Contrast
-    </namerecord>
-    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      ExtraLight
-    </namerecord>
-    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      TestFamily-ExtraLight
-    </namerecord>
-    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Light
-    </namerecord>
-    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      TestFamily-Light
-    </namerecord>
-    <namerecord nameID="262" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Regular
-    </namerecord>
-    <namerecord nameID="263" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      TestFamily-Regular
-    </namerecord>
-    <namerecord nameID="264" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Semibold
-    </namerecord>
-    <namerecord nameID="265" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      TestFamily-Semibold
-    </namerecord>
-    <namerecord nameID="266" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Bold
-    </namerecord>
-    <namerecord nameID="267" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      TestFamily-Bold
-    </namerecord>
-    <namerecord nameID="268" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Black
-    </namerecord>
-    <namerecord nameID="269" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      TestFamily-Black
-    </namerecord>
-    <namerecord nameID="270" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Black Medium Contrast
-    </namerecord>
-    <namerecord nameID="271" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      TestFamily-BlackMediumContrast
-    </namerecord>
-    <namerecord nameID="272" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Black High Contrast
-    </namerecord>
-    <namerecord nameID="273" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      TestFamily-BlackHighContrast
-    </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
       Test Family
     </namerecord>
@@ -517,60 +463,6 @@
     </namerecord>
     <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
       Master 1
-    </namerecord>
-    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
-      Weight
-    </namerecord>
-    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
-      Contrast
-    </namerecord>
-    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
-      ExtraLight
-    </namerecord>
-    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
-      TestFamily-ExtraLight
-    </namerecord>
-    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
-      Light
-    </namerecord>
-    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
-      TestFamily-Light
-    </namerecord>
-    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
-      Regular
-    </namerecord>
-    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
-      TestFamily-Regular
-    </namerecord>
-    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
-      Semibold
-    </namerecord>
-    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
-      TestFamily-Semibold
-    </namerecord>
-    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
-      Bold
-    </namerecord>
-    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
-      TestFamily-Bold
-    </namerecord>
-    <namerecord nameID="268" platformID="3" platEncID="1" langID="0x409">
-      Black
-    </namerecord>
-    <namerecord nameID="269" platformID="3" platEncID="1" langID="0x409">
-      TestFamily-Black
-    </namerecord>
-    <namerecord nameID="270" platformID="3" platEncID="1" langID="0x409">
-      Black Medium Contrast
-    </namerecord>
-    <namerecord nameID="271" platformID="3" platEncID="1" langID="0x409">
-      TestFamily-BlackMediumContrast
-    </namerecord>
-    <namerecord nameID="272" platformID="3" platEncID="1" langID="0x409">
-      Black High Contrast
-    </namerecord>
-    <namerecord nameID="273" platformID="3" platEncID="1" langID="0x409">
-      TestFamily-BlackHighContrast
     </namerecord>
   </name>
 

--- a/Tests/varLib/data/test_results/Mutator_IUP-instance.ttx
+++ b/Tests/varLib/data/test_results/Mutator_IUP-instance.ttx
@@ -237,15 +237,6 @@
     <namerecord nameID="6" platformID="1" platEncID="0" langID="0x0" unicode="True">
       VarFont-Regular
     </namerecord>
-    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Width
-    </namerecord>
-    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Ascender
-    </namerecord>
-    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Regular
-    </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
       VarFont
     </namerecord>
@@ -260,15 +251,6 @@
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
       VarFont-Regular
-    </namerecord>
-    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
-      Width
-    </namerecord>
-    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
-      Ascender
-    </namerecord>
-    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
-      Regular
     </namerecord>
   </name>
 


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/1227