### PR TITLE
[varLib.cff] Fix issues in building cff2 variable font

### DIFF
--- a/Lib/fontTools/cffLib/specializer.py
+++ b/Lib/fontTools/cffLib/specializer.py
@@ -421,10 +421,11 @@ def specializeCommands(commands,
 					(op == commands[i-1][0]) and
 					(not isinstance(args[0], list))):
 				_, other_args = commands[i-1]
-				assert len(args) == 1 and len(other_args) == 1
-				commands[i-1] = (op, [other_args[0]+args[0]])
-				del commands[i]
-				continue
+				if not isinstance(other_args[0], list):
+					assert len(args) == 1 and len(other_args) == 1
+					commands[i-1] = (op, [other_args[0]+args[0]])
+					del commands[i]
+					continue
 
 	# 4. Peephole optimization to revert back some of the h/v variants back into their
 	#    original "relative" operator (rline/rrcurveto) if that saves a byte.

--- a/Lib/fontTools/varLib/cff.py
+++ b/Lib/fontTools/varLib/cff.py
@@ -77,7 +77,7 @@ def lib_convertCFFToCFF2(cff, otFont):
 		privateOpOrder = buildOrder(privateDictOperators2)
 		for fontDict in fdArray:
 			fontDict.setCFF2(True)
-			for key in fontDict.rawDict.keys():
+			for key in list(fontDict.rawDict.keys()):
 				if key not in fontDict.order:
 					del fontDict.rawDict[key]
 					if hasattr(fontDict, key):


### PR DESCRIPTION
in varLib.cff2: shouldn't iterate through a dict while deleting keys
in cffLib.specializer.py: when doing peephole optimization, both the first and second args may be lists. Test for both cases.

It does bother me to have this test for list type args in specializeCommands(), since it is needed only for the one case where CFF2CharStringMergePen is being used to build up a list of source master coordinates in place of a single  coordinate.  I would rather add a function argument "doPeephole=True" for specializeCommands(), to allow suppressing this test. It will be  rare that it would be possible to satisfy the conditions for doing this optimization in a variable font, and suppressing the test makes more sense to me than complicating the common case for the sake of the special case.