### PR TITLE
[varLib] make `build` also accept DesignSpaceDocument objects

### DIFF
--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1282,13 +1282,15 @@ class DesignSpaceDocument(LogMixin, AsDictMixin):
         'path' attribute, or if the latter is not set, the concatenation of
         the source's (relative) 'filename' attribute and the designspace's
         directory.
+        The returned path uses the platform-specific path separator: i.e.
+        forward slash on POSIX, backslash on Windows.
 
         Raises DesignSpaceDocumentError if sourceDescriptor.path is None and
         self.path is None, or sourceDescriptor.filename is None.
         """
         if sourceDescriptor.path:
             # prefer absolute path if present
-            return sourceDescriptor.path
+            return os.path.normpath(sourceDescriptor.path)
         if self.path is None:
             raise DesignSpaceDocumentError(
                 "DesignSpaceDocument 'path' attribute is not defined; cannot "

--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -135,15 +135,18 @@ class SFNTReader(object):
 		obj = cls.__new__(cls)
 		for k, v in self.__dict__.items():
 			if k == "file":
-				f = self.file
-				start = f.tell()
-				f.seek(0)
-				buf = BytesIO(f.read())
-				f.seek(start)
-				buf.seek(start)
-				if hasattr(f, "name"):
-					buf.name = f.name
-				obj.file = buf
+				try:
+					obj.file = deepcopy(v, memo)
+				except TypeError:
+					f = self.file
+					pos = f.tell()
+					f.seek(0)
+					buf = BytesIO(f.read())
+					f.seek(pos)
+					buf.seek(pos)
+					if hasattr(f, "name"):
+						buf.name = f.name
+					obj.file = buf
 			else:
 				obj.__dict__[k] = deepcopy(v, memo)
 		return obj

--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -135,18 +135,14 @@ class SFNTReader(object):
 		obj = cls.__new__(cls)
 		for k, v in self.__dict__.items():
 			if k == "file":
-				try:
-					obj.file = deepcopy(v, memo)
-				except TypeError:
-					f = self.file
-					pos = f.tell()
-					f.seek(0)
-					buf = BytesIO(f.read())
-					f.seek(pos)
-					buf.seek(pos)
-					if hasattr(f, "name"):
-						buf.name = f.name
-					obj.file = buf
+				pos = v.tell()
+				v.seek(0)
+				buf = BytesIO(v.read())
+				v.seek(pos)
+				buf.seek(pos)
+				if hasattr(v, "name"):
+					buf.name = v.name
+				obj.file = buf
 			else:
 				obj.__dict__[k] = deepcopy(v, memo)
 		return obj

--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -123,6 +123,31 @@ class SFNTReader(object):
 	def close(self):
 		self.file.close()
 
+	def __deepcopy__(self, memo):
+		"""Overrides the default deepcopy of SFNTReader object, to make it work
+		in the case when TTFont is loaded with lazy=True, and thus reader holds a
+		reference to a file object which is not pickleable.
+		We work around it by manually copying the data into a in-memory stream.
+		"""
+		from copy import deepcopy
+
+		cls = self.__class__
+		obj = cls.__new__(cls)
+		for k, v in self.__dict__.items():
+			if k == "file":
+				f = self.file
+				start = f.tell()
+				f.seek(0)
+				buf = BytesIO(f.read())
+				f.seek(start)
+				buf.seek(start)
+				if hasattr(f, "name"):
+					buf.name = f.name
+				obj.file = buf
+			else:
+				obj.__dict__[k] = deepcopy(v, memo)
+		return obj
+
 
 # default compression level for WOFF 1.0 tables and metadata
 ZLIB_COMPRESSION_LEVEL = 6

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -693,19 +693,6 @@ class TTFont(object):
 		"""
 		return self["cmap"].getBestCmap(cmapPreferences=cmapPreferences)
 
