### PR TITLE
Remove unreachable source in ttx module

### DIFF
--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -218,7 +218,6 @@ class Options(object):
 			self.logLevel = logging.INFO
 		if self.mergeFile and self.flavor:
 			raise getopt.GetoptError("-m and --flavor options are mutually exclusive")
-			sys.exit(2)
 		if self.onlyTables and self.skipTables:
 			raise getopt.GetoptError("-t and -x options are mutually exclusive")
 		if self.mergeFile and numFiles > 1:


### PR DESCRIPTION
As discussed in #1261, this removes an unreachable `sys.exit` statement in `ttx.Options`