### PR TITLE
designspaceLib remove checkDefault, checkAxes

### DIFF
--- a/Doc/source/designspaceLib/readme.rst
+++ b/Doc/source/designspaceLib/readme.rst
@@ -573,6 +573,7 @@ There are two meanings for the ``lib`` element:
     - Child element of ``designspace`` and ``instance``
     - Contains arbitrary data about the whole document or about a specific
       instance.
+    - Items in the dict need to use **reverse domain name notation** <https://en.wikipedia.org/wiki/Reverse_domain_name_notation>__
 
 .. 32-info-element:
 

--- a/Doc/source/designspaceLib/scripting.rst
+++ b/Doc/source/designspaceLib/scripting.rst
@@ -59,6 +59,8 @@ Make a descriptor object and add it to the document.
 -  The ``tag`` attribute is the one of the registered `OpenType
    Variation Axis
    Tags <https://www.microsoft.com/typography/otspec/fvar.htm#VAT>`__
+-  The default master is expected at the intersection of all
+   default values of all axes. 
 
 Option: add label names
 -----------------------
@@ -122,6 +124,7 @@ So go ahead and add another master:
     s1.name = "master.bold"
     s1.location = dict(weight=1000)
     doc.addSource(s1)
+    
 
 Option: exclude glyphs
 ----------------------

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -178,16 +178,14 @@ class RuleDescriptor(SimpleDescriptor):
 
 
 def evaluateRule(rule, location):
-    """ Return True if any of the rule's conditionsets matches the
-    given location.
-    """
+    """ Return True if any of the rule's conditionsets matches the given location."""
     return any(evaluateConditions(c, location) for c in rule.conditionSets)
 
 
 def evaluateConditions(conditions, location):
     """ Return True if all the conditions matches the given location.
-    If a condition has no minimum, check for < maximum.
-    If a condition has no maximum, check for > minimum.
+        If a condition has no minimum, check for < maximum.
+        If a condition has no maximum, check for > minimum.
     """
     for cd in conditions:
         value = location[cd['name']]
@@ -885,49 +883,27 @@ class BaseDocReader(object):
         instanceObject.lib = from_plist(libElement[0])
 
     def readInfoElement(self, infoElement, instanceObject):
-        """ Read the info element.
-
-            ::
-
-                <info/>
-
-                Let's drop support for a different location for the info. Never needed it.
-
-            """
+        """ Read the info element."""
         infoLocation = self.locationFromElement(infoElement)
         instanceObject.info = True
 
     def readKerningElement(self, kerningElement, instanceObject):
-        """ Read the kerning element.
-
-        ::
-
-                Make kerning at the location and with the masters specified at the instance level.
-                <kerning/>
-
-        """
+        """ Read the kerning element."""
         kerningLocation = self.locationFromElement(kerningElement)
         instanceObject.addKerning(kerningLocation)
 
     def readGlyphElement(self, glyphElement, instanceObject):
         """
         Read the glyph element.
-
-        ::
-
             <glyph name="b" unicode="0x62"/>
-
             <glyph name="b"/>
-
             <glyph name="b">
                 <master location="location-token-bbb" source="master-token-aaa2"/>
                 <master glyphname="b.alt1" location="location-token-ccc" source="master-token-aaa3"/>
-
                 <note>
                     This is an instance from an anisotropic interpolation.
                 </note>
             </glyph>
-
         """
         glyphData = {}
         glyphName = glyphElement.attrib.get('name')

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -704,12 +704,12 @@ class BaseDocReader(object):
                 cd['maximum'] = None
             cd['name'] = conditionElement.attrib.get("name")
             # # test for things
-            # if cd.get('minimum') is None and cd.get('maximum') is None:
-            #     if ruleObject.name is not None:
-            #         n = ruleObject.name
-            #     else:
-            #         n = "%d" % len(rules)
-            #     raise DesignSpaceDocumentError("No minimum or maximum defined in rule \"%s\"." % n)
+            if cd.get('minimum') is None and cd.get('maximum') is None:
+                if ruleObject.name is not None:
+                    n = ruleObject.name
+                else:
+                    n = "%d" % len(rules)
+                raise DesignSpaceDocumentError("No minimum or maximum defined in rule \"%s\"." % n)
             cds.append(cd)
         return cds
 

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1161,53 +1161,6 @@ class DesignSpaceDocument(object):
             benderAxes[axisDescriptor.name] = d
         return benderAxes
 
