### PR TITLE
[cffLib] Replace `PrivateDict.__getattr__` with property for `in_cff2`

### DIFF
--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -2432,11 +2432,9 @@ class PrivateDict(BaseDict):
 			self.defaults = buildDefaults(privateDictOperators)
 			self.order = buildOrder(privateDictOperators)
 
-	def __getattr__(self, name):
-		if name == "in_cff2":
-			return self._isCFF2
-		value = BaseDict.__getattr__(self, name)
-		return value
+	@property
+	def in_cff2(self):
+		return self._isCFF2
 
 	def getNumRegions(self, vi=None):  # called from misc/psCharStrings.py
 		# if getNumRegions is being called, we can assume that VarStore exists.


### PR DESCRIPTION
The dunder method doesn't seem to be doing anything other than providing an `in_cff2` attribute. Do that with a property instead of bending `__getattr__`.

This one confused me when I was working on https://github.com/fonttools/fonttools/pull/1488.