### PR TITLE
designspaceLib: add loadSourceFonts method with custom opener

### DIFF
--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1272,6 +1272,15 @@ class DesignSpaceDocument(LogMixin, AsDictMixin):
         If the font attribute is already not None, it is not loaded again.
         Fonts with the same path are only loaded once and shared among SourceDescriptors.
 
+        For example, to load UFO sources using defcon:
+
+            designspace = DesignSpaceDocument.fromfile("path/to/my.designspace")
+            designspace.loadSourceFonts(defcon.Font)
+
+        Or to load masters as FontTools binary fonts, including extra options:
+
+            designspace.loadSourceFonts(ttLib.TTFont, recalcBBoxes=False)
+
         Args:
             opener (Callable): takes one required positional argument, the source.path,
                 and an optional list of keyword arguments, and returns a new font object

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1262,3 +1262,41 @@ class DesignSpaceDocument(LogMixin, AsDictMixin):
                     newConditions.append(dict(name=cond['name'], minimum=minimum, maximum=maximum))
                 newConditionSets.append(newConditions)
             rule.conditionSets = newConditionSets
+
+    def loadSourceFonts(self, opener, **kwargs):
+        """Ensure SourceDescriptor.font attributes are loaded, and return list of fonts.
+
+        Takes a callable which initializes a new font object (e.g. TTFont, or
+        defcon.Font, etc.) from the SourceDescriptor.path, and sets the
+        SourceDescriptor.font attribute.
+        If the font attribute is already not None, it is not loaded again.
+        Fonts with the same path are only loaded once and shared among SourceDescriptors.
+
+        Args:
+            opener (Callable): takes one required positional argument, the source.path,
+                and an optional list of keyword arguments, and returns a new font object
+                loaded from the path.
+            **kwargs: extra options passed on to the opener function.
+
+        Returns:
+            List of font objects in the order they appear in the sources list.
+        """
+        # we load fonts with the same source.path only once
+        loaded = {}
+        fonts = []
+        for source in self.sources:
+            if source.font is not None:  # font already loaded
+                fonts.append(source.font)
+                continue
+            if source.path in loaded:
+                source.font = loaded[source.path]
+            else:
+                if source.path is None:
+                    raise DesignSpaceDocumentError(
+                        "Designspace source '%s' has no 'path' attribute"
+                        % (source.name or "<Unknown>")
+                    )
+                source.font = opener(source.path, **kwargs)
+                loaded[source.path] = source.font
+            fonts.append(source.font)
+        return fonts


### PR DESCRIPTION
Added `loadSourceFonts` method to `DesignSpaceDocument` object, which allows to use a custom opener function to load a font object from a SourceDescriptor's `path`, and store the result in memory inside the SourceDescriptor's `font` attribute.

The opener function is any callable that takes a path and returns a font -- _any_ font really.

In ufo2ft we assume source descriptor `font` holds a UFO (defcon.Font or similar), whereas in varLib.build we assume it is set to a ttLib.TTFont.