### PR TITLE
Add PointPen support to TT Glyph objects

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1063,7 +1063,7 @@ class Glyph(object):
 			segmentType = "line" if cFlags[-1] == 1 else "qcurve"
 			for i, pt in enumerate(contour):
 				if cFlags[i] == 1:
-					pen.addPoint(pt, segmentType = segmentType)
+					pen.addPoint(pt, segmentType=segmentType)
 					segmentType = "line"
 				else:
 					pen.addPoint(pt)

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1060,14 +1060,14 @@ class Glyph(object):
 			start = end
 			pen.beginPath()
 			# Start with the appropriate segment type based on the final segment
-			s = "line" if cFlags[-1] == 1 else "qcurve"
+			segmentType = "line" if cFlags[-1] == 1 else "qcurve"
 			for i, pt in enumerate(contour):
 				if cFlags[i] == 1:
-					pen.addPoint(pt, segmentType = s)
-					s = "line"
+					pen.addPoint(pt, segmentType = segmentType)
+					segmentType = "line"
 				else:
 					pen.addPoint(pt)
-					s = "qcurve"
+					segmentType = "qcurve"
 			pen.endPath()
 
 	def __eq__(self, other):

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -755,12 +755,6 @@ class _TTGlyph(object):
 		"""
 		self._glyph.draw(pen)
 
-	def drawPoints(self, pen):
-		"""Draw the glyph onto PointPen. See ufoLib.pointPen for details
-		how that works.
-		"""
-		self._glyph.drawPoints(pen)
-
 class _TTGlyphCFF(_TTGlyph):
 	pass
 

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -755,6 +755,10 @@ class _TTGlyph(object):
 		"""
 		self._glyph.draw(pen)
 
+	def drawPoints(self, pen):
+		# drawPoints is only implemented for _TTGlyphGlyf at this time.
+		raise NotImplementedError
+
 class _TTGlyphCFF(_TTGlyph):
 	pass
 

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -732,9 +732,9 @@ class _TTGlyphSet(object):
 class _TTGlyph(object):
 
 	"""Wrapper for a TrueType glyph that supports the Pen protocol, meaning
-	that it has a .draw() method that takes a pen object as its only
-	argument. Additionally there are 'width' and 'lsb' attributes, read from
-	the 'hmtx' table.
+	that it has .draw() and .drawPoints() methods that take a pen object as
+	their only argument. Additionally there are 'width' and 'lsb' attributes,
+	read from the 'hmtx' table.
 
 	If the font contains a 'vmtx' table, there will also be 'height' and 'tsb'
 	attributes.
@@ -755,6 +755,12 @@ class _TTGlyph(object):
 		"""
 		self._glyph.draw(pen)
 
+	def drawPoints(self, pen):
+		"""Draw the glyph onto PointPen. See ufoLib.pointPen for details
+		how that works.
+		"""
+		self._glyph.drawPoints(pen)
+
 class _TTGlyphCFF(_TTGlyph):
 	pass
 
@@ -768,6 +774,15 @@ class _TTGlyphGlyf(_TTGlyph):
 		glyph = self._glyph
 		offset = self.lsb - glyph.xMin if hasattr(glyph, "xMin") else 0
 		glyph.draw(pen, glyfTable, offset)
+
+	def drawPoints(self, pen):
+		"""Draw the glyph onto PointPen. See ufoLib.pointPen for details
+		how that works.
+		"""
+		glyfTable = self._glyphset._glyphs
+		glyph = self._glyph
+		offset = self.lsb - glyph.xMin if hasattr(glyph, "xMin") else 0
+		glyph.drawPoints(pen, glyfTable, offset)
 
 
 class GlyphOrder(object):


### PR DESCRIPTION
See https://github.com/unified-font-object/ufo-spec/issues/74

Using Glyph.drawPoints() will make sure the point indices are not changed from the original. This is vital when the font has TrueType instructions which are based on point indices.