### PR TITLE
WIP: Fix deepcopy-ing of CFFs

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -890,7 +890,7 @@ def load_masters(designspace, master_finder=lambda s: s):
 				# 2. A SourceDescriptor's path might point an OpenType binary, a
 				# TTX file, or another source file (e.g. UFO), in which case we
 				# resolve the path using 'master_finder' function
-				font = _open_font(master.path, master_finder)
+				master.font = font = _open_font(master.path, master_finder)
 				master_fonts.append(font)
 
 	return master_fonts

--- a/Tests/cffLib/cffLib_test.py
+++ b/Tests/cffLib/cffLib_test.py
@@ -2,6 +2,8 @@ from __future__ import print_function, division, absolute_import
 from fontTools.cffLib import TopDict, PrivateDict, CharStrings
 from fontTools.misc.testTools import parseXML, DataFilesHandler
 from fontTools.ttLib import TTFont
+import copy
+import os
 import sys
 import unittest
 
@@ -58,6 +60,21 @@ class CffLibTest(DataFilesHandler):
         font2 = TTFont(save_path)
         topDict2 = font2["CFF "].cff.topDictIndex[0]
         self.assertEqual(topDict2.Encoding[32], "space")
+
+    def test_CFF_deepcopy(self):
+        """Test that deepcopying a TTFont with a CFF table does not recurse
+        infinitely."""
+        ttx_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "varLib",
+            "data",
+            "master_ttx_interpolatable_otf",
+            "TestFamily2-Master0.ttx",
+        )
+        font = TTFont(recalcBBoxes=False, recalcTimestamp=False)
+        font.importXML(ttx_path)
+        copy.deepcopy(font)
 
 
 if __name__ == "__main__":

--- a/Tests/varLib/interpolate_layout_test.py
+++ b/Tests/varLib/interpolate_layout_test.py
@@ -4,7 +4,7 @@ from fontTools.ttLib import TTFont
 from fontTools.varLib import build
 from fontTools.varLib.interpolate_layout import interpolate_layout
 from fontTools.varLib.interpolate_layout import main as interpolate_layout_main
-from fontTools.designspaceLib import DesignSpaceDocumentError
+from fontTools.designspaceLib import DesignSpaceDocument, DesignSpaceDocumentError
 from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
 import difflib
 import os
@@ -161,6 +161,22 @@ class InterpolateLayoutTest(unittest.TestCase):
         ds_path = self.get_test_input('InterpolateLayout3.designspace')
         with self.assertRaisesRegex(DesignSpaceDocumentError, "No axes defined"):
             instfont = interpolate_layout(ds_path, {'weight': 500})