-    def checkAxes(self, overwrite=False):
-        """
-            If we don't have axes in the document, make some, report
-            Should we include the instance locations when determining the axis extrema?
-        """
-        axisValues = {}
-        # find all the axes
-        locations = []
-        for sourceDescriptor in self.sources:
-            locations.append(sourceDescriptor.location)
-        for instanceDescriptor in self.instances:
-            locations.append(instanceDescriptor.location)
-            for name, glyphData in instanceDescriptor.glyphs.items():
-                loc = glyphData.get("instanceLocation")
-                if loc is not None:
-                    locations.append(loc)
-                for m in glyphData.get('masters', []):
-                    locations.append(m['location'])
-        for loc in locations:
-            for name, value in loc.items():
-                if not name in axisValues:
-                    axisValues[name] = []
-                if type(value)==tuple:
-                    for v in value:
-                        axisValues[name].append(v)
-                else:
-                    axisValues[name].append(value)
-        have = self.getAxisOrder()
-        for name, values in axisValues.items():
-            a = None
-            if name in have:
-                if overwrite:
-                    # we have the axis,
-                    a = self.getAxis(name)
-                else:
-                    continue
-            else:
-                # we need to make this axis
-                a = self.newAxisDescriptor()
-                self.addAxis(a)
-            a.name = name
-            a.minimum = min(values)
-            a.maximum = max(values)
-            a.default = a.minimum
-            a.tag, a.labelNames = tagForAxisName(a.name)
-            self.logger.info("CheckAxes: added a missing axis %s, %3.3f %3.3f", a.name, a.minimum, a.maximum)
-
     def normalizeLocation(self, location):
         # adapted from fontTools.varlib.models.normalizeLocation because:
         #   - this needs to work with axis names, not tags

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -775,43 +775,6 @@ class BaseDocReader(object):
                 loc[dimName] = xValue
         return loc
 
-    # def guessAxes(self):
-    #     # Called when we have no axes element in the file.
-    #     # Look at all locations and collect the axis names and values
-    #     # assumptions:
-    #     # look for the default value on an axis from a master location
-    #     # Needs deprecation warning
-    #     allLocations = []
-    #     minima = {}
-    #     maxima = {}
-    #     for locationElement in self.root.findall(".sources/source/location"):
-    #         allLocations.append(self._locationFromElement(locationElement))
-    #     for locationElement in self.root.findall(".instances/instance/location"):
-    #         allLocations.append(self._locationFromElement(locationElement))
-    #     for loc in allLocations:
-    #         for dimName, value in loc.items():
-    #             if not isinstance(value, tuple):
-    #                 value = [value]
-    #             for v in value:
-    #                 if dimName not in minima:
-    #                     minima[dimName] = v
-    #                     continue
-    #                 if minima[dimName] > v:
-    #                     minima[dimName] = v
-    #                 if dimName not in maxima:
-    #                     maxima[dimName] = v
-    #                     continue
-    #                 if maxima[dimName] < v:
-    #                     maxima[dimName] = v
-    #     newAxes = []
-    #     for axisName in maxima.keys():
-    #         a = self.axisDescriptorClass()
-    #         a.default = a.minimum = minima[axisName]
-    #         a.maximum = maxima[axisName]
-    #         a.name = axisName
-    #         a.tag, a.labelNames = tagForAxisName(axisName)
-    #         self.documentObject.axes.append(a)
-
     def readSources(self):
         for sourceCount, sourceElement in enumerate(self.root.findall(".sources/source")):
             filename = sourceElement.attrib.get('filename')

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -8,8 +8,6 @@ import posixpath
 import plistlib
 import warnings
 
-import fontTools.varLib
-
 try:
     import xml.etree.cElementTree as ET
 except ImportError:

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1202,7 +1202,9 @@ class DesignSpaceDocument(object):
                 self.default = sourceDescriptor
                 return sourceDescriptor
         # failing that, well, fail. We don't want to guess any more. 
+        warnings.warn("Can't find a suitable default location in this document")
         return None
