### PR TITLE
[feaLib] Correctly handle octal numbers

### DIFF
--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -6,6 +6,9 @@ import os
 
 class Lexer(object):
     NUMBER = "NUMBER"
+    HEXADECIMAL = "HEXADECIMAL"
+    OCTAL = "OCTAL"
+    NUMBERS = (NUMBER, HEXADECIMAL, OCTAL)
     FLOAT = "FLOAT"
     STRING = "STRING"
     NAME = "NAME"
@@ -123,10 +126,10 @@ class Lexer(object):
         if cur_char == "0" and next_char in "xX":
             self.pos_ += 2
             self.scan_over_(Lexer.CHAR_HEXDIGIT_)
-            return (Lexer.NUMBER, int(text[start:self.pos_], 16), location)
+            return (Lexer.HEXADECIMAL, int(text[start:self.pos_], 16), location)
         if cur_char == "0" and next_char in Lexer.CHAR_DIGIT_:
             self.scan_over_(Lexer.CHAR_DIGIT_)
-            return (Lexer.NUMBER, int(text[start:self.pos_], 8), location)
+            return (Lexer.OCTAL, int(text[start:self.pos_], 8), location)
         if cur_char in Lexer.CHAR_DIGIT_:
             self.scan_over_(Lexer.CHAR_DIGIT_)
             if self.pos_ >= limit or text[self.pos_] != ".":

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -124,6 +124,9 @@ class Lexer(object):
             self.pos_ += 2
             self.scan_over_(Lexer.CHAR_HEXDIGIT_)
             return (Lexer.NUMBER, int(text[start:self.pos_], 16), location)
+        if cur_char == "0" and next_char in Lexer.CHAR_DIGIT_:
+            self.scan_over_(Lexer.CHAR_DIGIT_)
+            return (Lexer.NUMBER, int(text[start:self.pos_], 8), location)
         if cur_char in Lexer.CHAR_DIGIT_:
             self.scan_over_(Lexer.CHAR_DIGIT_)
             if self.pos_ >= limit or text[self.pos_] != ".":

--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -67,9 +67,9 @@ class LexerTest(unittest.TestCase):
     def test_number(self):
         self.assertEqual(lex("123 -456"),
                          [(Lexer.NUMBER, 123), (Lexer.NUMBER, -456)])
-        self.assertEqual(lex("0xCAFED00D"), [(Lexer.NUMBER, 0xCAFED00D)])
-        self.assertEqual(lex("0xcafed00d"), [(Lexer.NUMBER, 0xCAFED00D)])
-        self.assertEqual(lex("010"), [(Lexer.NUMBER, 0o10)])
+        self.assertEqual(lex("0xCAFED00D"), [(Lexer.HEXADECIMAL, 0xCAFED00D)])
+        self.assertEqual(lex("0xcafed00d"), [(Lexer.HEXADECIMAL, 0xCAFED00D)])
+        self.assertEqual(lex("010"), [(Lexer.OCTAL, 0o10)])
 
     def test_float(self):
         self.assertEqual(lex("1.23 -4.5"),

--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -69,6 +69,7 @@ class LexerTest(unittest.TestCase):
                          [(Lexer.NUMBER, 123), (Lexer.NUMBER, -456)])
         self.assertEqual(lex("0xCAFED00D"), [(Lexer.NUMBER, 0xCAFED00D)])
         self.assertEqual(lex("0xcafed00d"), [(Lexer.NUMBER, 0xCAFED00D)])
+        self.assertEqual(lex("010"), [(Lexer.NUMBER, 0o10)])
 
     def test_float(self):
         self.assertEqual(lex("1.23 -4.5"),

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1117,6 +1117,36 @@ class ParserTest(unittest.TestCase):
             FeatureLibError, "Expected platform id 1 or 3",
             self.parse, 'table name { nameid 9 666 "Foo"; } name;')
 
+    def test_nameid_hexadecimal(self):
+        doc = self.parse(
+            r'table name { nameid 0x9 0x3 0x1 0x0409 "Test"; } name;')
+        name = doc.statements[0].statements[0]
+        self.assertEqual(name.nameID, 9)
+        self.assertEqual(name.platformID, 3)
+        self.assertEqual(name.platEncID, 1)
+        self.assertEqual(name.langID, 0x0409)
+
+    def test_nameid_octal(self):
+        doc = self.parse(
+            r'table name { nameid 011 03 012 02011 "Test"; } name;')
+        name = doc.statements[0].statements[0]
+        self.assertEqual(name.nameID, 9)
+        self.assertEqual(name.platformID, 3)
+        self.assertEqual(name.platEncID, 10)
+        self.assertEqual(name.langID, 0o2011)
+
+    def test_cv_hexadecimal(self):
+        doc = self.parse(
+            r'feature cv01 { cvParameters { Character 0x5DDE; }; } cv01;')
+        cv = doc.statements[0].statements[0].statements[0]
+        self.assertEqual(cv.character, 0x5DDE)
+
+    def test_cv_octal(self):
+        doc = self.parse(
+            r'feature cv01 { cvParameters { Character 056736; }; } cv01;')
+        cv = doc.statements[0].statements[0].statements[0]
+        self.assertEqual(cv.character, 0o56736)
+
     def test_rsub_format_a(self):
         doc = self.parse("feature test {rsub a [b B] c' d [e E] by C;} test;")
         rsub = doc.statements[0].statements[0]


### PR DESCRIPTION
From https://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html#9.e:
> Decimal numbers must begin with a non-0 digit, octal numbers with a 0
> digit, and hexadecimal numbers with a 0x prefix to numbers and
> hexadecimal letters a-f or A-F.

Fixes https://github.com/fonttools/fonttools/issues/1541