### PR TITLE
[varLib] Fix merging GDEF.GlyphClassDef in mutator

### DIFF
--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -119,10 +119,10 @@ def merge(merger, self, lst):
 		assert allNone(lst), (lst)
 		return
 
+	lst = [l.classDefs for l in lst]
 	self.classDefs = {}
 	# We only care about the .classDefs
 	self = self.classDefs
-	lst = [l.classDefs for l in lst]
 
 	allKeys = set()
 	allKeys.update(*[l.keys() for l in lst])

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily-Master0.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily-Master0.ttx
@@ -517,4 +517,14 @@
     </extraNames>
   </post>
 
+  <GDEF>
+    <Version value="0x00010003"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="uni0024" class="1"/>
+      <ClassDef glyph="uni0024.nostroke" class="1"/>
+      <ClassDef glyph="uni0041" class="1"/>
+      <ClassDef glyph="uni0061" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
 </ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily-Master1.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily-Master1.ttx
@@ -517,4 +517,14 @@
     </extraNames>
   </post>
 
+  <GDEF>
+    <Version value="0x00010003"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="uni0024" class="1"/>
+      <ClassDef glyph="uni0024.nostroke" class="1"/>
+      <ClassDef glyph="uni0041" class="1"/>
+      <ClassDef glyph="uni0061" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
 </ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily-Master2.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily-Master2.ttx
@@ -501,4 +501,14 @@
     </extraNames>
   </post>
 
+  <GDEF>
+    <Version value="0x00010003"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="uni0024" class="1"/>
+      <ClassDef glyph="uni0024.nostroke" class="1"/>
+      <ClassDef glyph="uni0041" class="1"/>
+      <ClassDef glyph="uni0061" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
 </ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily-Master3.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily-Master3.ttx
@@ -501,4 +501,14 @@
     </extraNames>
   </post>
 
+  <GDEF>
+    <Version value="0x00010003"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="uni0024" class="1"/>
+      <ClassDef glyph="uni0024.nostroke" class="1"/>
+      <ClassDef glyph="uni0041" class="1"/>
+      <ClassDef glyph="uni0061" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
 </ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily-Master4.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily-Master4.ttx
@@ -501,4 +501,14 @@
     </extraNames>
   </post>
 
+  <GDEF>
+    <Version value="0x00010003"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="uni0024" class="1"/>
+      <ClassDef glyph="uni0024.nostroke" class="1"/>
+      <ClassDef glyph="uni0041" class="1"/>
+      <ClassDef glyph="uni0061" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
 </ttFont>

--- a/Tests/varLib/data/test_results/Build.ttx
+++ b/Tests/varLib/data/test_results/Build.ttx
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.17">
 
+  <GDEF>
+    <Version value="0x00010003"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="uni0024" class="1"/>
+      <ClassDef glyph="uni0024.nostroke" class="1"/>
+      <ClassDef glyph="uni0041" class="1"/>
+      <ClassDef glyph="uni0061" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
   <HVAR>
     <Version value="0x00010000"/>
     <VarStore Format="1">

--- a/Tests/varLib/data/test_results/BuildMain.ttx
+++ b/Tests/varLib/data/test_results/BuildMain.ttx
@@ -613,6 +613,16 @@
     </extraNames>
   </post>
 
+  <GDEF>
+    <Version value="0x00010003"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="uni0024" class="1"/>
+      <ClassDef glyph="uni0024.nostroke" class="1"/>
+      <ClassDef glyph="uni0041" class="1"/>
+      <ClassDef glyph="uni0061" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
   <HVAR>
     <Version value="0x00010000"/>
     <VarStore Format="1">

--- a/Tests/varLib/data/test_results/InterpolateLayoutMain.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutMain.ttx
@@ -496,4 +496,14 @@
     </extraNames>
   </post>
 
+  <GDEF>
+    <Version value="0x00010003"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="uni0024" class="1"/>
+      <ClassDef glyph="uni0024.nostroke" class="1"/>
+      <ClassDef glyph="uni0041" class="1"/>
+      <ClassDef glyph="uni0061" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
 </ttFont>

--- a/Tests/varLib/data/test_results/Mutator.ttx
+++ b/Tests/varLib/data/test_results/Mutator.ttx
@@ -496,4 +496,14 @@
     </extraNames>
   </post>
 
+  <GDEF>
+    <Version value="0x00010000"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="uni0024" class="1"/>
+      <ClassDef glyph="uni0024.nostroke" class="1"/>
+      <ClassDef glyph="uni0041" class="1"/>
+      <ClassDef glyph="uni0061" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
 </ttFont>


### PR DESCRIPTION
The code was setting `GlyphClassDef.classDefs` for the base font to an empty dict then reading it from all fonts. It accidentally works when creating variable fonts because the `GlyphClassDef` of the other fonts
will be used, but when mutating there is only one font.

Fix by reading the glyph classes before assigning to an empty dict.