### PR TITLE
make the minimal examples work on windows 10

### DIFF
--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -31,6 +31,7 @@ Here is how to build a minimal TTF:
 from fontTools.fontBuilder import FontBuilder
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 
+
 def drawTestGlyph(pen):
     pen.moveTo((100, 100))
     pen.lineTo((100, 1000))
@@ -38,35 +39,39 @@ def drawTestGlyph(pen):
     pen.lineTo((500, 100))
     pen.closePath()
 
-fb = FontBuilder(1024, isTTF=True)
-fb.setupGlyphOrder([".notdef", ".null", "A", "a"])
-fb.setupCharacterMap({65: "A", 97: "a"})
 
-advanceWidths = {".notdef": 600, "A": 600, "a": 600, ".null": 600}
+fb = FontBuilder(1024, isTTF=True)
+fb.setupGlyphOrder([".notdef", ".null", ".space", "A", "a"])
+fb.setupCharacterMap({32: ".space", 65: "A", 97: "a"})
+advanceWidths = {".notdef": 600, ".space": 500, "A": 600, "a": 600, ".null": 0}
 
 familyName = "HelloTestFont"
 styleName = "TotallyNormal"
-nameStrings = dict(familyName=dict(en="HelloTestFont", nl="HalloTestFont"),
-                   styleName=dict(en="TotallyNormal", nl="TotaalNormaal"))
-nameStrings['psName'] = familyName + "-" + styleName
+version = "0.1"
+
+nameStrings = dict(
+    familyName=dict(en=familyName, nl="HalloTestFont"),
+    styleName=dict(en=styleName, nl="TotaalNormaal"),
+    uniqueFontIdentifier="fontBuilder: " + familyName + "." + styleName,
+    fullName=familyName + "-" + styleName,
+    psName=familyName + "-" + styleName,
+    version="Version " + version,
+)
 
 pen = TTGlyphPen(None)
 drawTestGlyph(pen)
 glyph = pen.glyph()
-glyphs = {".notdef": glyph, "A": glyph, "a": glyph, ".null": glyph}
+glyphs = {".notdef": glyph, ".space": glyph, "A": glyph, "a": glyph, ".null": glyph}
 fb.setupGlyf(glyphs)
-
 metrics = {}
 glyphTable = fb.font["glyf"]
 for gn, advanceWidth in advanceWidths.items():
     metrics[gn] = (advanceWidth, glyphTable[gn].xMin)
 fb.setupHorizontalMetrics(metrics)
-
-fb.setupHorizontalHeader(ascent=824, descent=200)
+fb.setupHorizontalHeader(ascent=824, descent=-200)
 fb.setupNameTable(nameStrings)
-fb.setupOS2()
+fb.setupOS2(sTypoAscender=824)
 fb.setupPost()
-
 fb.save("test.ttf")
 ```
 

--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -70,7 +70,7 @@ for gn, advanceWidth in advanceWidths.items():
 fb.setupHorizontalMetrics(metrics)
 fb.setupHorizontalHeader(ascent=824, descent=-200)
 fb.setupNameTable(nameStrings)
-fb.setupOS2(sTypoAscender=824)
+fb.setupOS2(sTypoAscender=824, usWinAscent=824, usWinDescent=200)
 fb.setupPost()
 fb.save("test.ttf")
 ```

--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -91,19 +91,21 @@ def drawTestGlyph(pen):
 
 
 fb = FontBuilder(1024, isTTF=False)
-fb.setupGlyphOrder([".notdef", ".null", "A", "a"])
-fb.setupCharacterMap({65: "A", 97: "a"})
-
-advanceWidths = {".notdef": 600, "A": 600, "a": 600, ".null": 600}
+fb.setupGlyphOrder([".notdef", ".null", "space", "A", "a"])
+fb.setupCharacterMap({32: "space", 65: "A", 97: "a"})
+advanceWidths = {".notdef": 600, "space": 500, "A": 600, "a": 600, ".null": 0}
 
 familyName = "HelloTestFont"
 styleName = "TotallyNormal"
+version = "0.1"
+
 nameStrings = dict(
     familyName=dict(en=familyName, nl="HalloTestFont"),
     styleName=dict(en=styleName, nl="TotaalNormaal"),
     uniqueFontIdentifier="fontBuilder: " + familyName + "." + styleName,
     fullName=familyName + "-" + styleName,
     psName=familyName + "-" + styleName,
+    version="Version " + version,
 )
 
 pen = T2CharStringPen(600, None)