-	def copy(self):
-		"""Return a new TTFont instance containing the same data.
-
-		>>> f1 = TTFont()
-		>>> f2 = f1.copy()
-		>>> f2 is not f1
-		True
-		"""
-		buf = BytesIO()
-		self.save(buf)
-		buf.seek(0)
-		return TTFont(buf)
-
 
 class _TTGlyphSet(object):
 

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -693,6 +693,19 @@ class TTFont(object):
 		"""
 		return self["cmap"].getBestCmap(cmapPreferences=cmapPreferences)
 
+	def copy(self):
+		"""Return a new TTFont instance containing the same data.
+
+		>>> f1 = TTFont()
+		>>> f2 = f1.copy()
+		>>> f2 is not f1
+		True
+		"""
+		buf = BytesIO()
+		self.save(buf)
+		buf.seek(0)
+		return TTFont(buf)
+
 
 class _TTGlyphSet(object):
 

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -809,26 +809,6 @@ def build(designspace, master_finder=lambda s:s, exclude=[], optimize=True):
 	return vf, model, master_ttfs
 
 
-# TODO: move to designspaceLib?
-def _get_master_path(designspace, master):
-	if master.path:
-		# prefer absolute path if present
-		return master.path
-	if designspace.path is None:
-		raise AttributeError(
-			"DesignSpaceDocument 'path' attribute is not defined; cannot "
-			"load master from relative filename"
-		)
-	if master.filename is None:
-		raise AttributeError(
-			"Designspace source '%s' has neither absolute 'path' nor "
-			"relative 'filename' defined"
-			% (master.name or "<Unknown>")
-		)
-	return os.path.join(os.path.dirname(designspace.path), master.filename)
-
-
-
 def load_masters(designspace, master_finder=lambda s: s):
 	"""Ensure that all SourceDescriptor.font attributes have an appropriate TTFont
 	object loaded.
@@ -855,7 +835,7 @@ def load_masters(designspace, master_finder=lambda s: s):
 			else:
 				# 2. A SourceDescriptor's filename might point to a UFO or an OpenType
 				# binary. Find out the hard way.
-				master_path = _get_master_path(designspace, master)
+				master_path = designspace.getSourcePath(master)
 				try:
 					font = TTFont(master_path)
 				except (IOError, TTLibError):

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -811,7 +811,12 @@ def build(designspace, master_finder=lambda s:s, exclude=[], optimize=True):
 
 def load_masters(designspace, master_finder=lambda s: s):
 	"""Ensure that all SourceDescriptor.font attributes have an appropriate TTFont
-	object loaded.
+	object loaded, or else open TTFont objects from the SourceDescriptor.path
+	attributes.
+
+	The paths can point to either an OpenType font or to a UFO. In the latter case,
+	use the provided master_finder callable to map from UFO paths to the respective
+	master font binaries (e.g. .ttf or .otf).
 
 	Return list of master TTFont objects in the same order they are listed in the
 	DesignSpaceDocument.

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -38,7 +38,6 @@ from fontTools.varLib.iup import iup_delta_optimize
 from fontTools.varLib.featureVars import addFeatureVariations
 from fontTools.designspaceLib import DesignSpaceDocument, AxisDescriptor
 from collections import OrderedDict, namedtuple
-import io
 import os.path
 import logging
 from pprint import pformat
@@ -737,18 +736,6 @@ def load_designspace(designspace):
 	)
 
 
-def _copy_font(ttFont):
-	try:
-		filename = ttFont.reader.file.name
-	except AttributeError:
-		buf = io.BytesIO()
-		ttFont.save(buf)
-		buf.seek(0)
-		return TTFont(buf)
-	else:
-		return TTFont(filename)
-
-
 def build(designspace, master_finder=lambda s:s, exclude=[], optimize=True):
 	"""
 	Build variation font from a designspace file.
@@ -777,7 +764,7 @@ def build(designspace, master_finder=lambda s:s, exclude=[], optimize=True):
 			master_ttfs.append(None)  # in-memory fonts have no path
 
 	# Copy the base master to work from it
-	vf = _copy_font(master_fonts[ds.base_idx])
+	vf = master_fonts[ds.base_idx].copy()
 
 	# TODO append masters as named-instances as well; needs .designspace change.
 	fvar = _add_fvar(vf, ds.axes, ds.instances)

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -833,9 +833,14 @@ def load_masters(designspace, master_finder=lambda s: s):
 					% (master.name or "<Unknown>")
 			)
 			else:
