### PR TITLE
Allow any languages under DFLT script

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -688,9 +688,6 @@ class Builder(object):
             raise FeatureLibError(
                 "Language statements are not allowed "
                 "within \"feature %s\"" % self.cur_feature_name_, location)
-        if language != 'dflt' and self.script_ == 'DFLT':
-            raise FeatureLibError("Need non-DFLT script when using non-dflt "
-                                  "language (was: \"%s\")" % language, location)
         self.cur_lookup_ = None
 
         key = (self.script_, language, self.cur_feature_name_)

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -316,11 +316,7 @@ class BuilderTest(unittest.TestCase):
         self.assertEqual(builder.language_systems,
                          {('cyrl', 'BGR ')})
         builder.start_feature(location=None, name='test2')
-        self.assertRaisesRegex(
-            FeatureLibError,
-            "Need non-DFLT script when using non-dflt language "
-            "\(was: \"FRA \"\)",
-            builder.set_language, None, 'FRA ', True, False)
+        self.assertEqual(builder.language_systems, {('latn', 'FRA ')})
 
     def test_language_in_aalt_feature(self):
         self.assertRaisesRegex(


### PR DESCRIPTION
The standard has been changed to allow any languages under the DFLT script. This patch removes the test and raised error that stops users from using languages other than dflt with the DFLT script.