### PR TITLE
Clean cff2 3

### DIFF
--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -2421,7 +2421,7 @@ class PrivateDict(BaseDict):
 			self.order = buildOrder(privateDictOperators2)
 			# Provide dummy values. This avoids needing to provide
 			# an isCFF2 state in a lot of places.
-			self.nominalWidthX = self.defaultWidthX = 0
+			self.nominalWidthX = self.defaultWidthX = None
 		else:
 			self.defaults = buildDefaults(privateDictOperators)
 			self.order = buildOrder(privateDictOperators)

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -461,7 +461,7 @@ class T2WidthExtractor(SimpleT2Decompiler):
 		if not self.gotWidth:
 			if evenOdd ^ (len(args) % 2):
 				# For CFF2 charstrings, this should never happen
-				assert self.defaultWidthX != None, "CFF2 CharStrings must not have an initial width value"
+				assert self.defaultWidthX is not None, "CFF2 CharStrings must not have an initial width value"
 				self.width = self.nominalWidthX + args[0]
 				args = args[1:]
 			else:

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -460,6 +460,8 @@ class T2WidthExtractor(SimpleT2Decompiler):
 		args = self.popall()
 		if not self.gotWidth:
 			if evenOdd ^ (len(args) % 2):
+				# For CFF2 charstrings, this should never happen
+				assert(self.defaultWidthX != None)
 				self.width = self.nominalWidthX + args[0]
 				args = args[1:]
 			else:

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -461,7 +461,7 @@ class T2WidthExtractor(SimpleT2Decompiler):
 		if not self.gotWidth:
 			if evenOdd ^ (len(args) % 2):
 				# For CFF2 charstrings, this should never happen
-				assert(self.defaultWidthX != None)
+				assert self.defaultWidthX != None, "CFF2 CharStrings must not have an initial width value"
 				self.width = self.nominalWidthX + args[0]
 				args = args[1:]
 			else:

--- a/Lib/fontTools/subset/cff.py
+++ b/Lib/fontTools/subset/cff.py
@@ -168,6 +168,8 @@ def drop_hints(self):
 		if hasattr(self, 'width'):
 			# Insert width back if needed
 			if self.width != self.private.defaultWidthX:
+				# For CFF2 charstrings, this should never happen
+				assert(self.private.defaultWidthX != None)
 				self.program.insert(0, self.width - self.private.nominalWidthX)
 
 	if hints.has_hintmask:

--- a/Lib/fontTools/subset/cff.py
+++ b/Lib/fontTools/subset/cff.py
@@ -169,7 +169,7 @@ def drop_hints(self):
 			# Insert width back if needed
 			if self.width != self.private.defaultWidthX:
 				# For CFF2 charstrings, this should never happen
-				assert self.private.defaultWidthX != None, "CFF2 CharStrings must not have an initial width value"
+				assert self.private.defaultWidthX is not None, "CFF2 CharStrings must not have an initial width value"
 				self.program.insert(0, self.width - self.private.nominalWidthX)
 
 	if hints.has_hintmask:

--- a/Lib/fontTools/subset/cff.py
+++ b/Lib/fontTools/subset/cff.py
@@ -169,7 +169,7 @@ def drop_hints(self):
 			# Insert width back if needed
 			if self.width != self.private.defaultWidthX:
 				# For CFF2 charstrings, this should never happen
-				assert(self.private.defaultWidthX != None)
+				assert self.private.defaultWidthX != None, "CFF2 CharStrings must not have an initial width value"
 				self.program.insert(0, self.width - self.private.nominalWidthX)
 
 	if hints.has_hintmask:


### PR DESCRIPTION
varLib subset CFF2] Set PrivateDict nominal and default WidthX to None
Address issues raised in #1403

I do think setting the dummy CFF2 PrivateDict nominalWidthX and defaultWidthX to None, which leads to the charstring.width also being None, is a good idea. I originally set them to 0, which produces a charstring width of 0, in order to avoid problems with logic that assumes that the field is good for math. However, I now think that it is better to find errors around charstring type assumptions earlier than later.

"drop_hints()" is actually not wrong - I did look at this when making the changes. For CFF2 charstrings, self.width is always equal to self.private.defaultWidthX, so the width is never inserted. This is because in psCharstrings.py::T2WidthExtractor.popallWidth(), the test "evenOdd ^ (len(args) % 2)" is alway False. Left to myself, I would not change this code. If the CFF2 charstring is correct, there is not a problem. if the CFF2 charstring is not correct, then both in drop_hints() and in T2WidthExtractor.popallWidth(), the logic will now hit an assert that I added.