### PR TITLE
fontBuilder: add options to setupNameTable to disable Mac (or Win) names

### DIFF
--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -394,14 +394,17 @@ class FontBuilder(object):
         self.font["cmap"].tableVersion = 0
         self.font["cmap"].tables = subTables
 
-    def setupNameTable(self, nameStrings):
+    def setupNameTable(self, nameStrings, windows=True, mac=True):
         """Create the `name` table for the font. The `nameStrings` argument must
         be a dict, mapping nameIDs or descriptive names for the nameIDs to name
         record values. A value is either a string, or a dict, mapping language codes
         to strings, to allow localized name table entries.
 
+        By default, both Windows (platformID=3) and Macintosh (platformID=1) name
+        records are added, unless any of `windows` or `mac` arguments is False.
+
         The following descriptive names are available for nameIDs:
-        
+
             copyright (nameID 0)
             familyName (nameID 1)
             styleName (nameID 2)
@@ -438,7 +441,9 @@ class FontBuilder(object):
                 nameID = _nameIDs[nameName]
             if isinstance(nameValue, basestring):
                 nameValue = dict(en=nameValue)
-            nameTable.addMultilingualName(nameValue, ttFont=self.font, nameID=nameID)
+            nameTable.addMultilingualName(
+                nameValue, ttFont=self.font, nameID=nameID, windows=windows, mac=mac
+            )
 
     def setupOS2(self, **values):
         """Create a new `OS/2` table and initialize it with default values,

--- a/Tests/fontBuilder/fontBuilder_test.py
+++ b/Tests/fontBuilder/fontBuilder_test.py
@@ -228,3 +228,19 @@ def test_build_cff2(tmpdir):
     fb.save(outPath)
 
     _verifyOutput(outPath)
+
+
+def test_setupNameTable_no_mac():
+    fb, _, nameStrings = _setupFontBuilder(True)
+    fb.setupNameTable(nameStrings, mac=False)
+
+    assert all(n for n in fb.font["name"].names if n.platformID == 3)
+    assert not any(n for n in fb.font["name"].names if n.platformID == 1)
+
+
+def test_setupNameTable_no_windows():
+    fb, _, nameStrings = _setupFontBuilder(True)
+    fb.setupNameTable(nameStrings, windows=False)
+
+    assert all(n for n in fb.font["name"].names if n.platformID == 1)
+    assert not any(n for n in fb.font["name"].names if n.platformID == 3)


### PR DESCRIPTION
as of https://github.com/fonttools/fonttools/pull/1359, both sets of names are added by default. This allows users to optionally exclude Macintosh platform names (i.e. mac=False).