### PR TITLE
[varLib] use addMultilingualName method to support localized axis and instance names

### DIFF
--- a/Doc/source/designspaceLib/readme.rst
+++ b/Doc/source/designspaceLib/readme.rst
@@ -277,7 +277,8 @@ AxisDescriptor object
    dicts. MutatorMath + Varlib.
 -  ``labelNames``: dict. When defining a non-registered axis, it will be
    necessary to define user-facing readable names for the axis. Keyed by
-   xml:lang code. Varlib.
+   xml:lang code. Values are required to be ``unicode`` strings, even if
+   they only contain ASCII characters.
 -  ``minimum``: number. The minimum value for this axis in user space.
    MutatorMath + Varlib.
 -  ``maximum``: number. The maximum value for this axis in user space.

--- a/Doc/source/designspaceLib/scripting.rst
+++ b/Doc/source/designspaceLib/scripting.rst
@@ -70,7 +70,7 @@ readable names for this axis if this is not an axis that is registered
 by OpenType. Think "The label next to the slider". The attribute is a
 dictionary. The key is the `xml language
 tag <https://www.w3.org/International/articles/language-tags/>`__, the
-value is a utf-8 string with the name. Whether or not this attribute is
+value is a ``unicode`` string with the name. Whether or not this attribute is
 used depends on the font building tool, the operating system and the
 authoring software. This, at least, is the place to record it.
 

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -753,8 +753,7 @@ class BaseDocReader(LogMixin):
                 # '{http://www.w3.org/XML/1998/namespace}lang'
                 for key, lang in labelNameElement.items():
                     if key == XML_LANG:
-                        labelName = labelNameElement.text
-                        axisObject.labelNames[lang] = labelName
+                        axisObject.labelNames[lang] = tounicode(labelNameElement.text)
             self.documentObject.axes.append(axisObject)
             self.axisDefaults[axisObject.name] = axisObject.default
         self.documentObject.defaultLoc = self.axisDefaults

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -246,25 +246,25 @@ class InstanceDescriptor(SimpleDescriptor):
     filename = posixpath_property("_filename")
 
     def setStyleName(self, styleName, languageCode="en"):
-        self.localisedStyleName[languageCode] = styleName
+        self.localisedStyleName[languageCode] = tounicode(styleName)
 
     def getStyleName(self, languageCode="en"):
         return self.localisedStyleName.get(languageCode)
 
     def setFamilyName(self, familyName, languageCode="en"):
-        self.localisedFamilyName[languageCode] = familyName
+        self.localisedFamilyName[languageCode] = tounicode(familyName)
 
     def getFamilyName(self, languageCode="en"):
         return self.localisedFamilyName.get(languageCode)
 
     def setStyleMapStyleName(self, styleMapStyleName, languageCode="en"):
-        self.localisedStyleMapStyleName[languageCode] = styleMapStyleName
+        self.localisedStyleMapStyleName[languageCode] = tounicode(styleMapStyleName)
 
     def getStyleMapStyleName(self, languageCode="en"):
         return self.localisedStyleMapStyleName.get(languageCode)
 
     def setStyleMapFamilyName(self, styleMapFamilyName, languageCode="en"):
-        self.localisedStyleMapFamilyName[languageCode] = styleMapFamilyName
+        self.localisedStyleMapFamilyName[languageCode] = tounicode(styleMapFamilyName)
 
     def getStyleMapFamilyName(self, languageCode="en"):
         return self.localisedStyleMapFamilyName.get(languageCode)

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -81,11 +81,18 @@ def _add_fvar(font, axes, instances):
 
 	for instance in instances:
 		coordinates = instance.location
-		name = tounicode(instance.styleName)
+
+		if "en" not in instance.localisedStyleName:
+			assert instance.styleName
+			localisedStyleName = dict(instance.localisedStyleName)
+			localisedStyleName["en"] = tounicode(instance.styleName)
+		else:
+			localisedStyleName = instance.localisedStyleName
+
 		psname = instance.postScriptFontName
 
 		inst = NamedInstance()
-		inst.subfamilyNameID = nameTable.addName(name)
+		inst.subfamilyNameID = nameTable.addMultilingualName(localisedStyleName)
 		if psname is not None:
 			psname = tounicode(psname)
 			inst.postscriptNameID = nameTable.addName(psname)

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -76,12 +76,7 @@ def _add_fvar(font, axes, instances):
 		axis.axisTag = Tag(a.tag)
 		# TODO Skip axes that have no variation.
 		axis.minValue, axis.defaultValue, axis.maxValue = a.minimum, a.default, a.maximum
