### PR TITLE
[varLib] Accept DesignspaceDocument objects in build() and load_designspace()

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -749,7 +749,6 @@ def build(designspace, master_finder=lambda s:s, exclude=[], optimize=True):
 
 	master_fonts = []
 	master_ttfs = []
-	master_source = ds.masters[ds.base_idx]
 	if hasattr(designspace, "sources"):  # Assume a DesignspaceDocument
 		basedir = getattr(designspace, "path", None)
 	else:  # Assume a path


### PR DESCRIPTION
We need a way to integrate sparse masters that come from ("brace") layers instead of stand-alone sparse UFOs. Instead of modifying `varLib.build()` and `MasterFinder` to go look for specially named files like in https://github.com/fonttools/fonttools/pull/1387, modify `varLib.build()` to take either 

1. a path and continue as before (masters from layers not supported then, unless you write the compiled `TTFont`s to disk and refer to them with the `filename` attribute and probably adjust `master_finder`)
2. or a `DesignspaceDocument` and demand that the caller already read and attached the `TTFont` objects to all `SourceDescriptor.font` attributes. ufo2ft will do this when calling https://github.com/googlei18n/ufo2ft/pull/300/files#diff-cd32d8abceb8eff27b2b4994f7322bc1R256.