### PR TITLE
[feaLib] Implement ValueRecord.asFea() 

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -963,12 +963,12 @@ class PairPosStatement(Statement):
         res = "enum " if self.enumerated else ""
         if self.valuerecord2:
             res += "pos {} {} {} {};".format(
-                self.glyphs1.asFea(), self.valuerecord1.makeString(),
-                self.glyphs2.asFea(), self.valuerecord2.makeString())
+                self.glyphs1.asFea(), self.valuerecord1.asFea(),
+                self.glyphs2.asFea(), self.valuerecord2.asFea())
         else:
             res += "pos {} {} {};".format(
                 self.glyphs1.asFea(), self.glyphs2.asFea(),
-                self.valuerecord1.makeString())
+                self.valuerecord1.asFea())
         return res
 
 
@@ -1069,12 +1069,12 @@ class SinglePosStatement(Statement):
             if len(self.prefix):
                 res += " ".join(map(asFea, self.prefix)) + " "
             res += " ".join([asFea(x[0]) + "'" + (
-                (" " + x[1].makeString()) if x[1] else "") for x in self.pos])
+                (" " + x[1].asFea()) if x[1] else "") for x in self.pos])
             if len(self.suffix):
                 res += " " + " ".join(map(asFea, self.suffix))
         else:
             res += " ".join([asFea(x[0]) + " " +
-                             (x[1].makeString() if x[1] else "") for x in self.pos])
+                             (x[1].asFea() if x[1] else "") for x in self.pos])
         res += ";"
         return res
 
@@ -1120,7 +1120,7 @@ class ValueRecord(Expression):
                 hash(self.xPlaDevice) ^ hash(self.yPlaDevice) ^
                 hash(self.xAdvDevice) ^ hash(self.yAdvDevice))
 
-    def makeString(self, vertical=None):
+    def asFea(self, indent=""):
         if not self:
             return "<NULL>"
 
@@ -1128,8 +1128,7 @@ class ValueRecord(Expression):
         xAdvance, yAdvance = self.xAdvance, self.yAdvance
         xPlaDevice, yPlaDevice = self.xPlaDevice, self.yPlaDevice
         xAdvDevice, yAdvDevice = self.xAdvDevice, self.yAdvDevice
-        if vertical is None:
-            vertical = self.vertical
+        vertical = self.vertical
 
         # Try format A, if possible.
         if x is None and y is None:

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1431,7 +1431,8 @@ class ParserTest(unittest.TestCase):
 
     def test_valuerecord_format_a_horizontal(self):
         doc = self.parse("feature liga {valueRecordDef 123 foo;} liga;")
-        value = doc.statements[0].statements[0].value
+        valuedef = doc.statements[0].statements[0]
+        value = valuedef.value
         self.assertIsNone(value.xPlacement)
         self.assertIsNone(value.yPlacement)
         self.assertEqual(value.xAdvance, 123)
@@ -1440,11 +1441,13 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.yPlaDevice)
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
+        self.assertEqual(valuedef.asFea(), "valueRecordDef 123 foo;")
         self.assertEqual(value.makeString(vertical=False), "123")
 
     def test_valuerecord_format_a_vertical(self):
         doc = self.parse("feature vkrn {valueRecordDef 123 foo;} vkrn;")
-        value = doc.statements[0].statements[0].value
+        valuedef = doc.statements[0].statements[0]
+        value = valuedef.value
         self.assertIsNone(value.xPlacement)
         self.assertIsNone(value.yPlacement)
         self.assertIsNone(value.xAdvance)
@@ -1453,11 +1456,13 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.yPlaDevice)
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
+        self.assertEqual(valuedef.asFea(), "valueRecordDef 123 foo;")
         self.assertEqual(value.makeString(vertical=True), "123")
 
     def test_valuerecord_format_a_zero_horizontal(self):
         doc = self.parse("feature liga {valueRecordDef 0 foo;} liga;")
-        value = doc.statements[0].statements[0].value
+        valuedef = doc.statements[0].statements[0]
+        value = valuedef.value
         self.assertIsNone(value.xPlacement)
         self.assertIsNone(value.yPlacement)
         self.assertEqual(value.xAdvance, 0)
@@ -1466,11 +1471,13 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.yPlaDevice)
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
+        self.assertEqual(valuedef.asFea(), "valueRecordDef 0 foo;")
         self.assertEqual(value.makeString(vertical=False), "0")
 
     def test_valuerecord_format_a_zero_vertical(self):
         doc = self.parse("feature vkrn {valueRecordDef 0 foo;} vkrn;")
