### PR TITLE
[varLib] Implement passing the layer name to MasterFinder

### DIFF
--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -204,6 +204,16 @@ class BuildTest(unittest.TestCase):
             save_before_dump=True,
         )
 
+    def test_MasterFinder_layerNames(self):
+        from fontTools.varLib import MasterFinder
+
+        master_finder = MasterFinder("{stem}.ttf")
+        self.assertTrue(master_finder("Test-Regular.ufo") == "Test-Regular.ttf")
+        self.assertTrue(
+            master_finder("Test-Regular.ufo", "Medium {450, 100}")
+            == "Test-Regular@M_edium {450, 100}.ttf"
+        )
+
     def test_varlib_main_ttf(self):
         """Mostly for testing varLib.main()
         """


### PR DESCRIPTION
This is preparatory work for https://github.com/googlei18n/ufo2ft/pull/295.

The idea is that `ufo2ft` should be able to produce sparse intermediate master OT binaries from ("brace") layers that varLib can then merge into a variable font, thanks to Behdad's sparse master work. varLib needs a way to associate a sparse "source" with an OT binary, so this PR adds passing the layer name, if existant, to `MasterFinder`.

To test-drive this, get [smastertest.zip](https://github.com/fonttools/fonttools/files/2610835/smastertest.zip), extract it somewhere and do in that folder:
```
$ python3 -m venv venv && . venv/bin/activate
$ pip install fonttools[ufo]  # to pull in ufoLib dependencies
$ pip install git+https://github.com/madig/fonttools.git@varLib-MasterFinder-add-layerName git+https://github.com/madig/ufo2ft.git@sparse-master-by-layerName
$ python build.py
```

Side-thought: in the spirit of avoiding assigning `None` to anything, maybe the `layer_name` argument should default to `"public.default"` instead?