### PR TITLE
DesignSpaceDocument.defaultLoc needs to be updated

### DIFF
--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -998,7 +998,7 @@ class DesignSpaceDocument(LogMixin, AsDictMixin):
         self.axes = []
         self.rules = []
         self.default = None         # name of the default master
-        self.defaultLoc = None
+        self.defaultLoc = {}
 
         self.lib = {}
         """Custom data associated with the whole document."""
@@ -1123,6 +1123,7 @@ class DesignSpaceDocument(LogMixin, AsDictMixin):
 
     def addAxis(self, axisDescriptor):
         self.axes.append(axisDescriptor)
+        self.defaultLoc[axisDescriptor.name] = axisDescriptor.default
 
     def addRule(self, ruleDescriptor):
         self.rules.append(ruleDescriptor)


### PR DESCRIPTION
defaultLoc is used in findDefault(), but it is not updated after first read. So any axes that are added after reading the doc or creating the object are ignored.