### PR TITLE
[cffLib] Allow charset to be a collections.deque

### DIFF
--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -1382,7 +1382,7 @@ def packCharset0(charset, isCID, strings):
 	else:
 		getNameID = getSIDfromName
 
-	for name in charset[1:]:
+	for name in list(charset)[1:]:
 		data.append(packCard16(getNameID(name, strings)))
 	return bytesjoin(data)
 
@@ -1397,7 +1397,7 @@ def packCharset(charset, isCID, strings):
 	else:
 		getNameID = getSIDfromName
 
-	for name in charset[1:]:
+	for name in list(charset)[1:]:
 		SID = getNameID(name, strings)
 		if first is None:
 			first = SID


### PR DESCRIPTION
While making an OTF with **fontBuilder** I used [`collections.deque`](https://docs.python.org/3/library/collections.html#collections.deque) (instead of a simple `list`) to assemble the font's glyph order.

This patch fixes the following error I ran into,

    TypeError: sequence index must be integer, not 'slice'