### PR TITLE
atttempt to fix offset overflows in MarkBasePos subtables

### DIFF
--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -1281,6 +1281,67 @@ def splitPairPos(oldSubTable, newSubTable, overflowRecord):
 	return ok
 
 
+def splitMarkBasePos(oldSubTable, newSubTable, overflowRecord):
+	# split half of the mark classes to the new subtable
+	classCount = oldSubTable.ClassCount
+	if classCount < 2:
+		# oh well, not much left to split...
+		return False
+
+	oldClassCount = classCount // 2
+	newClassCount = classCount - oldClassCount
+
+	oldMarkCoverage, oldMarkRecords = [], []
+	newMarkCoverage, newMarkRecords = [], []
+	for glyphName, markRecord in zip(
+		oldSubTable.MarkCoverage.glyphs,
+		oldSubTable.MarkArray.MarkRecord
+	):
+		if markRecord.Class < oldClassCount:
+			oldMarkCoverage.append(glyphName)
+			oldMarkRecords.append(markRecord)
+		else:
+			newMarkCoverage.append(glyphName)
+			newMarkRecords.append(markRecord)
+
+	oldBaseRecords, newBaseRecords = [], []
+	for rec in oldSubTable.BaseArray.BaseRecord:
+		oldBaseRecord, newBaseRecord = rec.__class__(), rec.__class__()
+		oldBaseRecord.BaseAnchor = rec.BaseAnchor[:oldClassCount]
+		newBaseRecord.BaseAnchor = rec.BaseAnchor[oldClassCount:]
+		oldBaseRecords.append(oldBaseRecord)
+		newBaseRecords.append(newBaseRecord)
+
+	newSubTable.Format = oldSubTable.Format
+
+	oldSubTable.MarkCoverage.glyphs = oldMarkCoverage
+	newSubTable.MarkCoverage = oldSubTable.MarkCoverage.__class__()
+	newSubTable.MarkCoverage.Format = oldSubTable.MarkCoverage.Format
+	newSubTable.MarkCoverage.glyphs = newMarkCoverage
+
+	# share the same BaseCoverage in both halves
+	newSubTable.BaseCoverage = oldSubTable.BaseCoverage
+
+	oldSubTable.ClassCount = oldClassCount
+	newSubTable.ClassCount = newClassCount
+
+	oldSubTable.MarkArray.MarkRecord = oldMarkRecords
+	newSubTable.MarkArray = oldSubTable.MarkArray.__class__()
+	newSubTable.MarkArray.MarkRecord = newMarkRecords
+
+	oldSubTable.MarkArray.MarkCount = len(oldMarkRecords)
+	newSubTable.MarkArray.MarkCount = len(newMarkRecords)
+
+	oldSubTable.BaseArray.BaseRecord = oldBaseRecords
+	newSubTable.BaseArray = oldSubTable.BaseArray.__class__()
+	newSubTable.BaseArray.BaseRecord = newBaseRecords
+
+	oldSubTable.BaseArray.BaseCount = len(oldBaseRecords)
+	newSubTable.BaseArray.BaseCount = len(newBaseRecords)
+
+	return True
+
+
 splitTable = {	'GSUB': {
 #					1: splitSingleSubst,
 #					2: splitMultipleSubst,
@@ -1295,7 +1356,7 @@ splitTable = {	'GSUB': {
 #					1: splitSinglePos,
 					2: splitPairPos,
 #					3: splitCursivePos,
-#					4: splitMarkBasePos,
+					4: splitMarkBasePos,
 #					5: splitMarkLigPos,
 #					6: splitMarkMarkPos,
 #					7: splitContextPos,

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -1347,6 +1347,11 @@ def fixSubTableOverFlows(ttf, overflowRecord):
 	try:
 		splitFunc = splitTable[overflowRecord.tableType][subTableType]
 	except KeyError:
+		log.error(
+			"Don't know how to split %s lookup type %s",
+			overflowRecord.tableType,
+			subTableType,
+		)
 		return ok
 
 	ok = splitFunc(subtable, newSubTable, overflowRecord)


### PR DESCRIPTION
if an offset overflows within a MarkBasePos (GPOS lookup type 4), we attempt to split it by moving half of the mark classes to the new subtable.

Fixes https://github.com/googlei18n/fontmake/issues/450