### PR TITLE
[subset] Prune empty strikes in EBDT data

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -1388,6 +1388,9 @@ def subset_glyphs(self, s):
 def subset_glyphs(self, s):
   self.strikeData = [{g: strike[g] for g in s.glyphs if g in strike}
 					 for strike in self.strikeData]
+  # Prune empty strikes
+  # https://github.com/fonttools/fonttools/issues/1633
+  self.strikeData = list(filter(bool, self.strikeData))
   return True
 
 @_add_method(ttLib.getTableClass('sbix'))


### PR DESCRIPTION
After subsetting some strikes might be empty (strikes don’t have to cover all glyphs equally) which would cause a key error later when saving the table.

Fixes https://github.com/fonttools/fonttools/issues/1633