### PR TITLE
[partial-instancer] support instantiating GDEF and GPOS

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -597,9 +597,15 @@ def _merge_OTL(font, model, master_fonts, axisTags):
 		GDEF = font['GDEF'].table
 		assert GDEF.Version <= 0x00010002
 	except KeyError:
-		font['GDEF']= newTable('GDEF')
+		font['GDEF'] = newTable('GDEF')
 		GDEFTable = font["GDEF"] = newTable('GDEF')
 		GDEF = GDEFTable.table = ot.GDEF()
+		GDEF.GlyphClassDef = None
+		GDEF.AttachList = None
+		GDEF.LigCaretList = None
+		GDEF.MarkAttachClassDef = None
+		GDEF.MarkGlyphSetsDef = None
+
 	GDEF.Version = 0x00010003
 	GDEF.VarStore = store
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -142,8 +142,6 @@ def instantiateCvar(varfont, location):
 
 
 def setMvarDeltas(varfont, deltas):
-    log.info("Setting MVAR deltas")
-
     mvar = varfont["MVAR"].table
     records = mvar.ValueRecord
     for rec in records:

--- a/Lib/fontTools/varLib/mutator.py
+++ b/Lib/fontTools/varLib/mutator.py
@@ -284,7 +284,7 @@ def instantiateVariableFont(varfont, location, inplace=False, overlap=True):
 		gdef = varfont['GDEF'].table
 		instancer = VarStoreInstancer(gdef.VarStore, fvar.axes, loc)
 
-		merger = MutatorMerger(varfont, loc)
+		merger = MutatorMerger(varfont, instancer)
 		merger.mergeTables(varfont, [varfont], ['GDEF', 'GPOS'])
 
 		# Downgrade GDEF.

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -326,7 +326,15 @@ class InstantiateItemVariationStoreTest(object):
             varStore, fvarAxes, location
         )
 
-        assert defaultDeltas == expected_deltas
+        defaultDeltaArray = []
+        for varidx, delta in sorted(defaultDeltas.items()):
+            major, minor = varidx >> 16, varidx & 0xFFFF
+            if major == len(defaultDeltaArray):
+                defaultDeltaArray.append([])
+            assert len(defaultDeltaArray[major]) == minor
+            defaultDeltaArray[major].append(delta)
+
+        assert defaultDeltaArray == expected_deltas
         assert varStore.VarRegionList.RegionCount == num_regions
 
 

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -473,8 +473,7 @@ class TupleVarStoreAdapterTest(object):
         itemVarStore2 = adapter.asItemVarStore()
 
         assert [
-            reg.get_support(fvarAxes)
-            for reg in itemVarStore2.VarRegionList.Region
+            reg.get_support(fvarAxes) for reg in itemVarStore2.VarRegionList.Region
         ] == regions
 
         assert itemVarStore2.VarDataCount == 2


### PR DESCRIPTION
this uses the same MutatorMerger class as is used in mutator module, slightly modified to optionally allow to keep VariationIndex tables when VarStore was only partially instanced.