### PR TITLE
[feaLib] Support subtable statement in more places

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1509,11 +1509,22 @@ class SingleSubstBuilder(LookupBuilder):
                 self.mapping == other.mapping)
 
     def build(self):
-        subtable = otl.buildSingleSubstSubtable(self.mapping)
-        return self.buildLookup_([subtable])
+        subtables = []
+        mapping = {}
+        for key in self.mapping:
+            if key[0] == self.SUBTABLE_BREAK_:
+                subtables.append(otl.buildSingleSubstSubtable(mapping))
+                mapping = {}
+            else:
+                mapping[key] = self.mapping[key]
+        subtables.append(otl.buildSingleSubstSubtable(mapping))
+        return self.buildLookup_(subtables)
 
     def getAlternateGlyphs(self):
         return {glyph: set([repl]) for glyph, repl in self.mapping.items()}
+
+    def add_subtable_break(self, location):
+        self.mapping[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
 
 
 class ClassPairPosSubtableBuilder(object):

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1494,6 +1494,10 @@ class ReverseChainSingleSubstBuilder(LookupBuilder):
             subtables.append(st)
         return self.buildLookup_(subtables)
 
+    def add_subtable_break(self, location):
+        # Nothing to do here, each substitution is in its own subtable.
+        pass
+
 
 class SingleSubstBuilder(LookupBuilder):
     def __init__(self, font, location):

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1308,8 +1308,19 @@ class LigatureSubstBuilder(LookupBuilder):
                 self.ligatures == other.ligatures)
 
     def build(self):
-        subtable = otl.buildLigatureSubstSubtable(self.ligatures)
-        return self.buildLookup_([subtable])
+        subtables = []
+        ligatures = {}
+        for key in self.ligatures:
+            if key[0] == self.SUBTABLE_BREAK_:
+                subtables.append(otl.buildLigatureSubstSubtable(ligatures))
+                ligatures = {}
+            else:
+                ligatures[key] = self.ligatures[key]
+        subtables.append(otl.buildLigatureSubstSubtable(ligatures))
+        return self.buildLookup_(subtables)
+
+    def add_subtable_break(self, location):
+        self.ligatures[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
 
 
 class MultipleSubstBuilder(LookupBuilder):

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1345,8 +1345,19 @@ class MultipleSubstBuilder(LookupBuilder):
                 self.mapping == other.mapping)
 
     def build(self):
