### PR TITLE
add otRound func to round floats to integer towards +Infinity

### DIFF
--- a/Lib/fontTools/misc/fixedTools.py
+++ b/Lib/fontTools/misc/fixedTools.py
@@ -64,7 +64,7 @@ def floatToFixed(value, precisionBits):
 	"""Converts a float to a fixed-point number given the number of
 	precisionBits.  Ie. round(value * (1<<precisionBits)).
 	"""
-	return round(value * (1<<precisionBits))
+	return otRound(value * (1<<precisionBits))
 
 def floatToFixedToFloat(value, precisionBits):
 	"""Converts a float to a fixed-point number given the number of
@@ -74,7 +74,7 @@ def floatToFixedToFloat(value, precisionBits):
 	which would return the shortest representation of the rounded value.
 	"""
 	scale = 1<<precisionBits
-	return round(value * scale) / scale
+	return otRound(value * scale) / scale
 
 def ensureVersionIsLong(value):
 	"""Ensure a table version is an unsigned long (unsigned short major,

--- a/Lib/fontTools/misc/fixedTools.py
+++ b/Lib/fontTools/misc/fixedTools.py
@@ -3,17 +3,31 @@
 
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+import math
 import logging
 
 log = logging.getLogger(__name__)
 
 __all__ = [
+	"otRound",
 	"fixedToFloat",
 	"floatToFixed",
     "floatToFixedToFloat",
 	"ensureVersionIsLong",
 	"versionToFixed",
 ]
+
+
+def otRound(value):
+	"""Round float value to nearest integer towards +Infinity.
+	For fractional values of 0.5 and higher, take the next higher integer;
+	for other fractional values, truncate.
+
+	https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview
+	https://github.com/fonttools/fonttools/issues/1248#issuecomment-383198166
+	"""
+	return int(math.floor(value + 0.5))
+
 
 def fixedToFloat(value, precisionBits):
 	"""Converts a fixed-point number to a float, choosing the float

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -4,7 +4,7 @@ CFF dictionary data and Type1/Type2 CharStrings.
 
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
-from fontTools.misc.fixedTools import fixedToFloat
+from fontTools.misc.fixedTools import fixedToFloat, otRound
 from fontTools.pens.boundsPen import BoundsPen
 import struct
 import logging
@@ -217,7 +217,7 @@ encodeIntT2 = getIntEncoder("t2")
 
 def encodeFixed(f, pack=struct.pack):
 	# For T2 only
-	return b"\xff" + pack(">l", round(f * 65536))
+	return b"\xff" + pack(">l", otRound(f * 65536))
 
 def encodeFloat(f):
 	# For CFF only, used in cffLib

--- a/Lib/fontTools/pens/t2CharStringPen.py
+++ b/Lib/fontTools/pens/t2CharStringPen.py
@@ -3,6 +3,7 @@
 
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+from fontTools.misc.fixedTools import otRound
 from fontTools.misc.psCharStrings import T2CharString
 from fontTools.pens.basePen import BasePen
 from fontTools.cffLib.specializer import specializeCommands, commandsToProgram
@@ -15,7 +16,7 @@ def makeRoundFunc(tolerance):
     def _round(number):
         if tolerance == 0:
             return number  # no-op
-        rounded = round(number)
+        rounded = otRound(number)
         # return rounded integer if the tolerance >= 0.5, or if the absolute
         # difference between the original float and the rounded integer is
         # within the tolerance
@@ -82,7 +83,7 @@ class T2CharStringPen(BasePen):
         program = commandsToProgram(commands)
         if self._width is not None:
             assert not self._CFF2, "CFF2 does not allow encoding glyph width in CharString."
