### PR TITLE
[subset CFF] Fix de-subroutinizing bug when subroutines contain hints

### DIFF
--- a/Tests/subset/data/expect_no_hinting_desubroutinize_CFF.ttx
+++ b/Tests/subset/data/expect_no_hinting_desubroutinize_CFF.ttx
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="OTTO" ttLibVersion="3.5">
+<ttFont sfntVersion="OTTO" ttLibVersion="3.37">
 
   <CFF>
     <major value="1"/>
     <minor value="0"/>
-    <CFFFont name="Lobster1.4">
-      <version value="001.001"/>
-      <Notice value="Copyright (c) 2010 by Pablo Impallari. www.impallari.com. All rights reserved."/>
-      <Copyright value="Copyright (c) 2010 by Pablo Impallari. All rights reserved."/>
-      <FullName value="Lobster 1.4"/>
-      <FamilyName value="Lobster 1.4"/>
-      <Weight value="Regular"/>
+    <CFFFont name="SourceSerifPro-Regular">
+      <version value="1.0"/>
+      <Notice value="Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries."/>
+      <Copyright value="Copyright 2014 Adobe Systems Incorporated. All Rights Reserved."/>
+      <FamilyName value="Source Serif Pro"/>
       <isFixedPitch value="0"/>
       <ItalicAngle value="0"/>
       <UnderlinePosition value="-100"/>
@@ -18,7 +16,7 @@
       <PaintType value="0"/>
       <CharstringType value="2"/>
       <FontMatrix value="0.001 0 0 0.001 0 0"/>
-      <FontBBox value="-209 -250 1186 1000"/>
+      <FontBBox value="0 -249 560 758"/>
       <StrokeWidth value="0"/>
       <!-- charset is dumped separately as the 'GlyphOrder' element -->
       <Encoding name="StandardEncoding"/>
@@ -30,165 +28,62 @@
         <LanguageGroup value="0"/>
         <ExpansionFactor value="0.06"/>
         <initialRandomSeed value="0"/>
-        <defaultWidthX value="267"/>
-        <nominalWidthX value="448"/>
+        <defaultWidthX value="0"/>
+        <nominalWidthX value="604"/>
       </Private>
       <CharStrings>
         <CharString name=".notdef">
-          -63 endchar
-        </CharString>
-        <CharString name="A">
-          220 535 hmoveto
-          157 736 rlineto
-          10 -24 -32 4 -23 hhcurveto
-          -117 -130 -135 -160 -101 hvcurveto
-          2 -21 -17 1 -14 hhcurveto
-          -118 -86 -55 -68 -39 28 -19 34 31 25 15 24 14 -8 17 -5 hvcurveto
-          13 34 42 14 62 4 rrcurveto
-          -87 -153 -60 -164 -90 vvcurveto
-          -104 80 -2 54 vhcurveto
-          -6 9 -8 15 32 vvcurveto
-          104 55 190 75 163 vhcurveto
-          44 -4 39 -9 51 -23 -77 -363 rcurveline
-          86 407 rmoveto
-          -39 16 -43 11 -40 8 56 112 64 93 60 32 rrcurveto
+          36 80 hmoveto
+          480 669 -480 hlineto
+          240 -286 rmoveto
+          -148 236 rlineto
+          296 hlineto
+          32 -523 rmoveto
+          -149 239 149 238 rlineto
+          -360 -477 rmoveto
+          477 vlineto
+          150 -238 rlineto
+          -118 -285 rmoveto
+          148 236 148 -236 rlineto
           endchar
         </CharString>
-        <CharString name="A.salt">
-          142 459 hmoveto
-          157 736 rlineto
-          12 -30 -26 3 -24 hhcurveto
-          -238 -290 -563 -189 -106 65 -2 69 -4 hvcurveto
-          -1 9 -13 -4 51 vvcurveto
-          97 42 172 64 154 vhcurveto
-          158 hlineto
-          -77 -366 rlineto
-          -59 418 rmoveto
-          58 126 72 106 73 32 -56 -264 rcurveline
+        <CharString name="y">
+          -92 92 -249 rmoveto
+          82 56 75 177 67 hvcurveto
+          161 425 54 11 rlineto
+          36 -195 vlineto
+          -36 vlineto
+          87 -12 -123 -340 rlineto
+          -125 341 88 10 rlineto
+          37 -240 vlineto
+          -36 vlineto
+          55 -8 181 -457 -4 -12 -19 -54 -29 -54 -42 -36 rlinecurve
+          -5 5 rlineto
+          28 -27 -21 10 -26 hhcurveto
+          -31 -29 -15 -29 -7 hvcurveto
+          -39 42 -27 50 vhcurveto
           endchar
         </CharString>
