### PR TITLE
[subset] set emptied CFF charstrings to 'endchar' with --retain-gids

### DIFF
--- a/Lib/fontTools/subset/cff.py
+++ b/Lib/fontTools/subset/cff.py
@@ -93,9 +93,10 @@ def prune_pre_subset(self, font, options):
 	cff.fontNames = cff.fontNames[:1]
 
 	if options.notdef_glyph and not options.notdef_outline:
+		isCFF2 = cff.major > 1
 		for fontname in cff.keys():
 			font = cff[fontname]
-			_empty_charstring(font, ".notdef", isCFF2=cff.major > 1)
+			_empty_charstring(font, ".notdef", isCFF2=isCFF2)
 
 	# Clear useless Encoding
 	for fontname in cff.keys():
@@ -113,8 +114,9 @@ def subset_glyphs(self, s):
 		cs = font.CharStrings
 
 		if s.options.retain_gids:
+			isCFF2 = cff.major > 1
 			for g in s.glyphs_emptied:
-				_empty_charstring(font, g, isCFF2=cff.major > 1, ignoreWidth=True)
+				_empty_charstring(font, g, isCFF2=isCFF2, ignoreWidth=True)
 		else:
 			# Load all glyphs
 			for g in font.charset:

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -507,7 +507,7 @@ class SubsetTest(unittest.TestCase):
         self.assertGreater(glyf["A"].numberOfContours, 0)
         self.assertEqual(glyf["B"].numberOfContours, 0)
 
-    def test_retain_gids_otf(self):
+    def test_retain_gids_cff(self):
         _, fontpath = self.compile_font(self.getpath("TestOTF-Regular.ttx"), ".otf")
         font = TTFont(fontpath)
 
@@ -519,7 +519,7 @@ class SubsetTest(unittest.TestCase):
         self.assertGreater(len(cs["A"].program), 0)
         self.assertGreater(len(cs["B"].program), 0)
 
-        subsetpath = self.temp_path(".ttf")
+        subsetpath = self.temp_path(".otf")
         subset.main(
             [
                 fontpath,
@@ -540,7 +540,41 @@ class SubsetTest(unittest.TestCase):
         subsetfont["CFF "].cff[0].decompileAllCharStrings()
         cs = subsetfont["CFF "].cff[0].CharStrings
         self.assertGreater(len(cs["A"].program), 0)
-        self.assertEqual(cs["B"].program, [-300, "endchar"])
+        self.assertEqual(cs["B"].program, ["endchar"])
+
+    def test_retain_gids_cff2(self):
+        fontpath = self.getpath("../../varLib/data/TestCFF2VF.otf")
+        font = TTFont(fontpath)
+
+        self.assertEqual(font["hmtx"]["A"], (600, 31))
+        self.assertEqual(font["hmtx"]["T"], (600, 41))
+
+        font["CFF2"].cff[0].decompileAllCharStrings()
+        cs = font["CFF2"].cff[0].CharStrings
+        self.assertGreater(len(cs["A"].program), 0)
+        self.assertGreater(len(cs["T"].program), 0)
+
+        subsetpath = self.temp_path(".otf")
+        subset.main(
+            [
+                fontpath,
+                "--retain-gids",
+                "--output-file=%s" % subsetpath,
+                "A",
+            ]
+        )
+        subsetfont = TTFont(subsetpath)
+
+        self.assertEqual(len(subsetfont.getGlyphOrder()), len(font.getGlyphOrder()))
+
+        hmtx = subsetfont["hmtx"]
+        self.assertEqual(hmtx["A"], (600, 31))
+        self.assertEqual(hmtx["glyph00002"], (0, 0))
+
+        subsetfont["CFF2"].cff[0].decompileAllCharStrings()
+        cs = subsetfont["CFF2"].cff[0].CharStrings
+        self.assertGreater(len(cs["A"].program), 0)
+        self.assertEqual(cs["glyph00002"].program, [])
 
 
 if __name__ == "__main__":

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -540,7 +540,7 @@ class SubsetTest(unittest.TestCase):
         subsetfont["CFF "].cff[0].decompileAllCharStrings()
         cs = subsetfont["CFF "].cff[0].CharStrings
         self.assertGreater(len(cs["A"].program), 0)
-        self.assertEqual(cs["B"].program, ["endchar"])
+        self.assertEqual(cs["B"].program, [-300, "endchar"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part of #1446

is it just setting the program to `["endchar"]` or am I missing something?