-		axis.axisNameID = nameTable.addName(tounicode(a.labelNames['en']))
-		# TODO:
-		# Replace previous line with the following when the following issues are resolved:
-		# https://github.com/fonttools/fonttools/issues/930
-		# https://github.com/fonttools/fonttools/issues/931
-		# axis.axisNameID = nameTable.addMultilingualName(a.labelname, font)
+		axis.axisNameID = nameTable.addMultilingualName(a.labelNames, font)
 		fvar.axes.append(axis)
 
 	for instance in instances:
@@ -662,10 +657,10 @@ def load_designspace(designspace):
 	instances = ds.instances
 
 	standard_axis_map = OrderedDict([
-		('weight',  ('wght', {'en':'Weight'})),
-		('width',   ('wdth', {'en':'Width'})),
-		('slant',   ('slnt', {'en':'Slant'})),
-		('optical', ('opsz', {'en':'Optical Size'})),
+		('weight',  ('wght', {'en': u'Weight'})),
+		('width',   ('wdth', {'en': u'Width'})),
+		('slant',   ('slnt', {'en': u'Slant'})),
+		('optical', ('opsz', {'en': u'Optical Size'})),
 		])
 
 	# Setup axes
@@ -684,7 +679,7 @@ def load_designspace(designspace):
 		else:
 			assert axis.tag is not None
 			if not axis.labelNames:
-				axis.labelNames["en"] = axis_name
+				axis.labelNames["en"] = tounicode(axis_name)
 
 		axes[axis_name] = axis
 	log.info("Axes:\n%s", pformat([axis.asdict() for axis in axes.values()]))

--- a/Lib/fontTools/varLib/mutator.py
+++ b/Lib/fontTools/varLib/mutator.py
@@ -345,6 +345,16 @@ def instantiateVariableFont(varfont, location, inplace=False):
 		for i in fvar.instances:
 			exclude.add(i.subfamilyNameID)
 			exclude.add(i.postscriptNameID)
+		if 'ltag' in varfont:
+			# Drop the whole 'ltag' table if all its language tags are referenced by
+			# name records to be pruned.
+			# TODO: prune unused ltag tags and re-enumerate langIDs accordingly
+			excludedUnicodeLangIDs = [
+				n.langID for n in varfont['name'].names
+				if n.nameID in exclude and n.platformID == 0 and n.langID != 0xFFFF
+			]
+			if set(excludedUnicodeLangIDs) == set(range(len((varfont['ltag'].tags)))):
+				del varfont['ltag']
 		varfont['name'].names[:] = [
 			n for n in varfont['name'].names
 			if n.nameID not in exclude

--- a/Tests/varLib/data/Build.designspace
+++ b/Tests/varLib/data/Build.designspace
@@ -4,6 +4,8 @@
         <axis default="368.0" maximum="1000.0" minimum="0.0" name="weight" tag="wght" />
         <axis default="0.0" maximum="100.0" minimum="0.0" name="contrast" tag="cntr">
             <labelname xml:lang="en">Contrast</labelname>
+            <labelname xml:lang="de">Kontrast</labelname>
+            <labelname xml:lang="fa">کنتراست</labelname>
         </axis>
     </axes>
     <sources>

--- a/Tests/varLib/data/test_results/BuildMain.ttx
+++ b/Tests/varLib/data/test_results/BuildMain.ttx
@@ -440,6 +440,9 @@
   </glyf>
 
   <name>
+    <namerecord nameID="257" platformID="0" platEncID="4" langID="0x0">
+      کنتراست
+    </namerecord>
     <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Weight
     </namerecord>
@@ -493,6 +496,12 @@
     </namerecord>
     <namerecord nameID="273" platformID="1" platEncID="0" langID="0x0" unicode="True">
       TestFamily-BlackHighContrast
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x2" unicode="True">
+      Kontrast
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x407">
+      Kontrast
     </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
       Test Family
@@ -2234,5 +2243,11 @@
       </tuple>
     </glyphVariations>
   </gvar>
+
+  <ltag>
+    <version value="1"/>
+    <flags value="0"/>
+    <LanguageTag tag="fa"/>
+  </ltag>
 
 </ttFont>


### PR DESCRIPTION
Now that addMultilingualName method also adds mac names by default (#1359), we can use it in
varLib instead of `addName`, thus enabling support for localized axes and named instances' names.
The language identifiers are expected to be minimized, i.e. not contain default script/region subtags -- until we implement the minimizeSubtags algorithm from ICU/CLDR (see discussion at #930).