-				# 2. A SourceDescriptor's filename might point to a UFO or an OpenType
+				if master.path is None:
+					raise AttributeError(
+						"Designspace source '%s' has neither 'font' nor 'path' "
+						"attributes" % (master.name or "<Unknown>")
+					)
+				# 2. A SourceDescriptor's path might point to a UFO or an OpenType
 				# binary. Find out the hard way.
-				master_path = designspace.getSourcePath(master)
+				master_path = os.path.normpath(master.path)
 				try:
 					font = TTFont(master_path)
 				except (IOError, TTLibError):

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -40,6 +40,7 @@ from fontTools.designspaceLib import DesignSpaceDocument, AxisDescriptor
 from collections import OrderedDict, namedtuple
 import os.path
 import logging
+from copy import deepcopy
 from pprint import pformat
 
 log = logging.getLogger("fontTools.varLib")
@@ -764,7 +765,7 @@ def build(designspace, master_finder=lambda s:s, exclude=[], optimize=True):
 			master_ttfs.append(None)  # in-memory fonts have no path
 
 	# Copy the base master to work from it
-	vf = master_fonts[ds.base_idx].copy()
+	vf = deepcopy(master_fonts[ds.base_idx])
 
 	# TODO append masters as named-instances as well; needs .designspace change.
 	fvar = _add_fvar(vf, ds.axes, ds.instances)

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -749,7 +749,6 @@ def build(designspace, master_finder=lambda s:s, exclude=[], optimize=True):
 
 	master_fonts = []
 	master_ttfs = []
-	master_source = ds.masters[ds.base_idx]
 	if hasattr(designspace, "sources"):  # Assume a DesignspaceDocument
 		basedir = getattr(designspace, "path", None)
 	else:  # Assume a path

--- a/Lib/fontTools/varLib/interpolate_layout.py
+++ b/Lib/fontTools/varLib/interpolate_layout.py
@@ -8,6 +8,7 @@ from fontTools.varLib import models, VarLibError, load_designspace, load_masters
 from fontTools.varLib.merger import InstancerMerger
 import os.path
 import logging
+from copy import deepcopy
 from pprint import pformat
 
 log = logging.getLogger("fontTools.varLib.interpolate_layout")
@@ -37,7 +38,7 @@ def interpolate_layout(designspace, loc, master_finder=lambda s:s, mapped=False)
 
 	log.info("Loading master fonts")
 	master_fonts = load_masters(designspace, master_finder)
-	font = master_fonts[ds.base_idx].copy()
+	font = deepcopy(master_fonts[ds.base_idx])
 
 	log.info("Location: %s", pformat(loc))
 	if not mapped:

--- a/Lib/fontTools/varLib/interpolate_layout.py
+++ b/Lib/fontTools/varLib/interpolate_layout.py
@@ -4,7 +4,7 @@ Interpolate OpenType Layout tables (GDEF / GPOS / GSUB).
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools.ttLib import TTFont
-from fontTools.varLib import models, VarLibError, load_designspace
+from fontTools.varLib import models, VarLibError, load_designspace, load_masters
 from fontTools.varLib.merger import InstancerMerger
 import os.path
 import logging
@@ -13,7 +13,7 @@ from pprint import pformat
 log = logging.getLogger("fontTools.varLib.interpolate_layout")
 
 
-def interpolate_layout(designspace_filename, loc, master_finder=lambda s:s, mapped=False):
+def interpolate_layout(designspace, loc, master_finder=lambda s:s, mapped=False):
 	"""
 	Interpolate GPOS from a designspace file and location.
 
@@ -26,18 +26,18 @@ def interpolate_layout(designspace_filename, loc, master_finder=lambda s:s, mapp
 	it is assumed that location is in designspace's internal space and
 	no mapping is performed.
 	"""
-	ds = load_designspace(designspace_filename)
+	if hasattr(designspace, "sources"):  # Assume a DesignspaceDocument
+		pass
+	else:  # Assume a file path
+		from fontTools.designspaceLib import DesignSpaceDocument
+		designspace = DesignSpaceDocument.fromfile(designspace)
 
+	ds = load_designspace(designspace)
 	log.info("Building interpolated font")
-	log.info("Loading master fonts")
-	basedir = os.path.dirname(designspace_filename)
-	master_ttfs = [
-		master_finder(os.path.join(basedir, m.filename)) for m in ds.masters
-	]
-	master_fonts = [TTFont(ttf_path) for ttf_path in master_ttfs]
 
