### PR TITLE
Optimize TTFont.getGlyphID

### DIFF
--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -622,8 +622,8 @@ class FontBuilder(object):
         self.font["loca"] = newTable("loca")
         self.font["glyf"] = newTable("glyf")
         self.font["glyf"].glyphs = glyphs
-        if hasattr(self.font, "glyphOrder"):
-            self.font["glyf"].glyphOrder = self.font.glyphOrder
+        if hasattr(self.font, "_glyphOrder"):
+            self.font["glyf"].glyphOrder = self.font._glyphOrder
         if calcGlyphBounds:
             self.calcGlyphBounds()
 

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -1815,7 +1815,7 @@ def subset_glyphs(self, s):
 @_add_method(ttLib.getTableClass('gvar'))
 def prune_pre_subset(self, font, options):
 	if options.notdef_glyph and not options.notdef_outline:
-		self.variations[font.glyphOrder[0]] = []
+		self.variations[font.getGlyphOrder()[0]] = []
 	return True
 
 @_add_method(ttLib.getTableClass('gvar'))

--- a/Tests/ttLib/tables/T_S_I__1_test.py
+++ b/Tests/ttLib/tables/T_S_I__1_test.py
@@ -33,7 +33,7 @@ def font(indextable):
     # ['a', 'b', 'c', ...]
     ch = 0x61
     n = len(indextable.indices)
-    font.glyphOrder = [unichr(i) for i in range(ch, ch+n)]
+    font.setGlyphOrder([unichr(i) for i in range(ch, ch+n)])
     font['TSI0'] = indextable
     return font
 
@@ -41,7 +41,7 @@ def font(indextable):
 @pytest.fixture
 def empty_font():
     font = TTFont()
-    font.glyphOrder = []
+    font.setGlyphOrder([])
     indextable = table_T_S_I__0()
     indextable.set([], [(0xFFFA, 0, 0),
                         (0xFFFB, 0, 0),
@@ -94,7 +94,7 @@ def test_decompile_empty(empty_font):
 
 
 def test_decompile_invalid_length(empty_font):
-    empty_font.glyphOrder = ['a']
+    empty_font.setGlyphOrder(['a'])
     empty_font['TSI0'].indices = [(0, 0x8000+1, 0)]
 
     table = table_T_S_I__1()
@@ -104,7 +104,7 @@ def test_decompile_invalid_length(empty_font):
 
 
 def test_decompile_offset_past_end(empty_font):
-    empty_font.glyphOrder = ['foo', 'bar']
+    empty_font.setGlyphOrder(['foo', 'bar'])
     content = 'baz'
     data = tobytes(content)
     empty_font['TSI0'].indices = [(0, len(data), 0), (1, 1, len(data)+1)]
@@ -131,7 +131,7 @@ def test_decompile_magic_length_last_extra(empty_font):
 
 
 def test_decompile_magic_length_last_glyph(empty_font):
-    empty_font.glyphOrder = ['foo', 'bar']
+    empty_font.setGlyphOrder(['foo', 'bar'])
     indextable = empty_font['TSI0']
     indextable.indices = [
         (0, 3, 0),

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -267,7 +267,7 @@ class GlyfTableTest(unittest.TestCase):
 
         glyfTable = newTable("glyf")
         glyfTable.glyphs = glyphSet
-        glyfTable.glyphOrder = sorted(glyphSet)
+        glyfTable.setGlyphOrder(sorted(glyphSet))
 
         composite.compact(glyfTable)
 

--- a/Tests/ttLib/tables/_h_m_t_x_test.py
+++ b/Tests/ttLib/tables/_h_m_t_x_test.py
@@ -27,7 +27,7 @@ class HmtxTableTest(unittest.TestCase):
         maxp = font['maxp'] = newTable('maxp')
         maxp.numGlyphs = numGlyphs
         # from A to ...
-        font.glyphOrder = [chr(i) for i in range(65, 65+numGlyphs)]
+        font.setGlyphOrder([chr(i) for i in range(65, 65+numGlyphs)])
         headerTag = self.tableClass.headerTag
         font[headerTag] = newTable(headerTag)
         numberOfMetricsName = self.tableClass.numberOfMetricsName
@@ -109,7 +109,7 @@ class HmtxTableTest(unittest.TestCase):
         font = TTFont()
         maxp = font['maxp'] = newTable('maxp')
         maxp.numGlyphs = 3
-        font.glyphOrder = ["A", "B", "C"]
+        font.setGlyphOrder(["A", "B", "C"])
 
         self.assertNotIn(self.tableClass.headerTag, font)
 
@@ -196,7 +196,7 @@ class HmtxTableTest(unittest.TestCase):
         font = TTFont()
         maxp = font['maxp'] = newTable('maxp')
         maxp.numGlyphs = 3
-        font.glyphOrder = [chr(i) for i in range(65, 68)]
+        font.setGlyphOrder([chr(i) for i in range(65, 68)])
         mtxTable = font[self.tag] = newTable(self.tag)
         mtxTable.metrics = {
             "A": (400, 30),

--- a/Tests/ttLib/woff2_test.py
+++ b/Tests/ttLib/woff2_test.py
@@ -761,7 +761,7 @@ class WOFF2GlyfTableTest(unittest.TestCase):
 
 	def test_reconstruct_glyf_missing_glyphOrder(self):
 		glyfTable = WOFF2GlyfTable()
-		del self.font.glyphOrder
+		del self.font._glyphOrder
 		numGlyphs = self.font['maxp'].numGlyphs
 		del self.font['maxp']
 		glyfTable.reconstruct(self.transformedGlyfData, self.font)

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1370,7 +1370,7 @@ def test_setMacOverlapFlags():
     flagOverlapSimple = _g_l_y_f.flagOverlapSimple
 
     glyf = ttLib.newTable("glyf")
-    glyf.glyphOrder = ["a", "b", "c"]
+    glyf.setGlyphOrder(["a", "b", "c"])
     a = _g_l_y_f.Glyph()
     a.numberOfContours = 1
     a.flags = [0]


### PR DESCRIPTION
If a `TTFont` has the attribute `_reverseGlyphOrderDict`, it must be consistent with `_glyphOrder`. The attribute `glyphOrder` is now a property whose setter upholds this invariant. This was suggested in https://github.com/fonttools/fonttools/issues/1536#issuecomment-472505536.