### PR TITLE
TupleVariation.toXML: sort attrs min/value/max in TTX dump

### DIFF
--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -71,7 +71,13 @@ class TupleVariation(object):
 				if minValue == defaultMinValue and maxValue == defaultMaxValue:
 					writer.simpletag("coord", axis=axis, value=value)
 				else:
-					writer.simpletag("coord", axis=axis, value=value, min=minValue, max=maxValue)
+					attrs = [
+						("axis", axis),
+						("min", minValue),
+						("value", value),
+						("max", maxValue),
+				        ]
+					writer.simpletag("coord", attrs)
 				writer.newline()
 		wrote_any_deltas = False
 		for i, delta in enumerate(self.coordinates):

--- a/Tests/ttLib/tables/TupleVariation_test.py
+++ b/Tests/ttLib/tables/TupleVariation_test.py
@@ -107,7 +107,7 @@ class TupleVariationTest(unittest.TestCase):
 		self.assertIn("bad delta format", [r.msg for r in captor.records])
 		self.assertEqual([
 			'<tuple>',
-			  '<coord axis="wdth" max="0.5" min="0.3" value="0.4"/>',
+			  '<coord axis="wdth" min="0.3" value="0.4" max="0.5"/>',
 			  '<!-- bad delta #0 -->',
 			'</tuple>',
 		], TupleVariationTest.xml_lines(writer))
@@ -118,7 +118,7 @@ class TupleVariationTest(unittest.TestCase):
 		g.toXML(writer, ["wdth", "wght", "opsz"])
 		self.assertEqual([
 			'<tuple>',
-			  '<coord axis="wdth" max="0.5" min="0.3" value="0.4"/>',
+			  '<coord axis="wdth" min="0.3" value="0.4" max="0.5"/>',
 			  '<coord axis="wght" value="1.0"/>',
 			  '<coord axis="opsz" value="-0.7"/>',
 			  '<delta cvt="0" value="42"/>',
@@ -134,7 +134,7 @@ class TupleVariationTest(unittest.TestCase):
 		g.toXML(writer, ["wdth", "wght", "opsz"])
 		self.assertEqual([
 			'<tuple>',
-			  '<coord axis="wdth" max="0.5" min="0.3" value="0.4"/>',
+			  '<coord axis="wdth" min="0.3" value="0.4" max="0.5"/>',
 			  '<coord axis="wght" value="1.0"/>',
 			  '<coord axis="opsz" value="-0.7"/>',
 			  '<delta pt="0" x="9" y="8"/>',

--- a/Tests/ttLib/tables/_g_v_a_r_test.py
+++ b/Tests/ttLib/tables/_g_v_a_r_test.py
@@ -93,7 +93,7 @@ GVAR_XML = [
     '</glyphVariations>',
     '<glyphVariations glyph="I">',
     '  <tuple>',
-    '    <coord axis="wght" max="1.0" min="0.0" value="0.5"/>',
+    '    <coord axis="wght" min="0.0" value="0.5" max="1.0"/>',
     '    <delta pt="0" x="3" y="3"/>',
     '    <delta pt="1" x="1" y="1"/>',
     '    <delta pt="2" x="4" y="4"/>',

--- a/Tests/varLib/data/test_results/SparseMasters.ttx
+++ b/Tests/varLib/data/test_results/SparseMasters.ttx
@@ -574,7 +574,7 @@
     </glyphVariations>
     <glyphVariations glyph="e">
       <tuple>
-        <coord axis="wght" max="1.0" min="0.0" value="0.36365"/>
+        <coord axis="wght" min="0.0" value="0.36365" max="1.0"/>
         <delta pt="0" x="-1" y="-25"/>
         <delta pt="1" x="0" y="0"/>
         <delta pt="2" x="-84" y="5"/>
@@ -594,7 +594,7 @@
         <delta pt="16" x="0" y="0"/>
       </tuple>
       <tuple>
-        <coord axis="wght" max="1.0" min="0.36365" value="1.0"/>
+        <coord axis="wght" min="0.36365" value="1.0" max="1.0"/>
         <delta pt="0" x="70" y="1"/>
         <delta pt="1" x="70" y="1"/>
         <delta pt="2" x="-76" y="1"/>


### PR DESCRIPTION
I think it makes it more legible if the peak value in a TupleVariation subtable is written _after_ the `min` and before the `max` value defining a given region, instead of alphabetically `max`, `min` and `value`.
The XMLWriter supports writing element attributes in an arbitrary order so let's use that.
TTX files from previous versions will continue to be parseable since attributes order is not significant in XML.