-	#font = master_fonts[ds.base_idx]
-	font = TTFont(master_ttfs[ds.base_idx])
+	log.info("Loading master fonts")
+	master_fonts = load_masters(designspace, master_finder)
+	font = master_fonts[ds.base_idx].copy()
 
 	log.info("Location: %s", pformat(loc))
 	if not mapped:

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -789,6 +789,11 @@ def test_documentLib(tmpdir):
 def test_getSourcePath():
     doc = DesignSpaceDocument()
     s1 = SourceDescriptor()
+    s1.path = "/tmp/foo/masters/Source1.ufo"
+
+    assert doc.getSourcePath(s1) == s1.path
+
+    s1.path = None
 
     with pytest.raises(
         DesignSpaceDocumentError,

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -792,7 +792,7 @@ def test_getSourcePath(tmpdir):
     s1 = SourceDescriptor()
     s1.path = str(tmpdir / "foo"/ "masters" / "Source1.ufo")
 
-    assert doc.getSourcePath(s1) == s1.path
+    assert doc.getSourcePath(s1) == os.path.normpath(s1.path)
 
     s1.path = None
 

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -785,3 +785,28 @@ def test_documentLib(tmpdir):
     assert dummyKey in new.lib
     assert new.lib[dummyKey] == dummyData
 
+
+def test_getSourcePath():
+    doc = DesignSpaceDocument()
+    s1 = SourceDescriptor()
+
+    with pytest.raises(
+        DesignSpaceDocumentError,
+        match="DesignSpaceDocument 'path' attribute is not defined",
+    ):
+        doc.getSourcePath(s1)
+
+    doc.path = "/tmp/foo/bar/MyDesignspace.designspace"
+
+    with pytest.raises(
+        DesignSpaceDocumentError,
+        match=(
+            "Designspace source '<Unknown>' has neither absolute 'path' nor "
+            "relative 'filename' defined"
+        ),
+    ):
+        doc.getSourcePath(s1)
+
+    s1.filename = "../masters/Source1.ufo"
+
+    assert doc.getSourcePath(s1) == "/tmp/foo/masters/Source1.ufo"

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -787,10 +787,10 @@ def test_documentLib(tmpdir):
     assert new.lib[dummyKey] == dummyData
 
 
-def test_getSourcePath():
+def test_getSourcePath(tmpdir):
     doc = DesignSpaceDocument()
     s1 = SourceDescriptor()
-    s1.path = "/tmp/foo/masters/Source1.ufo"
+    s1.path = str(tmpdir / "foo"/ "masters" / "Source1.ufo")
 
     assert doc.getSourcePath(s1) == s1.path
 
@@ -802,7 +802,7 @@ def test_getSourcePath():
     ):
         doc.getSourcePath(s1)
 
-    doc.path = "/tmp/foo/bar/MyDesignspace.designspace"
+    doc.path = str(tmpdir / "foo" / "bar" / "MyDesignspace.designspace")
 
     with pytest.raises(
         DesignSpaceDocumentError,
@@ -815,7 +815,7 @@ def test_getSourcePath():
 
     s1.filename = "../masters/Source1.ufo"
 
-    assert doc.getSourcePath(s1) == "/tmp/foo/masters/Source1.ufo"
+    assert doc.getSourcePath(s1) == str(tmpdir / "foo" / "masters" / "Source1.ufo")
 
 
 @pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason="pathlib is only tested on 3.6 and up")

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -12,6 +12,14 @@ import tempfile
 import unittest
 
 
+def reload_font(font):
+    """(De)serialize to get final binary layout."""
+    buf = BytesIO()
+    font.save(buf)
+    buf.seek(0)
+    return TTFont(buf)
+
+
 class BuildTest(unittest.TestCase):
     def __init__(self, methodName):
         unittest.TestCase.__init__(self, methodName)
@@ -113,10 +121,7 @@ class BuildTest(unittest.TestCase):
             # some data (e.g. counts printed in TTX inline comments) is only
             # calculated at compile time, so before we can compare the TTX
             # dumps we need to save to a temporary stream, and realod the font
