### PR TITLE
instancer: add IDEF to fpgm for GETVARIATION opcode

### DIFF
--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -669,6 +669,10 @@ def addGetVariationIdef(font, coordinates):
     asm.append("ENDF[ ]")
     fpgm.program.fromAssembly(asm)
 
+    maxp = font["maxp"]
+    maxp.maxInstructionDefs += 1
+    maxp.maxStackElements = max(len(coordinates), maxp.maxStackElements)
+
 
 def normalize(value, triple, avar_mapping):
     value = normalizeValue(value, triple)

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1102,12 +1102,21 @@ def test_addGetVariationIdefToFpgm():
     glyf.glyphs = {"a": a}
     font["glyf"] = glyf
 
+    maxp = ttLib.newTable("maxp")
+    maxp.tableVersion = 0x00010000
+    maxp.numGlyphs = 1
+    maxp.maxInstructionDefs = 0
+    maxp.maxStackElements = 0
+    font["maxp"] = maxp
+
     coordinates = [1.0, -1.0]
 
     instancer.addGetVariationIdef(font, coordinates)
 
     # no glyph instructions contain GETVARIATION so no fpgm table created
     assert "fpgm" not in font
+    assert maxp.maxInstructionDefs == 0
+    assert maxp.maxStackElements == 0
 
     # now we add GETVARIATION and a new fpgm table
     glyf["a"].program.fromAssembly(["GETVARIATION[]"])
@@ -1126,6 +1135,8 @@ def test_addGetVariationIdefToFpgm():
 
     # expect this fpgm table to be extended with the IDEF
     assert fpgm.program.getAssembly() == expected
+    assert maxp.maxInstructionDefs == 1
+    assert maxp.maxStackElements == 2
 
     del font["fpgm"]
 


### PR DESCRIPTION
as required by https://docs.microsoft.com/en-us/typography/opentype/spec/tt_instructions#get-variation
to support legacy environment that do not know about the GETVARIATION[] (0x91) opcode.

mostly copied from the mutator module.