### PR TITLE
[subset] HVAR/VVAR with --retain-gids

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -1803,15 +1803,17 @@ def _remap_index_map(s, varidx_map, table_map):
 def subset_glyphs(self, s):
 	table = self.table
 
-	# TODO Update for retain_gids
-
 	used = set()
+	advIdxes_ = set()
+	retainAdvMap = False
 
 	if table.AdvWidthMap:
 		table.AdvWidthMap.mapping = _dict_subset(table.AdvWidthMap.mapping, s.glyphs)
 		used.update(table.AdvWidthMap.mapping.values())
 	else:
 		used.update(s.reverseOrigGlyphMap.values())
+		advIdxes_ = used.copy()
+		retainAdvMap = s.options.retain_gids
 
 	if table.LsbMap:
 		table.LsbMap.mapping = _dict_subset(table.LsbMap.mapping, s.glyphs)
@@ -1820,7 +1822,7 @@ def subset_glyphs(self, s):
 		table.RsbMap.mapping = _dict_subset(table.RsbMap.mapping, s.glyphs)
 		used.update(table.RsbMap.mapping.values())
 
-	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, retainFirstMap=table.AdvWidthMap is None)
+	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, retainFirstMap=retainAdvMap, advIdxes=advIdxes_)
 
 	if table.AdvWidthMap:
 		table.AdvWidthMap.mapping = _remap_index_map(s, varidx_map, table.AdvWidthMap)
@@ -1837,12 +1839,16 @@ def subset_glyphs(self, s):
 	table = self.table
 
 	used = set()
+	advIdxes_ = set()
+	retainAdvMap = False
 
 	if table.AdvHeightMap:
 		table.AdvHeightMap.mapping = _dict_subset(table.AdvHeightMap.mapping, s.glyphs)
 		used.update(table.AdvHeightMap.mapping.values())
 	else:
 		used.update(s.reverseOrigGlyphMap.values())
+		advIdxes_ = used.copy()
+		retainAdvMap = s.options.retain_gids
 
 	if table.TsbMap:
 		table.TsbMap.mapping = _dict_subset(table.TsbMap.mapping, s.glyphs)
@@ -1854,7 +1860,7 @@ def subset_glyphs(self, s):
 		table.VOrgMap.mapping = _dict_subset(table.VOrgMap.mapping, s.glyphs)
 		used.update(table.VOrgMap.mapping.values())
 
-	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, retainFirstMap=table.AdvHeightMap is None)
+	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, retainFirstMap=retainAdvMap, advIdxes=advIdxes_)
 
 	if table.AdvHeightMap:
 		table.AdvHeightMap.mapping = _remap_index_map(s, varidx_map, table.AdvHeightMap)

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -1790,11 +1790,14 @@ def subset_glyphs(self, s):
 	return bool(self.variations)
 
 def _remap_index_map(s, varidx_map, table_map):
-	map = {k:varidx_map[v] for k,v in table_map.mapping.items()}
+	map_ = {k:varidx_map[v] for k,v in table_map.mapping.items()}
+	# Emptied glyphs are remapped to:
+	# if GID <= last retained GID, 0/0: delta set for 0/0 is expected to exist & zeros compress well
+	# if GID > last retained GID, major/minor of the last retained glyph: will be optimized out by table compiler
 	last_idx = varidx_map[table_map.mapping[s.last_retained_glyph]]
 	for g,i in s.reverseEmptiedGlyphMap.items():
-		map[g] = last_idx if i > s.last_retained_order else 0
-	return map
+		map_[g] = last_idx if i > s.last_retained_order else 0
+	return map_
 
 @_add_method(ttLib.getTableClass('HVAR'))
 def subset_glyphs(self, s):

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -1803,7 +1803,7 @@ def subset_glyphs(self, s):
 	# TODO Update for retain_gids
 
 	used = set()
-	zeroUnused = False
+	retainAdvMap = False
 
 	if table.AdvWidthMap:
 		table.AdvWidthMap.mapping = _dict_subset(table.AdvWidthMap.mapping, s.glyphs)
@@ -1811,7 +1811,7 @@ def subset_glyphs(self, s):
 	else:
 		assert table.LsbMap is None and table.RsbMap is None, "File a bug."
 		used.update(s.reverseOrigGlyphMap.values())
-		zeroUnused = s.options.retain_gids
+		retainAdvMap = s.options.retain_gids
 
 	if table.LsbMap:
 		table.LsbMap.mapping = _dict_subset(table.LsbMap.mapping, s.glyphs)
@@ -1820,7 +1820,7 @@ def subset_glyphs(self, s):
 		table.RsbMap.mapping = _dict_subset(table.RsbMap.mapping, s.glyphs)
 		used.update(table.RsbMap.mapping.values())
 
