### PR TITLE
Fix python3 file writing issues and table compression

### DIFF
--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -556,7 +556,6 @@ def calcChecksum(data):
 		3655064932
 	"""
 	remainder = len(data) % 4
-	data = data[:]          # py3 data is a bytearray so copy it before modifying
 	if remainder:
 		data += b"\0" * (4 - remainder)
 	value = 0

--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -556,6 +556,7 @@ def calcChecksum(data):
 		3655064932
 	"""
 	remainder = len(data) % 4
+	data = data[:]          # py3 data is a bytearray so copy it before modifying
 	if remainder:
 		data += b"\0" * (4 - remainder)
 	value = 0

--- a/Lib/fontTools/ttLib/tables/F__e_a_t.py
+++ b/Lib/fontTools/ttLib/tables/F__e_a_t.py
@@ -58,8 +58,8 @@ class table_F__e_a_t(DefaultTable.DefaultTable):
                     fobj.default = vid
 
     def compile(self, ttFont):
-        fdat = ""
-        vdat = ""
+        fdat = b""
+        vdat = b""
         offset = 0
         for f, v in sorted(self.features.items(), key=lambda x:x[1].index):
             fnum = grUtils.tag2num(f)

--- a/Lib/fontTools/ttLib/tables/G__l_a_t.py
+++ b/Lib/fontTools/ttLib/tables/G__l_a_t.py
@@ -141,8 +141,8 @@ class table_G__l_a_t(DefaultTable.DefaultTable):
     def compileAttributes12(self, attrs, fmt):
         data = b""
         for e in grUtils.entries(attrs):
-            data += sstruct.pack(fmt, {'attNum' : e[0], 'num' : e[1]})
-            data += struct.pack(('>%dh' % len(e[2])), *e[2])
+            data += sstruct.pack(fmt, {'attNum' : e[0], 'num' : e[1]}) + \
+                    struct.pack(('>%dh' % len(e[2])), *e[2])
         return data
     
     def compileAttributes3(self, attrs):

--- a/Lib/fontTools/ttLib/tables/G__l_a_t.py
+++ b/Lib/fontTools/ttLib/tables/G__l_a_t.py
@@ -139,11 +139,11 @@ class table_G__l_a_t(DefaultTable.DefaultTable):
         return data
 
     def compileAttributes12(self, attrs, fmt):
-        data = []
+        data = b""
         for e in grUtils.entries(attrs):
-            data.extend(sstruct.pack(fmt, {'attNum' : e[0], 'num' : e[1]}))
-            data.extend(struct.pack(('>%dh' % len(e[2])), *e[2]))
-        return "".join(data)
+            data += sstruct.pack(fmt, {'attNum' : e[0], 'num' : e[1]})
+            data += struct.pack(('>%dh' % len(e[2])), *e[2])
+        return data
     
     def compileAttributes3(self, attrs):
         if self.hasOctaboxes:
@@ -168,7 +168,7 @@ class table_G__l_a_t(DefaultTable.DefaultTable):
                 vals = {}
                 for k in names:
                     if k == 'subboxBitmap': continue
-                    vals[k] = "{:.3f}%".format(getattr(o, k) * 100. / 256)
+                    vals[k] = "{:.3f}%".format(getattr(o, k) * 100. / 255)
                 vals['bitmap'] = "{:0X}".format(o.subboxBitmap)
                 writer.begintag('octaboxes', **vals)
                 writer.newline()
@@ -176,7 +176,7 @@ class table_G__l_a_t(DefaultTable.DefaultTable):
                 for s in o.subboxes:
                     vals = {}
                     for k in names:
-                        vals[k] = "{:.3f}%".format(getattr(s, k) * 100. / 256)
+                        vals[k] = "{:.3f}%".format(getattr(s, k) * 100. / 255)
                     writer.simpletag('octabox', **vals)
                     writer.newline()
                 writer.endtag('octaboxes')
@@ -190,6 +190,7 @@ class table_G__l_a_t(DefaultTable.DefaultTable):
     def fromXML(self, name, attrs, content, ttFont):
         if name == 'version' :
             self.version = float(safeEval(attrs['version']))
