### PR TITLE
[subset] --no-hinting to drop LanguageGroup etc

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2522,7 +2522,8 @@ def prune_post_subset(self, font, options):
 				for k in ['BlueValues', 'OtherBlues',
 					  'FamilyBlues', 'FamilyOtherBlues',
 					  'BlueScale', 'BlueShift', 'BlueFuzz',
-					  'StemSnapH', 'StemSnapV', 'StdHW', 'StdVW']:
+					  'StemSnapH', 'StemSnapV', 'StdHW', 'StdVW',
+					  'ForceBold', 'LanguageGroup', 'ExpansionFactor']:
 					if hasattr(priv, k):
 						setattr(priv, k, None)
 


### PR DESCRIPTION
This change addresses an issue that pyftsubset --no-hinting on a CFF font does not drop three optional hinting dict keys from Private dict: ForceBold, LanguageGroup, and ExpansionFactor.

Before:
```
pyftsubset --no-hinting SourceHanSans-Regular.otf --unicodes=4E00 --output-file=out.otf ; tx -dcf out.otf |& grep LanguageGroup
  1 LanguageGroup
```
After:
```
pyftsubset --no-hinting SourceHanSans-Regular.otf --unicodes=4E00 --output-file=out.otf ; tx -dcf out.otf |& grep LanguageGroup
```