@@ -111,23 +113,21 @@ drawTestGlyph(pen)
 charString = pen.getCharString()
 charStrings = {
     ".notdef": charString,
+    "space": charString,
     "A": charString,
     "a": charString,
     ".null": charString,
 }
 fb.setupCFF(nameStrings["psName"], {"FullName": nameStrings["psName"]}, charStrings, {})
-
 lsb = {gn: cs.calcBounds(None)[0] for gn, cs in charStrings.items()}
 metrics = {}
 for gn, advanceWidth in advanceWidths.items():
     metrics[gn] = (advanceWidth, lsb[gn])
 fb.setupHorizontalMetrics(metrics)
-
 fb.setupHorizontalHeader(ascent=824, descent=200)
 fb.setupNameTable(nameStrings)
-fb.setupOS2()
+fb.setupOS2(sTypoAscender=824, usWinAscent=824, usWinDescent=200)
 fb.setupPost()
-
 fb.save("test.otf")
 ```
 """

--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -76,12 +76,14 @@ And here's how to build a minimal OTF:
 from fontTools.fontBuilder import FontBuilder
 from fontTools.pens.t2CharStringPen import T2CharStringPen
 
+
 def drawTestGlyph(pen):
     pen.moveTo((100, 100))
     pen.lineTo((100, 1000))
     pen.curveTo((200, 900), (400, 900), (500, 1000))
     pen.lineTo((500, 100))
     pen.closePath()
+
 
 fb = FontBuilder(1024, isTTF=False)
 fb.setupGlyphOrder([".notdef", ".null", "A", "a"])
@@ -91,15 +93,24 @@ advanceWidths = {".notdef": 600, "A": 600, "a": 600, ".null": 600}
 
 familyName = "HelloTestFont"
 styleName = "TotallyNormal"
-nameStrings = dict(familyName=dict(en="HelloTestFont", nl="HalloTestFont"),
-                   styleName=dict(en="TotallyNormal", nl="TotaalNormaal"))
-nameStrings['psName'] = familyName + "-" + styleName
+nameStrings = dict(
+    familyName=dict(en=familyName, nl="HalloTestFont"),
+    styleName=dict(en=styleName, nl="TotaalNormaal"),
+    uniqueFontIdentifier="fontBuilder: " + familyName + "." + styleName,
+    fullName=familyName + "-" + styleName,
+    psName=familyName + "-" + styleName,
+)
 
 pen = T2CharStringPen(600, None)
 drawTestGlyph(pen)
 charString = pen.getCharString()
-charStrings = {".notdef": charString, "A": charString, "a": charString, ".null": charString}
-fb.setupCFF(nameStrings['psName'], {"FullName": nameStrings['psName']}, charStrings, {})
+charStrings = {
+    ".notdef": charString,
+    "A": charString,
+    "a": charString,
+    ".null": charString,
+}
+fb.setupCFF(nameStrings["psName"], {"FullName": nameStrings["psName"]}, charStrings, {})
 
 lsb = {gn: cs.calcBounds(None)[0] for gn, cs in charStrings.items()}
 metrics = {}

--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -41,9 +41,9 @@ def drawTestGlyph(pen):
 
 
 fb = FontBuilder(1024, isTTF=True)
-fb.setupGlyphOrder([".notdef", ".null", ".space", "A", "a"])
-fb.setupCharacterMap({32: ".space", 65: "A", 97: "a"})
-advanceWidths = {".notdef": 600, ".space": 500, "A": 600, "a": 600, ".null": 0}
+fb.setupGlyphOrder([".notdef", ".null", "space", "A", "a"])
+fb.setupCharacterMap({32: "space", 65: "A", 97: "a"})
+advanceWidths = {".notdef": 600, "space": 500, "A": 600, "a": 600, ".null": 0}
 
 familyName = "HelloTestFont"
 styleName = "TotallyNormal"
@@ -61,7 +61,7 @@ nameStrings = dict(
 pen = TTGlyphPen(None)
 drawTestGlyph(pen)
 glyph = pen.glyph()
-glyphs = {".notdef": glyph, ".space": glyph, "A": glyph, "a": glyph, ".null": glyph}
+glyphs = {".notdef": glyph, "space": glyph, "A": glyph, "a": glyph, ".null": glyph}
 fb.setupGlyf(glyphs)
 metrics = {}
 glyphTable = fb.font["glyf"]


### PR DESCRIPTION
Partially addresses #1660. This makes the otf minimal example work. The ttf example still doesn't work.