### PR TITLE
[feaLib] Consistently escape glyph names

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -102,7 +102,8 @@ fea_keywords = set([
     "required", "righttoleft", "reversesub", "rsub",
     "script", "sub", "substitute", "subtable",
     "table",
-    "usemarkfilteringset", "useextension", "valuerecorddef"]
+    "usemarkfilteringset", "useextension", "valuerecorddef",
+    "base", "gdef", "head", "hhea", "name", "vhea", "vmtx"]
 )
 
 

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -160,7 +160,7 @@ class GlyphName(Expression):
         return (self.glyph,)
 
     def asFea(self, indent=""):
-        return str(self.glyph)
+        return asFea(self.glyph)
 
 
 class GlyphClass(Expression):

--- a/Tests/feaLib/ast_test.py
+++ b/Tests/feaLib/ast_test.py
@@ -1,0 +1,17 @@
+from __future__ import print_function, division, absolute_import
+from __future__ import unicode_literals
+from fontTools.feaLib import ast
+import unittest
+
+
+class AstTest(unittest.TestCase):
+    def test_glyphname_escape(self):
+        statement = ast.GlyphClass()
+        for name in ("BASE", "NULL", "foo", "a"):
+            statement.append(ast.GlyphName(name))
+        self.assertEqual(statement.asFea(), r"[\BASE \NULL foo a]")
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(unittest.main())


### PR DESCRIPTION
Add table names to the reserved keywords and make sure glyph names are always escaped written written back to feature files. This probably only affects AST tree that is created programmatically, not by parsing existing feature files. 