### PR TITLE
Fixes bug in misc.psCharStrings.encodeFloat and adds test

### DIFF
--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -242,11 +242,9 @@ def encodeFloat(f):
 		if c == "E":
 			c2 = s[:1]
 			if c2 == "-":
-				s = s[2:]
+				s = s[1:]
 				c = "E-"
 			elif c2 == "+":
-				s = s[2:]
-			else:
 				s = s[1:]
 		nibbles.append(realNibblesDict[c])
 	nibbles.append(0xf)

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -223,9 +223,14 @@ def encodeFixed(f, pack=struct.pack):
 	else:
 		return b"\xff" + pack(">l", value)  # encode the entire fixed point value
 
+
+realZeroBytes = bytechr(30) + bytechr(0xf)
+
 def encodeFloat(f):
 	# For CFF only, used in cffLib
-	s = str(f).upper()
+	if f == 0.0: # 0.0 == +0.0 == -0.0
+		return realZeroBytes
+	s = "%.14G" % f
 	if s[:2] == "0.":
 		s = s[1:]
 	elif s[:3] == "-0.":
@@ -234,9 +239,15 @@ def encodeFloat(f):
 	while s:
 		c = s[0]
 		s = s[1:]
-		if c == "E" and s[:1] == "-":
-			s = s[1:]
-			c = "E-"
+		if c == "E":
+			c2 = s[:1]
+			if c2 == "-":
+				s = s[2:]
+				c = "E-"
+			elif c2 == "+":
+				s = s[2:]
+			else:
+				s = s[1:]
 		nibbles.append(realNibblesDict[c])
 	nibbles.append(0xf)
 	if len(nibbles) % 2:

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -231,7 +231,7 @@ def encodeFloat(f):
 	if f == 0.0: # 0.0 == +0.0 == -0.0
 		return realZeroBytes
 	# Note: 14 decimal digits seems to be the limitation for CFF real numbers
-  # in macOS. However, we use 8 here to match the implementation of AFDKO.
+	# in macOS. However, we use 8 here to match the implementation of AFDKO.
 	s = "%.8G" % f
 	if s[:2] == "0.":
 		s = s[1:]

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -230,7 +230,9 @@ def encodeFloat(f):
 	# For CFF only, used in cffLib
 	if f == 0.0: # 0.0 == +0.0 == -0.0
 		return realZeroBytes
-	s = "%.14G" % f
+	# Note: 14 decimal digits seems to be the limitation for CFF real numbers
+  # in macOS. However, we use 8 here to match the implementation of AFDKO.
+	s = "%.8G" % f
 	if s[:2] == "0.":
 		s = s[1:]
 	elif s[:3] == "-0.":

--- a/Tests/misc/psCharStrings_test.py
+++ b/Tests/misc/psCharStrings_test.py
@@ -61,15 +61,16 @@ class T2CharStringTest(unittest.TestCase):
             (-9.399999999999999,   '1e e9 a4 ff'),  # -9.4
             (9.399999999999999999, '1e 9a 4f'),  # 9.4
             (456.8,                '1e 45 6a 8f'),  # 456.8
-            (0,                    '1e 0f'),  # 0
+            (0.0,                  '1e 0f'),  # 0
             (-0.0,                 '1e 0f'),  # 0
-            (1,                    '1e 1f'),  # 1
-            (-1,                   '1e e1 ff'),  # -1
+            (1.0,                  '1e 1f'),  # 1
+            (-1.0,                 '1e e1 ff'),  # -1
             (98765.37e2,           '1e 98 76 53 7f'),  # 9876537
-            (1234567890,           '1e 12 34 56 78 90 ff'),  # 1234567890
+            (1234567890.0,         '1e 1a 23 45 67 9b 09 ff'),  # 1234567890
             (9.876537e-4,          '1e a0 00 98 76 53 7f'),  # 9.876537e-24
             (9.876537e+4,          '1e 98 76 5a 37 ff'),  # 9.876537e+24
         ]
+
         for sample in testNums:
             encoded_result = encodeFloat(sample[0])
             
@@ -83,9 +84,9 @@ class T2CharStringTest(unittest.TestCase):
                 encoded_result,
                 1,
             )
-            self.assertEqual(decoded_result[0], float('%.14g' % sample[0]))
-            # Note: 14 decimal digits is the limitation for CFF real numbers
-            # as per a limitation in macOS.
+            self.assertEqual(decoded_result[0], float('%.8g' % sample[0]))
+            # We limit to 8 digits of precision to match the implementation
+            # of encodeFloat.
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch:

- Adds a unit test for `misc.psCharStrings.encodeFloat`
- Fixes a bug in `encodeFloat` where a number like `1.23e+4` would raise a KeyError exception
- Fixes an issue where the produced data would be of too high precision for 32-bit parsers, like macOS. See https://github.com/googlei18n/ufo2ft/issues/306

This is a follow-up PR to this small proof-of-issue PR: https://github.com/fonttools/fonttools/pull/1429

A faster implementation of `encodeFloat` is available here separately: https://gist.github.com/rsms/efd5663749a9b66bc53be8f85becc9d2 — introducing this more efficient implementation caused test failures in ttLib/tables/C_F_F_test which seemed like too much changes for one PR.