-        value = doc.statements[0].statements[0].value
+        valuedef = doc.statements[0].statements[0]
+        value = valuedef.value
         self.assertIsNone(value.xPlacement)
         self.assertIsNone(value.yPlacement)
         self.assertIsNone(value.xAdvance)
@@ -1479,6 +1486,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.yPlaDevice)
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
+        self.assertEqual(valuedef.asFea(), "valueRecordDef 0 foo;")
         self.assertEqual(value.makeString(vertical=True), "0")
 
     def test_valuerecord_format_a_vertical_contexts_(self):
@@ -1492,7 +1500,8 @@ class ParserTest(unittest.TestCase):
 
     def test_valuerecord_format_b(self):
         doc = self.parse("feature liga {valueRecordDef <1 2 3 4> foo;} liga;")
-        value = doc.statements[0].statements[0].value
+        valuedef = doc.statements[0].statements[0]
+        value = valuedef.value
         self.assertEqual(value.xPlacement, 1)
         self.assertEqual(value.yPlacement, 2)
         self.assertEqual(value.xAdvance, 3)
@@ -1501,11 +1510,13 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.yPlaDevice)
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
+        self.assertEqual(valuedef.asFea(), "valueRecordDef <1 2 3 4> foo;")
         self.assertEqual(value.makeString(vertical=False), "<1 2 3 4>")
 
     def test_valuerecord_format_b_zero(self):
         doc = self.parse("feature liga {valueRecordDef <0 0 0 0> foo;} liga;")
-        value = doc.statements[0].statements[0].value
+        valuedef = doc.statements[0].statements[0]
+        value = valuedef.value
         self.assertEqual(value.xPlacement, 0)
         self.assertEqual(value.yPlacement, 0)
         self.assertEqual(value.xAdvance, 0)
@@ -1514,6 +1525,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.yPlaDevice)
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
+        self.assertEqual(valuedef.asFea(), "valueRecordDef <0 0 0 0> foo;")
         self.assertEqual(value.makeString(vertical=False), "<0 0 0 0>")
 
     def test_valuerecord_format_c(self):

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -726,7 +726,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsInstance(pos, ast.SinglePosStatement)
         [(glyphs, value)] = pos.pos
         self.assertEqual(glyphstr([glyphs]), "one")
-        self.assertEqual(value.makeString(vertical=False), "<1 2 3 4>")
+        self.assertEqual(value.asFea(), "<1 2 3 4>")
 
     def test_gpos_type_1_glyphclass_horizontal(self):
         doc = self.parse("feature kern {pos [one two] -300;} kern;")
@@ -734,7 +734,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsInstance(pos, ast.SinglePosStatement)
         [(glyphs, value)] = pos.pos
         self.assertEqual(glyphstr([glyphs]), "[one two]")
-        self.assertEqual(value.makeString(vertical=False), "-300")
+        self.assertEqual(value.asFea(), "-300")
 
     def test_gpos_type_1_glyphclass_vertical(self):
         doc = self.parse("feature vkrn {pos [one two] -300;} vkrn;")
@@ -742,7 +742,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsInstance(pos, ast.SinglePosStatement)
         [(glyphs, value)] = pos.pos
         self.assertEqual(glyphstr([glyphs]), "[one two]")
-        self.assertEqual(value.makeString(vertical=True), "-300")
+        self.assertEqual(value.asFea(), "-300")
 
     def test_gpos_type_1_multiple(self):
         doc = self.parse("feature f {pos one'1 two'2 [five six]'56;} f;")
@@ -750,11 +750,11 @@ class ParserTest(unittest.TestCase):
         self.assertIsInstance(pos, ast.SinglePosStatement)
         [(glyphs1, val1), (glyphs2, val2), (glyphs3, val3)] = pos.pos
         self.assertEqual(glyphstr([glyphs1]), "one")
-        self.assertEqual(val1.makeString(vertical=False), "1")
+        self.assertEqual(val1.asFea(), "1")
         self.assertEqual(glyphstr([glyphs2]), "two")
-        self.assertEqual(val2.makeString(vertical=False), "2")
+        self.assertEqual(val2.asFea(), "2")
         self.assertEqual(glyphstr([glyphs3]), "[five six]")
