### PR TITLE
Optimize the charstring's bytecode

### DIFF
--- a/Tests/misc/psCharStrings_test.py
+++ b/Tests/misc/psCharStrings_test.py
@@ -26,6 +26,27 @@ class T2CharStringTest(unittest.TestCase):
         bounds = cs.calcBounds(None)
         self.assertEqual(bounds, (91.90524980688875, -12.5, 208.09475019311125, 100))
 
+    def test_charstring_bytecode_optimization(self):
+        cs = self.stringToT2CharString(
+            "100.0 100 rmoveto -50.0 -150 200.5 0.0 -50 150 rrcurveto endchar")
+        cs.isCFF2 = False
+        cs.private._isCFF2 = False
+        cs.compile()
+        cs.decompile()
+        self.assertEqual(
+            cs.program, [100, 100, 'rmoveto', -50, -150, 200.5, 0, -50, 150,
+                         'rrcurveto', 'endchar'])
+
+        cs2 = self.stringToT2CharString(
+            "100.0 rmoveto -50.0 -150 200.5 0.0 -50 150 rrcurveto")
+        cs2.isCFF2 = True
+        cs2.private._isCFF2 = True
+        cs2.compile(isCFF2=True)
+        cs2.decompile()
+        self.assertEqual(
+            cs2.program, [100, 'rmoveto', -50, -150, 200.5, 0, -50, 150,
+                          'rrcurveto'])
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
Optimizes the charstring's bytecode by encoding as integers all float values that have no decimal portion. This optimization is expected to reduce the file size of CFF2 fonts that have intermediate masters.

Related to adobe-type-tools/afdko#444

Many thanks to @cjchapman for the help on the fixed point math.