### PR TITLE
[partial-instancer] merge regions with same axes and optimize ItemVarStore

### DIFF
--- a/Tests/varLib/data/PartialInstancerTest-VF.ttx
+++ b/Tests/varLib/data/PartialInstancerTest-VF.ttx
@@ -644,6 +644,13 @@
         <Item index="1" value="[100, 0, -20]"/>
         <Item index="2" value="[50, -30, -20]"/>
       </VarData>
+      <VarData>
+        <!-- ItemCount=1 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="0"/>
+        <Item index="0" value="[30]"/>
+      </VarData>
     </VarStore>
     <ValueRecord index="0">
       <ValueTag value="strs"/>
@@ -656,6 +663,10 @@
     <ValueRecord index="2">
       <ValueTag value="unds"/>
       <VarIdx value="1"/>
+    </ValueRecord>
+    <ValueRecord index="3">
+      <ValueTag value="xhgt"/>
+      <VarIdx value="65536"/>
     </ValueRecord>
   </MVAR>
 

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -19,6 +19,11 @@ def varfont():
     return f
 
 
+@pytest.fixture(params=[True, False], ids=["optimize", "no-optimize"])
+def optimize(request):
+    return request.param
+
+
 def _get_coordinates(varfont, glyphname):
     # converts GlyphCoordinates to a list of (x, y) tuples, so that pytest's
     # assert will give us a nicer diff
@@ -27,10 +32,6 @@ def _get_coordinates(varfont, glyphname):
 
 class InstantiateGvarTest(object):
     @pytest.mark.parametrize("glyph_name", ["hyphen"])
-    @pytest.mark.parametrize(
-        "optimize",
-        [pytest.param(True, id="optimize"), pytest.param(False, id="no-optimize")],
-    )
     @pytest.mark.parametrize(
         "location, expected",
         [
@@ -98,8 +99,10 @@ class InstantiateGvarTest(object):
             for t in tuples
         )
 
-    def test_full_instance(self, varfont):
-        instancer.instantiateGvar(varfont, {"wght": 0.0, "wdth": -0.5})
+    def test_full_instance(self, varfont, optimize):
+        instancer.instantiateGvar(
+            varfont, {"wght": 0.0, "wdth": -0.5}, optimize=optimize
+        )
 
         assert _get_coordinates(varfont, "hyphen") == [
             (34, 229),


### PR DESCRIPTION
instantiateItemVarStore now calls VarStore.optimize() at the end and returns the mapping from old to new VarIdx (or None if varStore has been emptied).

We also merge regions that end up with identical axes configuration after partial-instancing, so that they only occupy a single column in the delta-set rows.