### PR TITLE
[voltLib] Return a tuple from parse_coverage_()

### DIFF
--- a/Lib/fontTools/voltLib/ast.py
+++ b/Lib/fontTools/voltLib/ast.py
@@ -96,15 +96,6 @@ class Enum(Expression):
         for e in self.glyphSet():
             yield e
 
-    def __len__(self):
-        return len(self.enum)
-
-    def __eq__(self, other):
-        return self.glyphSet() == other.glyphSet()
-
-    def __hash__(self):
-        return hash(self.glyphSet())
-
     def glyphSet(self, groups=None):
         glyphs = []
         for element in self.enum:


### PR DESCRIPTION
This is a followup to commit 94633e9f46975c356ec3a2d21ed30768c2fa0cd5, where I mistakenly made it return an `Enum` but `parse_coverage_()` it not used only for `ENUM`s and in many (most?) places returning an `Enum` is wrong as you have a list of separate items that has to remain separate.