+
+    def test_varlib_interpolate_layout_GSUB_only_otf(self):
+        """A smoke-test for layout-interpolating of OTFs."""
+        ds_path = self.get_test_input('InterpolateLayout.designspace')
+        ds = DesignSpaceDocument.fromfile(ds_path)
+        ttx_dir = self.get_test_input('master_ttx_interpolatable_otf')
+
+        self.temp_dir()
+        ttx_paths = self.get_file_list(ttx_dir, '.ttx', 'TestFamily2-')
+        for path, source in zip(ttx_paths, ds.sources):
+            font = TTFont(recalcBBoxes=False, recalcTimestamp=False)
+            font.importXML(path)
+            source.font = font
+
+        finder = lambda s: s
+        instfont = interpolate_layout(ds, {'weight': 500}, finder)
 
     def test_varlib_interpolate_layout_GPOS_only_size_feat_same_val_ttf(self):
         """Only GPOS; 'size' feature; same values in all masters.

--- a/Tests/varLib/interpolate_layout_test.py
+++ b/Tests/varLib/interpolate_layout_test.py
@@ -162,22 +162,6 @@ class InterpolateLayoutTest(unittest.TestCase):
         with self.assertRaisesRegex(DesignSpaceDocumentError, "No axes defined"):
             instfont = interpolate_layout(ds_path, {'weight': 500})
 
-    def test_varlib_interpolate_layout_GSUB_only_otf(self):
-        """A smoke-test for layout-interpolating of OTFs."""
-        ds_path = self.get_test_input('InterpolateLayout.designspace')
-        ds = DesignSpaceDocument.fromfile(ds_path)
-        ttx_dir = self.get_test_input('master_ttx_interpolatable_otf')
-
-        self.temp_dir()
-        ttx_paths = self.get_file_list(ttx_dir, '.ttx', 'TestFamily2-')
-        for path, source in zip(ttx_paths, ds.sources):
-            font = TTFont(recalcBBoxes=False, recalcTimestamp=False)
-            font.importXML(path)
-            source.font = font
-
-        finder = lambda s: s
-        instfont = interpolate_layout(ds, {'weight': 500}, finder)
-
     def test_varlib_interpolate_layout_GPOS_only_size_feat_same_val_ttf(self):
         """Only GPOS; 'size' feature; same values in all masters.
         """

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -366,11 +366,11 @@ class BuildTest(unittest.TestCase):
 
         ds_path = self.get_test_input("SparseMasters.designspace")
         ds = DesignSpaceDocument.fromfile(ds_path)
-        masters = load_masters(ds)
+        load_masters(ds)
 
         # Trigger MVAR generation so varLib is forced to create deltas with a
         # sparse master inbetween.
-        font_0_os2 = masters[0]["OS/2"]
+        font_0_os2 = ds.sources[0].font["OS/2"]
         font_0_os2.sTypoAscender = 1
         font_0_os2.sTypoDescender = 1
         font_0_os2.sTypoLineGap = 1
@@ -395,16 +395,16 @@ class BuildTest(unittest.TestCase):
         font_0_vhea.caretSlopeRise = 1
         font_0_vhea.caretSlopeRun = 1
         font_0_vhea.caretOffset = 1
-        masters[0]["vhea"] = font_0_vhea
-        font_0_hhea = masters[0]["hhea"]
+        ds.sources[0].font["vhea"] = font_0_vhea
+        font_0_hhea = ds.sources[0].font["hhea"]
         font_0_hhea.caretSlopeRise = 1
         font_0_hhea.caretSlopeRun = 1
         font_0_hhea.caretOffset = 1
-        font_0_post = masters[0]["post"]
+        font_0_post = ds.sources[0].font["post"]
         font_0_post.underlineThickness = 1
         font_0_post.underlinePosition = 1
 
-        font_2_os2 = masters[2]["OS/2"]
+        font_2_os2 = ds.sources[2].font["OS/2"]
         font_2_os2.sTypoAscender = 800
         font_2_os2.sTypoDescender = 800
         font_2_os2.sTypoLineGap = 800
@@ -429,17 +429,14 @@ class BuildTest(unittest.TestCase):
         font_2_vhea.caretSlopeRise = 800
         font_2_vhea.caretSlopeRun = 800
         font_2_vhea.caretOffset = 800
-        masters[2]["vhea"] = font_2_vhea
-        font_2_hhea = masters[2]["hhea"]
+        ds.sources[2].font["vhea"] = font_2_vhea
+        font_2_hhea = ds.sources[2].font["hhea"]
         font_2_hhea.caretSlopeRise = 800
         font_2_hhea.caretSlopeRun = 800
         font_2_hhea.caretOffset = 800
-        font_2_post = masters[2]["post"]
+        font_2_post = ds.sources[2].font["post"]
         font_2_post.underlineThickness = 800
         font_2_post.underlinePosition = 800
-
-        for m, s in zip(masters, ds.sources):
-            s.font = m
 
         varfont, _, _ = build(ds)
         mvar_tags = [vr.ValueTag for vr in varfont["MVAR"].table.ValueRecord]


### PR DESCRIPTION
Deepcopying a TTFont with a CFF table can result in an infinite recursion on Python 3 under certain circumstances.

@anthrotype found that CFFFontSet keeps a reference to the TTFont object that holds it to get at the glyph order at some point: https://github.com/fonttools/fonttools/blob/master/Lib/fontTools/cffLib/__init__.py#L34. Maybe this messes with `deepcopy`.