### PR TITLE
arrayTools: calcIntBounds should use otRound, not round3

### DIFF
--- a/Lib/fontTools/misc/arrayTools.py
+++ b/Lib/fontTools/misc/arrayTools.py
@@ -6,6 +6,7 @@
 
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+from fontTools.misc.fixedTools import otRound
 from numbers import Number
 import math
 import operator
@@ -20,10 +21,11 @@ def calcBounds(array):
     ys = [y for x, y in array]
     return min(xs), min(ys), max(xs), max(ys)
 
-def calcIntBounds(array):
+def calcIntBounds(array, round=otRound):
     """Return the integer bounding rectangle of a 2D points array as a
     tuple: (xMin, yMin, xMax, yMax)
-    Values are rounded to closest integer.
+    Values are rounded to closest integer towards +Infinity using otRound
+    function by default, unless an optional 'round' function is passed.
     """
     return tuple(round(v) for v in calcBounds(array))
 

--- a/Tests/misc/arrayTools_test.py
+++ b/Tests/misc/arrayTools_test.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 from fontTools.misc.py23 import *
+from fontTools.misc.py23 import round3
 from fontTools.misc.arrayTools import (
     calcBounds, calcIntBounds, updateBounds, pointInRect, pointsInRect,
     vectorLength, asInt16, normRect, scaleRect, offsetRect, insetRect,
@@ -15,8 +16,13 @@ def test_calcBounds():
 
 def test_calcIntBounds():
     assert calcIntBounds(
-        [(0.1, 40.1), (0.1, 100.1), (49.9, 49.9), (79.5, 9.5)]
-    ) == (0, 10, 80, 100)
+        [(0.1, 40.1), (0.1, 100.1), (49.9, 49.9), (78.5, 9.5)]
+    ) == (0, 10, 79, 100)
+
+    assert calcIntBounds(
+        [(0.1, 40.1), (0.1, 100.1), (49.9, 49.9), (78.5, 9.5)],
+        round=round3
+    ) == (0, 10, 78, 100)
 
 
 def test_updateBounds():


### PR DESCRIPTION
Somehow we forgot to replace `round` -> `otRound` in `arrayTools.calcIntBounds`.
This function is used by glyf table to compute the glyphs' bounding boxes.
We already use otRound (aka `int(math.floor(v + .5))`) to round glyph coordinates upon compiling glyf table. So, the use of python3's round in calcIntBounds was producing inconsistent roundings between the glyph coordinates and the glyph bbox (sometimes, i.e. only when the glyf table contains float coordinates, e.g. after instantiating with varLib.mutator).