-            program.insert(0, round(self._width))
+            program.insert(0, otRound(self._width))
         if not self._CFF2:
             program.append('endchar')
         charString = T2CharString(

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -4,6 +4,7 @@
 
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+from fontTools.misc.fixedTools import otRound
 from fontTools import ttLib
 from fontTools.ttLib.tables import otTables
 from fontTools.misc import psCharStrings
@@ -3070,7 +3071,7 @@ class Subsetter(object):
 					log.info("%s Unicode ranges pruned: %s", tag, sorted(new_uniranges))
 				if self.options.recalc_average_width:
 					widths = [m[0] for m in font["hmtx"].metrics.values() if m[0] > 0]
-					avg_width = round(sum(widths) / len(widths))
+					avg_width = otRound(sum(widths) / len(widths))
 					if avg_width != font[tag].xAvgCharWidth:
 						font[tag].xAvgCharWidth = avg_width
 						log.info("%s xAvgCharWidth updated: %d", tag, avg_width)

--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
-from fontTools.misc.fixedTools import fixedToFloat, floatToFixed
+from fontTools.misc.fixedTools import fixedToFloat, floatToFixed, otRound
 from fontTools.misc.textTools import safeEval
 import array
 import io
@@ -369,7 +369,7 @@ class TupleVariation(object):
 		assert runLength >= 1 and runLength <= 64
 		stream.write(bytechr(runLength - 1))
 		for i in range(offset, pos):
-			stream.write(struct.pack('b', round(deltas[i])))
+			stream.write(struct.pack('b', otRound(deltas[i])))
 		return pos
 
 	@staticmethod
@@ -403,7 +403,7 @@ class TupleVariation(object):
 		assert runLength >= 1 and runLength <= 64
 		stream.write(bytechr(DELTAS_ARE_WORDS | (runLength - 1)))
 		for i in range(offset, pos):
-			stream.write(struct.pack('>h', round(deltas[i])))
+			stream.write(struct.pack('>h', otRound(deltas[i])))
 		return pos
 
 	@staticmethod

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -9,7 +9,11 @@ from fontTools import version
 from fontTools.misc.textTools import safeEval, pad
 from fontTools.misc.arrayTools import calcBounds, calcIntBounds, pointInRect
 from fontTools.misc.bezierTools import calcQuadraticBounds
-from fontTools.misc.fixedTools import fixedToFloat as fi2fl, floatToFixed as fl2fi
+from fontTools.misc.fixedTools import (
+	fixedToFloat as fi2fl,
+	floatToFixed as fl2fi,
+	otRound,
+)
 from numbers import Number
 from . import DefaultTable
 from . import ttProgram
@@ -1114,8 +1118,8 @@ class GlyphComponent(object):
 				data = data + struct.pack(">HH", self.firstPt, self.secondPt)
 				flags = flags | ARG_1_AND_2_ARE_WORDS
 		else:
-			x = round(self.x)
-			y = round(self.y)
+			x = otRound(self.x)
+			y = otRound(self.y)
 			flags = flags | ARGS_ARE_XY_VALUES
 			if (-128 <= x <= 127) and (-128 <= y <= 127):
 				data = data + struct.pack(">bb", x, y)
@@ -1279,7 +1283,7 @@ class GlyphCoordinates(object):
 			return
 		a = array.array("h")
 		for n in self._a:
-			a.append(round(n))
+			a.append(otRound(n))
 		self._a = a
 
 	def relativeToAbsolute(self):

--- a/Lib/fontTools/ttLib/tables/_h_m_t_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+from fontTools.misc.fixedTools import otRound
 from fontTools import ttLib
 from fontTools.misc.textTools import safeEval
 from . import DefaultTable
@@ -78,14 +79,14 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
 				lastIndex = 1
 				break
 		additionalMetrics = metrics[lastIndex:]
-		additionalMetrics = [round(sb) for _, sb in additionalMetrics]
+		additionalMetrics = [otRound(sb) for _, sb in additionalMetrics]
 		metrics = metrics[:lastIndex]
 		numberOfMetrics = len(metrics)
 		setattr(ttFont[self.headerTag], self.numberOfMetricsName, numberOfMetrics)
 
 		allMetrics = []
 		for advance, sb in metrics:
-			allMetrics.extend([round(advance), round(sb)])
+			allMetrics.extend([otRound(advance), otRound(sb)])
 		metricsFmt = ">" + self.longMetricFormat * numberOfMetrics
 		try:
 			data = struct.pack(metricsFmt, *allMetrics)

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -21,6 +21,7 @@ API *will* change in near future.
 from __future__ import print_function, division, absolute_import
 from __future__ import unicode_literals
 from fontTools.misc.py23 import *
+from fontTools.misc.fixedTools import otRound
 from fontTools.misc.arrayTools import Vector
 from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables._n_a_m_e import NameRecord
@@ -268,12 +269,12 @@ def _SetCoordinates(font, glyphName, coord):
 
 	glyph.recalcBounds(glyf)
 
-	horizontalAdvanceWidth = round(rightSideX - leftSideX)
+	horizontalAdvanceWidth = otRound(rightSideX - leftSideX)
 	if horizontalAdvanceWidth < 0:
 		# unlikely, but it can happen, see:
 		# https://github.com/fonttools/fonttools/pull/1198
 		horizontalAdvanceWidth = 0
-	leftSideBearing = round(glyph.xMin - leftSideX)
+	leftSideBearing = otRound(glyph.xMin - leftSideX)
 	# XXX Handle vertical
 	font["hmtx"].metrics[glyphName] = horizontalAdvanceWidth, leftSideBearing
 
@@ -411,7 +412,7 @@ def _merge_TTHinting(font, model, master_ttfs, tolerance=0.5):
 	deltas = model.getDeltas(all_cvs)
 	supports = model.supports
 	for i,(delta,support) in enumerate(zip(deltas[1:], supports[1:])):
-		delta = [round(d) for d in delta]
+		delta = [otRound(d) for d in delta]
 		if all(abs(v) <= tolerance for v in delta):
 			continue
 		var = TupleVariation(support, delta)
@@ -426,7 +427,7 @@ def _add_HVAR(font, model, master_ttfs, axisTags):
 	for glyph in font.getGlyphOrder():
 		hAdvances = [metrics[glyph][0] for metrics in metricses]
 		# TODO move round somewhere else?
-		hAdvanceDeltas[glyph] = tuple(round(d) for d in model.getDeltas(hAdvances)[1:])
+		hAdvanceDeltas[glyph] = tuple(otRound(d) for d in model.getDeltas(hAdvances)[1:])
 
 	# Direct mapping
 	supports = model.supports[1:]

--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -3,6 +3,7 @@ Merge OpenType Layout tables (GDEF / GPOS / GSUB).
 """
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+from fontTools.misc.fixedTools import otRound
 from fontTools.misc import classifyTools
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.ttLib.tables import otBase as otBase
@@ -660,8 +661,8 @@ def merge(merger, self, lst):
 	YCoords = [a.YCoordinate for a in lst]
 	model = merger.model
 	scalars = merger.scalars
-	self.XCoordinate = round(model.interpolateFromMastersAndScalars(XCoords, scalars))
-	self.YCoordinate = round(model.interpolateFromMastersAndScalars(YCoords, scalars))
+	self.XCoordinate = otRound(model.interpolateFromMastersAndScalars(XCoords, scalars))
+	self.YCoordinate = otRound(model.interpolateFromMastersAndScalars(YCoords, scalars))
 
 @InstancerMerger.merger(otBase.ValueRecord)
 def merge(merger, self, lst):
@@ -677,7 +678,7 @@ def merge(merger, self, lst):
 
 		if hasattr(self, name):
 			values = [getattr(a, name, 0) for a in lst]
-			value = round(model.interpolateFromMastersAndScalars(values, scalars))
+			value = otRound(model.interpolateFromMastersAndScalars(values, scalars))
 			setattr(self, name, value)
 
 
@@ -738,7 +739,7 @@ def merge(merger, self, lst):
 
 		assert dev.DeltaFormat == 0x8000
 		varidx = (dev.StartSize << 16) + dev.EndSize
-		delta = round(instancer[varidx])
+		delta = otRound(instancer[varidx])
 
 		attr = v+'Coordinate'
 		setattr(self, attr, getattr(self, attr) + delta)
@@ -769,7 +770,7 @@ def merge(merger, self, lst):
 
 		assert dev.DeltaFormat == 0x8000
 		varidx = (dev.StartSize << 16) + dev.EndSize
-		delta = round(instancer[varidx])
+		delta = otRound(instancer[varidx])
 
 		setattr(self, name, getattr(self, name) + delta)
 

--- a/Lib/fontTools/varLib/mutator.py
+++ b/Lib/fontTools/varLib/mutator.py
@@ -5,7 +5,7 @@ $ fonttools varLib.mutator ./NotoSansArabic-VF.ttf wght=140 wdth=85
 """
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
-from fontTools.misc.fixedTools import floatToFixedToFloat
+from fontTools.misc.fixedTools import floatToFixedToFloat, otRound
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 from fontTools.varLib import _GetCoordinates, _SetCoordinates, _DesignspaceAxis
@@ -87,7 +87,7 @@ def instantiateVariableFont(varfont, location, inplace=False):
 				if c is not None:
 					deltas[i] = deltas.get(i, 0) + scalar * c
 		for i, delta in deltas.items():
-			cvt[i] += round(delta)
+			cvt[i] += otRound(delta)
 
 	if 'MVAR' in varfont:
 		log.info("Mutating MVAR table")
@@ -99,7 +99,7 @@ def instantiateVariableFont(varfont, location, inplace=False):
 			if mvarTag not in MVAR_ENTRIES:
 				continue
 			tableTag, itemName = MVAR_ENTRIES[mvarTag]
-			delta = round(varStoreInstancer[rec.VarIdx])
+			delta = otRound(varStoreInstancer[rec.VarIdx])
 			if not delta:
 				continue
 			setattr(varfont[tableTag], itemName,

--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+from fontTools.misc.fixedTools import otRound
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.varLib.models import supportScalar
 from fontTools.varLib.builder import (buildVarRegionList, buildVarStore,
@@ -57,7 +58,7 @@ class OnlineVarStoreBuilder(object):
 		self._store.VarData.append(data)
 
 	def storeMasters(self, master_values):
-		deltas = [round(d) for d in self._model.getDeltas(master_values)]
+		deltas = [otRound(d) for d in self._model.getDeltas(master_values)]
 		base = deltas.pop(0)
 		deltas = tuple(deltas)
 		varIdx = self._cache.get(deltas)

--- a/Tests/pens/t2CharStringPen_test.py
+++ b/Tests/pens/t2CharStringPen_test.py
@@ -142,14 +142,14 @@ class T2CharStringPenTest(unittest.TestCase):
         pen = T2CharStringPen(100.1, {}, roundTolerance=0.5)
         pen.moveTo((0, 0))
         pen.curveTo((10.1, 0.1), (19.9, 9.9), (20.49, 20.49))
-        pen.curveTo((20.49, 30.49), (9.9, 39.9), (0.1, 40.1))
+        pen.curveTo((20.49, 30.5), (9.9, 39.9), (0.1, 40.1))
         pen.closePath()
         charstring = pen.getCharString(None, None)
 
         self.assertEqual(
             [100,
              0, 'hmoveto',
-             10, 10, 10, 10, 10, -10, 10, -10, 'hvcurveto',
+             10, 10, 10, 10, 11, -10, 9, -10, 'hvcurveto',
              'endchar'],
             charstring.program)
 

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+from fontTools.misc.fixedTools import otRound
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 import sys
 import array
@@ -56,7 +57,7 @@ class GlyphCoordinatesTest(object):
     def test__round__(self):
         g = GlyphCoordinates([(-1.5,2)])
         g2 = round(g)
-        assert g2 == GlyphCoordinates([(-2,2)])
+        assert g2 == GlyphCoordinates([(-1,2)])
 
     def test__add__(self):
         g1 = GlyphCoordinates([(1,2)])
@@ -150,7 +151,7 @@ class GlyphCoordinatesTest(object):
         # this would return 242 if the internal array.array typecode is 'f',
         # since the Python float is truncated to a C float.
         # when using typecode 'd' it should return the correct value 243
-        assert g[0][0] == round(afloat)
+        assert g[0][0] == otRound(afloat)
 
     def test__checkFloat_overflow(self):
         g = GlyphCoordinates([(1, 1)], typecode="h")

--- a/Tests/ttLib/tables/_h_m_t_x_test.py
+++ b/Tests/ttLib/tables/_h_m_t_x_test.py
@@ -164,14 +164,14 @@ class HmtxTableTest(unittest.TestCase):
         font = self.makeFont(numGlyphs=3, numberOfMetrics=2)
         mtxTable = font[self.tag] = newTable(self.tag)
         mtxTable.metrics = {
-            'A': (0.5, 0.5),  # round -> (0, 0)
+            'A': (0.5, 0.5),  # round -> (1, 1)
             'B': (0.1, 0.9),  # round -> (0, 1)
             'C': (0.1, 0.1),  # round -> (0, 0)
         }
 
         data = mtxTable.compile(font)
 
-        self.assertEqual(data, deHexStr("0000 0000 0000 0001 0000"))
+        self.assertEqual(data, deHexStr("0001 0001 0000 0001 0000"))
 
     def test_toXML(self):
         font = self.makeFont(numGlyphs=2, numberOfMetrics=2)

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_1_diff.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_1_diff.ttx
@@ -38,7 +38,7 @@
             <Glyph value="A"/>
           </Coverage>
           <ValueFormat value="5"/>
-          <Value XPlacement="-88" XAdvance="-178"/>
+          <Value XPlacement="-88" XAdvance="-177"/>
         </SinglePos>
       </Lookup>
     </LookupList>

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_1_diff2.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_1_diff2.ttx
@@ -40,8 +40,8 @@
           </Coverage>
           <ValueFormat value="5"/>
           <!-- ValueCount=2 -->
-          <Value index="0" XPlacement="-88" XAdvance="-178"/>
-          <Value index="1" XPlacement="-28" XAdvance="-52"/>
+          <Value index="0" XPlacement="-88" XAdvance="-177"/>
+          <Value index="1" XPlacement="-27" XAdvance="-52"/>
         </SinglePos>
       </Lookup>
     </LookupList>

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_3_diff.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_3_diff.ttx
@@ -41,11 +41,11 @@
           <EntryExitRecord index="0">
             <EntryAnchor Format="1">
               <XCoordinate value="49"/>
-              <YCoordinate value="28"/>
+              <YCoordinate value="29"/>
             </EntryAnchor>
             <ExitAnchor Format="1">
               <XCoordinate value="444"/>
-              <YCoordinate value="294"/>
+              <YCoordinate value="295"/>
             </ExitAnchor>
           </EntryExitRecord>
         </CursivePos>

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_4_diff.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_4_diff.ttx
@@ -55,7 +55,7 @@
             <!-- BaseCount=1 -->
             <BaseRecord index="0">
               <BaseAnchor index="0" Format="1">
-                <XCoordinate value="272"/>
+                <XCoordinate value="273"/>
                 <YCoordinate value="510"/>
               </BaseAnchor>
             </BaseRecord>

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_6_diff.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_6_diff.ttx
@@ -56,7 +56,7 @@
             <Mark2Record index="0">
               <Mark2Anchor index="0" Format="1">
                 <XCoordinate value="0"/>
-                <YCoordinate value="702"/>
+                <YCoordinate value="703"/>
               </Mark2Anchor>
             </Mark2Record>
           </Mark2Array>

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_8_diff.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_8_diff.ttx
@@ -75,7 +75,7 @@
             <!-- BaseCount=1 -->
             <BaseRecord index="0">
               <BaseAnchor index="0" Format="1">
-                <XCoordinate value="272"/>
+                <XCoordinate value="273"/>
                 <YCoordinate value="510"/>
               </BaseAnchor>
             </BaseRecord>


### PR DESCRIPTION
Fixes #1248 

Instead of using the python3 built-in `round` function, which rounds away from zero towards the nearest _even_ integer (e.g. `round(-1.5) == -2` and `round(0.5) == 0`), we now define a new function called `otRound` ("ot" as in "OpenType") that rounds towards to the nearest integer towards positive Infinity:

https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview

We only use this when we deal with visually sensible data like X/Y coordinates, advance widths/heights, variation deltas, and similar. Everywhere else we deal with pure math stuff (or when we need to use the second argument for the decimal places) we keep using the built-in `round`.

Please take a careful look at this patch and make sure I didn't overlook anything.
