### PR TITLE
[ttLib] allow the glyf table to be incomplete when dumping to XML

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -140,7 +140,6 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 		for glyphName in glyphNames:
 			if glyphName not in self:
 				log.warning("glyph '%s' does not exist in glyf table", glyphName)
-				log.warning
 				continue
 			glyph = self[glyphName]
 			if glyph.numberOfContours:

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -139,6 +139,8 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 			existingGlyphFiles = set()
 		for glyphName in glyphNames:
 			if glyphName not in self:
+				log.warning("glyph '%s' does not exist in glyf table", glyphName)
+				log.warning
 				continue
 			glyph = self[glyphName]
 			if glyph.numberOfContours:

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -138,6 +138,8 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 			path, ext = os.path.splitext(writer.file.name)
 			existingGlyphFiles = set()
 		for glyphName in glyphNames:
+			if glyphName not in self:
+				continue
 			glyph = self[glyphName]
 			if glyph.numberOfContours:
 				if splitGlyphs:


### PR DESCRIPTION
Allow the glyf table to be incomplete — to not contain all glyphs listed in the glyph order — when writing to XML. Partially addresses #684.