### PR TITLE
make UFOWriter a subclass of UFOReader, use mixins for shared methods

### DIFF
--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -466,7 +466,7 @@ class UFOReader(_UFOBaseIO):
 			raise UFOLibError("fontinfo.plist is not properly formatted.")
 		return data
 
-	def readInfo(self, info, validate=None):
+	def readInfo(self, info=None, validate=None):
 		"""
 		Read fontinfo.plist. It requires an object that allows
 		setting attributes with names that follow the fontinfo.plist
@@ -509,12 +509,17 @@ class UFOReader(_UFOBaseIO):
 		# validate data
 		if validate:
 			infoDataToSet = validateInfoVersion3Data(infoDataToSet)
-		# populate the object
-		for attr, value in list(infoDataToSet.items()):
-			try:
-				setattr(info, attr, value)
-			except AttributeError:
-				raise UFOLibError("The supplied info object does not support setting a necessary attribute (%s)." % attr)
+		if info is not None:
+			# populate the object
+			for attr, value in infoDataToSet.items():
+				try:
+					setattr(info, attr, value)
+				except AttributeError:
+					raise UFOLibError(
+						"The supplied info object does not support setting a "
+						"necessary attribute (%s)." % attr
+					)
+		return infoDataToSet
 
 	# kerning.plist
 

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -1422,8 +1422,10 @@ class UFOWriter(UFOReader):
 			for existingLayerName, directory in self.layerContents.items():
 				if directory == DEFAULT_GLYPHS_DIRNAME:
 					if existingLayerName != layerName:
-						print(existingLayerName, layerName)
-						raise UFOLibError("Another layer is already mapped to the default directory.")
+						raise UFOLibError(
+							"Another layer ('%s') is already mapped to the default directory."
+							% existingLayerName
+						)
 				elif existingLayerName == layerName:
 					raise UFOLibError("The layer name is already mapped to a non-default layer.")
 		# get an existing directory name

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -1574,14 +1574,7 @@ class UFOWriter(UFOReader):
 			rootDir = os.path.splitext(os.path.basename(self._path))[0] + ".ufo"
 			with fs.zipfs.ZipFS(self._path, write=True, encoding="utf-8") as destFS:
 				fs.copy.copy_fs(self.fs, destFS.makedir(rootDir))
-		if self._shouldClose:
-			self.fs.close()
-
-	def __enter__(self):
-		return self
-
-	def __exit__(self, exc_type, exc_value, exc_tb):
-		self.close()
+		super(UFOWriter, self).close()
 
 
 # just an alias, makes it more explicit

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -107,7 +107,7 @@ class UFOFileStructure(enum.Enum):
 # --------------
 
 
-class _ModTimeGetterMixin(object):
+class _UFOBaseIO(object):
 
 	def _getFileModificationTime(self, path):
 		"""
@@ -122,9 +122,6 @@ class _ModTimeGetterMixin(object):
 			return None
 		else:
 			return datetimeAsTimestamp(dt)
-
-
-class _PlistReaderMixin(object):
 
 	def _getPlist(self, fileName, default=None):
 		"""
@@ -152,9 +149,6 @@ class _PlistReaderMixin(object):
 			raise UFOLibError(
 				"'%s' could not be read on %s: %s" % (fileName, self.fs, e)
 			)
-
-
-class _PlistWriterMixin(object):
 
 	def _writePlist(self, fileName, obj):
 		"""
@@ -198,7 +192,7 @@ class _PlistWriterMixin(object):
 # UFO Reader
 # ----------
 