-	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, zeroUnusedDeltas=zeroUnused)
+	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, retainFirstMap=retainAdvMap)
 
 	if table.AdvWidthMap:
 		table.AdvWidthMap.mapping = _remap_index_map(s, varidx_map, table.AdvWidthMap)
@@ -1837,7 +1837,7 @@ def subset_glyphs(self, s):
 	table = self.table
 
 	used = set()
-	zeroUnused = False
+	retainAdvMap = False
 
 	if table.AdvHeightMap:
 		table.AdvHeightMap.mapping = _dict_subset(table.AdvHeightMap.mapping, s.glyphs)
@@ -1845,7 +1845,7 @@ def subset_glyphs(self, s):
 	else:
 		assert table.TsbMap is None and table.BsbMap is None and table.VOrgMap is None, "File a bug."
 		used.update(s.reverseOrigGlyphMap.values())
-		zeroUnused = s.options.retain_gids
+		retainAdvMap = s.options.retain_gids
 
 	if table.TsbMap:
 		table.TsbMap.mapping = _dict_subset(table.TsbMap.mapping, s.glyphs)
@@ -1857,7 +1857,7 @@ def subset_glyphs(self, s):
 		table.VOrgMap.mapping = _dict_subset(table.VOrgMap.mapping, s.glyphs)
 		used.update(table.VOrgMap.mapping.values())
 
-	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, zeroUnusedDeltas=zeroUnused)
+	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, retainFirstMap=retainAdvMap)
 
 	if table.AdvHeightMap:
 		table.AdvHeightMap.mapping = _remap_index_map(s, varidx_map, table.AdvHeightMap)

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -1803,15 +1803,12 @@ def subset_glyphs(self, s):
 	# TODO Update for retain_gids
 
 	used = set()
-	retainAdvMap = False
 
 	if table.AdvWidthMap:
 		table.AdvWidthMap.mapping = _dict_subset(table.AdvWidthMap.mapping, s.glyphs)
 		used.update(table.AdvWidthMap.mapping.values())
 	else:
-		assert table.LsbMap is None and table.RsbMap is None, "File a bug."
 		used.update(s.reverseOrigGlyphMap.values())
-		retainAdvMap = s.options.retain_gids
 
 	if table.LsbMap:
 		table.LsbMap.mapping = _dict_subset(table.LsbMap.mapping, s.glyphs)
@@ -1820,7 +1817,7 @@ def subset_glyphs(self, s):
 		table.RsbMap.mapping = _dict_subset(table.RsbMap.mapping, s.glyphs)
 		used.update(table.RsbMap.mapping.values())
 
-	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, retainFirstMap=retainAdvMap)
+	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, retainFirstMap=table.AdvWidthMap is None)
 
 	if table.AdvWidthMap:
 		table.AdvWidthMap.mapping = _remap_index_map(s, varidx_map, table.AdvWidthMap)
@@ -1837,15 +1834,12 @@ def subset_glyphs(self, s):
 	table = self.table
 
 	used = set()
-	retainAdvMap = False
 
 	if table.AdvHeightMap:
 		table.AdvHeightMap.mapping = _dict_subset(table.AdvHeightMap.mapping, s.glyphs)
 		used.update(table.AdvHeightMap.mapping.values())
 	else:
-		assert table.TsbMap is None and table.BsbMap is None and table.VOrgMap is None, "File a bug."
 		used.update(s.reverseOrigGlyphMap.values())
-		retainAdvMap = s.options.retain_gids
 
 	if table.TsbMap:
 		table.TsbMap.mapping = _dict_subset(table.TsbMap.mapping, s.glyphs)
@@ -1857,7 +1851,7 @@ def subset_glyphs(self, s):
 		table.VOrgMap.mapping = _dict_subset(table.VOrgMap.mapping, s.glyphs)
 		used.update(table.VOrgMap.mapping.values())
 
-	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, retainFirstMap=retainAdvMap)
+	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, retainFirstMap=table.AdvHeightMap is None)
 
 	if table.AdvHeightMap:
 		table.AdvHeightMap.mapping = _remap_index_map(s, varidx_map, table.AdvHeightMap)

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -1789,6 +1789,13 @@ def subset_glyphs(self, s):
 	self.glyphCount = len(self.variations)
 	return bool(self.variations)
 
+def _remap_index_map(s, varidx_map, table_map):
+	map = {k:varidx_map[v] for k,v in table_map.mapping.items()}
+	last_idx = varidx_map[table_map.mapping[s.last_retained_glyph]]
+	for g,i in s.reverseEmptiedGlyphMap.items():
+		map[g] = last_idx if i > s.last_retained_order else 0
+	return map
+
 @_add_method(ttLib.getTableClass('HVAR'))
 def subset_glyphs(self, s):
 	table = self.table
@@ -1796,32 +1803,31 @@ def subset_glyphs(self, s):
 	# TODO Update for retain_gids
 
 	used = set()
+	zeroUnused = False
 
 	if table.AdvWidthMap:
-		if not s.options.retain_gids:
-			table.AdvWidthMap.mapping = _dict_subset(table.AdvWidthMap.mapping, s.glyphs)
+		table.AdvWidthMap.mapping = _dict_subset(table.AdvWidthMap.mapping, s.glyphs)
 		used.update(table.AdvWidthMap.mapping.values())
 	else:
 		assert table.LsbMap is None and table.RsbMap is None, "File a bug."
 		used.update(s.reverseOrigGlyphMap.values())
+		zeroUnused = s.options.retain_gids
 
 	if table.LsbMap:
-		if not s.options.retain_gids:
-			table.LsbMap.mapping = _dict_subset(table.LsbMap.mapping, s.glyphs)
+		table.LsbMap.mapping = _dict_subset(table.LsbMap.mapping, s.glyphs)
 		used.update(table.LsbMap.mapping.values())
 	if table.RsbMap:
-		if not s.options.retain_gids:
-			table.RsbMap.mapping = _dict_subset(table.RsbMap.mapping, s.glyphs)
+		table.RsbMap.mapping = _dict_subset(table.RsbMap.mapping, s.glyphs)
 		used.update(table.RsbMap.mapping.values())
 
-	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used)
+	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, zeroUnusedDeltas=zeroUnused)
 
 	if table.AdvWidthMap:
-		table.AdvWidthMap.mapping = {k:varidx_map[v] for k,v in table.AdvWidthMap.mapping.items()}
+		table.AdvWidthMap.mapping = _remap_index_map(s, varidx_map, table.AdvWidthMap)
 	if table.LsbMap:
-		table.LsbMap.mapping = {k:varidx_map[v] for k,v in table.LsbMap.mapping.items()}
+		table.LsbMap.mapping = _remap_index_map(s, varidx_map, table.LsbMap)
 	if table.RsbMap:
-		table.RsbMap.mapping = {k:varidx_map[v] for k,v in table.RsbMap.mapping.items()}
+		table.RsbMap.mapping = _remap_index_map(s, varidx_map, table.RsbMap)
 
 	# TODO Return emptiness...
 	return True
@@ -1831,37 +1837,36 @@ def subset_glyphs(self, s):
 	table = self.table
 
 	used = set()
+	zeroUnused = False
 
 	if table.AdvHeightMap:
-		if not s.options.retain_gids:
-			table.AdvHeightMap.mapping = _dict_subset(table.AdvHeightMap.mapping, s.glyphs)
+		table.AdvHeightMap.mapping = _dict_subset(table.AdvHeightMap.mapping, s.glyphs)
 		used.update(table.AdvHeightMap.mapping.values())
 	else:
 		assert table.TsbMap is None and table.BsbMap is None and table.VOrgMap is None, "File a bug."
 		used.update(s.reverseOrigGlyphMap.values())
+		zeroUnused = s.options.retain_gids
+
 	if table.TsbMap:
-		if not s.options.retain_gids:
-			table.TsbMap.mapping = _dict_subset(table.TsbMap.mapping, s.glyphs)
+		table.TsbMap.mapping = _dict_subset(table.TsbMap.mapping, s.glyphs)
 		used.update(table.TsbMap.mapping.values())
 	if table.BsbMap:
-		if not s.options.retain_gids:
-			table.BsbMap.mapping = _dict_subset(table.BsbMap.mapping, s.glyphs)
+		table.BsbMap.mapping = _dict_subset(table.BsbMap.mapping, s.glyphs)
 		used.update(table.BsbMap.mapping.values())
 	if table.VOrgMap:
-		if not s.options.retain_gids:
-			table.VOrgMap.mapping = _dict_subset(table.VOrgMap.mapping, s.glyphs)
+		table.VOrgMap.mapping = _dict_subset(table.VOrgMap.mapping, s.glyphs)
 		used.update(table.VOrgMap.mapping.values())
 
-	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used)
+	varidx_map = varStore.VarStore_subset_varidxes(table.VarStore, used, zeroUnusedDeltas=zeroUnused)
 
 	if table.AdvHeightMap:
-		table.AdvHeightMap.mapping = {k:varidx_map[v] for k,v in table.AdvHeightMap.mapping.items()}
+		table.AdvHeightMap.mapping = _remap_index_map(s, varidx_map, table.AdvHeightMap)
 	if table.TsbMap:
-		table.TsbMap.mapping = {k:varidx_map[v] for k,v in table.TsbMap.mapping.items()}
+		table.TsbMap.mapping = _remap_index_map(s, varidx_map, table.TsbMap)
 	if table.BsbMap:
-		table.BsbMap.mapping = {k:varidx_map[v] for k,v in table.BsbMap.mapping.items()}
+		table.BsbMap.mapping = _remap_index_map(s, varidx_map, table.BsbMap)
 	if table.VOrgMap:
