### PR TITLE
[cff2] fix AttributeError 'isCFF2' when dumping CFF2 with ttx

### DIFF
--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -1005,6 +1005,10 @@ class T2CharString(object):
 				bytecode.append(encodeFixed(token))
 			else:
 				assert 0, "unsupported type: %s" % type(token)
+		if not isCFF2 and program and not isinstance(program[-1], basestring):
+			raise CharStringCompileError(
+				"T2CharString or Subr has items on the stack after last operator."
+			)
 		try:
 			bytecode = bytesjoin(bytecode)
 		except TypeError:
@@ -1088,13 +1092,12 @@ class T2CharString(object):
 				else:
 					args.append(token)
 			if args:
-				if self.isCFF2:
-					# CFF2Subr's can have numeric arguments on the stack after the last operator.
-					args = [str(arg) for arg in args]
-					line = ' '.join(args)
-					xmlWriter.write(line)
-				else:
-					assert 0, "T2Charstring or Subr has items on the stack after last operator."
+				# NOTE: only CFF2 charstrings/subrs can have numeric arguments on
+				# the stack after the last operator. Compiling this would fail if
+				# this is part of CFF 1.0 table.
+				args = [str(arg) for arg in args]
+				line = ' '.join(args)
+				xmlWriter.write(line)
 
 	def fromXML(self, name, attrs, content):
 		from fontTools.misc.textTools import binary2num, readHex


### PR DESCRIPTION
This is an attempt to fix #1451 when dumping CFF2 table to ttx.

Instead of changing the signature of basically all the toXML/xmlWrite methods in cffLib to add an `isCFF2=False` parameter, what about we add a 'context' namespace attribute to XMLWriter that can hold misc data, such as whether 'isCFF2' the table we are dumping?