-        <CharString name="B">
-          187 230 636 rmoveto
-          -136 -636 rlineto
-          144 hlineto
-          82 383 rlineto
-          2 18 20 1 8 hhcurveto
-          73 22 -57 -70 hvcurveto
-          -76 -26 -104 -73 -23 -19 10 26 -25 vhcurveto
-          -9 -23 -4 -19 -16 vvcurveto
-          -61 56 -13 43 167 52 192 96 75 -33 69 -85 17 vhcurveto
-          65 37 35 63 59 vvcurveto
-          82 -66 77 -147 -189 -174 -127 -138 -67 41 -25 66 vhcurveto
-          -1 9 -13 8 51 vvcurveto
-          165 133 78 117 95 37 -51 -57 -75 -64 -87 -80 vhcurveto
-          -6 hlineto
-          47 222 rlineto
-          endchar
-        </CharString>
-        <CharString name="B.salt">
-          185 230 636 rmoveto
-          -136 -636 rlineto
-          144 hlineto
-          6 30 rlineto
-          -41 39 41 -17 39 hhcurveto
-          125 110 175 136 72 -32 62 -82 15 hvcurveto
-          64 38 36 61 58 vvcurveto
-          83 -74 78 -144 -183 -177 -126 -139 -67 41 -25 66 vhcurveto
-          -1 9 -13 8 51 vvcurveto
-          152 116 91 138 101 25 -49 -53 -81 -59 -87 -83 vhcurveto
-          -6 hlineto
-          47 222 rlineto
-          -59 -592 rmoveto
-          -20 -21 8 21 -20 hvcurveto
-          62 290 rlineto
-          2 18 20 1 7 hhcurveto
-          63 21 -49 -57 -96 -58 -120 -72 hvcurveto
-          endchar
-        </CharString>
-        <CharString name="I">
-          -73 397 748 rmoveto
-          1 -13 -13 1 -14 hhcurveto
-          -167 -184 -127 -133 -72 38 -25 69 hvcurveto
-          -1 9 -13 8 51 vvcurveto
-          107 53 75 87 36 vhcurveto
-          -145 -679 rlineto
-          144 hlineto
-          endchar
-        </CharString>
-        <CharString name="IJ">
-          215 397 748 rmoveto
-          1 -13 -13 1 -14 hhcurveto
-          -167 -184 -127 -133 -72 38 -25 69 hvcurveto
-          -1 9 -13 8 51 vvcurveto
-          107 53 75 87 36 vhcurveto
-          -145 -679 rlineto
-          34 hlineto
-          -11 -20 -5 -23 -27 vvcurveto
-          -79 48 -58 113 155 66 109 138 29 vhcurveto
-          150 710 -150 -33 -164 -751 rlineto
-          -100 -22 -30 -23 -40 hhcurveto
-          -44 -27 29 39 40 29 33 36 16 17 -7 -16 16 hvcurveto
-          4 11 3 11 11 vvcurveto
-          34 -26 24 -41 6 vhcurveto
-          endchar
-        </CharString>
-        <CharString name="J">
-          88 538 750 rmoveto
-          -167 -184 -127 -133 -72 38 -25 69 hvcurveto
-          -1 9 -13 8 51 vvcurveto
-          107 54 76 87 36 vhcurveto
-          -157 -714 rlineto
-          -103 -23 -27 -20 -45 hhcurveto
-          -29 -39 18 52 37 24 37 46 20 15 -5 -21 25 hvcurveto
-          4 15 2 14 11 vvcurveto
-          64 -58 3 -40 -79 -43 -66 -68 -83 53 -58 95 164 67 94 153 32 vhcurveto
-          150 710 rlineto
-          endchar
-        </CharString>
-        <CharString name="one">
-          -131 324 748 rmoveto
-          -72 -121 -78 -6 -55 hhcurveto
-          -12 -46 rlineto
-          95 hlineto
-          -132 -624 rlineto
-          144 hlineto
-          endchar
-        </CharString>
-        <CharString name="three">
-          66 205 257 rmoveto
-          38 -8 -33 13 -37 hhcurveto
-          -80 -41 -60 -83 -154 141 -16 58 171 111 136 121 71 -38 65 -88 29 hvcurveto
-          92 46 45 74 66 vvcurveto
-          78 -63 68 -123 vhcurveto
-          -116 -91 -61 -91 -54 32 -31 40 24 27 11 23 25 hvcurveto
-          -28 8 -10 36 27 vvcurveto
-          47 31 31 48 51 25 -36 -46 -70 -58 -94 -113 -31 vhcurveto
-          93 -33 40 -80 -76 vvcurveto
-          -87 -53 -82 -86 -37 -39 13 76 40 10 62 78 6 vhcurveto
-          endchar
-        </CharString>
-        <CharString name="two">
-          44 111 132 rmoveto
-          -5 hlineto
-          83 135 273 98 223 vvcurveto
-          97 -53 64 -137 -151 -55 -79 -68 -58 31 -32 41 24 26 11 23 26 vhcurveto
-          -28 8 -10 37 23 vvcurveto
-          50 14 31 67 29 32 -33 -49 vhcurveto
-          -266 -329 -98 -219 vvcurveto
-          -11 0 -11 2 -11 vhcurveto
-          7 20 36 21 23 hhcurveto
-          102 37 -36 109 hhcurveto
-          99 20 52 98 14 0 14 -1 16 hvcurveto
-          -44 -47 -17 -25 -70 hhcurveto
-          -75 -57 18 -59 hhcurveto
-          endchar
-        </CharString>
-        <CharString name="zero">
-          98 377 750 rmoveto
-          -215 -132 -223 -273 -166 35 -97 172 205 113 299 199 168 -53 93 -125 hvcurveto
-          -189 -425 rmoveto
-          225 17 105 148 60 hhcurveto
-          47 7 -63 -82 -232 -68 -246 -114 -48 -11 77 74 37 3 35 2 27 hvcurveto
+        <CharString name="yacute">
+          -92 92 -249 rmoveto
+          82 56 75 177 67 hvcurveto
+          161 425 54 11 rlineto
+          36 -195 vlineto
+          -36 vlineto
+          87 -12 -123 -340 rlineto
+          -125 341 88 10 rlineto
+          37 -240 vlineto
+          -36 vlineto
+          55 -8 181 -457 -4 -12 -19 -54 -29 -54 -42 -36 rlinecurve
+          -5 5 rlineto
+          28 -27 -21 10 -26 hhcurveto
+          -31 -29 -15 -29 -7 hvcurveto
+          -39 42 -27 50 vhcurveto
+          155 825 rmoveto
+          26 -19 41 36 39 35 41 37 rlinecurve
+          28 26 6 15 14 vvcurveto
+          26 -19 12 -19 -18 -17 -10 -31 -19 vhcurveto
+          -32 -48 -29 -46 -28 -47 rrcurveto
           endchar
         </CharString>
       </CharStrings>

