### PR TITLE
[partial-instancer] convert item to tuple varstore to reuse code

### DIFF
--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -133,8 +133,11 @@ def VarData_addItem(self, deltas):
 ot.VarData.addItem = VarData_addItem
 
 def VarRegion_get_support(self, fvar_axes):
-	return {fvar_axes[i].axisTag: (reg.StartCoord,reg.PeakCoord,reg.EndCoord)
-		for i,reg in enumerate(self.VarRegionAxis)}
+	return {
+		fvar_axes[i].axisTag: (reg.StartCoord,reg.PeakCoord,reg.EndCoord)
+		for i, reg in enumerate(self.VarRegionAxis)
+		if reg.PeakCoord != 0
+	}
 
 ot.VarRegion.get_support = VarRegion_get_support
 

--- a/Tests/varLib/data/PartialInstancerTest-VF.ttx
+++ b/Tests/varLib/data/PartialInstancerTest-VF.ttx
@@ -644,6 +644,13 @@
         <Item index="1" value="[100, 0, -20]"/>
         <Item index="2" value="[50, -30, -20]"/>
       </VarData>
+      <VarData>
+        <!-- ItemCount=1 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="0"/>
+        <Item index="0" value="[30]"/>
+      </VarData>
     </VarStore>
     <ValueRecord index="0">
       <ValueTag value="strs"/>
@@ -656,6 +663,10 @@
     <ValueRecord index="2">
       <ValueTag value="unds"/>
       <VarIdx value="1"/>
+    </ValueRecord>
+    <ValueRecord index="3">
+      <ValueTag value="xhgt"/>
+      <VarIdx value="65536"/>
     </ValueRecord>
   </MVAR>
 

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -19,6 +19,11 @@ def varfont():
     return f
 
 
+@pytest.fixture(params=[True, False], ids=["optimize", "no-optimize"])
+def optimize(request):
+    return request.param
+
+
 def _get_coordinates(varfont, glyphname):
     # converts GlyphCoordinates to a list of (x, y) tuples, so that pytest's
     # assert will give us a nicer diff
@@ -27,10 +32,6 @@ def _get_coordinates(varfont, glyphname):
 
 class InstantiateGvarTest(object):
     @pytest.mark.parametrize("glyph_name", ["hyphen"])
-    @pytest.mark.parametrize(
-        "optimize",
-        [pytest.param(True, id="optimize"), pytest.param(False, id="no-optimize")],
-    )
     @pytest.mark.parametrize(
         "location, expected",
         [
@@ -98,8 +99,10 @@ class InstantiateGvarTest(object):
             for t in tuples
         )
 
-    def test_full_instance(self, varfont):
-        instancer.instantiateGvar(varfont, {"wght": 0.0, "wdth": -0.5})
+    def test_full_instance(self, varfont, optimize):
+        instancer.instantiateGvar(
+            varfont, {"wght": 0.0, "wdth": -0.5}, optimize=optimize
+        )
 
         assert _get_coordinates(varfont, "hyphen") == [
             (34, 229),


### PR DESCRIPTION
This is an alternative approach to #1577 
The first two commits are the same in this and the previous PR, they only diverge on the last commit.

The difference is that, instead of reimplementing the same logic twice for tuple and item variation stores, here I reduce the latter to the former using an adapter class, then run instantiateTupleVarStore and build a new Item VarStore from the result.