-        subtable = otl.buildMultipleSubstSubtable(self.mapping)
-        return self.buildLookup_([subtable])
+        subtables = []
+        mapping = {}
+        for key in self.mapping:
+            if key[0] == self.SUBTABLE_BREAK_:
+                subtables.append(otl.buildMultipleSubstSubtable(mapping))
+                mapping = {}
+            else:
+                mapping[key] = self.mapping[key]
+        subtables.append(otl.buildMultipleSubstSubtable(mapping))
+        return self.buildLookup_(subtables)
+
+    def add_subtable_break(self, location):
+        self.mapping[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
 
 
 class CursivePosBuilder(LookupBuilder):

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1179,10 +1179,10 @@ class LookupBuilder(object):
         return subtables
 
     def add_subtable_break(self, location):
-        raise FeatureLibError(
+        log.warning(FeatureLibError(
             'unsupported "subtable" statement for lookup type',
             location
-        )
+        ))
 
 
 class AlternateSubstBuilder(LookupBuilder):

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -996,14 +996,7 @@ class Builder(object):
         lookup.addClassPair(location, glyphclass1, value1, glyphclass2, value2)
 
     def add_subtable_break(self, location):
-        if type(self.cur_lookup_) is not PairPosBuilder:
-            raise FeatureLibError(
-                'explicit "subtable" statement is intended for use with only '
-                "Pair Adjustment Positioning Format 2 (i.e. pair class kerning)",
-                location
-            )
-        lookup = self.get_lookup_(location, PairPosBuilder)
-        lookup.add_subtable_break(location)
+        self.cur_lookup_.add_subtable_break(location)
 
     def add_specific_pair_pos(self, location, glyph1, value1, glyph2, value2):
         lookup = self.get_lookup_(location, PairPosBuilder)
@@ -1190,6 +1183,12 @@ class LookupBuilder(object):
         for g in glyphs:
             coverage = otl.buildCoverage(g, self.glyphMap)
             subtable.InputCoverage.append(coverage)
+
+    def add_subtable_break(self, location):
+        raise FeatureLibError(
+            'unsupported "subtable" statement for lookup type',
+            location
+        )
 
 
 class AlternateSubstBuilder(LookupBuilder):

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -9,7 +9,7 @@ from fontTools.feaLib.ast import FeatureFile
 from fontTools.otlLib import builder as otl
 from fontTools.ttLib import newTable, getTableModule
 from fontTools.ttLib.tables import otBase, otTables
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import itertools
 import logging
 
@@ -1188,7 +1188,7 @@ class LookupBuilder(object):
 class AlternateSubstBuilder(LookupBuilder):
     def __init__(self, font, location):
         LookupBuilder.__init__(self, font, location, 'GSUB', 3)
-        self.alternates = {}
+        self.alternates = OrderedDict()
 
     def equals(self, other):
         return (LookupBuilder.equals(self, other) and
@@ -1315,7 +1315,7 @@ class ChainContextSubstBuilder(LookupBuilder):
 class LigatureSubstBuilder(LookupBuilder):
     def __init__(self, font, location):
         LookupBuilder.__init__(self, font, location, 'GSUB', 4)
-        self.ligatures = {}  # {('f','f','i'): 'f_f_i'}
+        self.ligatures = OrderedDict()  # {('f','f','i'): 'f_f_i'}
 
     def equals(self, other):
         return (LookupBuilder.equals(self, other) and
@@ -1333,7 +1333,7 @@ class LigatureSubstBuilder(LookupBuilder):
 class MultipleSubstBuilder(LookupBuilder):
     def __init__(self, font, location):
         LookupBuilder.__init__(self, font, location, 'GSUB', 2)
-        self.mapping = {}
+        self.mapping = OrderedDict()
 
     def equals(self, other):
         return (LookupBuilder.equals(self, other) and
@@ -1490,7 +1490,7 @@ class ReverseChainSingleSubstBuilder(LookupBuilder):
 class SingleSubstBuilder(LookupBuilder):
     def __init__(self, font, location):
         LookupBuilder.__init__(self, font, location, 'GSUB', 1)
-        self.mapping = {}
+        self.mapping = OrderedDict()
 
     def equals(self, other):
         return (LookupBuilder.equals(self, other) and

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1185,11 +1185,23 @@ class AlternateSubstBuilder(LookupBuilder):
                 self.alternates == other.alternates)
 
     def build(self):
-        subtable = otl.buildAlternateSubstSubtable(self.alternates)
-        return self.buildLookup_([subtable])
+        subtables = []
+        alternates = {}
+        for key in self.alternates:
+            if key[0] == self.SUBTABLE_BREAK_:
+                subtables.append(otl.buildAlternateSubstSubtable(alternates))
+                alternates = {}
+            else:
+                alternates[key] = self.alternates[key]
+        if alternates:
+            subtables.append(otl.buildAlternateSubstSubtable(alternates))
+        return self.buildLookup_(subtables)
 
     def getAlternateGlyphs(self):
         return self.alternates
+
+    def add_subtable_break(self, location):
+        self.alternates[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
 
 
 class ChainContextPosBuilder(LookupBuilder):

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1168,6 +1168,16 @@ class LookupBuilder(object):
             coverage = otl.buildCoverage(g, self.glyphMap)
             subtable.InputCoverage.append(coverage)
 
+    def build_subst_subtables(self, mapping, klass):
+        substitutions = [{}]
+        for key in mapping:
+            if key[0] == self.SUBTABLE_BREAK_:
+                substitutions.append({})
+            else:
+                substitutions[-1][key] = mapping[key]
+        subtables = [klass(s) for s in substitutions]
+        return subtables
+
     def add_subtable_break(self, location):
         raise FeatureLibError(
             'unsupported "subtable" statement for lookup type',
@@ -1185,16 +1195,8 @@ class AlternateSubstBuilder(LookupBuilder):
                 self.alternates == other.alternates)
 
     def build(self):
-        subtables = []
-        alternates = {}
-        for key in self.alternates:
-            if key[0] == self.SUBTABLE_BREAK_:
-                subtables.append(otl.buildAlternateSubstSubtable(alternates))
-                alternates = {}
-            else:
-                alternates[key] = self.alternates[key]
-        if alternates:
-            subtables.append(otl.buildAlternateSubstSubtable(alternates))
+        subtables = self.build_subst_subtables(self.alternates,
+                otl.buildAlternateSubstSubtable)
         return self.buildLookup_(subtables)
 
     def getAlternateGlyphs(self):
@@ -1320,15 +1322,8 @@ class LigatureSubstBuilder(LookupBuilder):
                 self.ligatures == other.ligatures)
 
     def build(self):
-        subtables = []
-        ligatures = {}
-        for key in self.ligatures:
-            if key[0] == self.SUBTABLE_BREAK_:
-                subtables.append(otl.buildLigatureSubstSubtable(ligatures))
-                ligatures = {}
-            else:
-                ligatures[key] = self.ligatures[key]
-        subtables.append(otl.buildLigatureSubstSubtable(ligatures))
+        subtables = self.build_subst_subtables(self.ligatures,
+                otl.buildLigatureSubstSubtable)
         return self.buildLookup_(subtables)
 
     def add_subtable_break(self, location):
@@ -1345,15 +1340,8 @@ class MultipleSubstBuilder(LookupBuilder):
                 self.mapping == other.mapping)
 
     def build(self):
-        subtables = []
-        mapping = {}
-        for key in self.mapping:
-            if key[0] == self.SUBTABLE_BREAK_:
-                subtables.append(otl.buildMultipleSubstSubtable(mapping))
-                mapping = {}
-            else:
-                mapping[key] = self.mapping[key]
-        subtables.append(otl.buildMultipleSubstSubtable(mapping))
+        subtables = self.build_subst_subtables(self.mapping,
+                otl.buildMultipleSubstSubtable)
         return self.buildLookup_(subtables)
 
     def add_subtable_break(self, location):
@@ -1509,15 +1497,8 @@ class SingleSubstBuilder(LookupBuilder):
                 self.mapping == other.mapping)
 
     def build(self):
-        subtables = []
-        mapping = {}
-        for key in self.mapping:
-            if key[0] == self.SUBTABLE_BREAK_:
-                subtables.append(otl.buildSingleSubstSubtable(mapping))
-                mapping = {}
-            else:
-                mapping[key] = self.mapping[key]
-        subtables.append(otl.buildSingleSubstSubtable(mapping))
+        subtables = self.build_subst_subtables(self.mapping,
+                otl.buildSingleSubstSubtable)
         return self.buildLookup_(subtables)
 
     def getAlternateGlyphs(self):

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -70,7 +70,7 @@ class BuilderTest(unittest.TestCase):
         ZeroValue_SinglePos_horizontal ZeroValue_SinglePos_vertical
         ZeroValue_PairPos_horizontal ZeroValue_PairPos_vertical
         ZeroValue_ChainSinglePos_horizontal ZeroValue_ChainSinglePos_vertical
-        PairPosSubtable ChainSubstSubtable ChainPosSubtable
+        PairPosSubtable ChainSubstSubtable ChainPosSubtable LigatureSubtable
     """.split()
 
     def __init__(self, methodName):
@@ -517,11 +517,11 @@ class BuilderTest(unittest.TestCase):
             FeatureLibError,
             'unsupported "subtable" statement for lookup type',
             self.build,
-            "feature liga {"
-            "    sub f f by f_f;"
+            "feature test {"
+            "    sub a by b;"
             "    subtable;"
-            "    sub f i by f_i;"
-            "} liga;"
+            "    sub c by d;"
+            "} test;"
         )
 
     def test_skip_featureNames_if_no_name_table(self):

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -71,7 +71,7 @@ class BuilderTest(unittest.TestCase):
         ZeroValue_PairPos_horizontal ZeroValue_PairPos_vertical
         ZeroValue_ChainSinglePos_horizontal ZeroValue_ChainSinglePos_vertical
         PairPosSubtable ChainSubstSubtable ChainPosSubtable LigatureSubtable
-        AlternateSubtable MultipleSubstSubtable
+        AlternateSubtable MultipleSubstSubtable SingleSubstSubtable
     """.split()
 
     def __init__(self, methodName):
@@ -519,9 +519,9 @@ class BuilderTest(unittest.TestCase):
             'unsupported "subtable" statement for lookup type',
             self.build,
             "feature test {"
-            "    sub a by b;"
+            "    pos a 10;"
             "    subtable;"
-            "    sub c by d;"
+            "    pos b 10;"
             "} test;"
         )
 

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -70,7 +70,7 @@ class BuilderTest(unittest.TestCase):
         ZeroValue_SinglePos_horizontal ZeroValue_SinglePos_vertical
         ZeroValue_PairPos_horizontal ZeroValue_PairPos_vertical
         ZeroValue_ChainSinglePos_horizontal ZeroValue_ChainSinglePos_vertical
-        PairPosSubtable
+        PairPosSubtable ChainSubstSubtable
     """.split()
 
     def __init__(self, methodName):

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -515,7 +515,7 @@ class BuilderTest(unittest.TestCase):
     def test_unsupported_subtable_break(self):
         self.assertRaisesRegex(
             FeatureLibError,
-            'explicit "subtable" statement is intended for .* class kerning',
+            'unsupported "subtable" statement for lookup type',
             self.build,
             "feature liga {"
             "    sub f f by f_f;"

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -514,16 +514,17 @@ class BuilderTest(unittest.TestCase):
         assert "GSUB" in font
 
     def test_unsupported_subtable_break(self):
-        self.assertRaisesRegex(
-            FeatureLibError,
-            'unsupported "subtable" statement for lookup type',
-            self.build,
-            "feature test {"
-            "    pos a 10;"
-            "    subtable;"
-            "    pos b 10;"
-            "} test;"
-        )
+        with self.assertLogs(level='WARNING') as logs:
+            self.build(
+                "feature test {"
+                "    pos a 10;"
+                "    subtable;"
+                "    pos b 10;"
+                "} test;"
+            )
+        self.assertEqual(logs.output,
+                ['WARNING:fontTools.feaLib.builder:<features>:1:32: '
+                 'unsupported "subtable" statement for lookup type'])
 
     def test_skip_featureNames_if_no_name_table(self):
         features = (

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -71,7 +71,7 @@ class BuilderTest(unittest.TestCase):
         ZeroValue_PairPos_horizontal ZeroValue_PairPos_vertical
         ZeroValue_ChainSinglePos_horizontal ZeroValue_ChainSinglePos_vertical
         PairPosSubtable ChainSubstSubtable ChainPosSubtable LigatureSubtable
-        AlternateSubtable
+        AlternateSubtable MultipleSubstSubtable
     """.split()
 
     def __init__(self, methodName):

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -70,7 +70,7 @@ class BuilderTest(unittest.TestCase):
         ZeroValue_SinglePos_horizontal ZeroValue_SinglePos_vertical
         ZeroValue_PairPos_horizontal ZeroValue_PairPos_vertical
         ZeroValue_ChainSinglePos_horizontal ZeroValue_ChainSinglePos_vertical
-        PairPosSubtable ChainSubstSubtable
+        PairPosSubtable ChainSubstSubtable ChainPosSubtable
     """.split()
 
     def __init__(self, methodName):

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -71,6 +71,7 @@ class BuilderTest(unittest.TestCase):
         ZeroValue_PairPos_horizontal ZeroValue_PairPos_vertical
         ZeroValue_ChainSinglePos_horizontal ZeroValue_ChainSinglePos_vertical
         PairPosSubtable ChainSubstSubtable ChainPosSubtable LigatureSubtable
+        AlternateSubtable
     """.split()
 
     def __init__(self, methodName):

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -513,6 +513,8 @@ class BuilderTest(unittest.TestCase):
         addOpenTypeFeatures(font, tree)
         assert "GSUB" in font
 
+    @unittest.skipIf(sys.version_info[0:2] < (3, 4),
+                     "assertLogs() was introduced in 3.4")
     def test_unsupported_subtable_break(self):
         with self.assertLogs(level='WARNING') as logs:
             self.build(

--- a/Tests/feaLib/data/AlternateSubtable.fea
+++ b/Tests/feaLib/data/AlternateSubtable.fea
@@ -1,5 +1,5 @@
-feature salt {
+feature test {
     sub A from [A.alt1 A.alt2];
-    sub B from [B.alt1 B.alt2 B.alt3];
-    sub C from [C.alt1];
-} salt;
+    subtable;
+    sub B from [B.alt1 B.alt2];
+} test;

--- a/Tests/feaLib/data/AlternateSubtable.fea
+++ b/Tests/feaLib/data/AlternateSubtable.fea
@@ -1,0 +1,5 @@
+feature salt {
+    sub A from [A.alt1 A.alt2];
+    sub B from [B.alt1 B.alt2 B.alt3];
+    sub C from [C.alt1];
+} salt;

--- a/Tests/feaLib/data/AlternateSubtable.ttx
+++ b/Tests/feaLib/data/AlternateSubtable.ttx
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="3"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=2 -->
+        <AlternateSubst index="0">
+          <AlternateSet glyph="A">
+            <Alternate glyph="A.alt1"/>
+            <Alternate glyph="A.alt2"/>
+          </AlternateSet>
+        </AlternateSubst>
+        <AlternateSubst index="1">
+          <AlternateSet glyph="B">
+            <Alternate glyph="B.alt1"/>
+            <Alternate glyph="B.alt2"/>
+          </AlternateSet>
+        </AlternateSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/Tests/feaLib/data/ChainPosSubtable.fea
+++ b/Tests/feaLib/data/ChainPosSubtable.fea
@@ -1,0 +1,7 @@
+feature test {
+    pos X [A-B]' -40 B' -40 A' -40 Y;
+    subtable;
+    pos X A' -111 Y;
+    subtable;
+    pos X B' -40 A' -111 [A-C]' -40 Y;
+} test;

--- a/Tests/feaLib/data/ChainPosSubtable.ttx
+++ b/Tests/feaLib/data/ChainPosSubtable.ttx
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=5 -->
+      <Lookup index="0">
+        <LookupType value="8"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=3 -->
+        <ChainContextPos index="0" Format="3">
+          <!-- BacktrackGlyphCount=1 -->
+          <BacktrackCoverage index="0">
+            <Glyph value="X"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=3 -->
+          <InputCoverage index="0">
+            <Glyph value="A"/>
+            <Glyph value="B"/>
+          </InputCoverage>
+          <InputCoverage index="1">
+            <Glyph value="B"/>
+          </InputCoverage>
+          <InputCoverage index="2">
+            <Glyph value="A"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=1 -->
+          <LookAheadCoverage index="0">
+            <Glyph value="Y"/>
+          </LookAheadCoverage>
+          <!-- PosCount=3 -->
+          <PosLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="1"/>
+          </PosLookupRecord>
+          <PosLookupRecord index="1">
+            <SequenceIndex value="1"/>
+            <LookupListIndex value="1"/>
+          </PosLookupRecord>
+          <PosLookupRecord index="2">
+            <SequenceIndex value="2"/>
+            <LookupListIndex value="1"/>
+          </PosLookupRecord>
+        </ChainContextPos>
+        <ChainContextPos index="1" Format="3">
+          <!-- BacktrackGlyphCount=1 -->
+          <BacktrackCoverage index="0">
+            <Glyph value="X"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0">
+            <Glyph value="A"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=1 -->
+          <LookAheadCoverage index="0">
+            <Glyph value="Y"/>
+          </LookAheadCoverage>
+          <!-- PosCount=1 -->
+          <PosLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="2"/>
+          </PosLookupRecord>
+        </ChainContextPos>
+        <ChainContextPos index="2" Format="3">
+          <!-- BacktrackGlyphCount=1 -->
+          <BacktrackCoverage index="0">
+            <Glyph value="X"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=3 -->
+          <InputCoverage index="0">
+            <Glyph value="B"/>
+          </InputCoverage>
+          <InputCoverage index="1">
+            <Glyph value="A"/>
+          </InputCoverage>
+          <InputCoverage index="2">
+            <Glyph value="A"/>
+            <Glyph value="B"/>
+            <Glyph value="C"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=1 -->
+          <LookAheadCoverage index="0">
+            <Glyph value="Y"/>
+          </LookAheadCoverage>
+          <!-- PosCount=3 -->
+          <PosLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="3"/>
+          </PosLookupRecord>
+          <PosLookupRecord index="1">
+            <SequenceIndex value="1"/>
+            <LookupListIndex value="3"/>
+          </PosLookupRecord>
+          <PosLookupRecord index="2">
+            <SequenceIndex value="2"/>
+            <LookupListIndex value="4"/>
+          </PosLookupRecord>
+        </ChainContextPos>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="A"/>
+            <Glyph value="B"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="-40"/>
+        </SinglePos>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="A"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="-111"/>
+        </SinglePos>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="2">
+          <Coverage>
+            <Glyph value="A"/>
+            <Glyph value="B"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <!-- ValueCount=2 -->
+          <Value index="0" XAdvance="-111"/>
+          <Value index="1" XAdvance="-40"/>
+        </SinglePos>
+      </Lookup>
+      <Lookup index="4">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="A"/>
+            <Glyph value="B"/>
+            <Glyph value="C"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="-40"/>
+        </SinglePos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/feaLib/data/ChainSubstSubtable.fea
+++ b/Tests/feaLib/data/ChainSubstSubtable.fea
@@ -1,0 +1,9 @@
+feature test {
+    sub G' by G.swash;
+    subtable;
+    sub H' by H.swash;
+    subtable;
+    sub G' by g;
+    subtable;
+    sub H' by H.swash;
+} test;

--- a/Tests/feaLib/data/ChainSubstSubtable.ttx
+++ b/Tests/feaLib/data/ChainSubstSubtable.ttx
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=5 -->
+      <Lookup index="0">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=4 -->
+        <ChainContextSubst index="0" Format="3">
+          <!-- BacktrackGlyphCount=0 -->
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0">
+            <Glyph value="G"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=1 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="1"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+        <ChainContextSubst index="1" Format="3">
+          <!-- BacktrackGlyphCount=0 -->
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0">
+            <Glyph value="H"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=1 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="2"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+        <ChainContextSubst index="2" Format="3">
+          <!-- BacktrackGlyphCount=0 -->
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0">
+            <Glyph value="G"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=1 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="3"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+        <ChainContextSubst index="3" Format="3">
+          <!-- BacktrackGlyphCount=0 -->
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0">
+            <Glyph value="H"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=1 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="4"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="G" out="G.swash"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="H" out="H.swash"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="G" out="g"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="4">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="H" out="H.swash"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/Tests/feaLib/data/LigatureSubtable.fea
+++ b/Tests/feaLib/data/LigatureSubtable.fea
@@ -1,0 +1,5 @@
+feature test {
+    sub f f by f_f;
+    subtable;
+    sub f i by f_i;
+} test;

--- a/Tests/feaLib/data/LigatureSubtable.ttx
+++ b/Tests/feaLib/data/LigatureSubtable.ttx
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=2 -->
+        <LigatureSubst index="0">
+          <LigatureSet glyph="f">
+            <Ligature components="f" glyph="f_f"/>
+          </LigatureSet>
+        </LigatureSubst>
+        <LigatureSubst index="1">
+          <LigatureSet glyph="f">
+            <Ligature components="i" glyph="f_i"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/Tests/feaLib/data/MultipleSubstSubtable.fea
+++ b/Tests/feaLib/data/MultipleSubstSubtable.fea
@@ -1,0 +1,5 @@
+feature test {
+    sub c_t by c t;
+    subtable;
+    sub f_i by f i;
+} test;

--- a/Tests/feaLib/data/MultipleSubstSubtable.ttx
+++ b/Tests/feaLib/data/MultipleSubstSubtable.ttx
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=2 -->
+        <MultipleSubst index="0">
+          <Substitution in="c_t" out="c,t"/>
+        </MultipleSubst>
+        <MultipleSubst index="1">
+          <Substitution in="f_i" out="f,i"/>
+        </MultipleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/Tests/feaLib/data/SingleSubstSubtable.fea
+++ b/Tests/feaLib/data/SingleSubstSubtable.fea
@@ -1,0 +1,5 @@
+feature test {
+    sub a by b;
+    subtable;
+    sub c by d;
+} test;

--- a/Tests/feaLib/data/SingleSubstSubtable.ttx
+++ b/Tests/feaLib/data/SingleSubstSubtable.ttx
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=2 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="b"/>
+        </SingleSubst>
+        <SingleSubst index="1">
+          <Substitution in="c" out="d"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
Although AFDKO’s makeotf supports subtable breaks only in pair pos lookups, I believe that is an implementation limit that we don’t have to follow; all OpenType lookups has subtables and it should be possible to code that in the feature files.

This PR adds `subtable` statement support to many lookups, but not all of them; I added it to the lookups I had tests for or was easy enough to construct tests for.

This also make unsupported `subtable` a warning instead of an error, to follow makeotf.