### PR TITLE
[feaLib] Fix double indentation of markClass

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -425,7 +425,7 @@ class MarkClass(object):
         return tuple(self.glyphs.keys())
 
     def asFea(self, indent=""):
-        res = "\n".join(d.asFea(indent=indent) for d in self.definitions)
+        res = "\n".join(d.asFea() for d in self.definitions)
         return res
 
 
@@ -440,8 +440,8 @@ class MarkClassDefinition(Statement):
         return self.glyphs.glyphSet()
 
     def asFea(self, indent=""):
-        return "{}markClass {} {} @{};".format(
-            indent, self.glyphs.asFea(), self.anchor.asFea(),
+        return "markClass {} {} @{};".format(
+            self.glyphs.asFea(), self.anchor.asFea(),
             self.markClass.name)
 
 


### PR DESCRIPTION
When a `MarkClassDefinition` is inside a block, it gets double indentation compared to the rest of the block. It should ignore the `indent` argument like other similar statements.