### PR TITLE
[voltLib] Don’t try to read past END

### DIFF
--- a/Lib/fontTools/voltLib/parser.py
+++ b/Lib/fontTools/voltLib/parser.py
@@ -44,10 +44,7 @@ class Parser(object):
                 func = getattr(self, PARSE_FUNCS[self.cur_token_])
                 statements.append(func())
             elif self.is_cur_keyword_("END"):
-                if self.next_token_type_ is not None:
-                    raise VoltLibError("Expected the end of the file",
-                                       self.cur_token_location_)
-                return self.doc_
+                break
             else:
                 raise VoltLibError(
                     "Expected " + ", ".join(sorted(PARSE_FUNCS.keys())),
@@ -602,6 +599,8 @@ class Parser(object):
         self.cur_token_type_, self.cur_token_, self.cur_token_location_ = (
             self.next_token_type_, self.next_token_, self.next_token_location_)
         try:
+            if self.is_cur_keyword_("END"):
+                raise StopIteration
             (self.next_token_type_, self.next_token_,
              self.next_token_location_) = self.lexer_.next()
         except StopIteration:

--- a/Tests/voltLib/parser_test.py
+++ b/Tests/voltLib/parser_test.py
@@ -1028,6 +1028,14 @@ class ParserTest(unittest.TestCase):
              ("CMAP_FORMAT", (3, 1, 4)))
         )
 
+    def test_stop_at_end(self):
+        [def_glyph] = self.parse(
+            'DEF_GLYPH ".notdef" ID 0 TYPE BASE END_GLYPH END\0\0\0\0'
+        ).statements
+        self.assertEqual((def_glyph.name, def_glyph.id, def_glyph.unicode,
+                          def_glyph.type, def_glyph.components),
+                         (".notdef", 0, None, "BASE", None))
+
     def setUp(self):
         self.tempdir = None
         self.num_tempfiles = 0


### PR DESCRIPTION
The parser was still trying to read the next token even when the current token was END, but I think it should just stop reading here. When reading from `TSIV` table there can be null bytes at the end when would cause an exception in the lexer.