-		table.VOrgMap.mapping = {k:varidx_map[v] for k,v in table.VOrgMap.mapping.items()}
+		table.VOrgMap.mapping = _remap_index_map(s, varidx_map, table.VOrgMap)
 
 	# TODO Return emptiness...
 	return True
@@ -2565,6 +2570,9 @@ class Subsetter(object):
 
 		order = font.getReverseGlyphMap()
 		self.reverseOrigGlyphMap = {g:order[g] for g in self.glyphs_retained}
+		self.reverseEmptiedGlyphMap = {g:order[g] for g in self.glyphs_emptied}
+		self.last_retained_order = max(self.reverseOrigGlyphMap.values())
+		self.last_retained_glyph = font.getGlyphOrder()[self.last_retained_order]
 
 		log.info("Retaining %d glyphs", len(self.glyphs_retained))
 

--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -188,7 +188,7 @@ class VarStoreInstancer(object):
 # Optimizations
 #
 
-def VarStore_subset_varidxes(self, varIdxes, optimize=True):
+def VarStore_subset_varidxes(self, varIdxes, optimize=True, zeroUnusedDeltas=False):
 
 	# Sort out used varIdxes by major/minor.
 	used = {}
@@ -217,10 +217,16 @@ def VarStore_subset_varidxes(self, varIdxes, optimize=True):
 
 		items = data.Item
 		newItems = []
-		for minor in sorted(usedMinors):
-			newMinor = len(newItems)
-			newItems.append(items[minor])
-			varDataMap[(major<<16)+minor] = (newMajor<<16)+newMinor
+		if major == 0 and zeroUnusedDeltas:
+			zeros = [0] * len(items[0])
+			for minor in range(len(items)):
+				newItems.append(items[minor] if minor in usedMinors else zeros)
+				varDataMap[minor] = minor
+		else:
+			for minor in sorted(usedMinors):
+				newMinor = len(newItems)
+				newItems.append(items[minor])
+				varDataMap[(major<<16)+minor] = (newMajor<<16)+newMinor
 
 		data.Item = newItems
 		data.ItemCount = len(data.Item)

--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -187,8 +187,10 @@ class VarStoreInstancer(object):
 #
 # Optimizations
 #
+# retainFirstMap - If true, major 0 mappings are retained. Deltas for unused indices are zeroed
+# advIdxes - Set of major 0 indices for advance deltas to be listed first. Other major 0 indices follow.
 
-def VarStore_subset_varidxes(self, varIdxes, optimize=True, retainFirstMap=False):
+def VarStore_subset_varidxes(self, varIdxes, optimize=True, retainFirstMap=False, advIdxes=set()):
 
 	# Sort out used varIdxes by major/minor.
 	used = {}
