### PR TITLE
[feaLib] Skip noop class PairPos subtables

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1494,6 +1494,8 @@ class ClassPairPosSubtableBuilder(object):
             return
         st = otl.buildPairPosClassesSubtable(self.values_,
                                              self.builder_.glyphMap)
+        if st.Coverage is None:
+            return
         self.subtables_.append(st)
         self.forceSubtableBreak_ = False
 

--- a/Tests/feaLib/data/PairPosSubtable.fea
+++ b/Tests/feaLib/data/PairPosSubtable.fea
@@ -4,6 +4,7 @@ languagesystem latn dflt;
 @group1 = [b o];
 @group2 = [c d];
 @group3 = [v w];
+@group4 = [];
 
 lookup kernlookup {
     pos A V -34;
@@ -12,6 +13,9 @@ lookup kernlookup {
     subtable;
     pos @group1 @group3 -10;
     pos @group3 @group2 -20;
+    subtable;
+    pos @group4 @group1 -10;
+    pos @group4 @group4 -10;
 } kernlookup;
 
 feature kern {


### PR DESCRIPTION
If Coverage is None then the subtable is a noop that does nothing and there is no point in building it. As a bonus, it makes OTS happy since it will reject subtables where coverageOffset is NULL (0), and the spec does not say whether this is allowed or not.