### PR TITLE
instancer: bugfixes and tests for instantiateFeatureVariations

### DIFF
--- a/Lib/fontTools/varLib/featureVars.py
+++ b/Lib/fontTools/varLib/featureVars.py
@@ -283,6 +283,7 @@ def addFeatureVariationsRaw(font, conditionalSubstitutions):
 
     rvrnFeature = buildFeatureRecord('rvrn', [])
     gsub.FeatureList.FeatureRecord.append(rvrnFeature)
+    gsub.FeatureList.FeatureCount = len(gsub.FeatureList.FeatureRecord)
 
     sortFeatureList(gsub)
     rvrnFeatureIndex = gsub.FeatureList.FeatureRecord.index(rvrnFeature)
@@ -346,6 +347,7 @@ def buildGSUB():
     srec.Script.DefaultLangSys = langrec.LangSys
 
     gsub.ScriptList.ScriptRecord.append(srec)
+    gsub.ScriptList.ScriptCount = 1
     gsub.FeatureVariations = None
 
     return fontTable
@@ -380,6 +382,7 @@ def buildSubstitutionLookups(gsub, allSubstitutions):
         lookup = buildLookup([buildSingleSubstSubtable(substMap)])
         gsub.LookupList.Lookup.append(lookup)
         assert gsub.LookupList.Lookup[lookupMap[subst]] is lookup
+    gsub.LookupList.LookupCount = len(gsub.LookupList.Lookup)
     return lookupMap
 
 
@@ -397,6 +400,7 @@ def buildFeatureRecord(featureTag, lookupListIndices):
     fr.FeatureTag = featureTag
     fr.Feature = ot.Feature()
     fr.Feature.LookupListIndex = lookupListIndices
+    fr.Feature.populateDefaults()
     return fr
 
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -18,6 +18,9 @@ from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables.TupleVariation import TupleVariation
 from fontTools.ttLib.tables import _g_l_y_f
 from fontTools import varLib
+# we import the `subset` module because we use the `prune_lookups` method on the GSUB
+# table class, and that method is only defined dynamically upon importing `subset`
+from fontTools import subset  # noqa: F401
 from fontTools.varLib import builder
 from fontTools.varLib.mvar import MVAR_ENTRIES
 from fontTools.varLib.merger import MutatorMerger
@@ -408,6 +411,8 @@ def instantiateFeatureVariations(varfont, location):
         _instantiateFeatureVariations(
             varfont[tableTag].table, varfont["fvar"].axes, location
         )
+        # remove unreferenced lookups
+        varfont[tableTag].prune_lookups()
 
 
 def _instantiateFeatureVariations(table, fvarAxes, location):

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -33,7 +33,7 @@ import os
 import re
 
 
-log = logging.getLogger("fontTools.varlib.instancer")
+log = logging.getLogger("fontTools.varLib.instancer")
 
 
 def instantiateTupleVariationStore(variations, location, origCoords=None, endPts=None):

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -419,8 +419,8 @@ def _featureVariationRecordIsUnique(rec, seen):
     conditionSet = []
     for cond in rec.ConditionSet.ConditionTable:
         if cond.Format != 1:
-            # can't tell whether this is duplicate, assume not seen
-            return False
+            # can't tell whether this is duplicate, assume is unique
+            return True
         conditionSet.append(
             (cond.AxisIndex, cond.FilterRangeMinValue, cond.FilterRangeMaxValue)
         )
@@ -474,6 +474,7 @@ def _instantiateFeatureVariations(table, fvarAxes, location):
                 )
                 applies = False
                 newConditions.append(condition)
+                break
 
         if retainRecord and newConditions:
             record.ConditionSet.ConditionTable = newConditions

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -688,7 +688,7 @@ def normalize(value, triple, avar_mapping):
 
 def normalizeAxisLimits(varfont, axis_limits):
     fvar = varfont["fvar"]
-    bad_limits = axis_limits.keys() - {a.axisTag for a in fvar.axes}
+    bad_limits = set(axis_limits.keys()).difference(a.axisTag for a in fvar.axes)
     if bad_limits:
         raise ValueError("Cannot limit: {} not present in fvar".format(bad_limits))
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -474,7 +474,6 @@ def _instantiateFeatureVariations(table, fvarAxes, location):
                 )
                 applies = False
                 newConditions.append(condition)
-                break
 
         if retainRecord and newConditions:
             record.ConditionSet.ConditionTable = newConditions

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1335,3 +1335,24 @@ class InstantiateFeatureVariationsTest(object):
         assert featureVariations.FeatureVariationRecord[0] is rec1
         assert len(rec1.ConditionSet.ConditionTable) == 2
         assert rec1.ConditionSet.ConditionTable[0].Format == 2
+
+
+@pytest.mark.parametrize(
+    "limits, expected",
+    [
+        (["wght=400", "wdth=100"], {"wght": 400, "wdth": 100}),
+        (["wght=400:900"], {"wght": (400, 900)}),
+        (["slnt=11.4"], {"slnt": 11.4}),
+        (["ABCD=drop"], {"ABCD": None}),
+    ],
+)
+def test_parseLimits(limits, expected):
+    assert instancer.parseLimits(limits) == expected
+
+
+@pytest.mark.parametrize(
+    "limits", [["abcde=123", "=0", "wght=:", "wght=1:", "wght=abcd", "wght=x:y"]]
+)
+def test_parseLimits_invalid(limits):
+    with pytest.raises(ValueError, match="invalid location format"):
+        instancer.parseLimits(limits)

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1316,18 +1316,22 @@ class InstantiateFeatureVariationsTest(object):
                 )
             ]
         )