--- a/Tests/subset/data/test_hinted_subrs_CFF.desub.ttx
+++ b/Tests/subset/data/test_hinted_subrs_CFF.desub.ttx
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="3.37">
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="SourceSerifPro-Regular">
+      <version value="1.0"/>
+      <Notice value="Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries."/>
+      <Copyright value="Copyright 2014 Adobe Systems Incorporated. All Rights Reserved."/>
+      <FamilyName value="Source Serif Pro"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlinePosition value="-100"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="0 -249 560 758"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueValues value="-15 0 475 488 527 540 549 563 646 659 669 684 729 749"/>
+        <OtherBlues value="-249 -239"/>
+        <FamilyBlues value="-15 0 475 488 527 540 549 563 646 659 669 684 729 749"/>
+        <FamilyOtherBlues value="-249 -239"/>
+        <BlueScale value="0.0375"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="0"/>
+        <StdHW value="56"/>
+        <StdVW value="85"/>
+        <StemSnapH value="41 56"/>
+        <StemSnapV value="85 95"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="0"/>
+        <nominalWidthX value="604"/>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          36 0 50 569 50 hstem
+          80 60 360 60 vstem
+          80 hmoveto
+          480 669 -480 hlineto
+          240 -286 rmoveto
+          -148 236 rlineto
+          296 hlineto
+          32 -523 rmoveto
+          -149 239 149 238 rlineto
+          -360 -477 rmoveto
+          477 vlineto
+          150 -238 rlineto
+          -118 -285 rmoveto
+          148 236 148 -236 rlineto
+          endchar
+        </CharString>
+        <CharString name="y">
+          -92 -249 110 572 42 -40 40 -36 36 0 1 hstemhm
+          0 512 -195 195 vstemhm
+          92 -249 rmoveto
+          82 56 75 177 67 hvcurveto
+          161 425 54 11 rlineto
+          36 -195 vlineto
+          -36 vlineto
+          87 -12 -123 -340 rlineto
+          -125 341 88 10 rlineto
+          37 -240 vlineto
+          -36 vlineto
+          55 -8 181 -457 -4 -12 -19 -54 -29 -54 -42 -36 rlinecurve
+          -5 5 rlineto
+          28 -27 -21 10 -26 hhcurveto
+          -31 -29 -15 -29 -7 hvcurveto
+          -39 42 -27 50 vhcurveto
+          hintmask 11001000
+          endchar
+        </CharString>
+        <CharString name="yacute">
+          -92 -249 110 572 42 -40 40 -36 36 10 5 5 4 3 2 2 1 1 0 hstemhm
+          0 512 -195 195 vstemhm
+          92 -249 rmoveto
+          82 56 75 177 67 hvcurveto
+          161 425 54 11 rlineto
+          36 -195 vlineto
+          -36 vlineto
+          87 -12 -123 -340 rlineto
+          -125 341 88 10 rlineto
+          37 -240 vlineto
+          -36 vlineto
+          55 -8 181 -457 -4 -12 -19 -54 -29 -54 -42 -36 rlinecurve
+          -5 5 rlineto
+          28 -27 -21 10 -26 hhcurveto
+          -31 -29 -15 -29 -7 hvcurveto
+          -39 42 -27 50 vhcurveto
+          hintmask 1100100010000000
+          155 825 rmoveto
+          26 -19 41 36 39 35 41 37 rlinecurve
+          28 26 6 15 14 vvcurveto
+          26 -19 12 -19 -18 -17 -10 -31 -19 vhcurveto
+          -32 -48 -29 -46 -28 -47 rrcurveto
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+</ttFont>

