### PR TITLE
[feaLib] Fix double indentation of subtable

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1088,7 +1088,7 @@ class SubtableStatement(Statement):
         builder.add_subtable_break(self.location)
 
     def asFea(self, indent=""):
-        return indent + "subtable;"
+        return "subtable;"
 
 
 class ValueRecord(Expression):


### PR DESCRIPTION
Similar to 05329ed033ae0aa2451272a39ada9aad9f1f5ed7.