### PR TITLE
Make glyphSet param consistently optional for pens

### DIFF
--- a/Lib/fontTools/pens/boundsPen.py
+++ b/Lib/fontTools/pens/boundsPen.py
@@ -22,7 +22,7 @@ class ControlBoundsPen(BasePen):
 	If 'ignoreSinglePoints' is True, single points are ignored.
 	"""
 
-	def __init__(self, glyphSet, ignoreSinglePoints=False):
+	def __init__(self, glyphSet=None, ignoreSinglePoints=False):
 		BasePen.__init__(self, glyphSet)
 		self.ignoreSinglePoints = ignoreSinglePoints
 		self.init()

--- a/Lib/fontTools/pens/cocoaPen.py
+++ b/Lib/fontTools/pens/cocoaPen.py
@@ -8,7 +8,7 @@ __all__ = ["CocoaPen"]
 
 class CocoaPen(BasePen):
 
-	def __init__(self, glyphSet, path=None):
+	def __init__(self, glyphSet=None, path=None):
 		BasePen.__init__(self, glyphSet)
 		if path is None:
 			from AppKit import NSBezierPath

--- a/Lib/fontTools/pens/qtPen.py
+++ b/Lib/fontTools/pens/qtPen.py
@@ -8,7 +8,7 @@ __all__ = ["QtPen"]
 
 class QtPen(BasePen):
 
-	def __init__(self, glyphSet, path=None):
+	def __init__(self, glyphSet=None, path=None):
 		BasePen.__init__(self, glyphSet)
 		if path is None:
 			from PyQt5.QtGui import QPainterPath

--- a/Lib/fontTools/pens/reportLabPen.py
+++ b/Lib/fontTools/pens/reportLabPen.py
@@ -11,7 +11,7 @@ class ReportLabPen(BasePen):
 
 	"""A pen for drawing onto a reportlab.graphics.shapes.Path object."""
 
-	def __init__(self, glyphSet, path=None):
+	def __init__(self, glyphSet=None, path=None):
 		BasePen.__init__(self, glyphSet)
 		if path is None:
 			path = Path()

--- a/Lib/fontTools/pens/svgPathPen.py
+++ b/Lib/fontTools/pens/svgPathPen.py
@@ -9,7 +9,7 @@ def pointToString(pt):
 
 class SVGPathPen(BasePen):
 
-    def __init__(self, glyphSet):
+    def __init__(self, glyphSet=None):
         BasePen.__init__(self, glyphSet)
         self._commands = []
         self._lastCommand = None

--- a/Lib/fontTools/pens/t2CharStringPen.py
+++ b/Lib/fontTools/pens/t2CharStringPen.py
@@ -44,7 +44,7 @@ class T2CharStringPen(BasePen):
     which are close to their integral part within the tolerated range.
     """
 
-    def __init__(self, width, glyphSet, roundTolerance=0.5, CFF2=False):
+    def __init__(self, width, glyphSet=None, roundTolerance=0.5, CFF2=False):
         super(T2CharStringPen, self).__init__(glyphSet)
         self.roundPoint = makeRoundFunc(roundTolerance)
         self._CFF2 = CFF2

--- a/Lib/fontTools/pens/wxPen.py
+++ b/Lib/fontTools/pens/wxPen.py
@@ -8,7 +8,7 @@ __all__ = ["WxPen"]
 
 class WxPen(BasePen):
 
-	def __init__(self, glyphSet, path=None):
+	def __init__(self, glyphSet=None, path=None):
 		BasePen.__init__(self, glyphSet)
 		if path is None:
 			import wx


### PR DESCRIPTION
The following pens have `glyphSet` as a required param to their constructor:

  - `ControlBoundsPen`, `BoundsPen`
  - `CocoaPen`
  - `PointInsidePen`
  - `QtPen`
  - `ReportLabPen`
  - `SVGPathPen`
  - `T2CharStringPen`
  - `TTGlyphPen`
  - `WxPen`

All other pens make it optional (defaulting to None):

  - `AreaPen`
  - `FilterPen`, `ContourFilterPen`, `ReverseContourPen`
  - `MomentsPen`
  - `PerimeterPen`
  - `PointToSegmentPen`, `SegmentToPointPen`, `GuessSmoothPointPen`,
    `ReverseContourPointPen`
  - `RecordingPen`, `DecomposingRecordingPen`
  - `StatisticsPen`
  - `TeePen`
  - `TransformPen`

Of the above pens that require `glyphSet` (to be passed into the parent constructor for `DecomposingPen`--a superclass of `BasePen`), only `TTGlyphPen` actually uses `self.glyphSet` and `addComponent` (a method added by `DecomposingPen`). Several pens override `addComponent` or call it on pens they own (such as `TeePen`, which calls it on all of its subpens).

The fact that so many pens (which on the surface seem like they may need to support `addComponent`--like `AreaPen`, `StatisticsPen`, etc.) make `glyphSet` optional indicates that it should be safe to make it more uniformly optional. This way, it isn't so cumbersome to construct an `SVGPathPen`, for example.

Note that `PointInsidePen` cannot have `glyphSet` made optional, because it is followed by a required param:

    def __init__(self, glyphSet, testPoint, evenOdd=False):

Reordering the params to accommodate would be a breaking change.