### PR TITLE
varLib: use vmtx to compute phantom pts; fix the sign of bottomSideY

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -233,9 +233,13 @@ def _GetCoordinates(font, glyphName):
 		glyph.recalcBounds(glyf)
 	leftSideX = glyph.xMin - leftSideBearing
 	rightSideX = leftSideX + horizontalAdvanceWidth
-	# XXX these are incorrect.  Load vmtx and fix.
-	topSideY = glyph.yMax
-	bottomSideY = -glyph.yMin
+	if "vmtx" in font:
+		verticalAdvanceWidth, topSideBearing = font["vmtx"].metrics[glyphName]
+		topSideY = topSideBearing + glyph.yMax
+		bottomSideY = topSideY - verticalAdvanceWidth
+	else:
+		topSideY = glyph.yMax
+		bottomSideY = glyph.yMin
 	coord = coord.copy()
 	coord.extend([(leftSideX, 0),
 	              (rightSideX, 0),

--- a/Tests/varLib/data/test_results/Build.ttx
+++ b/Tests/varLib/data/test_results/Build.ttx
@@ -689,7 +689,7 @@
         <delta pt="61" x="0" y="0"/>
         <delta pt="62" x="32" y="0"/>
         <delta pt="63" x="0" y="16"/>
-        <delta pt="64" x="0" y="3"/>
+        <delta pt="64" x="0" y="-3"/>
       </tuple>
       <tuple>
         <coord axis="cntr" value="1.0"/>

--- a/Tests/varLib/data/test_results/Build.ttx
+++ b/Tests/varLib/data/test_results/Build.ttx
@@ -281,7 +281,7 @@
         <delta pt="15" x="0" y="0"/>
         <delta pt="16" x="0" y="0"/>
         <delta pt="17" x="0" y="0"/>
-        <delta pt="18" x="0" y="7"/>
+        <delta pt="18" x="0" y="0"/>
         <delta pt="19" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -304,7 +304,7 @@
         <delta pt="15" x="0" y="0"/>
         <delta pt="16" x="0" y="0"/>
         <delta pt="17" x="0" y="0"/>
-        <delta pt="18" x="0" y="-18"/>
+        <delta pt="18" x="0" y="0"/>
         <delta pt="19" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -424,7 +424,7 @@
         <delta pt="23" x="-2" y="0"/>
         <delta pt="24" x="0" y="0"/>
         <delta pt="25" x="-10" y="0"/>
-        <delta pt="26" x="0" y="9"/>
+        <delta pt="26" x="0" y="0"/>
         <delta pt="27" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -455,7 +455,7 @@
         <delta pt="23" x="12" y="0"/>
         <delta pt="24" x="0" y="0"/>
         <delta pt="25" x="17" y="0"/>
-        <delta pt="26" x="0" y="-23"/>
+        <delta pt="26" x="0" y="0"/>
         <delta pt="27" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -620,7 +620,7 @@
         <delta pt="60" x="33" y="-1"/>
         <delta pt="61" x="0" y="0"/>
         <delta pt="62" x="-3" y="0"/>
-        <delta pt="63" x="0" y="-4"/>
+        <delta pt="63" x="0" y="0"/>
         <delta pt="64" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -688,8 +688,8 @@
         <delta pt="60" x="-25" y="-13"/>
         <delta pt="61" x="0" y="0"/>
         <delta pt="62" x="32" y="0"/>
-        <delta pt="63" x="0" y="16"/>
-        <delta pt="64" x="0" y="-3"/>
+        <delta pt="63" x="0" y="0"/>
+        <delta pt="64" x="0" y="0"/>
       </tuple>
       <tuple>
         <coord axis="cntr" value="1.0"/>
@@ -965,7 +965,7 @@
         <delta pt="61" x="-15" y="0"/>
         <delta pt="62" x="0" y="0"/>
         <delta pt="63" x="-7" y="0"/>
-        <delta pt="64" x="0" y="12"/>
+        <delta pt="64" x="0" y="0"/>
         <delta pt="65" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -1034,7 +1034,7 @@
         <delta pt="61" x="39" y="0"/>
         <delta pt="62" x="0" y="0"/>
         <delta pt="63" x="63" y="0"/>
-        <delta pt="64" x="0" y="-19"/>
+        <delta pt="64" x="0" y="0"/>
         <delta pt="65" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -1314,7 +1314,7 @@
         <delta pt="61" x="-15" y="0"/>
         <delta pt="62" x="0" y="0"/>
         <delta pt="63" x="-7" y="0"/>
-        <delta pt="64" x="0" y="12"/>
+        <delta pt="64" x="0" y="0"/>
         <delta pt="65" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -1383,7 +1383,7 @@
         <delta pt="61" x="49" y="0"/>
         <delta pt="62" x="0" y="0"/>
         <delta pt="63" x="63" y="0"/>
-        <delta pt="64" x="0" y="-19"/>
+        <delta pt="64" x="0" y="0"/>
         <delta pt="65" x="0" y="0"/>
       </tuple>
       <tuple>

--- a/Tests/varLib/data/test_results/BuildMain.ttx
+++ b/Tests/varLib/data/test_results/BuildMain.ttx
@@ -927,7 +927,7 @@
         <delta pt="15" x="0" y="0"/>
         <delta pt="16" x="0" y="0"/>
         <delta pt="17" x="0" y="0"/>
-        <delta pt="18" x="0" y="7"/>
+        <delta pt="18" x="0" y="0"/>
         <delta pt="19" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -950,7 +950,7 @@
         <delta pt="15" x="0" y="0"/>
         <delta pt="16" x="0" y="0"/>
         <delta pt="17" x="0" y="0"/>
-        <delta pt="18" x="0" y="-18"/>
+        <delta pt="18" x="0" y="0"/>
         <delta pt="19" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -1070,7 +1070,7 @@
         <delta pt="23" x="-2" y="0"/>
         <delta pt="24" x="0" y="0"/>
         <delta pt="25" x="-10" y="0"/>
-        <delta pt="26" x="0" y="9"/>
+        <delta pt="26" x="0" y="0"/>
         <delta pt="27" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -1101,7 +1101,7 @@
         <delta pt="23" x="12" y="0"/>
         <delta pt="24" x="0" y="0"/>
         <delta pt="25" x="17" y="0"/>
-        <delta pt="26" x="0" y="-23"/>
+        <delta pt="26" x="0" y="0"/>
         <delta pt="27" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -1266,7 +1266,7 @@
         <delta pt="60" x="33" y="-1"/>
         <delta pt="61" x="0" y="0"/>
         <delta pt="62" x="-3" y="0"/>
-        <delta pt="63" x="0" y="-4"/>
+        <delta pt="63" x="0" y="0"/>
         <delta pt="64" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -1334,8 +1334,8 @@
         <delta pt="60" x="-25" y="-13"/>
         <delta pt="61" x="0" y="0"/>
         <delta pt="62" x="32" y="0"/>
-        <delta pt="63" x="0" y="16"/>
-        <delta pt="64" x="0" y="-3"/>
+        <delta pt="63" x="0" y="0"/>
+        <delta pt="64" x="0" y="0"/>
       </tuple>
       <tuple>
         <coord axis="cntr" value="1.0"/>
@@ -1611,7 +1611,7 @@
         <delta pt="61" x="-15" y="0"/>
         <delta pt="62" x="0" y="0"/>
         <delta pt="63" x="-7" y="0"/>
-        <delta pt="64" x="0" y="12"/>
+        <delta pt="64" x="0" y="0"/>
         <delta pt="65" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -1680,7 +1680,7 @@
         <delta pt="61" x="39" y="0"/>
         <delta pt="62" x="0" y="0"/>
         <delta pt="63" x="63" y="0"/>
-        <delta pt="64" x="0" y="-19"/>
+        <delta pt="64" x="0" y="0"/>
         <delta pt="65" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -1960,7 +1960,7 @@
         <delta pt="61" x="-15" y="0"/>
         <delta pt="62" x="0" y="0"/>
         <delta pt="63" x="-7" y="0"/>
-        <delta pt="64" x="0" y="12"/>
+        <delta pt="64" x="0" y="0"/>
         <delta pt="65" x="0" y="0"/>
       </tuple>
       <tuple>
@@ -2029,7 +2029,7 @@
         <delta pt="61" x="49" y="0"/>
         <delta pt="62" x="0" y="0"/>
         <delta pt="63" x="63" y="0"/>
-        <delta pt="64" x="0" y="-19"/>
+        <delta pt="64" x="0" y="0"/>
         <delta pt="65" x="0" y="0"/>
       </tuple>
       <tuple>

--- a/Tests/varLib/data/test_results/BuildMain.ttx
+++ b/Tests/varLib/data/test_results/BuildMain.ttx
@@ -1335,7 +1335,7 @@
         <delta pt="61" x="0" y="0"/>
         <delta pt="62" x="32" y="0"/>
         <delta pt="63" x="0" y="16"/>
-        <delta pt="64" x="0" y="3"/>
+        <delta pt="64" x="0" y="-3"/>
       </tuple>
       <tuple>
         <coord axis="cntr" value="1.0"/>

--- a/Tests/varLib/data/test_results/SparseMasters.ttx
+++ b/Tests/varLib/data/test_results/SparseMasters.ttx
@@ -610,7 +610,7 @@
         <delta pt="12" x="25" y="-1"/>
         <delta pt="13" x="0" y="0"/>
         <delta pt="14" x="0" y="0"/>
-        <delta pt="15" x="0" y="35"/>
+        <delta pt="15" x="0" y="0"/>
         <delta pt="16" x="0" y="0"/>
       </tuple>
     </glyphVariations>
@@ -632,7 +632,7 @@
         <delta pt="12" x="0" y="0"/>
         <delta pt="13" x="0" y="0"/>
         <delta pt="14" x="0" y="0"/>
-        <delta pt="15" x="0" y="-45"/>
+        <delta pt="15" x="0" y="0"/>
       </tuple>
     </glyphVariations>
     <glyphVariations glyph="dotabovecomb">
@@ -644,15 +644,14 @@
         <delta pt="3" x="-27" y="-20"/>
         <delta pt="4" x="0" y="0"/>
         <delta pt="5" x="0" y="0"/>
-        <delta pt="6" x="0" y="28"/>
-        <delta pt="7" x="0" y="-18"/>
+        <delta pt="6" x="0" y="0"/>
+        <delta pt="7" x="0" y="0"/>
       </tuple>
     </glyphVariations>
     <glyphVariations glyph="edotabove">
       <tuple>
         <coord axis="wght" value="1.0"/>
         <delta pt="1" x="-6" y="91"/>
-        <delta pt="4" x="0" y="119"/>
       </tuple>
     </glyphVariations>
   </gvar>

--- a/Tests/varLib/data/test_results/SparseMasters.ttx
+++ b/Tests/varLib/data/test_results/SparseMasters.ttx
@@ -632,7 +632,7 @@
         <delta pt="12" x="0" y="0"/>
         <delta pt="13" x="0" y="0"/>
         <delta pt="14" x="0" y="0"/>
-        <delta pt="15" x="0" y="45"/>
+        <delta pt="15" x="0" y="-45"/>
       </tuple>
     </glyphVariations>
     <glyphVariations glyph="dotabovecomb">
@@ -645,7 +645,7 @@
         <delta pt="4" x="0" y="0"/>
         <delta pt="5" x="0" y="0"/>
         <delta pt="6" x="0" y="28"/>
-        <delta pt="7" x="0" y="18"/>
+        <delta pt="7" x="0" y="-18"/>
       </tuple>
     </glyphVariations>
     <glyphVariations glyph="edotabove">


### PR DESCRIPTION
when 'vmtx' is present in a font, use that to compute the third and fourth 'phantom points'.
When not present, use the glyph bbox yMax and yMin coords.

NOTE that previously the bottomSideY was incorrectly set to `-glyph.yMin` (with a minus sign).
However, the minus is not needed when we use the bbox.

Positive vertical advance grows towards negative Y axis.
In the absence of vmtx, we default to using `yMax` as the y coordinate of the top origin and `yMax - yMin` as the vertical advance width; so the y coordinate of the advance height _point_ (bottomSideY) is `yMax - (yMax - yMin) => yMin`