--- a/Tests/subset/data/test_hinted_subrs_CFF.ttx
+++ b/Tests/subset/data/test_hinted_subrs_CFF.ttx
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="3.37">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="y"/>
+    <GlyphID id="2" name="yacute"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="2.0"/>
+    <checkSumAdjustment value="0x30fffb39"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Wed Jan  4 11:55:59 2017"/>
+    <modified value="Sat Feb  9 07:43:13 2019"/>
+    <xMin value="0"/>
+    <yMin value="-249"/>
+    <xMax value="560"/>
+    <yMax value="758"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1036"/>
+    <descent value="-335"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="640"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="0"/>
+    <xMaxExtent value="560"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="2"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="3"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="3"/>
+    <xAvgCharWidth value="554"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="285"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="4"/>
+      <bWeight value="6"/>
+      <bProportion value="3"/>
+      <bContrast value="5"/>
+      <bStrokeVariation value="4"/>
+      <bArmStyle value="5"/>
+      <bLetterForm value="2"/>
+      <bMidline value="2"/>
+      <bXHeight value="4"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000011"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="ADBO"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="121"/>
+    <usLastCharIndex value="253"/>
+    <sTypoAscender value="730"/>
+    <sTypoDescender value="-270"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1036"/>
+    <usWinDescent value="335"/>
+    <ulCodePageRange1 value="00100000 00000000 00000001 10011111"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="475"/>
+    <sCapHeight value="670"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="3"/>
+  </OS_2>
+
+  <name>
+    <namerecord nameID="0" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Copyright 2014, 2015, 2016 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name 'Source'.
+    </namerecord>
+    <namerecord nameID="1" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Source Serif Pro
+    </namerecord>
+    <namerecord nameID="2" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      2.000;ADBO;SourceSerifPro-Regular;ADOBE
+    </namerecord>
+    <namerecord nameID="4" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Source Serif Pro
+    </namerecord>
+    <namerecord nameID="5" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Version 2.000;PS 1.0;hotconv 16.6.51;makeotf.lib2.5.65220
+    </namerecord>
+    <namerecord nameID="6" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      SourceSerifPro-Regular
+    </namerecord>
+    <namerecord nameID="7" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries.
+    </namerecord>
+    <namerecord nameID="8" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Adobe Systems Incorporated
+    </namerecord>
+    <namerecord nameID="9" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Frank Grießhammer
+    </namerecord>
+    <namerecord nameID="11" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      http://www.adobe.com/type
+    </namerecord>
+    <namerecord nameID="13" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1.&#13;
+&#13;
+This Font Software is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2014, 2015, 2016 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name 'Source'.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Source Serif Pro
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      2.000;ADBO;SourceSerifPro-Regular;ADOBE
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Source Serif Pro
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 2.000;PS 1.0;hotconv 16.6.51;makeotf.lib2.5.65220
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      SourceSerifPro-Regular
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries.
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Adobe Systems Incorporated
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Frank Grießhammer
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://www.adobe.com/type
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      This Font Software is licensed under the SIL Open Font License, Version 1.1.&#13;
+&#13;
+This Font Software is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://scripts.sil.org/OFL
+    </namerecord>
+  </name>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x79" name="y"/><!-- LATIN SMALL LETTER Y -->
+      <map code="0xfd" name="yacute"/><!-- LATIN SMALL LETTER Y WITH ACUTE -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x79" name="y"/><!-- LATIN SMALL LETTER Y -->
+      <map code="0xfd" name="yacute"/><!-- LATIN SMALL LETTER Y WITH ACUTE -->
+    </cmap_format_4>
+    <cmap_format_12 platformID="3" platEncID="10" format="12" reserved="0" length="40" language="0" nGroups="2">
+      <map code="0x79" name="y"/><!-- LATIN SMALL LETTER Y -->
+      <map code="0xfd" name="yacute"/><!-- LATIN SMALL LETTER Y WITH ACUTE -->
+    </cmap_format_12>
+  </cmap>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="SourceSerifPro-Regular">
+      <version value="1.0"/>
+      <Notice value="Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries."/>
+      <Copyright value="Copyright 2014 Adobe Systems Incorporated. All Rights Reserved."/>
+      <FamilyName value="Source Serif Pro"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlinePosition value="-100"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="0 -249 560 758"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueValues value="-15 0 475 488 527 540 549 563 646 659 669 684 729 749"/>
+        <OtherBlues value="-249 -239"/>
+        <FamilyBlues value="-15 0 475 488 527 540 549 563 646 659 669 684 729 749"/>
+        <FamilyOtherBlues value="-249 -239"/>
+        <BlueScale value="0.0375"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="0"/>
+        <StdHW value="56"/>
+        <StdVW value="85"/>
+        <StemSnapH value="41 56"/>
+        <StemSnapV value="85 95"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="0"/>
+        <nominalWidthX value="604"/>
+        <Subrs>
+          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+          <CharString index="0">
+            rmoveto
+            26 -19 41 36 39 35 41 37 rlinecurve
+            28 26 6 15 14 vvcurveto
+            26 -19 12 -19 -18 -17 -10 -31 -19 vhcurveto
+            -32 -48 -29 -46 -28 -47 rrcurveto
+            endchar
+          </CharString>
+          <CharString index="1">
+            195 vstemhm
+            -107 callgsubr
+            161 425 54 11 rlineto
+            36 -195 vlineto
+            -36 vlineto
+            87 -12 -123 -340 rlineto
+            -125 341 88 10 rlineto
+            37 -240 vlineto
+            -105 callsubr
+            -39 42 -27 50 vhcurveto
+            return
+          </CharString>
+          <CharString index="2">
+            -36 vlineto
+            55 -8 181 -457 -4 -12 -19 -54 -29 -54 -42 -36 rlinecurve
+            -5 5 rlineto
+            28 -27 -21 10 -26 hhcurveto
+            -31 -29 -15 -29 -7 hvcurveto
+            return
+          </CharString>
+          <CharString index="3">
+            -92 -249 110 572 42 -40 40 -36 36 return
+          </CharString>
+          <CharString index="4">
+            hstemhm
+            return
+          </CharString>
+        </Subrs>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          36 0 50 569 50 hstem
+          80 60 360 60 vstem
+          80 hmoveto
+          480 669 -480 hlineto
+          240 -286 rmoveto
+          -148 236 rlineto
+          296 hlineto
+          32 -523 rmoveto
+          -149 239 149 238 rlineto
+          -360 -477 rmoveto
+          477 vlineto
+          150 -238 rlineto
+          -118 -285 rmoveto
+          148 236 148 -236 rlineto
+          endchar
+        </CharString>
+        <CharString name="y">
+          -104 callsubr
+          0 1 -103 callsubr
+          0 512 -195 -106 callsubr
+          hintmask 11001000
+          endchar
+        </CharString>
+        <CharString name="yacute">
+          -104 callsubr
+          10 5 5 4 3 2 2 1 1 0 -103 callsubr
+          0 512 -195 -106 callsubr
+          hintmask 1100100010000000
+          155 825 -107 callsubr
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+      <CharString index="0">
+        92 -249 rmoveto
+        82 56 75 177 67 hvcurveto
+        return
+      </CharString>
+    </GlobalSubrs>
+  </CFF>
+
+  <hmtx>
+    <mtx name=".notdef" width="640" lsb="80"/>
+    <mtx name="y" width="512" lsb="0"/>
+    <mtx name="yacute" width="512" lsb="0"/>
+  </hmtx>
+
+</ttFont>

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -416,6 +416,16 @@ class SubsetTest(unittest.TestCase):
         self.expect_ttx(subsetfont, self.getpath(
             "expect_desubroutinize_CFF.ttx"), ["CFF "])
 