+
 
     def _prepAxesForBender(self):
         """

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1126,14 +1126,14 @@ class DesignSpaceDocument(object):
 
     def findDefault(self):
         # new default finder
-        # take the master with the location at all the defaults
+        # take the sourcedescriptor with the location at all the defaults
         self.default = None
         for sourceDescriptor in self.sources:
             if sourceDescriptor.location == self.defaultLoc:
                 # we choose you!
                 self.default = sourceDescriptor
                 return sourceDescriptor
-        # failing that, tkae the master with the copyInfo flag
+        # failing that, find the sourcedescriptor with the copyInfo flag
         for sourceDescriptor in self.sources:
             names = set()
             if sourceDescriptor.copyInfo:
@@ -1141,7 +1141,7 @@ class DesignSpaceDocument(object):
                 self.default = sourceDescriptor
                 return sourceDescriptor
         # failing that, well, fail. We don't want to guess any more. 
-        warnings.warn("Can't find a suitable default location in this document")
+        warnings.warn("Can't find a suitable default location in this document.")
         return None
 
     def _axesAsDict(self):

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -12,6 +12,23 @@ from fontTools.designspaceLib import (
     DesignSpaceDocument, SourceDescriptor, AxisDescriptor, RuleDescriptor,
     InstanceDescriptor, evaluateRule, processRules, posix, DesignSpaceDocumentError)
 
+def _axesAsDict(axes):
+    """
+        Make the axis data we have available in
+    """
+    axesDict = {}
+    for axisDescriptor in axes:
+        d = {
+            'name': axisDescriptor.name,
+            'tag': axisDescriptor.tag,
+            'minimum': axisDescriptor.minimum,
+            'maximum': axisDescriptor.maximum,
+            'default': axisDescriptor.default,
+            'map': axisDescriptor.map,
+        }
+        axesDict[axisDescriptor.name] = d
+    return axesDict
+
 
 def assert_equals_test_file(path, test_filename):
     with open(path) as fp:
@@ -710,7 +727,7 @@ def test_rulesDocument(tmpdir):
     assert len(doc.rules) == 1
     assert len(doc.rules[0].conditionSets) == 1
     assert len(doc.rules[0].conditionSets[0]) == 2
-    assert doc._axesAsDict() == {'axisName_a': {'map': [], 'name': 'axisName_a', 'default': 0, 'minimum': 0, 'maximum': 1000, 'tag': 'TAGA'}, 'axisName_b': {'map': [], 'name': 'axisName_b', 'default': 2000, 'minimum': 2000, 'maximum': 3000, 'tag': 'TAGB'}}
+    assert _axesAsDict(doc.axes) == {'axisName_a': {'map': [], 'name': 'axisName_a', 'default': 0, 'minimum': 0, 'maximum': 1000, 'tag': 'TAGA'}, 'axisName_b': {'map': [], 'name': 'axisName_b', 'default': 2000, 'minimum': 2000, 'maximum': 3000, 'tag': 'TAGB'}}
     assert doc.rules[0].conditionSets == [[
         {'minimum': 0, 'maximum': 1000, 'name': 'axisName_a'},
         {'minimum': 0, 'maximum': 3000, 'name': 'axisName_b'}]]

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -604,6 +604,25 @@ def test_normalise4():
     r.sort()
     assert r == [('ddd', [(0, 0.1), (300, 0.5), (600, 0.5), (1000, 0.9)])]
 
+def test_axisMapping():
+    # note: because designspance lib does not do any actual
+    # processing of the mapping data, we can only check if there data is there.
+    doc = DesignSpaceDocument()
+    # write some axes
+    a4 = AxisDescriptor()
+    a4.minimum = 0
+    a4.maximum = 1000
+    a4.default = 0
+    a4.name = "ddd"
+    a4.map = [(0,100), (300, 500), (600, 500), (1000,900)]
+    doc.addAxis(a4)
+    doc.normalize()
+    r = []
+    for axis in doc.axes:
+        r.append((axis.name, axis.map))
+    r.sort()
+    assert r == [('ddd', [(0, 0.1), (300, 0.5), (600, 0.5), (1000, 0.9)])]
+
 def test_rulesConditions(tmpdir):
     # tests of rules, conditionsets and conditions
     r1 = RuleDescriptor()

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -774,6 +774,27 @@ def test_incompleteRule(tmpdir):
         new.read(testDocPath1)
     assert "No minimum or maximum defined in rule" in str(excinfo.value)
 
+def test_documentLib(tmpdir):
+    # roundtrip test of the document lib with some nested data
+    tmpdir = str(tmpdir)
+    testDocPath1 = os.path.join(tmpdir, "testDocumentLibTest.designspace")
+    doc = DesignSpaceDocument()
+    a1 = AxisDescriptor()
+    a1.tag = "TAGA"
+    a1.name = "axisName_a"
+    a1.minimum = 0
+    a1.maximum = 1000
+    a1.default = 0
+    doc.addAxis(a1)
+    dummyData = dict(a=123, b=u"äbc"+chr(127921), c=[1,2,3], d={'a':123})
+    dummyKey = "org.fontTools.designspaceLib"
+    doc.lib = {dummyKey: dummyData}
+    doc.write(testDocPath1)
+    new = DesignSpaceDocument()
+    new.read(testDocPath1)
+    assert dummyKey in new.lib
+    assert new.lib[dummyKey] == dummyData
+
 def __removeConditionMinimumMaximumDesignSpace(path):
     # only for testing, so we can make an invalid designspace file
     # without making the designSpaceDocument also support it.


### PR DESCRIPTION
* remove checkDefault, checkAxes and any kind of guessing about the axes. The default is the master located at the default value of all axes.
* add findDefault returns the sourceDescriptor for the default. 
* stray conditions are wrapped in a conditionset when reading.
* add some tests.