-            buf = BytesIO()
-            varfont.save(buf)
-            buf.seek(0)
-            varfont = TTFont(buf)
+            varfont = reload_font(varfont)
 
         expected_ttx_path = self.get_test_output(expected_ttx_name + '.ttx')
         self.expect_ttx(varfont, expected_ttx_path, tables)
@@ -230,10 +235,7 @@ class BuildTest(unittest.TestCase):
         # some data (e.g. counts printed in TTX inline comments) is only
         # calculated at compile time, so before we can compare the TTX
         # dumps we need to save to a temporary stream, and realod the font
-        buf = BytesIO()
-        varfont.save(buf)
-        buf.seek(0)
-        varfont = TTFont(buf)
+        varfont = reload_font(varfont)
 
         expected_ttx_path = self.get_test_output(expected_ttx_name + '.ttx')
         self.expect_ttx(varfont, expected_ttx_path, tables)
@@ -290,13 +292,6 @@ class BuildTest(unittest.TestCase):
         ttx_dir = self.get_test_input("master_ttx_interpolatable_ttf")
         expected_ttx_path = self.get_test_output("BuildMain.ttx")
 
-        def reload_font(font):
-            """(De)serialize to get final binary layout."""
-            buf = BytesIO()
-            font.save(buf)
-            buf.seek(0)
-            return TTFont(buf)
-
         ds = DesignSpaceDocument.fromfile(ds_path)
         for source in ds.sources:
             filename = os.path.join(
@@ -304,7 +299,7 @@ class BuildTest(unittest.TestCase):
             )
             font = TTFont(recalcBBoxes=False, recalcTimestamp=False)
             font.importXML(filename)
-            source.font = reload_font(font)
+            source.font = font
             source.filename = None  # Make sure no file path gets into build()
 
         varfont, _, _ = build(ds)

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -2,14 +2,17 @@ from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools.ttLib import TTFont
 from fontTools.varLib import build
-from fontTools.varLib import main as varLib_main
-from fontTools.designspaceLib import DesignSpaceDocumentError, DesignSpaceDocument
+from fontTools.varLib import main as varLib_main, load_masters
+from fontTools.designspaceLib import (
+    DesignSpaceDocumentError, DesignSpaceDocument, SourceDescriptor,
+)
 import difflib
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+import pytest
 
 
 def reload_font(font):
@@ -306,6 +309,20 @@ class BuildTest(unittest.TestCase):
         varfont = reload_font(varfont)
         tables = [table_tag for table_tag in varfont.keys() if table_tag != "head"]
         self.expect_ttx(varfont, expected_ttx_path, tables)
+
+
+def test_load_masters_layerName_without_required_font():
+    ds = DesignSpaceDocument()
+    s = SourceDescriptor()
+    s.font = None
+    s.layerName = "Medium"
+    ds.addSource(s)
+
+    with pytest.raises(
+        AttributeError,
+        match="specified a layer name but lacks the required TTFont object",
+    ):
+        load_masters(ds)
 
 
 if __name__ == "__main__":

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -295,14 +295,18 @@ class BuildTest(unittest.TestCase):
         ttx_dir = self.get_test_input("master_ttx_interpolatable_ttf")
         expected_ttx_path = self.get_test_output("BuildMain.ttx")
 
+        self.temp_dir()
+        for path in self.get_file_list(ttx_dir, '.ttx', 'TestFamily-'):
+            self.compile_font(path, ".ttf", self.tempdir)
+
         ds = DesignSpaceDocument.fromfile(ds_path)
         for source in ds.sources:
             filename = os.path.join(
-                ttx_dir, os.path.basename(source.filename).replace(".ufo", ".ttx")
+                self.tempdir, os.path.basename(source.filename).replace(".ufo", ".ttf")
             )
-            font = TTFont(recalcBBoxes=False, recalcTimestamp=False)
-            font.importXML(filename)
-            source.font = font
+            source.font = TTFont(
+                filename, recalcBBoxes=False, recalcTimestamp=False, lazy=True
+            )
             source.filename = None  # Make sure no file path gets into build()
 
         varfont, _, _ = build(ds)


### PR DESCRIPTION
with source descriptors containing pre-loaded TTFont instances

Continuation of https://github.com/fonttools/fonttools/pull/1416