### PR TITLE
Update etree.py

### DIFF
--- a/Lib/fontTools/misc/etree.py
+++ b/Lib/fontTools/misc/etree.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, unicode_literals
 from fontTools.misc.py23 import basestring, unicode, tounicode, open
 
 
-XML_DECLARATION = """<?xml version='1.0' encoding='%s'?>"""
+XML_DECLARATION = """<?xml version="1.0" encoding="%s"?>"""
 
 __all__ = [
     # public symbols


### PR DESCRIPTION
To conform with the output from UFOnormalizer (and the rest of the XML file).
Along similar lines, I wonder what needs to happen to write a tabbed XML file (instead of two-spaced, as lxml does)?