### PR TITLE
Pin STAT to version 1.1

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -184,7 +184,7 @@ def _add_stat(font, axes):
 
 	STAT = font["STAT"] = newTable('STAT')
 	stat = STAT.table = ot.STAT()
-	stat.Version = 0x00010002
+	stat.Version = 0x00010001
 
 	axisRecords = []
 	for i, a in enumerate(fvarTable.axes):

--- a/Tests/varLib/data/test_results/BuildMain.ttx
+++ b/Tests/varLib/data/test_results/BuildMain.ttx
@@ -782,7 +782,7 @@
   </MVAR>
 
   <STAT>
-    <Version value="0x00010002"/>
+    <Version value="0x00010001"/>
     <DesignAxisRecordSize value="8"/>
     <!-- DesignAxisCount=2 -->
     <DesignAxisRecord>


### PR DESCRIPTION
The Windows 10 Font preview can handle fonts with STAT version 1.2 but other applications do not and only display the default named instance.
For example the Windows\Fonts folder, Word or WordPad only show the default named instance when the STAT is version 1.2 but they display all the named instances when the STAT is version 1.1.

This was tested in Windows 10 Pro, Version 1803, build 17134.407.