### PR TITLE
fontBuilder: Don't add a stub signature to DSIG

### DIFF
--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -712,25 +712,14 @@ class FontBuilder(object):
         self._initTableWithValues("maxp", defaults, {})
 
     def setupDummyDSIG(self):
-        """This adds a dummy DSIG table to the font to make some MS applications
+        """This adds an empty DSIG table to the font to make some MS applications
         happy. This does not properly sign the font.
         """
-        from .ttLib.tables.D_S_I_G_ import SignatureRecord
-
-        sig = SignatureRecord()
-        sig.ulLength = 20
-        sig.cbSignature = 12
-        sig.usReserved2 = 0
-        sig.usReserved1 = 0
-        sig.pkcs7 = b'\xd3M4\xd3M5\xd3M4\xd3M4'
-        sig.ulFormat = 1
-        sig.ulOffset = 20
-
         values = dict(
             ulVersion = 1,
-            usFlag = 1,
-            usNumSigs = 1,
-            signatureRecords = [sig],
+            usFlag = 0,
+            usNumSigs = 0,
+            signatureRecords = [],
         )
         self._initTableWithValues("DSIG", {}, values)
 

--- a/Tests/fontBuilder/data/test.otf.ttx
+++ b/Tests/fontBuilder/data/test.otf.ttx
@@ -293,12 +293,7 @@
 
   <DSIG>
     <!-- note that the Digital Signature will be invalid after recompilation! -->
-    <tableHeader flag="0x1" numSigs="1" version="1"/>
-    <SignatureRecord format="1">
------BEGIN PKCS7-----
-0000000100000000
------END PKCS7-----
-    </SignatureRecord>
+    <tableHeader flag="0x0" numSigs="0" version="1"/>
   </DSIG>
 
 </ttFont>

--- a/Tests/fontBuilder/data/test.ttf.ttx
+++ b/Tests/fontBuilder/data/test.ttf.ttx
@@ -298,12 +298,7 @@
 
   <DSIG>
     <!-- note that the Digital Signature will be invalid after recompilation! -->
-    <tableHeader flag="0x1" numSigs="1" version="1"/>
-    <SignatureRecord format="1">
------BEGIN PKCS7-----
-0000000100000000
------END PKCS7-----
-    </SignatureRecord>
+    <tableHeader flag="0x0" numSigs="0" version="1"/>
   </DSIG>
 
 </ttFont>

--- a/Tests/fontBuilder/data/test_var.ttf.ttx
+++ b/Tests/fontBuilder/data/test_var.ttf.ttx
@@ -365,12 +365,7 @@
 
   <DSIG>
     <!-- note that the Digital Signature will be invalid after recompilation! -->
-    <tableHeader flag="0x1" numSigs="1" version="1"/>
-    <SignatureRecord format="1">
------BEGIN PKCS7-----
-0000000100000000
------END PKCS7-----
-    </SignatureRecord>
+    <tableHeader flag="0x0" numSigs="0" version="1"/>
   </DSIG>
 
 </ttFont>


### PR DESCRIPTION
An empty DSIG is enough to make MS applications happy and also fixes an error reported by MS Font Validator.