+    def test_desubroutinize_hinted_subrs_CFF(self):
+        ttxpath = self.getpath("test_hinted_subrs_CFF.ttx")
+        _, fontpath = self.compile_font(ttxpath, ".otf")
+        subsetpath = self.temp_path(".otf")
+        subset.main([fontpath, "--desubroutinize", "--notdef-outline",
+                     "--output-file=%s" % subsetpath, "*"])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath(
+            "test_hinted_subrs_CFF.desub.ttx"), ["CFF "])
+
     def test_no_hinting_desubroutinize_CFF(self):
         ttxpath = self.getpath("Lobster.subset.ttx")
         _, fontpath = self.compile_font(ttxpath, ".otf")

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -427,7 +427,7 @@ class SubsetTest(unittest.TestCase):
             "test_hinted_subrs_CFF.desub.ttx"), ["CFF "])
 
     def test_no_hinting_desubroutinize_CFF(self):
-        ttxpath = self.getpath("Lobster.subset.ttx")
+        ttxpath = self.getpath("test_hinted_subrs_CFF.ttx")
         _, fontpath = self.compile_font(ttxpath, ".otf")
         subsetpath = self.temp_path(".otf")
         subset.main([fontpath, "--no-hinting", "--desubroutinize", "--notdef-outline",


### PR DESCRIPTION
Fixes issue 1493

The  code was skipping executing a subroutine if it had already been desubroutinized. The initial set of vstemhm and hstemhm operators and values may be in a subroutine. If a charstring is being executed which calls such subroutines, they still need to be executed in order to count the number of hint values seen, so that the byte length of the hintmask can be calculated.

I fixed this bug by executing subroutines even if they have already been desubroutinized, as long  as  (we don't know yet if we are doing hintmasks) or ( we do need a hintmask, but have not yet seen it).