### PR TITLE
[cffLib.specializer] Leave 1 stack free area for subroutinizer use

### DIFF
--- a/Lib/fontTools/cffLib/specializer.py
+++ b/Lib/fontTools/cffLib/specializer.py
@@ -493,7 +493,9 @@ def specializeCommands(commands,
 				if d0 is None: continue
 				new_op = d0+d+'curveto'
 
-		if new_op and len(args1) + len(args2) <= maxstack:
+		# Make sure the stack depth does not exceed (maxstack - 1), so
+		# that subroutinizer can insert subroutine calls at any point.
+		if new_op and len(args1) + len(args2) <= maxstack - 1:
 			commands[i-1] = (new_op, args1+args2)
 			del commands[i]
 

--- a/Tests/cffLib/specializer_test.py
+++ b/Tests/cffLib/specializer_test.py
@@ -904,12 +904,12 @@ class CFFSpecializeProgramTest(unittest.TestCase):
         xpct_charstr = '1 64 10 51 29 39 15 21 15 20 15 18 rlinecurve'
         self.assertEqual(get_specialized_charstr(test_charstr), xpct_charstr)
 
-# maxstack CFF=48
+# maxstack CFF=48, specializer uses up to 47
     def test_maxstack(self):
         operands = '1 2 3 4 5 6 '
         operator = 'rrcurveto '
         test_charstr = (operands + operator)*9
-        xpct_charstr = (operands + operator + operands*8 + operator).rstrip()
+        xpct_charstr = (operands*2 + operator + operands*7 + operator).rstrip()
         self.assertEqual(get_specialized_charstr(test_charstr), xpct_charstr)
 
 


### PR DESCRIPTION
Fixes https://github.com/googlei18n/ufo2ft/issues/266.