-        gsub = font["GSUB"].table
-        featureVariations = gsub.FeatureVariations
+        featureVariations = font["GSUB"].table.FeatureVariations
         rec1 = featureVariations.FeatureVariationRecord[0]
+        assert len(rec1.ConditionSet.ConditionTable) == 2
         rec1.ConditionSet.ConditionTable[0].Format = 2
 
         with CapturingLogHandler("fontTools.varLib.instancer", "WARNING") as captor:
-            instancer.instantiateFeatureVariations(font, {"wght": 0})
+            instancer.instantiateFeatureVariations(font, {"wdth": 0})
 
         captor.assertRegex(
             r"Condition table 0 of FeatureVariationRecord 0 "
             r"has unsupported format \(2\); ignored"
         )
 
-        # check that record with unsupported condition format is kept
+        # check that record with unsupported condition format (but whose other
+        # conditions do not reference pinned axes) is kept as is
+        featureVariations = font["GSUB"].table.FeatureVariations
         assert featureVariations.FeatureVariationRecord[0] is rec1
+        assert len(rec1.ConditionSet.ConditionTable) == 2
+        assert rec1.ConditionSet.ConditionTable[0].Format == 2

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1356,3 +1356,42 @@ def test_parseLimits(limits, expected):
 def test_parseLimits_invalid(limits):
     with pytest.raises(ValueError, match="invalid location format"):
         instancer.parseLimits(limits)
+
+
+def test_main(varfont, tmpdir):
+    fontfile = str(tmpdir / "PartialInstancerTest-VF.ttf")
+    varfont.save(fontfile)
+    args = [fontfile, "wght=400"]
+
+    # exits without errors
+    assert instancer.main(args) is None
+
+
+def test_main_exit_nonexistent_file(capsys):
+    with pytest.raises(SystemExit):
+        instancer.main([""])
+    captured = capsys.readouterr()
+
+    assert "No such file ''" in captured.err
+
+
+def test_main_exit_invalid_location(varfont, tmpdir, capsys):
+    fontfile = str(tmpdir / "PartialInstancerTest-VF.ttf")
+    varfont.save(fontfile)
+
+    with pytest.raises(SystemExit):
+        instancer.main([fontfile, "wght:100"])
+    captured = capsys.readouterr()
+
+    assert "invalid location format" in captured.err
+
+
+def test_main_exit_multiple_limits(varfont, tmpdir, capsys):
+    fontfile = str(tmpdir / "PartialInstancerTest-VF.ttf")
+    varfont.save(fontfile)
+
+    with pytest.raises(SystemExit):
+        instancer.main([fontfile, "wght=400", "wght=90"])
+    captured = capsys.readouterr()
+
+    assert "Specified multiple limits for the same axis" in captured.err

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1285,9 +1285,8 @@ class InstantiateFeatureVariationsTest(object):
     def test_unsupported_condition_format(self, varfont3):
         gsub = varfont3["GSUB"].table
         featureVariations = gsub.FeatureVariations
-        cd = featureVariations.FeatureVariationRecord[0].ConditionSet.ConditionTable[0]
-        assert cd.Format == 1
-        cd.Format = 2
+        rec1 = featureVariations.FeatureVariationRecord[0]
+        rec1.ConditionSet.ConditionTable[0].Format = 2
 
         with CapturingLogHandler("fontTools.varLib.instancer", "WARNING") as captor:
             instancer.instantiateFeatureVariations(varfont3, {"wght": 0})
@@ -1296,3 +1295,6 @@ class InstantiateFeatureVariationsTest(object):
             r"Condition table 0 of FeatureVariationRecord 0 "
             r"has unsupported format \(2\); ignored"
         )
+
+        # check that record with unsupported condition format is kept
+        assert featureVariations.FeatureVariationRecord[0] is rec1

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1358,6 +1358,35 @@ def test_parseLimits_invalid(limits):
         instancer.parseLimits(limits)
 
 
+def test_normalizeAxisLimits_tuple(varfont):
+    normalized = instancer.normalizeAxisLimits(varfont, {"wght": (100, 400)})
+    assert normalized == {"wght": (-1.0, 0)}
+
+
+def test_normalizeAxisLimits_no_avar(varfont):
+    del varfont["avar"]
+
+    normalized = instancer.normalizeAxisLimits(varfont, {"wght": (500, 600)})
+
+    assert normalized["wght"] == pytest.approx((0.2, 0.4), 1e-4)
+
+
+def test_normalizeAxisLimits_missing_from_fvar(varfont):
+    with pytest.raises(ValueError, match="not present in fvar"):
+        instancer.normalizeAxisLimits(varfont, {"ZZZZ": 1000})
+
+
+def test_sanityCheckVariableTables(varfont):
+    font = ttLib.TTFont()
+    with pytest.raises(ValueError, match="Missing required table fvar"):
+        instancer.sanityCheckVariableTables(font)
+
+    del varfont["glyf"]
+
+    with pytest.raises(ValueError, match="Can't have gvar without glyf"):
+        instancer.sanityCheckVariableTables(varfont)
+
+
 def test_main(varfont, tmpdir):
     fontfile = str(tmpdir / "PartialInstancerTest-VF.ttf")
     varfont.save(fontfile)


### PR DESCRIPTION
we had forgotten to remap the ConditionTable.AxisIndex of remaining FeatureVariationRecords after dropping axes from fvar.

Also, we can drop lookups that are no longer referenced after we have subsetted or completely removed the FeatureVariations table.

This also adds unit tests for the instantiateFeatureVariations function, using the same test file "FeatureVars.ttx" used in varLib_test.py (the one built from Tests/varLib/data/FeatureVars.designspace with the dollar trick).