### PR TITLE
[feaLib] don’t write None in ast.ValueRecord.asFea()

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1143,6 +1143,12 @@ class ValueRecord(Expression):
             elif yAdvance is None and not vertical:
                 return str(xAdvance)
 
+        # Make any remaining None value 0 to avoid generating invalid records.
+        x = x or 0
+        y = y or 0
+        xAdvance = xAdvance or 0
+        yAdvance = yAdvance or 0
+
         # Try format B, if possible.
         if (xPlaDevice is None and yPlaDevice is None and
                 xAdvDevice is None and yAdvDevice is None):

--- a/Tests/feaLib/ast_test.py
+++ b/Tests/feaLib/ast_test.py
@@ -11,6 +11,10 @@ class AstTest(unittest.TestCase):
             statement.append(ast.GlyphName(name))
         self.assertEqual(statement.asFea(), r"[\BASE \NULL foo a]")
 
+    def test_valuerecord_none(self):
+        statement = ast.ValueRecord(xPlacement=10, xAdvance=20)
+        self.assertEqual(statement.asFea(), "<10 0 20 0>")
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
The code tries to write the short format when some values as None, but when writing the long format it would write any None value as is which is invalid, use 0 for None values instead.