-        self.assertEqual(val3.makeString(vertical=False), "56")
+        self.assertEqual(val3.asFea(), "56")
         self.assertEqual(pos.prefix, [])
         self.assertEqual(pos.suffix, [])
 
@@ -774,7 +774,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsInstance(pos, ast.SinglePosStatement)
         [(glyphs, value)] = pos.pos
         self.assertEqual(glyphstr([glyphs]), "[T Y]")
-        self.assertEqual(value.makeString(vertical=False), "20")
+        self.assertEqual(value.asFea(), "20")
         self.assertEqual(glyphstr(pos.prefix), "[A B]")
         self.assertEqual(glyphstr(pos.suffix), "comma")
 
@@ -786,10 +786,9 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(type(pos), ast.PairPosStatement)
         self.assertFalse(pos.enumerated)
         self.assertEqual(glyphstr([pos.glyphs1]), "[T V]")
-        self.assertEqual(pos.valuerecord1.makeString(vertical=False), "-60")
+        self.assertEqual(pos.valuerecord1.asFea(), "-60")
         self.assertEqual(glyphstr([pos.glyphs2]), "[a b c]")
-        self.assertEqual(pos.valuerecord2.makeString(vertical=False),
-                         "<1 2 3 4>")
+        self.assertEqual(pos.valuerecord2.asFea(), "<1 2 3 4>")
 
     def test_gpos_type_2_format_a_enumerated(self):
         doc = self.parse("feature kern {"
@@ -799,10 +798,9 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(type(pos), ast.PairPosStatement)
         self.assertTrue(pos.enumerated)
         self.assertEqual(glyphstr([pos.glyphs1]), "[T V]")
-        self.assertEqual(pos.valuerecord1.makeString(vertical=False), "-60")
+        self.assertEqual(pos.valuerecord1.asFea(), "-60")
         self.assertEqual(glyphstr([pos.glyphs2]), "[a b c]")
-        self.assertEqual(pos.valuerecord2.makeString(vertical=False),
-                         "<1 2 3 4>")
+        self.assertEqual(pos.valuerecord2.asFea(), "<1 2 3 4>")
 
     def test_gpos_type_2_format_a_with_null_first(self):
         doc = self.parse("feature kern {"
@@ -813,10 +811,9 @@ class ParserTest(unittest.TestCase):
         self.assertFalse(pos.enumerated)
         self.assertEqual(glyphstr([pos.glyphs1]), "[T V]")
         self.assertFalse(pos.valuerecord1)
-        self.assertEqual(pos.valuerecord1.makeString(), "<NULL>")
+        self.assertEqual(pos.valuerecord1.asFea(), "<NULL>")
         self.assertEqual(glyphstr([pos.glyphs2]), "[a b c]")
-        self.assertEqual(pos.valuerecord2.makeString(vertical=False),
-                         "<1 2 3 4>")
+        self.assertEqual(pos.valuerecord2.asFea(), "<1 2 3 4>")
         self.assertEqual(pos.asFea(), "pos [T V] <NULL> [a b c] <1 2 3 4>;")
 
     def test_gpos_type_2_format_a_with_null_second(self):
@@ -827,8 +824,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(type(pos), ast.PairPosStatement)
         self.assertFalse(pos.enumerated)
         self.assertEqual(glyphstr([pos.glyphs1]), "[T V]")
-        self.assertEqual(pos.valuerecord1.makeString(vertical=False),
-                         "<1 2 3 4>")
+        self.assertEqual(pos.valuerecord1.asFea(), "<1 2 3 4>")
         self.assertEqual(glyphstr([pos.glyphs2]), "[a b c]")
         self.assertFalse(pos.valuerecord2)
         self.assertEqual(pos.asFea(), "pos [T V] [a b c] <1 2 3 4>;")
@@ -841,8 +837,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(type(pos), ast.PairPosStatement)
         self.assertFalse(pos.enumerated)
         self.assertEqual(glyphstr([pos.glyphs1]), "[T V]")
-        self.assertEqual(pos.valuerecord1.makeString(vertical=False),
-                         "<1 2 3 4>")
+        self.assertEqual(pos.valuerecord1.asFea(), "<1 2 3 4>")
         self.assertEqual(glyphstr([pos.glyphs2]), "[a b c]")
         self.assertIsNone(pos.valuerecord2)
 
@@ -854,8 +849,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(type(pos), ast.PairPosStatement)
         self.assertTrue(pos.enumerated)
         self.assertEqual(glyphstr([pos.glyphs1]), "[T V]")
-        self.assertEqual(pos.valuerecord1.makeString(vertical=False),
-                         "<1 2 3 4>")
+        self.assertEqual(pos.valuerecord1.asFea(), "<1 2 3 4>")
         self.assertEqual(glyphstr([pos.glyphs2]), "[a b c]")
         self.assertIsNone(pos.valuerecord2)
 
@@ -1442,7 +1436,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
         self.assertEqual(valuedef.asFea(), "valueRecordDef 123 foo;")
-        self.assertEqual(value.makeString(vertical=False), "123")
+        self.assertEqual(value.asFea(), "123")
 
     def test_valuerecord_format_a_vertical(self):
         doc = self.parse("feature vkrn {valueRecordDef 123 foo;} vkrn;")
@@ -1457,7 +1451,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
         self.assertEqual(valuedef.asFea(), "valueRecordDef 123 foo;")
-        self.assertEqual(value.makeString(vertical=True), "123")
+        self.assertEqual(value.asFea(), "123")
 
     def test_valuerecord_format_a_zero_horizontal(self):
         doc = self.parse("feature liga {valueRecordDef 0 foo;} liga;")
@@ -1472,7 +1466,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
         self.assertEqual(valuedef.asFea(), "valueRecordDef 0 foo;")
-        self.assertEqual(value.makeString(vertical=False), "0")
+        self.assertEqual(value.asFea(), "0")
 
     def test_valuerecord_format_a_zero_vertical(self):
         doc = self.parse("feature vkrn {valueRecordDef 0 foo;} vkrn;")
@@ -1487,7 +1481,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
         self.assertEqual(valuedef.asFea(), "valueRecordDef 0 foo;")
-        self.assertEqual(value.makeString(vertical=True), "0")
+        self.assertEqual(value.asFea(), "0")
 
     def test_valuerecord_format_a_vertical_contexts_(self):
         for tag in "vkrn vpal vhal valt".split():
@@ -1511,7 +1505,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
         self.assertEqual(valuedef.asFea(), "valueRecordDef <1 2 3 4> foo;")
-        self.assertEqual(value.makeString(vertical=False), "<1 2 3 4>")
+        self.assertEqual(value.asFea(), "<1 2 3 4>")
 
     def test_valuerecord_format_b_zero(self):
         doc = self.parse("feature liga {valueRecordDef <0 0 0 0> foo;} liga;")
@@ -1526,7 +1520,7 @@ class ParserTest(unittest.TestCase):
         self.assertIsNone(value.xAdvDevice)
         self.assertIsNone(value.yAdvDevice)
         self.assertEqual(valuedef.asFea(), "valueRecordDef <0 0 0 0> foo;")
-        self.assertEqual(value.makeString(vertical=False), "<0 0 0 0>")
+        self.assertEqual(value.asFea(), "<0 0 0 0>")
 
     def test_valuerecord_format_c(self):
         doc = self.parse(
@@ -1548,7 +1542,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(value.yPlaDevice, ((11, 111), (12, 112)))
         self.assertIsNone(value.xAdvDevice)
         self.assertEqual(value.yAdvDevice, ((33, -113), (44, -114), (55, 115)))
-        self.assertEqual(value.makeString(vertical=False),
+        self.assertEqual(value.asFea(),
                          "<1 2 3 4 <device 8 88> <device 11 111, 12 112>"
                          " <device NULL> <device 33 -113, 44 -114, 55 115>>")
 
@@ -1556,7 +1550,7 @@ class ParserTest(unittest.TestCase):
         doc = self.parse("feature test {valueRecordDef <NULL> foo;} test;")
         value = doc.statements[0].statements[0].value
         self.assertFalse(value)
-        self.assertEqual(value.makeString(), "<NULL>")
+        self.assertEqual(value.asFea(), "<NULL>")
 
     def test_valuerecord_named(self):
         doc = self.parse("valueRecordDef <1 2 3 4> foo;"


### PR DESCRIPTION
`ValueRecord` had a `makeString()` method that takes an optional `vertical` argument, but no code outside the tests sets this argument. Renamed it to `asFea()` and dropped the `vertical`, so that it consistent with the
rest of feaLib.ast classes. This also fixes `ValueRecordDefinition.asFea()` which was calling the not implemented `ValueRecord.asFea()`