### PR TITLE
[feaLib] Allow hyphen in glyph class names

### DIFF
--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -28,7 +28,7 @@ class Lexer(object):
     CHAR_NAME_START_ = CHAR_LETTER_ + "_+*:.^~!\\"
     CHAR_NAME_CONTINUATION_ = CHAR_LETTER_ + CHAR_DIGIT_ + "_.+*:^~!/-"
 
-    RE_GLYPHCLASS = re.compile(r"^[A-Za-z_0-9.]+$")
+    RE_GLYPHCLASS = re.compile(r"^[A-Za-z_0-9.\-]+$")
 
     MODE_NORMAL_ = "NORMAL"
     MODE_FILENAME_ = "FILENAME"
@@ -113,7 +113,7 @@ class Lexer(object):
             if not Lexer.RE_GLYPHCLASS.match(glyphclass):
                 raise FeatureLibError(
                     "Glyph class names must consist of letters, digits, "
-                    "underscore, or period", location)
+                    "underscore, period or hyphen", location)
             return (Lexer.GLYPHCLASS, glyphclass, location)
         if cur_char in Lexer.CHAR_NAME_START_:
             self.pos_ += 1

--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -39,6 +39,7 @@ class LexerTest(unittest.TestCase):
 
     def test_glyphclass(self):
         self.assertEqual(lex("@Vowel.sc"), [(Lexer.GLYPHCLASS, "Vowel.sc")])
+        self.assertEqual(lex("@Vowel-sc"), [(Lexer.GLYPHCLASS, "Vowel-sc")])
         self.assertRaisesRegex(FeatureLibError,
                                "Expected glyph class", lex, "@(a)")
         self.assertRaisesRegex(FeatureLibError,


### PR DESCRIPTION
Matches AFDKO’s makeotf behaviour.