### PR TITLE
[plistlib] Treat Mapping objects as dicts

### DIFF
--- a/Lib/fontTools/misc/plistlib.py
+++ b/Lib/fontTools/misc/plistlib.py
@@ -7,6 +7,11 @@ from base64 import b64encode, b64decode
 from numbers import Integral
 
 try:
+    from collections.abc import Mapping # python >= 3.3
+except ImportError:
+    from collections import Mapping
+
+try:
     from functools import singledispatch
 except ImportError:
     try:
@@ -384,7 +389,7 @@ if singledispatch is not None:
     _make_element.register(bool)(_bool_element)
     _make_element.register(Integral)(_integer_element)
     _make_element.register(float)(_real_element)
-    _make_element.register(dict)(_dict_element)
+    _make_element.register(Mapping)(_dict_element)
     _make_element.register(list)(_array_element)
     _make_element.register(tuple)(_array_element)
     _make_element.register(datetime)(_date_element)
@@ -404,7 +409,7 @@ else:
             return _integer_element(value, ctx)
         elif isinstance(value, float):
             return _real_element(value, ctx)
-        elif isinstance(value, dict):
+        elif isinstance(value, Mapping):
             return _dict_element(value, ctx)
         elif isinstance(value, (list, tuple)):
             return _array_element(value, ctx)

--- a/Tests/misc/plistlib_test.py
+++ b/Tests/misc/plistlib_test.py
@@ -14,6 +14,10 @@ from fontTools.ufoLib.plistlib import (
 )
 import pytest
 
+try:
+    from collections.abc import Mapping # python >= 3.3
+except ImportError:
+    from collections import Mapping
 
 PY2 = sys.version_info < (3,)
 if PY2:
@@ -528,6 +532,25 @@ def test_dump_use_builtin_types_default(pl_no_builtin_types):
 def test_non_ascii_bytes():
     with pytest.raises(ValueError, match="invalid non-ASCII bytes"):
         plistlib.dumps("\U0001f40d".encode("utf-8"), use_builtin_types=False)
+
+
+class CustomMapping(Mapping):
+    a = {"a": 1, "b": 2}
+
+    def __getitem__(self, key):
+        return self.a[key]
+
+    def __iter__(self):
+        return iter(self.a)
+
+    def __len__(self):
+        return len(self.a)
+
+
+def test_custom_mapping():
+    test_mapping = CustomMapping()
+    data = plistlib.dumps(test_mapping)
+    assert plistlib.loads(data) == {"a": 1, "b": 2}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is needed to make ufoLib2's fontinfo guidelines and gasp records serialize correctly.