+            self.scheme = int(safeEval(attrs['compressionScheme']))
         if name != 'glyph' : return
         if not hasattr(self, 'attributes'):
             self.attributes = {}
@@ -209,13 +210,13 @@ class table_G__l_a_t(DefaultTable.DefaultTable):
                 o.subboxes = []
                 del attrs['bitmap']
                 for k, v in attrs.items():
-                    setattr(o, k, int(float(v[:-1]) * 256. / 100. + 0.5))
+                    setattr(o, k, int(float(v[:-1]) * 255. / 100. + 0.5))
                 for element in subcontent:
                     if not isinstance(element, tuple): continue
                     (tag, attrs, subcontent) = element
                     so = _Object()
                     for k, v in attrs.items():
-                        setattr(so, k, int(float(v[:-1]) * 256. / 100. + 0.5))
+                        setattr(so, k, int(float(v[:-1]) * 255. / 100. + 0.5))
                     o.subboxes.append(so)
                 attributes.octabox = o
         self.attributes[gname] = attributes

--- a/Lib/fontTools/ttLib/tables/S__i_l_l.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_l.py
@@ -42,8 +42,8 @@ class table_S__i_l_l(DefaultTable.DefaultTable):
                 self.langs[c].append(finfo[i])
 
     def compile(self, ttFont):
-        ldat = ""
-        fdat = ""
+        ldat = b""
+        fdat = b""
         offset = 0
         for c, inf in sorted(self.langs.items()):
             ldat += struct.pack(">4sHH", c.encode('utf8'), len(inf), 8 * (offset + len(self.langs) + 1))

--- a/Lib/fontTools/ttLib/tables/grUtils.py
+++ b/Lib/fontTools/ttLib/tables/grUtils.py
@@ -13,7 +13,7 @@ def decompress(data):
     if scheme == 0:
         pass
     elif scheme == 1 and lz4:
-        res = lz4.decompress(struct.pack("<L", size) + data[8:])
+        res = lz4.block.decompress(struct.pack("<L", size) + data[8:])
         if len(res) != size:
             warnings.warn("Table decompression failed.")
         else:
@@ -27,8 +27,8 @@ def compress(scheme, data):
     if scheme == 0 :
         return data
     elif scheme == 1 and lz4:
-        res = lz4.compress(hdr + data)
-        return res
+        res = lz4.block.compress(data, mode='high_compression', compression=16, store_size=False)
+        return hdr + res
     else:
         warnings.warn("Table failed to compress by unsupported compression scheme")
     return data
@@ -47,7 +47,7 @@ def _entries(attrs, sameval):
     yield (ak - len(vals) + 1, len(vals), vals)
 
 def entries(attributes, sameval = False):
-    g = _entries(sorted(attributes.iteritems(), key=lambda x:int(x[0])), sameval)
+    g = _entries(sorted(attributes.items(), key=lambda x:int(x[0])), sameval)
     return g
 
 def bininfo(num, size=1):
@@ -59,7 +59,7 @@ def bininfo(num, size=1):
         srange *= 2
         select += 1
     select -= 1
-    srange /= 2
+    srange //= 2
     srange *= size
     shift = num * size - srange
     return struct.pack(">4H", num, srange, select, shift)

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,10 @@ extras_require = {
 			"python_version < '3.7' and platform_python_implementation != 'PyPy'"
 		),
 	],
+	# for graphite type tables in ttLib/tables (Silf, Glat, Gloc)
+	"graphite": [
+		"lz4 >= 1.7.4.2"
+	],
 	# for fontTools.interpolatable: to solve the "minimum weight perfect
 	# matching problem in bipartite graphs" (aka Assignment problem)
 	"interpolatable": [


### PR DESCRIPTION
This fixes a number of python3 issues affecting Graphite tables particularly regarding writing binary fonts.

The only issue outside of Graphite tables is that under python3 writing an sfnt resulted in a table length including the padding 0 bytes (to a 4 byte boundary) when it should not.