### PR TITLE
Read special case of contextual positioning

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -404,7 +404,9 @@ class Parser(object):
             return ([], prefix, [None] * len(prefix), values, [], hasMarks)
         else:
             assert not any(values[:len(prefix)]), values
-            values = values[len(prefix):][:len(glyphs)]
+            format1 = values[len(prefix):][:len(glyphs)]
+            format2 = values[len(prefix) + len(glyphs):][:len(suffix)]
+            values = format2 if format2 and isinstance(format2[0], self.ast.ValueRecord) else format1
             return (prefix, glyphs, lookups, values, suffix, hasMarks)
 
     def parse_chain_context_(self):

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -405,7 +405,7 @@ class Parser(object):
         else:
             assert not any(values[:len(prefix)]), values
             format1 = values[len(prefix):][:len(glyphs)]
-            format2 = values[len(prefix) + len(glyphs):][:len(suffix)]
+            format2 = values[(len(prefix) + len(glyphs)):][:len(suffix)]
             values = format2 if format2 and isinstance(format2[0], self.ast.ValueRecord) else format1
             return (prefix, glyphs, lookups, values, suffix, hasMarks)
 

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -778,6 +778,26 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(glyphstr(pos.prefix), "[A B]")
         self.assertEqual(glyphstr(pos.suffix), "comma")
 
+    def test_gpos_type_1_chained_special_kern_format_valuerecord_format_a(self):
+        doc = self.parse("feature kern {pos [A B] [T Y]' comma 20;} kern;")
+        pos = doc.statements[0].statements[0]
+        self.assertIsInstance(pos, ast.SinglePosStatement)
+        [(glyphs, value)] = pos.pos
+        self.assertEqual(glyphstr([glyphs]), "[T Y]")
+        self.assertEqual(value.asFea(), "20")
+        self.assertEqual(glyphstr(pos.prefix), "[A B]")
+        self.assertEqual(glyphstr(pos.suffix), "comma")
+
+    def test_gpos_type_1_chained_special_kern_format_valuerecord_format_b(self):
+        doc = self.parse("feature kern {pos [A B] [T Y]' comma <0 0 0 0>;} kern;")
+        pos = doc.statements[0].statements[0]
+        self.assertIsInstance(pos, ast.SinglePosStatement)
+        [(glyphs, value)] = pos.pos
+        self.assertEqual(glyphstr([glyphs]), "[T Y]")
+        self.assertEqual(value.asFea(), "<0 0 0 0>")
+        self.assertEqual(glyphstr(pos.prefix), "[A B]")
+        self.assertEqual(glyphstr(pos.suffix), "comma")
+
     def test_gpos_type_2_format_a(self):
         doc = self.parse("feature kern {"
                          "    pos [T V] -60 [a b c] <1 2 3 4>;"


### PR DESCRIPTION
As explained here: https://github.com/fonttools/fonttools/issues/1468
If the ValueRecord comes after a suffix instead of directly after the affected glyphs then we still want to read it. Currently the ValueRecord is silently skipped, resulting in missing kerning. 

There's really no way to roundtrip with asFea() because from a compiled source we can't know that the original FDK code was written this way. That means if the original code is 

`position L' quoteright -150;`

then the asFea() output will become

`position L' -150 quoteright;`

I don't see any problem with this as this "special case" format is really just a convenience for FDK source and I assume most code is written the normal way. If not we probably would have run into this long ago. 