-class UFOReader(_PlistReaderMixin, _ModTimeGetterMixin):
+class UFOReader(_UFOBaseIO):
 
 	"""
 	Read the various components of the .ufo.
@@ -811,7 +805,7 @@ class UFOReader(_PlistReaderMixin, _ModTimeGetterMixin):
 # UFO Writer
 # ----------
 
-class UFOWriter(_PlistWriterMixin, UFOReader):
+class UFOWriter(UFOReader):
 
 	"""
 	Write the various components of the .ufo.

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -58,6 +58,7 @@ __all__ = [
 	"UFOLibError",
 	"UFOReader",
 	"UFOWriter",
+	"UFOReaderWriter",
 	"UFOFileStructure",
 	"fontInfoAttributesVersion1",
 	"fontInfoAttributesVersion2",
@@ -1585,6 +1586,10 @@ class UFOWriter(_PlistWriterMixin, UFOReader):
 
 	def __exit__(self, exc_type, exc_value, exc_tb):
 		self.close()
+
+
+# just an alias, makes it more explicit
+UFOReaderWriter = UFOWriter
 
 
 # ----------------

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -466,7 +466,7 @@ class UFOReader(_UFOBaseIO):
 			raise UFOLibError("fontinfo.plist is not properly formatted.")
 		return data
 
-	def readInfo(self, info=None, validate=None):
+	def readInfo(self, info, validate=None):
 		"""
 		Read fontinfo.plist. It requires an object that allows
 		setting attributes with names that follow the fontinfo.plist
@@ -509,17 +509,12 @@ class UFOReader(_UFOBaseIO):
 		# validate data
 		if validate:
 			infoDataToSet = validateInfoVersion3Data(infoDataToSet)
-		if info is not None:
-			# populate the object
-			for attr, value in infoDataToSet.items():
-				try:
-					setattr(info, attr, value)
-				except AttributeError:
-					raise UFOLibError(
-						"The supplied info object does not support setting a "
-						"necessary attribute (%s)." % attr
-					)
-		return infoDataToSet
+		# populate the object
+		for attr, value in list(infoDataToSet.items()):
+			try:
+				setattr(info, attr, value)
+			except AttributeError:
+				raise UFOLibError("The supplied info object does not support setting a necessary attribute (%s)." % attr)
 
 	# kerning.plist
 

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -109,7 +109,7 @@ class UFOFileStructure(enum.Enum):
 
 class _UFOBaseIO(object):
 
-	def _getFileModificationTime(self, path):
+	def getFileModificationTime(self, path):
 		"""
 		Returns the modification time for the file at the given path, as a
 		floating point number giving the number of seconds since the epoch.

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -34,6 +34,7 @@ from fontTools.ufoLib.validators import (
 	glyphLibValidator,
 )
 from fontTools.misc import etree
+from fontTools.ufoLib import _PlistReaderMixin, _PlistWriterMixin, _ModTimeGetterMixin
 from fontTools.ufoLib.utils import integerTypes, numberTypes
 
 
@@ -88,7 +89,7 @@ class Glyph(object):
 # Glyph Set
 # ---------
 
-class GlyphSet(object):
+class GlyphSet(_PlistWriterMixin, _PlistReaderMixin, _ModTimeGetterMixin):
 
 	"""
 	GlyphSet manages a set of .glif files inside one directory.
@@ -168,9 +169,6 @@ class GlyphSet(object):
 		self._reverseContents = None
 
 		self.rebuildContents()
-
-	# here we reuse the same methods from UFOReader/UFOWriter
-	from fontTools.ufoLib import _getPlist, _writePlist, _getFileModificationTime
 
 	def rebuildContents(self, validateRead=None):
 		"""

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -306,7 +306,7 @@ class GlyphSet(_UFOBaseIO):
 		Raises KeyError if the glyphName is not in contents.plist.
 		"""
 		fileName = self.contents[glyphName]
-		return self._getFileModificationTime(fileName)
+		return self.getFileModificationTime(fileName)
 
 	# reading/writing API
 

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -34,7 +34,7 @@ from fontTools.ufoLib.validators import (
 	glyphLibValidator,
 )
 from fontTools.misc import etree
-from fontTools.ufoLib import _PlistReaderMixin, _PlistWriterMixin, _ModTimeGetterMixin
+from fontTools.ufoLib import _UFOBaseIO
 from fontTools.ufoLib.utils import integerTypes, numberTypes
 
 
@@ -89,7 +89,7 @@ class Glyph(object):
 # Glyph Set
 # ---------
 
-class GlyphSet(_PlistWriterMixin, _PlistReaderMixin, _ModTimeGetterMixin):
+class GlyphSet(_UFOBaseIO):
 
 	"""
 	GlyphSet manages a set of .glif files inside one directory.


### PR DESCRIPTION
UFOWriter is already sharing some methods with UFOReader.
I think it would make sense to make it a subclass so that it extends the reader class with its additional writer-specific methods, effectively becoming a UFOReaderWriter.

This would allow, for example, to use the same UFOWriter instance for initializing a Font object, do stuff with it, and finally writing to it inplace.

Comments?