@@ -222,7 +224,11 @@ def VarStore_subset_varidxes(self, varIdxes, optimize=True, retainFirstMap=False
 				newItems.append(items[minor] if minor in usedMinors else [0] * len(items[minor]))
 				varDataMap[minor] = minor
 		else:
-			for minor in sorted(usedMinors):
+			if major == 0:
+				minors = sorted(advIdxes) + sorted(usedMinors - advIdxes)
+			else:
+				minors = sorted(usedMinors)
+			for minor in minors:
 				newMinor = len(newItems)
 				newItems.append(items[minor])
 				varDataMap[(major<<16)+minor] = (newMajor<<16)+newMinor

--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -218,9 +218,8 @@ def VarStore_subset_varidxes(self, varIdxes, optimize=True, retainFirstMap=False
 		items = data.Item
 		newItems = []
 		if major == 0 and retainFirstMap:
-			zeros = [0] * len(items[0])
 			for minor in range(len(items)):
-				newItems.append(items[minor] if minor in usedMinors else zeros)
+				newItems.append(items[minor] if minor in usedMinors else [0] * len(items[minor]))
 				varDataMap[minor] = minor
 		else:
 			for minor in sorted(usedMinors):

--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -188,7 +188,7 @@ class VarStoreInstancer(object):
 # Optimizations
 #
 
-def VarStore_subset_varidxes(self, varIdxes, optimize=True, zeroUnusedDeltas=False):
+def VarStore_subset_varidxes(self, varIdxes, optimize=True, retainFirstMap=False):
 
 	# Sort out used varIdxes by major/minor.
 	used = {}
@@ -217,7 +217,7 @@ def VarStore_subset_varidxes(self, varIdxes, optimize=True, zeroUnusedDeltas=Fal
 
 		items = data.Item
 		newItems = []
-		if major == 0 and zeroUnusedDeltas:
+		if major == 0 and retainFirstMap:
 			zeros = [0] * len(items[0])
 			for minor in range(len(items)):
 				newItems.append(items[minor] if minor in usedMinors else zeros)

--- a/Tests/subset/data/TestHVVAR.ttx
+++ b/Tests/subset/data/TestHVVAR.ttx
@@ -1,0 +1,443 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.40">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="A"/>
+    <GlyphID id="2" name="B"/>
+    <GlyphID id="3" name="C"/>
+    <GlyphID id="4" name="D"/>
+    <GlyphID id="5" name="E"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0xddab44f"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000001"/>
+    <unitsPerEm value="1000"/>
+    <created value="Tue Apr 23 17:22:52 2019"/>
+    <modified value="Tue Apr 23 17:22:52 2019"/>
+    <xMin value="0"/>
+    <yMin value="0"/>
+    <xMax value="0"/>
+    <yMax value="0"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="7"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="700"/>
+    <minLeftSideBearing value="40"/>
+    <minRightSideBearing value="580"/>
+    <xMaxExtent value="80"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="4"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="6"/>
+    <maxPoints value="1"/>
+    <maxContours value="1"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="1"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="3"/>
+    <xAvgCharWidth value="606"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="5"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="UKWN"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="8722"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="700" lsb="80"/>
+    <mtx name="A" width="700" lsb="0"/>
+    <mtx name="B" width="625" lsb="40"/>
+    <mtx name="C" width="660" lsb="80"/>
+    <mtx name="D" width="660" lsb="80"/>
+    <mtx name="E" width="660" lsb="80"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x41" name="A"/><!-- SPACE -->
+      <map code="0x42" name="B"/><!-- DIGIT ZERO -->
+      <map code="0x43" name="C"/><!-- EQUALS SIGN -->
+      <map code="0x44" name="D"/><!-- MINUS SIGN -->
+      <map code="0x45" name="E"/><!-- PLUS SIGN -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="0" yMin="0" xMax="0" yMax="0">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="A"/><!-- contains no outline data -->
+
+    <TTGlyph name="B" xMin="0" yMin="0" xMax="0" yMax="0">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="C" xMin="0" yMin="0" xMax="0" yMax="0">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="D" xMin="0" yMin="0" xMax="0" yMax="0">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="E" xMin="0" yMin="0" xMax="0" yMax="0">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="1" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      TestHVVAR
+    </namerecord>
+    <namerecord nameID="2" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      1.000;UKWN;TestHVVAR-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      TestHVVAR
+    </namerecord>
+    <namerecord nameID="5" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Version 1.000
+    </namerecord>
+    <namerecord nameID="6" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      TestHVVAR-Regular
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      TestHVVAR
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.000;UKWN;TestHVVAR-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      TestHVVAR-Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      TestHVVAR-Regular
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=2 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="-1.0"/>
+            <PeakCoord value="-1.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=2 -->
+      <VarData index="0">
+        <!-- ItemCount=6 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="1"/>
+        <Item index="0" value="[1]"/>
+        <Item index="1" value="[2]"/>
+        <Item index="2" value="[3]"/>
+        <Item index="3" value="[4]"/>
+        <Item index="4" value="[5]"/>
+        <Item index="5" value="[6]"/>
+      </VarData>
+      <VarData index="1">
+        <!-- ItemCount=6 -->
+        <NumShorts value="1"/>
+        <!-- VarRegionCount=2 -->
+        <VarRegionIndex index="0" value="0"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[10, 21]"/>
+        <Item index="1" value="[11, 22]"/>
+        <Item index="2" value="[126, 23]"/>
+        <Item index="3" value="[127, 24]"/>
+        <Item index="4" value="[-128, 25]"/>
+        <Item index="5" value="[-129, 26]"/>
+      </VarData>
+    </VarStore>
+    <LsbMap>
+      <Map glyph=".notdef" outer="0" inner="2"/>
+      <Map glyph="A" outer="0" inner="5"/>
+      <Map glyph="B" outer="1" inner="1"/>
+      <Map glyph="C" outer="1" inner="4"/>
+      <Map glyph="D" outer="0" inner="3"/>
+      <Map glyph="E" outer="1" inner="0"/>
+    </LsbMap>
+    <RsbMap>
+      <Map glyph=".notdef" outer="0" inner="1"/>
+      <Map glyph="A" outer="0" inner="4"/>
+      <Map glyph="B" outer="1" inner="5"/>
+      <Map glyph="C" outer="0" inner="0"/>
+      <Map glyph="D" outer="1" inner="2"/>
+      <Map glyph="E" outer="1" inner="3"/>
+    </RsbMap>
+  </HVAR>
+
+  <VVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=4 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="-1.0"/>
+            <PeakCoord value="-1.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="2">
+          <VarRegionAxis index="0">
+            <StartCoord value="-1.0"/>
+            <PeakCoord value="-0.5"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="3">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.5"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=2 -->
+      <VarData index="0">
+        <!-- ItemCount=4 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="1"/>
+        <Item index="0" value="[32]"/>
+        <Item index="1" value="[17]"/>
+        <Item index="2" value="[0]"/>
+        <Item index="3" value="[14]"/>
+        <Item index="4" value="[5]"/>
+        <Item index="5" value="[6]"/>
+      </VarData>
+      <VarData index="1">
+        <!-- ItemCount=6 -->
+        <NumShorts value="3"/>
+        <!-- VarRegionCount=4 -->
+        <VarRegionIndex index="0" value="0"/>
+        <VarRegionIndex index="1" value="1"/>
+        <VarRegionIndex index="2" value="2"/>
+        <VarRegionIndex index="3" value="3"/>
+        <Item index="0" value="[0, 1, 11, 21]"/>
+        <Item index="1" value="[0, 2, 12, 22]"/>
+        <Item index="2" value="[128, 130, 13, 23]"/>
+        <Item index="3" value="[0, 4, 14, 24]"/>
+        <Item index="4" value="[0, 5, -129, 25]"/>
+        <Item index="5" value="[14, 6, 16, 26]"/>
+      </VarData>
+    </VarStore>
+    <AdvHeightMap>
+      <Map glyph=".notdef" outer="1" inner="0"/>
+      <Map glyph="A" outer="1" inner="2"/>
+      <Map glyph="B" outer="0" inner="2"/>
+      <Map glyph="C" outer="0" inner="0"/>
+      <Map glyph="D" outer="1" inner="1"/>
+      <Map glyph="E" outer="0" inner="1"/>
+    </AdvHeightMap>
+    <VOrgMap>
+      <Map glyph=".notdef" outer="1" inner="3"/>
+      <Map glyph="A" outer="1" inner="5"/>
+      <Map glyph="B" outer="0" inner="5"/>
+      <Map glyph="C" outer="0" inner="3"/>
+      <Map glyph="D" outer="1" inner="4"/>
+      <Map glyph="E" outer="0" inner="4"/>
+    </VOrgMap>
+  </VVAR>
+
+  <avar>
+    <segment axis="wght">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.3" to="0.5"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+  <fvar>
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>100.0</MinValue>
+      <DefaultValue>400.0</DefaultValue>
+      <MaxValue>900.0</MaxValue>
+      <AxisNameID>257</AxisNameID>
+    </Axis>
+    <NamedInstance flags="0x0" subfamilyNameID="258">
+      <coord axis="wght" value="100.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="259">
+      <coord axis="wght" value="300.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="260">
+      <coord axis="wght" value="400.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="261">
+      <coord axis="wght" value="700.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="262">
+      <coord axis="wght" value="900.0"/>
+    </NamedInstance>
+  </fvar>
+
+</ttFont>

--- a/Tests/subset/data/expect_HVVAR.ttx
+++ b/Tests/subset/data/expect_HVVAR.ttx
@@ -32,16 +32,15 @@
       </VarRegionList>
       <!-- VarDataCount=2 -->
       <VarData index="0">
-        <!-- ItemCount=6 -->
+        <!-- ItemCount=5 -->
         <NumShorts value="0"/>
         <!-- VarRegionCount=1 -->
         <VarRegionIndex index="0" value="1"/>
         <Item index="0" value="[1]"/>
-        <Item index="1" value="[2]"/>
-        <Item index="2" value="[3]"/>
-        <Item index="3" value="[4]"/>
-        <Item index="4" value="[5]"/>
-        <Item index="5" value="[0]"/>
+        <Item index="1" value="[3]"/>
+        <Item index="2" value="[5]"/>
+        <Item index="3" value="[2]"/>
+        <Item index="4" value="[4]"/>
       </VarData>
       <VarData index="1">
         <!-- ItemCount=3 -->
@@ -55,12 +54,12 @@
       </VarData>
     </VarStore>
     <LsbMap>
-      <Map glyph=".notdef" outer="0" inner="2"/>
+      <Map glyph=".notdef" outer="0" inner="1"/>
       <Map glyph="B" outer="1" inner="0"/>
-      <Map glyph="D" outer="0" inner="3"/>
+      <Map glyph="D" outer="0" inner="4"/>
     </LsbMap>
     <RsbMap>
-      <Map glyph=".notdef" outer="0" inner="1"/>
+      <Map glyph=".notdef" outer="0" inner="3"/>
       <Map glyph="B" outer="1" inner="2"/>
       <Map glyph="D" outer="1" inner="1"/>
     </RsbMap>

--- a/Tests/subset/data/expect_HVVAR.ttx
+++ b/Tests/subset/data/expect_HVVAR.ttx
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.40">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="B"/>
+    <GlyphID id="2" name="D"/>
+  </GlyphOrder>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=2 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="-1.0"/>
+            <PeakCoord value="-1.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=2 -->
+      <VarData index="0">
+        <!-- ItemCount=6 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="1"/>
+        <Item index="0" value="[1]"/>
+        <Item index="1" value="[2]"/>
+        <Item index="2" value="[3]"/>
+        <Item index="3" value="[4]"/>
+        <Item index="4" value="[5]"/>
+        <Item index="5" value="[0]"/>
+      </VarData>
+      <VarData index="1">
+        <!-- ItemCount=3 -->
+        <NumShorts value="1"/>
+        <!-- VarRegionCount=2 -->
+        <VarRegionIndex index="0" value="0"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[11, 22]"/>
+        <Item index="1" value="[126, 23]"/>
+        <Item index="2" value="[-129, 26]"/>
+      </VarData>
+    </VarStore>
+    <LsbMap>
+      <Map glyph=".notdef" outer="0" inner="2"/>
+      <Map glyph="B" outer="1" inner="0"/>
+      <Map glyph="D" outer="0" inner="3"/>
+    </LsbMap>
+    <RsbMap>
+      <Map glyph=".notdef" outer="0" inner="1"/>
+      <Map glyph="B" outer="1" inner="2"/>
+      <Map glyph="D" outer="1" inner="1"/>
+    </RsbMap>
+  </HVAR>
+
+  <VVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=3 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="-1.0"/>
+            <PeakCoord value="-0.5"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="2">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.5"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=2 -->
+      <VarData index="0">
+        <!-- ItemCount=2 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="0"/>
+        <Item index="0" value="[0]"/>
+        <Item index="1" value="[6]"/>
+      </VarData>
+      <VarData index="1">
+        <!-- ItemCount=4 -->
+        <NumShorts value="1"/>
+        <!-- VarRegionCount=3 -->
+        <VarRegionIndex index="0" value="1"/>
+        <VarRegionIndex index="1" value="0"/>
+        <VarRegionIndex index="2" value="2"/>
+        <Item index="0" value="[11, 1, 21]"/>
+        <Item index="1" value="[12, 2, 22]"/>
+        <Item index="2" value="[14, 4, 24]"/>
+        <Item index="3" value="[-129, 5, 25]"/>
+      </VarData>
+    </VarStore>
+    <AdvHeightMap>
+      <Map glyph=".notdef" outer="1" inner="0"/>
+      <Map glyph="B" outer="0" inner="0"/>
+      <Map glyph="D" outer="1" inner="1"/>
+    </AdvHeightMap>
+    <VOrgMap>
+      <Map glyph=".notdef" outer="1" inner="2"/>
+      <Map glyph="B" outer="0" inner="1"/>
+      <Map glyph="D" outer="1" inner="3"/>
+    </VOrgMap>
+  </VVAR>
+
+  <avar>
+    <segment axis="wght">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.3" to="0.5"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+  <fvar>
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>100.0</MinValue>
+      <DefaultValue>400.0</DefaultValue>
+      <MaxValue>900.0</MaxValue>
+      <AxisNameID>257</AxisNameID>
+    </Axis>
+    <NamedInstance flags="0x0" subfamilyNameID="258">
+      <coord axis="wght" value="100.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="259">
+      <coord axis="wght" value="300.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="260">
+      <coord axis="wght" value="400.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="261">
+      <coord axis="wght" value="700.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="262">
+      <coord axis="wght" value="900.0"/>
+    </NamedInstance>
+  </fvar>
+
+</ttFont>

--- a/Tests/subset/data/expect_HVVAR_retain_gids.ttx
+++ b/Tests/subset/data/expect_HVVAR_retain_gids.ttx
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.40">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="glyph00001"/>
+    <GlyphID id="2" name="B"/>
+    <GlyphID id="3" name="glyph00003"/>
+    <GlyphID id="4" name="D"/>
+    <GlyphID id="5" name="glyph00005"/>
+  </GlyphOrder>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=2 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="-1.0"/>
+            <PeakCoord value="-1.0"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=2 -->
+      <VarData index="0">
+        <!-- ItemCount=6 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="1"/>
+        <Item index="0" value="[1]"/>
+        <Item index="1" value="[2]"/>
+        <Item index="2" value="[3]"/>
+        <Item index="3" value="[4]"/>
+        <Item index="4" value="[5]"/>
+        <Item index="5" value="[0]"/>
+      </VarData>
+      <VarData index="1">
+        <!-- ItemCount=3 -->
+        <NumShorts value="1"/>
+        <!-- VarRegionCount=2 -->
+        <VarRegionIndex index="0" value="0"/>
+        <VarRegionIndex index="1" value="1"/>
+        <Item index="0" value="[11, 22]"/>
+        <Item index="1" value="[126, 23]"/>
+        <Item index="2" value="[-129, 26]"/>
+      </VarData>
+    </VarStore>
+    <LsbMap>
+      <Map glyph=".notdef" outer="0" inner="2"/>
+      <Map glyph="B" outer="1" inner="0"/>
+      <Map glyph="D" outer="0" inner="3"/>
+      <Map glyph="glyph00001" outer="0" inner="0"/>
+      <Map glyph="glyph00003" outer="0" inner="0"/>
+      <Map glyph="glyph00005" outer="0" inner="3"/>
+    </LsbMap>
+    <RsbMap>
+      <Map glyph=".notdef" outer="0" inner="1"/>
+      <Map glyph="B" outer="1" inner="2"/>
+      <Map glyph="D" outer="1" inner="1"/>
+      <Map glyph="glyph00001" outer="0" inner="0"/>
+      <Map glyph="glyph00003" outer="0" inner="0"/>
+      <Map glyph="glyph00005" outer="1" inner="1"/>
+    </RsbMap>
+  </HVAR>
+
+  <VVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=3 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="-1.0"/>
+            <PeakCoord value="-0.5"/>
+            <EndCoord value="0.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="2">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.5"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=2 -->
+      <VarData index="0">
+        <!-- ItemCount=2 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="0"/>
+        <Item index="0" value="[0]"/>
+        <Item index="1" value="[6]"/>
+      </VarData>
+      <VarData index="1">
+        <!-- ItemCount=4 -->
+        <NumShorts value="1"/>
+        <!-- VarRegionCount=3 -->
+        <VarRegionIndex index="0" value="1"/>
+        <VarRegionIndex index="1" value="0"/>
+        <VarRegionIndex index="2" value="2"/>
+        <Item index="0" value="[11, 1, 21]"/>
+        <Item index="1" value="[12, 2, 22]"/>
+        <Item index="2" value="[14, 4, 24]"/>
+        <Item index="3" value="[-129, 5, 25]"/>
+      </VarData>
+    </VarStore>
+    <AdvHeightMap>
+      <Map glyph=".notdef" outer="1" inner="0"/>
+      <Map glyph="B" outer="0" inner="0"/>
+      <Map glyph="D" outer="1" inner="1"/>
+      <Map glyph="glyph00001" outer="0" inner="0"/>
+      <Map glyph="glyph00003" outer="0" inner="0"/>
+      <Map glyph="glyph00005" outer="1" inner="1"/>
+    </AdvHeightMap>
+    <VOrgMap>
+      <Map glyph=".notdef" outer="1" inner="2"/>
+      <Map glyph="B" outer="0" inner="1"/>
+      <Map glyph="D" outer="1" inner="3"/>
+      <Map glyph="glyph00001" outer="0" inner="0"/>
+      <Map glyph="glyph00003" outer="0" inner="0"/>
+      <Map glyph="glyph00005" outer="1" inner="3"/>
+    </VOrgMap>
+  </VVAR>
+
+  <avar>
+    <segment axis="wght">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.3" to="0.5"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
+  <fvar>
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>100.0</MinValue>
+      <DefaultValue>400.0</DefaultValue>
+      <MaxValue>900.0</MaxValue>
+      <AxisNameID>257</AxisNameID>
+    </Axis>
+    <NamedInstance flags="0x0" subfamilyNameID="258">
+      <coord axis="wght" value="100.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="259">
+      <coord axis="wght" value="300.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="260">
+      <coord axis="wght" value="400.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="261">
+      <coord axis="wght" value="700.0"/>
+    </NamedInstance>
+    <NamedInstance flags="0x0" subfamilyNameID="262">
+      <coord axis="wght" value="900.0"/>
+    </NamedInstance>
+  </fvar>
+
+</ttFont>

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -586,6 +586,20 @@ class SubsetTest(unittest.TestCase):
         self.assertGreater(len(cs["A"].program), 0)
         self.assertEqual(cs["glyph00002"].program, [])
 
+    def test_HVAR_VVAR(self):
+        _, fontpath = self.compile_font(self.getpath("TestHVVAR.ttx"), ".ttf")
+        subsetpath = self.temp_path(".ttf")
+        subset.main([fontpath, "--text=BD", "--output-file=%s" % subsetpath])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath("expect_HVVAR.ttx"), ["GlyphOrder", "HVAR", "VVAR", "avar", "fvar"])
+
+    def test_HVAR_VVAR_retain_gids(self):
+        _, fontpath = self.compile_font(self.getpath("TestHVVAR.ttx"), ".ttf")
+        subsetpath = self.temp_path(".ttf")
+        subset.main([fontpath, "--text=BD", "--retain-gids", "--output-file=%s" % subsetpath])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath("expect_HVVAR_retain_gids.ttx"), ["GlyphOrder", "HVAR", "VVAR", "avar", "fvar"])
+
 
 if __name__ == "__main__":
     sys.exit(unittest.main())


### PR DESCRIPTION
Fixes subsetting HVAR/VVAR issues #1448 & #1587

When AdvWidth(Height)Map is missing from HVAR/VVAR, unused deltas are zeroed (with or without --retain-gids).
With --retain-gids, major/minor indices for an unused glyph is set to 0/0 if gid <= last used gid
With --retain-gids, if unused gid > last used gid, then its major/minor is set to that of last used gid (they are optimized out when the table is written out).

Added test cases to test_subset.py for HVAR & VVAR with and without --retain-gids
