### PR TITLE
Prevent UnicodeDecodeError on py27; this fixes #1494

### DIFF
--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -1599,10 +1599,10 @@ def _sniffFileStructure(ufo_path):
 		return UFOFileStructure.PACKAGE
 	elif os.path.isfile(ufo_path):
 		raise UFOLibError(
-			"The specified UFO does not have a known structure: '%s'" % ufo_path
+			"The specified UFO does not have a known structure: %r" % ufo_path
 		)
 	else:
-		raise UFOLibError("No such file or directory: '%s'" % ufo_path)
+		raise UFOLibError("No such file or directory: %r" % ufo_path)
 
 
 def makeUFOPath(path):


### PR DESCRIPTION
I forgot, there wasn't something agains using `%r` for paths? Using it here does prevent #1494 from happening. I could add a test, but it seems it would require a new test file, as all ufoLib test files seem to have a special subject, and none seems to fit the bill for this little thing.