### PR TITLE
[subset] Fix 'AttributeError: GlobalSubrs' with --desubroutinize option

### DIFF
--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -607,6 +607,9 @@ class Index(object):
 	def getCompiler(self, strings, parent, isCFF2=None):
 		return self.compilerClass(self, strings, parent, isCFF2=isCFF2)
 
+	def clear(self):
+		del self.items[:]
+
 
 class GlobalSubrsIndex(Index):
 

--- a/Lib/fontTools/subset/cff.py
+++ b/Lib/fontTools/subset/cff.py
@@ -470,9 +470,7 @@ def desubroutinize(self):
 				del pd.Subrs
 			if 'Subrs' in pd.rawDict:
 				del pd.rawDict['Subrs']
-	# clear GlobalSubrsIndex
-	if cff.GlobalSubrs:
-		cff.GlobalSubrs.items = []
+	cff.GlobalSubrs.clear()
 
 
 @_add_method(ttLib.getTableClass('CFF '))

--- a/Lib/fontTools/subset/cff.py
+++ b/Lib/fontTools/subset/cff.py
@@ -425,16 +425,12 @@ def prune_post_subset(self, ttfFont, options):
 	# Desubroutinize if asked for
 	if options.desubroutinize:
 		self.desubroutinize()
-	else:
-		for fontname in cff.keys():
-			font = cff[fontname]
-			self.remove_unused_subroutines()
 
 	# Drop hints if not needed
 	if not options.hinting:
 		self.remove_hints()
-
-
+	elif not options.desubroutinize:
+		self.remove_unused_subroutines()
 	return True
 
 
@@ -468,7 +464,15 @@ def desubroutinize(self):
 					del pd.Subrs
 				if 'Subrs' in pd.rawDict:
 					del pd.rawDict['Subrs']
-	self.remove_unused_subroutines()
+		else:
+			pd = font.Private
+			if hasattr(pd, 'Subrs'):
+				del pd.Subrs
+			if 'Subrs' in pd.rawDict:
+				del pd.rawDict['Subrs']
+	# clear GlobalSubrsIndex
+	if cff.GlobalSubrs:
+		cff.GlobalSubrs.items = []
 
 
 @_add_method(ttLib.getTableClass('CFF '))
@@ -506,7 +510,7 @@ def remove_hints(self):
 		for charstring in css:
 			charstring.drop_hints()
 		del css
-		
+
 		# Drop font-wide hinting values
 		all_privs = []
 		if hasattr(font, 'FDArray'):


### PR DESCRIPTION
@readroberts PTAL

Fixes #1483

'remove_unused_subroutines' method expects a 'GlobalSubrs' attribute but the 'desubroutinize'
method deletes it. We don't have to call 'remove_unused_subroutines' at the end of 'desubroutinize'
method, we can just delete all the local subroutines, and clear the GlobalSubrsIndex.

Only call 'remove_unused_subroutines' method once, when we are not desubroutinizing.