### PR TITLE
[partial-instancer] merge overlapping tuple variations

### DIFF
--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -54,10 +54,7 @@ class TupleVariation(object):
 		If the result is False, the TupleVariation can be omitted from the font
 		without making any visible difference.
 		"""
-		for c in self.coordinates:
-			if c is not None:
-				return True
-		return False
+		return any(c is not None for c in self.coordinates)
 
 	def toXML(self, writer, axisTags):
 		writer.begintag("tuple")
@@ -446,14 +443,23 @@ class TupleVariation(object):
 			size += axisCount * 4
 		return size
 
-	def scaleDeltas(self, scalar):
-		if scalar == 1.0:
-			return  # no change
+	def checkDeltaType(self):
 		# check if deltas are (x, y) as in gvar, or single values as in cvar
 		firstDelta = next((c for c in self.coordinates if c is not None), None)
 		if firstDelta is None:
-			return  # nothing to scale
+			return  # empty or has no impact
 		if type(firstDelta) is tuple and len(firstDelta) == 2:
+			return "gvar"
+		elif type(firstDelta) in (int, float):
+			return "cvar"
+		else:
+			raise TypeError("invalid type of delta: %s" % type(firstDelta))
+
+	def scaleDeltas(self, scalar):
+		if scalar == 1.0:
+			return  # no change
+		deltaType = self.checkDeltaType()
+		if deltaType == "gvar":
 			if scalar == 0:
 				self.coordinates = [(0, 0)] * len(self.coordinates)
 			else:
@@ -461,7 +467,7 @@ class TupleVariation(object):
 					(d[0] * scalar, d[1] * scalar) if d is not None else None
 					for d in self.coordinates
 				]
-		elif type(firstDelta) in (int, float):
+		else:
 			if scalar == 0:
 				self.coordinates = [0] * len(self.coordinates)
 			else:
@@ -469,25 +475,96 @@ class TupleVariation(object):
 					d * scalar if d is not None else None
 					for d in self.coordinates
 				]
-		else:
-			raise TypeError("invalid type of delta: %s" % type(firstDelta))
 
 	def roundDeltas(self):
-		# check if deltas are (x, y) as in gvar, or single values as in cvar
-		firstDelta = next((c for c in self.coordinates if c is not None), None)
-		if firstDelta is None:
-			return  # nothing to round
-		if type(firstDelta) is tuple and len(firstDelta) == 2:
+		deltaType = self.checkDeltaType()
+		if deltaType == "gvar":
 			self.coordinates = [
 				(otRound(d[0]), otRound(d[1])) if d is not None else None
 				for d in self.coordinates
 			]
-		elif type(firstDelta) in (int, float):
+		else:
 			self.coordinates = [
 				otRound(d) if d is not None else None for d in self.coordinates
 			]
-		else:
-			raise TypeError("invalid type of delta: %s" % type(firstDelta))
+
+	def calcInferredDeltas(self, origCoords, endPts):
+		from fontTools.varLib.iup import iup_delta
+
+		if self.checkDeltaType() == "cvar":
+			raise TypeError(
+				"Only 'gvar' TupleVariation can have inferred deltas"
+			)
+		if None in self.coordinates:
+			if len(self.coordinates) != len(origCoords):
+				raise ValueError(
+					"Expected len(origCoords) == %d; found %d"
+					% (len(self.coordinates), len(origCoords))
+				)
+			self.coordinates = iup_delta(self.coordinates, origCoords, endPts)
+
+	def optimize(self, origCoords, endPts, tolerance=0.5, isComposite=False):
+		from fontTools.varLib.iup import iup_delta_optimize
+
+		if None in self.coordinates:
+			return  # already optimized
+
+		deltaOpt = iup_delta_optimize(
+		    self.coordinates, origCoords, endPts, tolerance=tolerance
+		)
+		if None in deltaOpt:
+			if isComposite and all(d is None for d in deltaOpt):
+				# Fix for macOS composites
+				# https://github.com/fonttools/fonttools/issues/1381
+				deltaOpt = [(0, 0)] + [None] * (len(deltaOpt) - 1)
+			# Use "optimized" version only if smaller...
+			varOpt = TupleVariation(self.axes, deltaOpt)
+
+			# Shouldn't matter that this is different from fvar...?
+			axisTags = sorted(self.axes.keys())
+			tupleData, auxData, _ = self.compile(axisTags, [], None)
+			unoptimizedLength = len(tupleData) + len(auxData)
+			tupleData, auxData, _ = varOpt.compile(axisTags, [], None)
+			optimizedLength = len(tupleData) + len(auxData)
+
+			if optimizedLength < unoptimizedLength:
+				self.coordinates = varOpt.coordinates
+
+	def sumDeltas(self, variations, origCoords=None, endPts=None):
+		# to sum the gvar deltas we need to first interpolate any inferred deltas
+		if origCoords is not None:
+			self.calcInferredDeltas(origCoords, endPts)
+		deltas1 = self.coordinates
+		axes = self.axes
+		length = len(deltas1)
+		deltaRange = range(length)
+		deltaType = self.checkDeltaType()
+		for other in variations:
+			if other.axes != axes:
+				raise ValueError(
+					"cannot merge TupleVariations with different axes"
+				)
+			if origCoords is not None:
+				other.calcInferredDeltas(origCoords, endPts)
+			deltas2 = other.coordinates
+			if len(deltas2) != length:
+				raise ValueError(
+					"cannot merge TupleVariations with different lengths"
+				)
+			for i, d2 in zip(deltaRange, deltas2):
+				d1 = deltas1[i]
+				if d1 is not None and d2 is not None:
+					if deltaType == "gvar":
+						deltas1[i] = (d1[0] + d2[0], d1[1] + d2[1])
+					else:
+						deltas1[i] = d1 + d2
+				else:
+					if deltaType == "gvar":
+						raise ValueError(
+							"cannot merge gvar deltas with inferred points"
+						)
+					if d1 is None and d2 is not None:
+						deltas1[i] = d2
 
 
 def decompileSharedTuples(axisTags, sharedTupleCount, data, offset):

--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -530,41 +530,32 @@ class TupleVariation(object):
 			if optimizedLength < unoptimizedLength:
 				self.coordinates = varOpt.coordinates
 
-	def sumDeltas(self, variations, origCoords=None, endPts=None):
-		# to sum the gvar deltas we need to first interpolate any inferred deltas
-		if origCoords is not None:
-			self.calcInferredDeltas(origCoords, endPts)
+	def __iadd__(self, other):
+		if not isinstance(other, TupleVariation):
+			return NotImplemented
 		deltas1 = self.coordinates
-		axes = self.axes
 		length = len(deltas1)
-		deltaRange = range(length)
 		deltaType = self.checkDeltaType()
-		for other in variations:
-			if other.axes != axes:
-				raise ValueError(
-					"cannot merge TupleVariations with different axes"
-				)
-			if origCoords is not None:
-				other.calcInferredDeltas(origCoords, endPts)
-			deltas2 = other.coordinates
-			if len(deltas2) != length:
-				raise ValueError(
-					"cannot merge TupleVariations with different lengths"
-				)
-			for i, d2 in zip(deltaRange, deltas2):
-				d1 = deltas1[i]
-				if d1 is not None and d2 is not None:
-					if deltaType == "gvar":
-						deltas1[i] = (d1[0] + d2[0], d1[1] + d2[1])
-					else:
-						deltas1[i] = d1 + d2
+		deltas2 = other.coordinates
+		if len(deltas2) != length:
+			raise ValueError(
+				"cannot sum TupleVariation deltas with different lengths"
+			)
+		for i, d2 in zip(range(length), deltas2):
+			d1 = deltas1[i]
+			if d1 is not None and d2 is not None:
+				if deltaType == "gvar":
+					deltas1[i] = (d1[0] + d2[0], d1[1] + d2[1])
 				else:
-					if deltaType == "gvar":
-						raise ValueError(
-							"cannot merge gvar deltas with inferred points"
-						)
-					if d1 is None and d2 is not None:
-						deltas1[i] = d2
+					deltas1[i] = d1 + d2
+			else:
+				if deltaType == "gvar":
+					raise ValueError(
+						"cannot sum gvar deltas with inferred points"
+					)
+				if d1 is None and d2 is not None:
+					deltas1[i] = d2
+		return self
 
 
 def decompileSharedTuples(axisTags, sharedTupleCount, data, offset):

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -379,8 +379,7 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 		topSideY = coord[-2][1]
 		bottomSideY = coord[-1][1]
 
-		for _ in range(4):
-			del coord[-1]
+		coord = coord[:-4]
 
 		if glyph.isComposite():
 			assert len(coord) == len(glyph.components)
@@ -391,7 +390,7 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 			assert len(coord) == 0
 		else:
 			assert len(coord) == len(glyph.coordinates)
-			glyph.coordinates = coord
+			glyph.coordinates = GlyphCoordinates(coord)
 
 		glyph.recalcBounds(self)
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -40,6 +40,7 @@ def instantiateTupleVariationStore(variations, location, origCoords=None, endPts
             # no influence, drop the TupleVariation
             continue
 
+        # compute inferred deltas only for gvar ('origCoords' is None for cvar)
         if origCoords is not None:
             var.calcInferredDeltas(origCoords, endPts)
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -14,10 +14,10 @@ from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
 from fontTools.misc.fixedTools import floatToFixedToFloat, otRound
 from fontTools.varLib.models import supportScalar, normalizeValue, piecewiseLinearMap
-from fontTools.varLib.iup import iup_delta
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 from fontTools.varLib.mvar import MVAR_ENTRIES
+import collections
 from copy import deepcopy
 import logging
 import os
@@ -27,9 +27,8 @@ import re
 log = logging.getLogger("fontTools.varlib.instancer")
 
 
-def instantiateTupleVariationStore(variations, location):
-    newVariations = []
-    defaultDeltas = []
+def instantiateTupleVariationStore(variations, location, origCoords=None, endPts=None):
+    varGroups = collections.OrderedDict()
     for var in variations:
         # Compute the scalar support of the axes to be pinned at the desired location,
         # excluding any axes that we are not pinning.
@@ -40,49 +39,70 @@ def instantiateTupleVariationStore(variations, location):
         if scalar == 0.0:
             # no influence, drop the TupleVariation
             continue
-        elif scalar != 1.0:
-            var.scaleDeltas(scalar)
-        if not var.axes:
-            # if no axis is left in the TupleVariation, also drop it; its deltas
-            # will be folded into the neutral
-            defaultDeltas.append(var.coordinates)
+
+        var.scaleDeltas(scalar)
+
+        # group TupleVariations by overlapping "tents" (can be empty if all the axes
+        # were instanced)
+        axes = tuple(var.axes.items())
+        if axes in varGroups:
+            varGroups[axes].append(var)
         else:
-            # keep the TupleVariation, and round the scaled deltas to integers
-            if scalar != 1.0:
-                var.roundDeltas()
+            varGroups[axes] = [var]
+
+    defaultDeltas = None
+    newVariations = []
+    for axes, varGroup in varGroups.items():
+        var = varGroup.pop(0)
+
+        # merge TupleVariations having the same (or none) axes
+        if varGroup:
+            var.sumDeltas(varGroup, origCoords, endPts)
+
+        if axes is ():
+            # if no axis is left in the TupleVariation, we drop it and its deltas
+            # will be later added to the default instance; we need to interpolate
+            # any inferred (i.e. None) deltas to be able to sum the coordinates
+            if origCoords is not None:
+                var.calcInferredDeltas(origCoords, endPts)
+            defaultDeltas = var.coordinates
+        else:
+            var.roundDeltas()
             newVariations.append(var)
+
     variations[:] = newVariations
-    return defaultDeltas
+    return defaultDeltas or []
 
 
-def setGvarGlyphDeltas(varfont, glyphname, deltasets):
+def instantiateGvarGlyph(varfont, glyphname, location, optimize=True):
     glyf = varfont["glyf"]
-    coordinates = glyf.getCoordinates(glyphname, varfont)
-    origCoords = None
+    coordinates, ctrl = glyf.getCoordinatesAndControls(glyphname, varfont)
+    endPts = ctrl.endPts
 
-    for deltas in deltasets:
-        hasUntouchedPoints = None in deltas
-        if hasUntouchedPoints:
-            if origCoords is None:
-                origCoords, g = glyf.getCoordinatesAndControls(glyphname, varfont)
-            deltas = iup_delta(deltas, origCoords, g.endPts)
-        coordinates += GlyphCoordinates(deltas)
-
-    glyf.setCoordinates(glyphname, coordinates, varfont)
-
-
-def instantiateGvarGlyph(varfont, glyphname, location):
     gvar = varfont["gvar"]
+    tupleVarStore = gvar.variations[glyphname]
 
-    defaultDeltas = instantiateTupleVariationStore(gvar.variations[glyphname], location)
+    defaultDeltas = instantiateTupleVariationStore(
+        tupleVarStore, location, coordinates, endPts
+    )
+
     if defaultDeltas:
-        setGvarGlyphDeltas(varfont, glyphname, defaultDeltas)
+        coordinates += GlyphCoordinates(defaultDeltas)
+        # this will also set the hmtx advance widths and sidebearings from
+        # the fourth-last and third-last phantom points (and glyph.xMin)
+        glyf.setCoordinates(glyphname, coordinates, varfont)
 
-    if not gvar.variations[glyphname]:
+    if not tupleVarStore:
         del gvar.variations[glyphname]
+        return
+
+    if optimize:
+        isComposite = glyf[glyphname].isComposite()
+        for var in tupleVarStore:
+            var.optimize(coordinates, endPts, isComposite)
 
 
-def instantiateGvar(varfont, location):
+def instantiateGvar(varfont, location, optimize=True):
     log.info("Instantiating glyf/gvar tables")
 
     gvar = varfont["gvar"]
@@ -101,31 +121,28 @@ def instantiateGvar(varfont, location):
         ),
     )
     for glyphname in glyphnames:
-        instantiateGvarGlyph(varfont, glyphname, location)
+        instantiateGvarGlyph(varfont, glyphname, location, optimize=optimize)
 
     if not gvar.variations:
         del varfont["gvar"]
 
 
-def setCvarDeltas(cvt, deltasets):
-    # copy cvt values internally represented as array.array("h") to a list,
-    # accumulating deltas (that may be float since we scaled them) and only
-    # do the rounding to integer once at the end to reduce rounding errors
-    values = list(cvt)
-    for deltas in deltasets:
-        for i, delta in enumerate(deltas):
-            if delta is not None:
-                values[i] += delta
-    for i, v in enumerate(values):
-        cvt[i] = otRound(v)
+def setCvarDeltas(cvt, deltas):
+    for i, delta in enumerate(deltas):
+        if delta is not None:
+            cvt[i] += otRound(delta)
 
 
 def instantiateCvar(varfont, location):
     log.info("Instantiating cvt/cvar tables")
+
     cvar = varfont["cvar"]
-    cvt = varfont["cvt "]
+
     defaultDeltas = instantiateTupleVariationStore(cvar.variations, location)
-    setCvarDeltas(cvt, defaultDeltas)
+
+    if defaultDeltas:
+        setCvarDeltas(varfont["cvt "], defaultDeltas)
+
     if not cvar.variations:
         del varfont["cvar"]
 
@@ -370,7 +387,7 @@ def sanityCheckVariableTables(varfont):
             raise ValueError("Can't have gvar without glyf")
 
 
-def instantiateVariableFont(varfont, axis_limits, inplace=False):
+def instantiateVariableFont(varfont, axis_limits, inplace=False, optimize=True):
     sanityCheckVariableTables(varfont)
 
     if not inplace:
@@ -384,7 +401,7 @@ def instantiateVariableFont(varfont, axis_limits, inplace=False):
         raise NotImplementedError("Axes range limits are not supported yet")
 
     if "gvar" in varfont:
-        instantiateGvar(varfont, axis_limits)
+        instantiateGvar(varfont, axis_limits, optimize=optimize)
 
     if "cvar" in varfont:
         instantiateCvar(varfont, axis_limits)
@@ -451,6 +468,12 @@ def parseArgs(args):
         default=None,
         help="Output instance TTF file (default: INPUT-instance.ttf).",
     )
+    parser.add_argument(
+        "--no-optimize",
+        dest="optimize",
+        action="store_false",
+        help="do not perform IUP optimization on the remaining gvar TupleVariations",
+    )
     logging_group = parser.add_mutually_exclusive_group(required=False)
     logging_group.add_argument(
         "-v", "--verbose", action="store_true", help="Run more verbosely."
@@ -473,17 +496,19 @@ def parseArgs(args):
     axis_limits = parseLimits(options.locargs)
     if len(axis_limits) != len(options.locargs):
         raise ValueError("Specified multiple limits for the same axis")
-    return (infile, outfile, axis_limits)
+    return (infile, outfile, axis_limits, options)
 
 
 def main(args=None):
-    infile, outfile, axis_limits = parseArgs(args)
+    infile, outfile, axis_limits, options = parseArgs(args)
     log.info("Restricting axes: %s", axis_limits)
 
     log.info("Loading variable font")
     varfont = TTFont(infile)
 
-    instantiateVariableFont(varfont, axis_limits, inplace=True)
+    instantiateVariableFont(
+        varfont, axis_limits, inplace=True, optimize=options.optimize
+    )
 
     log.info("Saving partial variable font %s", outfile)
     varfont.save(outfile)

--- a/Tests/ttLib/tables/TupleVariation_test.py
+++ b/Tests/ttLib/tables/TupleVariation_test.py
@@ -788,29 +788,23 @@ class TupleVariationTest(unittest.TestCase):
 		var.optimize([(0, 0)]*129, list(range(129-4)), isComposite=True)
 		self.assertEqual(var.coordinates, [(0, 0)] + [None]*128)
 
-	def test_sumDeltas_gvar(self):
-		coordinates = [
-			(0, 0), (0, 100), (100, 100), (100, 0),
-			(0, 0), (100, 0), (0, 0), (0, 0),
-		]
-		endPts = [3]
-		axes = {"wght": (0.0, 1.0, 1.0)}
+	def test_sum_deltas_gvar(self):
 		var1 = TupleVariation(
-			axes,
+			{},
 			[
-				(-20, 0), None, None, (20, 0),
-				None, None, None, None,
+				(-20, 0), (-20, 0), (20, 0), (20, 0),
+				(0, 0), (0, 0), (0, 0), (0, 0),
 			]
 		)
 		var2 = TupleVariation(
-			axes,
+			{},
 			[
-				(-10, 0), None, None, (10, 0),
-				None, (20, 0), None, None,
+				(-10, 0), (-10, 0), (10, 0), (10, 0),
+				(0, 0), (20, 0), (0, 0), (0, 0),
 			]
 		)
 
-		var1.sumDeltas([var2], coordinates, endPts)
+		var1 += var2
 
 		self.assertEqual(
 			var1.coordinates,
@@ -820,13 +814,14 @@ class TupleVariationTest(unittest.TestCase):
 			]
 		)
 
-	def test_sumDeltas_cvar(self):
+	def test_sum_deltas_cvar(self):
 		axes = {"wght": (0.0, 1.0, 1.0)}
 		var1 = TupleVariation(axes, [0, 1, None, None])
 		var2 = TupleVariation(axes, [None, 2, None, 3])
 		var3 = TupleVariation(axes, [None, None, None, 4])
 
-		var1.sumDeltas([var2, var3])
+		var1 += var2
+		var1 += var3
 
 		self.assertEqual(var1.coordinates, [0, 3, None, 7])
 

--- a/Tests/ttLib/tables/TupleVariation_test.py
+++ b/Tests/ttLib/tables/TupleVariation_test.py
@@ -681,6 +681,155 @@ class TupleVariationTest(unittest.TestCase):
 		content = writer.file.getvalue().decode("utf-8")
 		return [line.strip() for line in content.splitlines()][1:]
 
+	def test_checkDeltaType(self):
+		empty = TupleVariation({}, [])
+		self.assertIsNone(empty.checkDeltaType())
+
+		empty = TupleVariation({}, [None])
+		self.assertIsNone(empty.checkDeltaType())
+
+		gvarTuple = TupleVariation({}, [None, (0, 0)])
+		self.assertEqual(gvarTuple.checkDeltaType(), "gvar")
+
+		cvarTuple = TupleVariation({}, [None, 0])
+		self.assertEqual(cvarTuple.checkDeltaType(), "cvar")
+
+		cvarTuple.coordinates[1] *= 1.0
+		self.assertEqual(cvarTuple.checkDeltaType(), "cvar")
+
+		with self.assertRaises(TypeError):
+			TupleVariation({}, [None, "a"]).checkDeltaType()
+
+	def test_scaleDeltas_cvar(self):
+		var = TupleVariation({}, [100, None])
+
+		var.scaleDeltas(1.0)
+		self.assertEqual(var.coordinates, [100, None])
+
+		var.scaleDeltas(0.5)
+		self.assertEqual(var.coordinates, [50.0, None])
+
+		var.scaleDeltas(0.0)
+		self.assertEqual(var.coordinates, [0, 0])
+
+	def test_scaleDeltas_gvar(self):
+		var = TupleVariation({}, [(100, 200), None])
+
+		var.scaleDeltas(1.0)
+		self.assertEqual(var.coordinates, [(100, 200), None])
+
+		var.scaleDeltas(0.5)
+		self.assertEqual(var.coordinates, [(50.0, 100.0), None])
+
+		var.scaleDeltas(0.0)
+		self.assertEqual(var.coordinates, [(0, 0), (0, 0)])
+
+	def test_roundDeltas_cvar(self):
+		var = TupleVariation({}, [55.5, None, 99.9])
+		var.roundDeltas()
+		self.assertEqual(var.coordinates, [56, None, 100])
+
+	def test_roundDeltas_gvar(self):
+		var = TupleVariation({}, [(55.5, 100.0), None, (99.9, 100.0)])
+		var.roundDeltas()
+		self.assertEqual(var.coordinates, [(56, 100), None, (100, 100)])
+
+	def test_calcInferredDeltas(self):
+		var = TupleVariation({}, [(0, 0), None, None, None])
+		coords = [(1, 1), (1, 1), (1, 1), (1, 1)]
+
+		var.calcInferredDeltas(coords, [])
+
+		self.assertEqual(
+			var.coordinates,
+			[(0, 0), (0, 0), (0, 0), (0, 0)]
+		)
+
+	def test_calcInferredDeltas_invalid(self):
+		# cvar tuples can't have inferred deltas
+		with self.assertRaises(TypeError):
+			TupleVariation({}, [0]).calcInferredDeltas([], [])
+
+		# origCoords must have same length as self.coordinates
+		with self.assertRaises(ValueError):
+			TupleVariation({}, [(0, 0), None]).calcInferredDeltas([], [])
+
+		# at least 4 phantom points required
+		with self.assertRaises(AssertionError):
+			TupleVariation({}, [(0, 0), None]).calcInferredDeltas([(0, 0), (0, 0)], [])
+
+		with self.assertRaises(AssertionError):
+			TupleVariation({}, [(0, 0)] + [None]*5).calcInferredDeltas(
+				[(0, 0)]*6,
+				[1, 0]  # endPts not in increasing order
+			)
+
+	def test_optimize(self):
+		var = TupleVariation({"wght": (0.0, 1.0, 1.0)}, [(0, 0)]*5)
+
+		var.optimize([(0, 0)]*5, [0])
+
+		self.assertEqual(var.coordinates, [None, None, None, None, None])
+
+	def test_optimize_isComposite(self):
+		# when a composite glyph's deltas are all (0, 0), we still want
+		# to write out an entry in gvar, else macOS doesn't apply any
+		# variations to the composite glyph (even if its individual components
+		# do vary).
+		# https://github.com/fonttools/fonttools/issues/1381
+		var = TupleVariation({"wght": (0.0, 1.0, 1.0)}, [(0, 0)]*5)
+		var.optimize([(0, 0)]*5, [0], isComposite=True)
+		self.assertEqual(var.coordinates, [(0, 0)]*5)
+
+		# it takes more than 128 (0, 0) deltas before the optimized tuple with
+		# (None) inferred deltas (except for the first) becomes smaller than
+		# the un-optimized one that has all deltas explicitly set to (0, 0).
+		var = TupleVariation({"wght": (0.0, 1.0, 1.0)}, [(0, 0)]*129)
+		var.optimize([(0, 0)]*129, list(range(129-4)), isComposite=True)
+		self.assertEqual(var.coordinates, [(0, 0)] + [None]*128)
+
+	def test_sumDeltas_gvar(self):
+		coordinates = [
+			(0, 0), (0, 100), (100, 100), (100, 0),
+			(0, 0), (100, 0), (0, 0), (0, 0),
+		]
+		endPts = [3]
+		axes = {"wght": (0.0, 1.0, 1.0)}
+		var1 = TupleVariation(
+			axes,
+			[
+				(-20, 0), None, None, (20, 0),
+				None, None, None, None,
+			]
+		)
+		var2 = TupleVariation(
+			axes,
+			[
+				(-10, 0), None, None, (10, 0),
+				None, (20, 0), None, None,
+			]
+		)
+
+		var1.sumDeltas([var2], coordinates, endPts)
+
+		self.assertEqual(
+			var1.coordinates,
+			[
+				(-30, 0), (-30, 0), (30, 0), (30, 0),
+				(0, 0), (20, 0), (0, 0), (0, 0),
+			]
+		)
+
+	def test_sumDeltas_cvar(self):
+		axes = {"wght": (0.0, 1.0, 1.0)}
+		var1 = TupleVariation(axes, [0, 1, None, None])
+		var2 = TupleVariation(axes, [None, 2, None, 3])
+		var3 = TupleVariation(axes, [None, None, None, 4])
+
+		var1.sumDeltas([var2, var3])
+
+		self.assertEqual(var1.coordinates, [0, 3, None, 7])
+
 
 if __name__ == "__main__":
 	import sys

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -54,10 +54,10 @@ class InstantiateGvarTest(object):
                 {"wdth": -0.5},
                 {
                     "hyphen": [
-                        (33.5, 229),
-                        (33.5, 308.5),
-                        (264.5, 308.5),
-                        (264.5, 229),
+                        (34, 229),
+                        (34, 309),
+                        (265, 309),
+                        (265, 229),
                         (0, 0),
                         (298, 0),
                         (0, 1000),
@@ -102,10 +102,10 @@ class InstantiateGvarTest(object):
         instancer.instantiateGvar(varfont, {"wght": 0.0, "wdth": -0.5})
 
         assert _get_coordinates(varfont, "hyphen") == [
-            (33.5, 229),
-            (33.5, 308.5),
-            (264.5, 308.5),
-            (264.5, 229),
+            (34, 229),
+            (34, 309),
+            (265, 309),
+            (265, 229),
             (0, 0),
             (298, 0),
             (0, 1000),


### PR DESCRIPTION
This modifies `instantiateTupleVariationStore` function so that it merges TupleVariation tables that end up having the same axes 'tents' following partial instancing, by summing their deltas.
To do that, it needs to calculate the inferred deltas so it now takes two optional lists (origCoords and endPts) that are passed on to iup_delta function.
It also run iup_delta_optimize on the gvar deltas that are left after partial instancing and whose inferred deltas had to be interpolated (this can be optionally be disabled with `--no-optimize` CLI option).