### PR TITLE
[varLib] Fixing #1365: AttributeError in addFeatureVariations()

### DIFF
--- a/Lib/fontTools/varLib/featureVars.py
+++ b/Lib/fontTools/varLib/featureVars.py
@@ -210,7 +210,8 @@ def addFeatureVariationsRaw(font, conditionalSubstitutions):
     rvrnFeatureIndex = gsub.FeatureList.FeatureRecord.index(rvrnFeature)
 
     for scriptRecord in gsub.ScriptList.ScriptRecord:
-        for langSys in [scriptRecord.Script.DefaultLangSys] + scriptRecord.Script.LangSysRecord:
+        langSystems = [lsr.LangSys for lsr in scriptRecord.Script.LangSysRecord]
+        for langSys in [scriptRecord.Script.DefaultLangSys] + langSystems:
             langSys.FeatureIndex.append(rvrnFeatureIndex)
 
     # setup lookups


### PR DESCRIPTION
Fixed bug that tried to get an attr off a LangSysRecord rather than a LangSys. Fixes #1365

A test case would be nice, but I don't see a quick way to add this. Open for suggestions. To add this to the existing test requires adding some OT features to (some of the) ufos in the master_ufo folder.