### PR TITLE
Fix: ttLib _h_e_a_d FontBBox rounding

### DIFF
--- a/Lib/fontTools/ttLib/tables/_h_e_a_d.py
+++ b/Lib/fontTools/ttLib/tables/_h_e_a_d.py
@@ -4,6 +4,7 @@ from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval, num2binary, binary2num
 from fontTools.misc.timeTools import timestampFromString, timestampToString, timestampNow
 from fontTools.misc.timeTools import epoch_diff as mac_epoch_diff # For backward compat
+from fontTools.misc.arrayTools import intRect
 from . import DefaultTable
 import logging
 
@@ -63,7 +64,7 @@ class table__h_e_a_d(DefaultTable.DefaultTable):
 			# For TT-flavored fonts, xMin, yMin, xMax and yMax are set in table__m_a_x_p.recalc().
 			if 'CFF ' in ttFont:
 				topDict = ttFont['CFF '].cff.topDictIndex[0]
-				self.xMin, self.yMin, self.xMax, self.yMax = topDict.FontBBox
+				self.xMin, self.yMin, self.xMax, self.yMax = intRect(topDict.FontBBox)
 		if ttFont.recalcTimestamp:
 			self.modified = timestampNow()
 		data = sstruct.pack(headFormat, self)

--- a/README.rst
+++ b/README.rst
@@ -363,7 +363,7 @@ In alphabetical order:
 
 Olivier Berten, Samyak Bhuta, Erik van Blokland, Petr van Blokland,
 Jelle Bosma, Sascha Brawer, Tom Byrer, Frédéric Coiffier, Vincent
-Connare, Dave Crossland, Simon Daniels, Behdad Esfahbod, Behnam
+Connare, Dave Crossland, Simon Daniels, Peter Dekkers, Behdad Esfahbod, Behnam
 Esfahbod, Hannes Famira, Sam Fishman, Matt Fontaine, Yannis Haralambous,
 Greg Hitchcock, Jeremie Hornus, Khaled Hosny, John Hudson, Denis Moyogo
 Jacquerye, Jack Jansen, Tom Kacvinsky, Jens Kutilek, Antoine Leca,

--- a/README.rst
+++ b/README.rst
@@ -363,15 +363,15 @@ In alphabetical order:
 
 Olivier Berten, Samyak Bhuta, Erik van Blokland, Petr van Blokland,
 Jelle Bosma, Sascha Brawer, Tom Byrer, Frédéric Coiffier, Vincent
-Connare, Dave Crossland, Simon Daniels, Peter Dekkers, Behdad Esfahbod, Behnam
-Esfahbod, Hannes Famira, Sam Fishman, Matt Fontaine, Yannis Haralambous,
-Greg Hitchcock, Jeremie Hornus, Khaled Hosny, John Hudson, Denis Moyogo
-Jacquerye, Jack Jansen, Tom Kacvinsky, Jens Kutilek, Antoine Leca,
-Werner Lemberg, Tal Leming, Peter Lofting, Cosimo Lupo, Masaya Nakamura,
-Dave Opstad, Laurence Penney, Roozbeh Pournader, Garret Rieger, Read
-Roberts, Guido van Rossum, Just van Rossum, Andreas Seidel, Georg
-Seifert, Miguel Sousa, Adam Twardoch, Adrien Tétar, Vitaly Volkov, Paul
-Wise.
+Connare, Dave Crossland, Simon Daniels, Peter Dekkers, Behdad Esfahbod,
+Behnam Esfahbod, Hannes Famira, Sam Fishman, Matt Fontaine, Yannis
+Haralambous, Greg Hitchcock, Jeremie Hornus, Khaled Hosny, John Hudson,
+Denis Moyogo Jacquerye, Jack Jansen, Tom Kacvinsky, Jens Kutilek,
+Antoine Leca, Werner Lemberg, Tal Leming, Peter Lofting, Cosimo Lupo,
+Masaya Nakamura, Dave Opstad, Laurence Penney, Roozbeh Pournader, Garret
+Rieger, Read Roberts, Guido van Rossum, Just van Rossum, Andreas Seidel,
+Georg Seifert, Miguel Sousa, Adam Twardoch, Adrien Tétar, Vitaly Volkov,
+Paul Wise.
 
 Copyrights
 ~~~~~~~~~~


### PR DESCRIPTION
Ensures that CFF FontBBox float values are rounded before being read into `_h_e_a_d` table.

Note: I had a look in regards to adding a unit test for this fix, but couldn't find any existing tests for class `table__h_e_a_d`. Do let me know if I missed an obvious place to add a test.

Resolves #1604