### PR TITLE
[instancer] support instantiating HVAR and VVAR  (TTF only for now)

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -372,8 +372,6 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 
 		# Handle phantom points for (left, right, top, bottom) positions.
 		assert len(coord) >= 4
-		if not hasattr(glyph, 'xMin'):
-			glyph.recalcBounds(self)
 		leftSideX = coord[-4][0]
 		rightSideX = coord[-3][0]
 		topSideY = coord[-2][1]

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -362,9 +362,9 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 		"coord" is an array of GlyphCoordinates which must include the four
 		"phantom points".
 
-		Only the horizontal advance and sidebearings in "hmtx" table are updated
-		from the first two phantom points. The last two phantom points for
-		vertical typesetting are currently ignored.
+		Both the horizontal/vertical advances and left/top sidebearings in "hmtx"
+		and "vmtx" tables (if any) are updated from four phantom points and
+		the glyph's bounding boxes.
 		"""
 		# TODO: Create new glyph if not already present
 		assert glyphName in self.glyphs
@@ -400,8 +400,14 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 			# https://github.com/fonttools/fonttools/pull/1198
 			horizontalAdvanceWidth = 0
 		leftSideBearing = otRound(glyph.xMin - leftSideX)
-		# TODO Handle vertical metrics?
 		ttFont["hmtx"].metrics[glyphName] = horizontalAdvanceWidth, leftSideBearing
+
+		if "vmtx" in ttFont:
+			verticalAdvanceWidth = otRound(topSideY - bottomSideY)
+			if verticalAdvanceWidth < 0:  # unlikely but do the same as horizontal
+				verticalAdvanceWidth = 0
+			topSideBearing = otRound(topSideY - glyph.yMax)
+			ttFont["vmtx"].metrics[glyphName] = verticalAdvanceWidth, topSideBearing
 
 
 _GlyphControls = namedtuple(

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -367,20 +367,20 @@ def _merge_TTHinting(font, masterModel, master_ttfs, tolerance=0.5):
 		var = TupleVariation(support, delta)
 		cvar.variations.append(var)
 
-MetricsFields = namedtuple('MetricsFields',
+_MetricsFields = namedtuple('_MetricsFields',
 	['tableTag', 'metricsTag', 'sb1', 'sb2', 'advMapping', 'vOrigMapping'])
 
-hvarFields = MetricsFields(tableTag='HVAR', metricsTag='hmtx', sb1='LsbMap',
+HVAR_FIELDS = _MetricsFields(tableTag='HVAR', metricsTag='hmtx', sb1='LsbMap',
 	sb2='RsbMap', advMapping='AdvWidthMap', vOrigMapping=None)
 
-vvarFields = MetricsFields(tableTag='VVAR', metricsTag='vmtx', sb1='TsbMap',
+VVAR_FIELDS = _MetricsFields(tableTag='VVAR', metricsTag='vmtx', sb1='TsbMap',
 	sb2='BsbMap', advMapping='AdvHeightMap', vOrigMapping='VOrgMap')
 
 def _add_HVAR(font, masterModel, master_ttfs, axisTags):
-	_add_VHVAR(font, masterModel, master_ttfs, axisTags, hvarFields)
+	_add_VHVAR(font, masterModel, master_ttfs, axisTags, HVAR_FIELDS)
 
 def _add_VVAR(font, masterModel, master_ttfs, axisTags):
-	_add_VHVAR(font, masterModel, master_ttfs, axisTags, vvarFields)
+	_add_VHVAR(font, masterModel, master_ttfs, axisTags, VVAR_FIELDS)
 
 def _add_VHVAR(font, masterModel, master_ttfs, axisTags, tableFields):
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -200,15 +200,18 @@ def _instantiateVHVAR(varfont, location, tableFields):
     instantiateItemVariationStore(varStore, fvarAxes, location)
 
     if varStore.VarRegionList.Region:
+        # Only re-optimize VarStore if the HVAR/VVAR already uses indirect AdvWidthMap
+        # or AdvHeightMap. If a direct, implicit glyphID->VariationIndex mapping is
+        # used for advances, skip re-optimizing and maintain original VariationIndex.
         if getattr(vhvar, tableFields.advMapping):
             varIndexMapping = varStore.optimize()
             glyphOrder = varfont.getGlyphOrder()
             _remapVarIdxMap(vhvar, tableFields.advMapping, varIndexMapping, glyphOrder)
-            if getattr(vhvar, tableFields.sb1):
+            if getattr(vhvar, tableFields.sb1):  # left or top sidebearings
                 _remapVarIdxMap(vhvar, tableFields.sb1, varIndexMapping, glyphOrder)
-            if getattr(vhvar, tableFields.sb2):
+            if getattr(vhvar, tableFields.sb2):  # right or bottom sidebearings
                 _remapVarIdxMap(vhvar, tableFields.sb2, varIndexMapping, glyphOrder)
-            if tableFields.vOrigMapping and getattr(vhvar, tableFields.vOrigMapping):
+            if tableTag == "VVAR" and getattr(vhvar, tableFields.vOrigMapping):
                 _remapVarIdxMap(
                     vhvar, tableFields.vOrigMapping, varIndexMapping, glyphOrder
                 )

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -297,6 +297,8 @@ class _TupleVarStoreAdapter(object):
                 )
         regionList = builder.buildVarRegionList(self.regions, self.axisOrder)
         itemVarStore = builder.buildVarStore(regionList, varDatas)
+        # remove unused regions from VarRegionList
+        itemVarStore.prune_regions()
         return itemVarStore
 
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -158,7 +158,7 @@ def setMvarDeltas(varfont, deltas):
             )
 
 
-def instantiateMvar(varfont, location):
+def instantiateMVAR(varfont, location):
     log.info("Instantiating MVAR table")
 
     mvar = varfont["MVAR"].table
@@ -461,7 +461,7 @@ def instantiateVariableFont(varfont, axis_limits, inplace=False, optimize=True):
         instantiateCvar(varfont, axis_limits)
 
     if "MVAR" in varfont:
-        instantiateMvar(varfont, axis_limits)
+        instantiateMVAR(varfont, axis_limits)
 
     instantiateOTL(varfont, axis_limits)
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -83,8 +83,8 @@ def instantiateGvarGlyph(varfont, glyphname, location, optimize=True):
 
     if defaultDeltas:
         coordinates += GlyphCoordinates(defaultDeltas)
-        # this will also set the hmtx advance widths and sidebearings from
-        # the fourth-last and third-last phantom points (and glyph.xMin)
+        # this will also set the hmtx/vmtx advance widths and sidebearings from
+        # the four phantom points and glyph bounding boxes
         glyf.setCoordinates(glyphname, coordinates, varfont)
 
     if not tupleVarStore:
@@ -513,9 +513,8 @@ def instantiateVariableFont(varfont, axis_limits, inplace=False, optimize=True):
     if "HVAR" in varfont:
         instantiateHVAR(varfont, axis_limits)
 
-    # TODO(anthrotype) Uncomment this once we apply gvar deltas to vmtx
-    # if "VVAR" in varfont:
-    #     instantiateVVAR(varfont, axis_limits)
+    if "VVAR" in varfont:
+        instantiateVVAR(varfont, axis_limits)
 
     instantiateOTL(varfont, axis_limits)
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -434,6 +434,11 @@ def sanityCheckVariableTables(varfont):
     if "gvar" in varfont:
         if "glyf" not in varfont:
             raise ValueError("Can't have gvar without glyf")
+    # TODO(anthrotype) Remove once we do support partial instancing CFF2
+    if "CFF2" in varfont:
+        raise NotImplementedError(
+            "Instancing CFF2 variable fonts is not supported yet"
+        )
 
 
 def instantiateVariableFont(varfont, axis_limits, inplace=False, optimize=True):

--- a/Tests/varLib/data/PartialInstancerTest-VF.ttx
+++ b/Tests/varLib/data/PartialInstancerTest-VF.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.39">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.40">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -12,12 +12,12 @@
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
     <fontRevision value="2.001"/>
-    <checkSumAdjustment value="0x9184e88f"/>
+    <checkSumAdjustment value="0x9180a393"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000011"/>
     <unitsPerEm value="1000"/>
     <created value="Tue Mar  5 00:05:14 2019"/>
-    <modified value="Sat Apr 20 14:38:56 2019"/>
+    <modified value="Sat Apr 20 17:03:24 2019"/>
     <xMin value="40"/>
     <yMin value="-200"/>
     <xMax value="450"/>
@@ -570,7 +570,7 @@
       </VarRegionList>
       <!-- VarDataCount=1 -->
       <VarData index="0">
-        <!-- ItemCount=3 -->
+        <!-- ItemCount=2 -->
         <NumShorts value="0"/>
         <!-- VarRegionCount=5 -->
         <VarRegionIndex index="0" value="2"/>
@@ -578,11 +578,15 @@
         <VarRegionIndex index="2" value="4"/>
         <VarRegionIndex index="3" value="5"/>
         <VarRegionIndex index="4" value="6"/>
-        <Item index="0" value="[0, 0, 0, 0, 0]"/>
-        <Item index="1" value="[-4, -48, -11, 31, 55]"/>
-        <Item index="2" value="[0, 0, 0, 0, 0]"/>
+        <Item index="0" value="[-4, -48, -11, 31, 55]"/>
+        <Item index="1" value="[0, 0, 0, 0, 0]"/>
       </VarData>
     </VarStore>
+    <AdvWidthMap>
+      <Map glyph=".notdef" outer="0" inner="1"/>
+      <Map glyph="hyphen" outer="0" inner="0"/>
+      <Map glyph="space" outer="0" inner="1"/>
+    </AdvWidthMap>
   </HVAR>
 
   <MVAR>

--- a/Tests/varLib/data/PartialInstancerTest-VF.ttx
+++ b/Tests/varLib/data/PartialInstancerTest-VF.ttx
@@ -12,12 +12,12 @@
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
     <fontRevision value="2.001"/>
-    <checkSumAdjustment value="0x45c905be"/>
+    <checkSumAdjustment value="0x9184e88f"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000011"/>
     <unitsPerEm value="1000"/>
     <created value="Tue Mar  5 00:05:14 2019"/>
-    <modified value="Mon Mar 25 12:51:29 2019"/>
+    <modified value="Sat Apr 20 14:38:56 2019"/>
     <xMin value="40"/>
     <yMin value="-200"/>
     <xMax value="450"/>
@@ -589,7 +589,7 @@
     <Version value="0x00010000"/>
     <Reserved value="0"/>
     <ValueRecordSize value="8"/>
-    <!-- ValueRecordCount=3 -->
+    <!-- ValueRecordCount=4 -->
     <VarStore Format="1">
       <Format value="1"/>
       <VarRegionList>
@@ -632,7 +632,7 @@
           </VarRegionAxis>
         </Region>
       </VarRegionList>
-      <!-- VarDataCount=1 -->
+      <!-- VarDataCount=2 -->
       <VarData index="0">
         <!-- ItemCount=3 -->
         <NumShorts value="1"/>
@@ -644,7 +644,7 @@
         <Item index="1" value="[100, 0, -20]"/>
         <Item index="2" value="[50, -30, -20]"/>
       </VarData>
-      <VarData>
+      <VarData index="1">
         <!-- ItemCount=1 -->
         <NumShorts value="0"/>
         <!-- VarRegionCount=1 -->
@@ -1015,5 +1015,11 @@
       </tuple>
     </glyphVariations>
   </gvar>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="100"/>
+    <mtx name="hyphen" height="536" tsb="229"/>
+    <mtx name="space" height="600" tsb="0"/>
+  </vmtx>
 
 </ttFont>

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -328,7 +328,7 @@ class InstantiateItemVariationStoreTest(object):
     def test_instantiate_default_deltas(
         self, varStore, fvarAxes, location, expected_deltas, num_regions
     ):
-        defaultDeltas, _ = instancer.instantiateItemVariationStore(
+        defaultDeltas = instancer.instantiateItemVariationStore(
             varStore, fvarAxes, location
         )
 

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -169,7 +169,7 @@ class InstantiateCvarTest(object):
         assert "cvar" not in varfont
 
 
-class InstantiateMvarTest(object):
+class InstantiateMVARTest(object):
     @pytest.mark.parametrize(
         "location, expected",
         [
@@ -217,7 +217,7 @@ class InstantiateMvarTest(object):
         assert mvar.VarStore.VarData[1].VarRegionCount == 1
         assert all(len(item) == 1 for item in mvar.VarStore.VarData[1].Item)
 
-        instancer.instantiateMvar(varfont, location)
+        instancer.instantiateMVAR(varfont, location)
 
         for mvar_tag, expected_value in expected.items():
             table_tag, item_name = MVAR_ENTRIES[mvar_tag]
@@ -268,7 +268,7 @@ class InstantiateMvarTest(object):
         ],
     )
     def test_full_instance(self, varfont, location, expected):
-        instancer.instantiateMvar(varfont, location)
+        instancer.instantiateMVAR(varfont, location)
 
         for mvar_tag, expected_value in expected.items():
             table_tag, item_name = MVAR_ENTRIES[mvar_tag]

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -67,7 +67,7 @@ class InstantiateGvarTest(object):
                         (247, 229),
                         (0, 0),
                         (274, 0),
-                        (0, 1000),
+                        (0, 536),
                         (0, 0),
                     ]
                 },
@@ -83,7 +83,7 @@ class InstantiateGvarTest(object):
                         (265, 229),
                         (0, 0),
                         (298, 0),
-                        (0, 1000),
+                        (0, 536),
                         (0, 0),
                     ]
                 },
@@ -101,7 +101,7 @@ class InstantiateGvarTest(object):
                         (282, 229),
                         (0, 0),
                         (322, 0),
-                        (0, 1000),
+                        (0, 536),
                         (0, 0),
                     ]
                 },
@@ -133,7 +133,7 @@ class InstantiateGvarTest(object):
             (265, 229),
             (0, 0),
             (298, 0),
-            (0, 1000),
+            (0, 536),
             (0, 0),
         ]
 


### PR DESCRIPTION
We don't actually apply deltas to hmtx/vmtx from HVAR/VVAR since these have already been applied from the gvar deltas when we call `glyf.setCoordinates` method using the glyph's four phantom points.

We simply call `instantiateItemVariationStore` on `{H,V}VAR.VarStore` in order to remove regions and scale remaining deltas, but we ignore the return value.

Also, we run `VarStore.optimize()` (which modifies the VarDatas layout) only when the HVAR/VVAR originally have an AdvWidthMap/AdvHeightMap.
If they do not (they use a direct implicit GID->VariationIndex mapping for advance deltas), then we keep the VariationIndex unchanged by not optimizing the VarStore.

If all the axes in fvar are being instanced, then we simply delete HVAR (just like varLib.mutator currently does).

Finally, supporting CFF2 would need more work, in that HVAR is required and we need to apply the deltas to hmtx in here. Let's do that after we add support for partial instancing CFF2 charstrings.

I'll add some tests later.