### PR TITLE
[varLib.cff] Fix important bug in merging CFF2 PrivateDicts.

### DIFF
--- a/Lib/fontTools/varLib/cff.py
+++ b/Lib/fontTools/varLib/cff.py
@@ -270,7 +270,9 @@ def getfd_map(varFont, fonts_list):
 	num_regions = len(region_fonts)
 	topDict = default_font['CFF '].cff.topDictIndex[0]
 	if not hasattr(topDict, 'FDSelect'):
-		fd_map[0] = [0]*num_regions
+		# All glyphs reference only one FontDict. 
+		# Map the FD index for regions to index 0.
+		fd_map[0] = {ri:0 for ri in range(num_regions)}
 		return fd_map
 
 	gname_mapping = {}

--- a/Tests/varLib/data/test_results/BuildTestCFF2.ttx
+++ b/Tests/varLib/data/test_results/BuildTestCFF2.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="OTTO" ttLibVersion="3.38">
+<ttFont sfntVersion="OTTO" ttLibVersion="3.42">
 
   <fvar>
 
@@ -67,29 +67,29 @@
             <BlueValues>
                 <blend value="-12 0 0"/>
                 <blend value="0 0 0"/>
-                <blend value="486 -8 -8"/>
+                <blend value="486 -8 14"/>
                 <blend value="498 0 0"/>
-                <blend value="574 4 4"/>
+                <blend value="574 4 -8"/>
                 <blend value="586 0 0"/>
-                <blend value="638 6 6"/>
+                <blend value="638 6 -10"/>
                 <blend value="650 0 0"/>
-                <blend value="656 2 2"/>
+                <blend value="656 2 -2"/>
                 <blend value="668 0 0"/>
-                <blend value="712 6 6"/>
+                <blend value="712 6 -10"/>
                 <blend value="724 0 0"/>
             </BlueValues>
             <OtherBlues>
-                <blend value="-217 -17 -17"/>
+                <blend value="-217 -17 29"/>
                 <blend value="-205 0 0"/>
             </OtherBlues>
             <BlueScale value="0.0625"/>
             <BlueShift value="7"/>
             <BlueFuzz value="0"/>
             <StdHW>
-                <blend value="67 -39.0 -39.0"/>
+                <blend value="67 -39.0 67.0"/>
             </StdHW>
             <StdVW>
-                <blend value="85 -51.0 -51.0"/>
+                <blend value="85 -51.0 87.0"/>
             </StdVW>
           </Private>
         </FontDict>


### PR DESCRIPTION
There was a bug that caused the PrivateDict of the first region to be used for all others.

Fixes issue [varLib.cffLib] Bug in merging CFF2 PrivateDicts #1643.