### PR TITLE
italicAngle should be set to -(slnt value)

### DIFF
--- a/Lib/fontTools/varLib/mutator.py
+++ b/Lib/fontTools/varLib/mutator.py
@@ -145,7 +145,7 @@ def instantiateVariableFont(varfont, location, inplace=False):
 		else:
 			varfont["OS/2"].usWidthClass = 9
 	if "slnt" in location and "post" in varfont:
-		varfont["post"].italicAngle = max(-90, min(location["slnt"], 90))
+          varfont["post"].italicAngle = -(max(-90, min(location["slnt"], 90)))
 
 	log.info("Removing variable tables")
 	for tag in ('avar','cvar','fvar','gvar','HVAR','MVAR','VVAR','STAT'):


### PR DESCRIPTION
slnt angle is measured clockwise while italicAngle is measured counter-clockwise (as per spec). 

https://docs.microsoft.com/en-us/typography/opentype/spec/post#header
https://drafts.csswg.org/css-fonts-4/#valdef-font-style-oblique-angle

@anthrotype does that seem right?