### PR TITLE
More depths to allowing languages in DFLT

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -704,10 +704,7 @@ class Builder(object):
                 if key[:2] in self.get_default_language_systems_():
                     lookups = [l for l in lookups if l not in dflt_lookups]
                 self.features_.setdefault(key, []).extend(lookups)
-        if self.script_ == 'DFLT':
-            langsys = set(self.get_default_language_systems_())
-        else:
-            langsys = set()
+        langsys = set()
         langsys.add((self.script_, language))
         self.language_systems = frozenset(langsys)
 

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1207,10 +1207,6 @@ class Parser(object):
         script = self.expect_script_tag_()
         language = self.expect_language_tag_()
         self.expect_symbol_(";")
-        if script == "DFLT" and language != "dflt":
-            raise FeatureLibError(
-                'For script "DFLT", the language must be "dflt"',
-                self.cur_token_location_)
         return self.ast.LanguageSystemStatement(script, language,
                                                 location=location)
 


### PR DESCRIPTION
Need to allow DFLT based languagesystem commands.

Fix the problem that if a sublanguage is used in the DFLT script that all those lookups end up in DFLT dflt. Just treat it all like any other script.