### PR TITLE
Refactor deprecated array tostring/fromstring methods to tobytes/frombytes

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2075,7 +2075,7 @@ def remapComponentsFast(self, glyphidmap):
 		elif flags & 0x0080: i += 8	# WE_HAVE_A_TWO_BY_TWO
 		more = flags & 0x0020	# MORE_COMPONENTS
 
-	self.data = data.tostring()
+	self.data = data.tobytes()
 
 @_add_method(ttLib.getTableClass('glyf'))
 def closure_glyphs(self, s):

--- a/Lib/fontTools/ttLib/tables/G_P_K_G_.py
+++ b/Lib/fontTools/ttLib/tables/G_P_K_G_.py
@@ -56,7 +56,7 @@ class table_G_P_K_G_(DefaultTable.DefaultTable):
 			GMAPoffsets[i] = pos
 		gmapArray = array.array("I", GMAPoffsets)
 		if sys.byteorder != "big": gmapArray.byteswap()
-		dataList.append(gmapArray.tostring())
+		dataList.append(gmapArray.tobytes())
 
 		glyphletOffsets[0] = pos
 		for i in range(1, self.numGlyplets +1):
@@ -64,7 +64,7 @@ class table_G_P_K_G_(DefaultTable.DefaultTable):
 			glyphletOffsets[i] = pos
 		glyphletArray = array.array("I", glyphletOffsets)
 		if sys.byteorder != "big": glyphletArray.byteswap()
-		dataList.append(glyphletArray.tostring())
+		dataList.append(glyphletArray.tobytes())
 		dataList += self.GMAPs
 		dataList += self.glyphlets
 		data = bytesjoin(dataList)

--- a/Lib/fontTools/ttLib/tables/G_P_K_G_.py
+++ b/Lib/fontTools/ttLib/tables/G_P_K_G_.py
@@ -23,7 +23,7 @@ class table_G_P_K_G_(DefaultTable.DefaultTable):
 
 		GMAPoffsets = array.array("I")
 		endPos = (self.numGMAPs+1) * 4
-		GMAPoffsets.fromstring(newData[:endPos])
+		GMAPoffsets.frombytes(newData[:endPos])
 		if sys.byteorder != "big": GMAPoffsets.byteswap()
 		self.GMAPs = []
 		for i in range(self.numGMAPs):
@@ -33,7 +33,7 @@ class table_G_P_K_G_(DefaultTable.DefaultTable):
 		pos = endPos
 		endPos = pos + (self.numGlyplets + 1)*4
 		glyphletOffsets = array.array("I")
-		glyphletOffsets.fromstring(newData[pos:endPos])
+		glyphletOffsets.frombytes(newData[pos:endPos])
 		if sys.byteorder != "big": glyphletOffsets.byteswap()
 		self.glyphlets = []
 		for i in range(self.numGlyplets):

--- a/Lib/fontTools/ttLib/tables/G__l_o_c.py
+++ b/Lib/fontTools/ttLib/tables/G__l_o_c.py
@@ -42,11 +42,11 @@ class table_G__l_o_c(DefaultTable.DefaultTable):
                 flags=(bool(self.attribIds) << 1) + (self.locations.typecode == 'I'),
                 numAttribs=self.numAttribs))
         if sys.byteorder != "big": self.locations.byteswap()
-        data += self.locations.tostring()
+        data += self.locations.tobytes()
         if sys.byteorder != "big": self.locations.byteswap()
         if self.attribIds:
             if sys.byteorder != "big": self.attribIds.byteswap()
-            data += self.attribIds.tostring()
+            data += self.attribIds.tobytes()
             if sys.byteorder != "big": self.attribIds.byteswap()
         return data
 

--- a/Lib/fontTools/ttLib/tables/G__l_o_c.py
+++ b/Lib/fontTools/ttLib/tables/G__l_o_c.py
@@ -30,11 +30,11 @@ class table_G__l_o_c(DefaultTable.DefaultTable):
         flags = self.flags
         del self.flags
         self.locations = array.array('I' if flags & 1 else 'H')
-        self.locations.fromstring(data[:len(data) - self.numAttribs * (flags & 2)])
+        self.locations.frombytes(data[:len(data) - self.numAttribs * (flags & 2)])
         if sys.byteorder != "big": self.locations.byteswap()
         self.attribIds = array.array('H')
         if flags & 2:
-            self.attribIds.fromstring(data[-self.numAttribs * 2:])
+            self.attribIds.frombytes(data[-self.numAttribs * 2:])
             if sys.byteorder != "big": self.attribIds.byteswap()
 
     def compile(self, ttFont):

--- a/Lib/fontTools/ttLib/tables/L_T_S_H_.py
+++ b/Lib/fontTools/ttLib/tables/L_T_S_H_.py
@@ -33,7 +33,7 @@ class table_L_T_S_H_(DefaultTable.DefaultTable):
 		for name in names:
 			yPels[ttFont.getGlyphID(name)] = self.yPels[name]
 		yPels = array.array("B", yPels)
-		return struct.pack(">HH", version, numGlyphs) + yPels.tostring()
+		return struct.pack(">HH", version, numGlyphs) + yPels.tobytes()
 
 	def toXML(self, writer, ttFont):
 		names = sorted(self.yPels.keys())

--- a/Lib/fontTools/ttLib/tables/L_T_S_H_.py
+++ b/Lib/fontTools/ttLib/tables/L_T_S_H_.py
@@ -18,7 +18,7 @@ class table_L_T_S_H_(DefaultTable.DefaultTable):
 		# ouch: the assertion is not true in Chicago!
 		#assert numGlyphs == ttFont['maxp'].numGlyphs
 		yPels = array.array("B")
-		yPels.fromstring(data)
+		yPels.frombytes(data)
 		self.yPels = {}
 		for i in range(numGlyphs):
 			self.yPels[ttFont.getGlyphName(i)] = yPels[i]

--- a/Lib/fontTools/ttLib/tables/S__i_l_f.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_f.py
@@ -745,7 +745,7 @@ class Pass(object):
         transes = []
         for t in self.stateTrans:
             if sys.byteorder != "big": t.byteswap()
-            transes.append(t.tostring())
+            transes.append(t.tobytes())
             if sys.byteorder != "big": t.byteswap()
         if not len(transes):
             self.startStates = [0]

--- a/Lib/fontTools/ttLib/tables/T_S_I__5.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__5.py
@@ -28,7 +28,7 @@ class table_T_S_I__5(DefaultTable.DefaultTable):
 		for i in range(len(glyphNames)):
 			a.append(self.glyphGrouping.get(glyphNames[i], 0))
 		if sys.byteorder != "big": a.byteswap()
-		return a.tostring()
+		return a.tobytes()
 
 	def toXML(self, writer, ttFont):
 		names = sorted(self.glyphGrouping.keys())

--- a/Lib/fontTools/ttLib/tables/T_S_I__5.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__5.py
@@ -16,7 +16,7 @@ class table_T_S_I__5(DefaultTable.DefaultTable):
 		numGlyphs = ttFont['maxp'].numGlyphs
 		assert len(data) == 2 * numGlyphs
 		a = array.array("H")
-		a.fromstring(data)
+		a.frombytes(data)
 		if sys.byteorder != "big": a.byteswap()
 		self.glyphGrouping = {}
 		for i in range(numGlyphs):

--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -269,7 +269,7 @@ class TupleVariation(object):
 			else:
 				points = array.array("B")
 				pointsSize = numPointsInRun
-			points.fromstring(data[pos:pos+pointsSize])
+			points.frombytes(data[pos:pos+pointsSize])
 			if sys.byteorder != "big": points.byteswap()
 
 			assert len(points) == numPointsInRun
@@ -426,7 +426,7 @@ class TupleVariation(object):
 				else:
 					deltas = array.array("b")
 					deltasSize = numDeltasInRun
-				deltas.fromstring(data[pos:pos+deltasSize])
+				deltas.frombytes(data[pos:pos+deltasSize])
 				if sys.byteorder != "big": deltas.byteswap()
 				assert len(deltas) == numDeltasInRun
 				pos += deltasSize

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -252,7 +252,7 @@ class cmap_format_0(CmapSubtable):
 		data = self.data # decompileHeader assigns the data after the header to self.data
 		assert 262 == self.length, "Format 0 cmap subtable not 262 bytes"
 		gids = array.array("B")
-		gids.fromstring(self.data)
+		gids.frombytes(self.data)
 		charCodes = list(range(len(gids)))
 		self.cmap = _make_map(self.ttFont, charCodes, gids)
 
@@ -336,7 +336,7 @@ class cmap_format_2(CmapSubtable):
 		maxSubHeaderindex = 0
 		# get the key array, and determine the number of subHeaders.
 		allKeys = array.array("H")
-		allKeys.fromstring(data[:512])
+		allKeys.frombytes(data[:512])
 		data = data[512:]
 		if sys.byteorder != "big": allKeys.byteswap()
 		subHeaderKeys = [ key//8 for key in allKeys]
@@ -352,7 +352,7 @@ class cmap_format_2(CmapSubtable):
 			pos += 8
 			giDataPos = pos + subHeader.idRangeOffset-2
 			giList = array.array("H")
-			giList.fromstring(data[giDataPos:giDataPos + subHeader.entryCount*2])
+			giList.frombytes(data[giDataPos:giDataPos + subHeader.entryCount*2])
 			if sys.byteorder != "big": giList.byteswap()
 			subHeader.glyphIndexArray = giList
 			subHeaderList.append(subHeader)
@@ -694,7 +694,7 @@ class cmap_format_4(CmapSubtable):
 		segCount = segCountX2 // 2
 
 		allCodes = array.array("H")
-		allCodes.fromstring(data)
+		allCodes.frombytes(data)
 		self.data = data = None
 
 		if sys.byteorder != "big": allCodes.byteswap()
@@ -864,7 +864,7 @@ class cmap_format_6(CmapSubtable):
 		data = data[4:]
 		#assert len(data) == 2 * entryCount  # XXX not true in Apple's Helvetica!!!
 		gids = array.array("H")
-		gids.fromstring(data[:2 * int(entryCount)])
+		gids.frombytes(data[:2 * int(entryCount)])
 		if sys.byteorder != "big": gids.byteswap()
 		self.data = data = None
 

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -266,7 +266,7 @@ class cmap_format_0(CmapSubtable):
 		valueList = [getGlyphID(cmap[i]) if i in cmap else 0 for i in range(256)]
 
 		gids = array.array("B", valueList)
-		data = struct.pack(">HHH", 0, 262, self.language) + gids.tostring()
+		data = struct.pack(">HHH", 0, 262, self.language) + gids.tobytes()
 		assert len(data) == 262
 		return data
 
@@ -826,7 +826,7 @@ class cmap_format_4(CmapSubtable):
 		if sys.byteorder != "big": charCodeArray.byteswap()
 		if sys.byteorder != "big": idDeltaArray.byteswap()
 		if sys.byteorder != "big": restArray.byteswap()
-		data = charCodeArray.tostring() + idDeltaArray.tostring() + restArray.tostring()
+		data = charCodeArray.tobytes() + idDeltaArray.tobytes() + restArray.tobytes()
 
 		length = struct.calcsize(cmap_format_4_format) + len(data)
 		header = struct.pack(cmap_format_4_format, self.format, length, self.language,
@@ -885,7 +885,7 @@ class cmap_format_6(CmapSubtable):
 			]
 			gids = array.array("H", valueList)
 			if sys.byteorder != "big": gids.byteswap()
-			data = gids.tostring()
+			data = gids.tobytes()
 		else:
 			data = b""
 			firstCode = 0

--- a/Lib/fontTools/ttLib/tables/_c_v_t.py
+++ b/Lib/fontTools/ttLib/tables/_c_v_t.py
@@ -8,7 +8,7 @@ class table__c_v_t(DefaultTable.DefaultTable):
 
 	def decompile(self, data, ttFont):
 		values = array.array("h")
-		values.fromstring(data)
+		values.frombytes(data)
 		if sys.byteorder != "big": values.byteswap()
 		self.values = values
 

--- a/Lib/fontTools/ttLib/tables/_c_v_t.py
+++ b/Lib/fontTools/ttLib/tables/_c_v_t.py
@@ -15,7 +15,7 @@ class table__c_v_t(DefaultTable.DefaultTable):
 	def compile(self, ttFont):
 		values = self.values[:]
 		if sys.byteorder != "big": values.byteswap()
-		return values.tostring()
+		return values.tobytes()
 
 	def toXML(self, writer, ttFont):
 		for i in range(len(self.values)):

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -795,7 +795,7 @@ class Glyph(object):
 		data = []
 		endPtsOfContours = array.array("h", self.endPtsOfContours)
 		if sys.byteorder != "big": endPtsOfContours.byteswap()
-		data.append(endPtsOfContours.tostring())
+		data.append(endPtsOfContours.tobytes())
 		instructions = self.program.getBytecode()
 		data.append(struct.pack(">h", len(instructions)))
 		data.append(instructions)
@@ -859,7 +859,7 @@ class Glyph(object):
 				repeat = 0
 				compressedflags.append(flag)
 			lastflag = flag
-		compressedFlags = array.array("B", compressedflags).tostring()
+		compressedFlags = array.array("B", compressedflags).tobytes()
 		compressedXs = bytesjoin(xPoints)
 		compressedYs = bytesjoin(yPoints)
 		return (compressedFlags, compressedXs, compressedYs)
@@ -914,9 +914,9 @@ class Glyph(object):
 			raise Exception("internal error")
 		except StopIteration:
 			pass
-		compressedFlags = compressedFlags.tostring()
-		compressedXs = compressedXs.tostring()
-		compressedYs = compressedYs.tostring()
+		compressedFlags = compressedFlags.tobytes()
+		compressedXs = compressedXs.tobytes()
+		compressedYs = compressedYs.tobytes()
 
 		return (compressedFlags, compressedXs, compressedYs)
 
@@ -1156,7 +1156,7 @@ class Glyph(object):
 			# Remove padding
 			data = data[:i]
 
-		self.data = data.tostring()
+		self.data = data.tobytes()
 
 	def removeHinting(self):
 		self.trim (remove_hinting=True)

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -681,7 +681,7 @@ class Glyph(object):
 
 	def decompileCoordinates(self, data):
 		endPtsOfContours = array.array("h")
-		endPtsOfContours.fromstring(data[:2*self.numberOfContours])
+		endPtsOfContours.frombytes(data[:2*self.numberOfContours])
 		if sys.byteorder != "big": endPtsOfContours.byteswap()
 		self.endPtsOfContours = endPtsOfContours.tolist()
 

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -126,7 +126,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			# Long format: array of UInt32
 			offsets = array.array("I")
 			offsetsSize = (glyphCount + 1) * 4
-		offsets.fromstring(data[0 : offsetsSize])
+		offsets.frombytes(data[0 : offsetsSize])
 		if sys.byteorder != "big": offsets.byteswap()
 
 		# In the short format, offsets need to be multiplied by 2.

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -158,7 +158,7 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			packed = array.array("I", offsets)
 			tableFormat = 1
 		if sys.byteorder != "big": packed.byteswap()
-		return (packed.tostring(), tableFormat)
+		return (packed.tobytes(), tableFormat)
 
 	def toXML(self, writer, ttFont):
 		writer.simpletag("version", value=self.version)

--- a/Lib/fontTools/ttLib/tables/_h_m_t_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x.py
@@ -108,7 +108,7 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
 				raise
 		additionalMetrics = array.array("h", additionalMetrics)
 		if sys.byteorder != "big": additionalMetrics.byteswap()
-		data = data + additionalMetrics.tostring()
+		data = data + additionalMetrics.tobytes()
 		return data
 
 	def toXML(self, writer, ttFont):

--- a/Lib/fontTools/ttLib/tables/_l_o_c_a.py
+++ b/Lib/fontTools/ttLib/tables/_l_o_c_a.py
@@ -46,7 +46,7 @@ class table__l_o_c_a(DefaultTable.DefaultTable):
 			locations = array.array("I", self.locations)
 			ttFont['head'].indexToLocFormat = 1
 		if sys.byteorder != "big": locations.byteswap()
-		return locations.tostring()
+		return locations.tobytes()
 
 	def set(self, locations):
 		self.locations = array.array("I", locations)

--- a/Lib/fontTools/ttLib/tables/_l_o_c_a.py
+++ b/Lib/fontTools/ttLib/tables/_l_o_c_a.py
@@ -19,7 +19,7 @@ class table__l_o_c_a(DefaultTable.DefaultTable):
 		else:
 			format = "H"
 		locations = array.array(format)
-		locations.fromstring(data)
+		locations.frombytes(data)
 		if sys.byteorder != "big": locations.byteswap()
 		if not longFormat:
 			l = array.array("I")

--- a/Lib/fontTools/ttLib/tables/_p_o_s_t.py
+++ b/Lib/fontTools/ttLib/tables/_p_o_s_t.py
@@ -82,7 +82,7 @@ class table__p_o_s_t(DefaultTable.DefaultTable):
 			numGlyphs = ttFont['maxp'].numGlyphs
 		data = data[2:]
 		indices = array.array("H")
-		indices.fromstring(data[:2*numGlyphs])
+		indices.frombytes(data[:2*numGlyphs])
 		if sys.byteorder != "big": indices.byteswap()
 		data = data[2*numGlyphs:]
 		self.extraNames = extraNames = unpackPStrings(data)
@@ -131,7 +131,7 @@ class table__p_o_s_t(DefaultTable.DefaultTable):
 		from fontTools import agl
 		numGlyphs = ttFont['maxp'].numGlyphs
 		indices = array.array("H")
-		indices.fromstring(data)
+		indices.frombytes(data)
 		if sys.byteorder != "big": indices.byteswap()
 		# In some older fonts, the size of the post table doesn't match
 		# the number of glyphs. Sometimes it's bigger, sometimes smaller.

--- a/Lib/fontTools/ttLib/tables/_p_o_s_t.py
+++ b/Lib/fontTools/ttLib/tables/_p_o_s_t.py
@@ -171,7 +171,7 @@ class table__p_o_s_t(DefaultTable.DefaultTable):
 				extraNames.append(psName)
 			indices.append(index)
 		if sys.byteorder != "big": indices.byteswap()
-		return struct.pack(">H", numGlyphs) + indices.tostring() + packPStrings(extraNames)
+		return struct.pack(">H", numGlyphs) + indices.tobytes() + packPStrings(extraNames)
 
 	def encode_format_4_0(self, ttFont):
 		from fontTools import agl
@@ -188,7 +188,7 @@ class table__p_o_s_t(DefaultTable.DefaultTable):
 			else:
 				indices.append(0xFFFF)
 		if sys.byteorder != "big": indices.byteswap()
-		return indices.tostring()
+		return indices.tobytes()
 
 	def toXML(self, writer, ttFont):
 		formatstring, names, fixes = sstruct.getformat(postFormat)

--- a/Lib/fontTools/ttLib/tables/ttProgram.py
+++ b/Lib/fontTools/ttLib/tables/ttProgram.py
@@ -222,7 +222,7 @@ class Program(object):
 	def getBytecode(self):
 		if not hasattr(self, "bytecode"):
 			self._assemble()
-		return self.bytecode.tostring()
+		return self.bytecode.tobytes()
 
 	def getAssembly(self, preserve=True):
 		if not hasattr(self, "assembly"):

--- a/Lib/fontTools/ttLib/woff2.py
+++ b/Lib/fontTools/ttLib/woff2.py
@@ -651,7 +651,7 @@ class WOFF2LocaTable(getTableClass('loca')):
 			else:
 				locations = array.array("I", self.locations)
 			if sys.byteorder != "big": locations.byteswap()
-			data = locations.tostring()
+			data = locations.tobytes()
 		else:
 			# use the most compact indexFormat given the current glyph offsets
 			data = super(WOFF2LocaTable, self).compile(ttFont)
@@ -733,7 +733,7 @@ class WOFF2GlyfTable(getTableClass('glyf')):
 		for glyphID in range(self.numGlyphs):
 			self._encodeGlyph(glyphID)
 
-		self.bboxStream = self.bboxBitmap.tostring() + self.bboxStream
+		self.bboxStream = self.bboxBitmap.tobytes() + self.bboxStream
 		for stream in self.subStreams:
 			setattr(self, stream + 'Size', len(getattr(self, stream)))
 		self.version = 0
@@ -961,8 +961,8 @@ class WOFF2GlyfTable(getTableClass('glyf')):
 				triplets.append(absY >> 8)
 				triplets.append(absY & 0xff)
 
-		self.flagStream += flags.tostring()
-		self.glyphStream += triplets.tostring()
+		self.flagStream += flags.tobytes()
+		self.glyphStream += triplets.tobytes()
 
 
 class WOFF2HmtxTable(getTableClass("hmtx")):
@@ -1093,7 +1093,7 @@ class WOFF2HmtxTable(getTableClass("hmtx")):
 		)
 		if sys.byteorder != "big":
 			advanceWidthArray.byteswap()
-		data += advanceWidthArray.tostring()
+		data += advanceWidthArray.tobytes()
 
 		if hasLsbArray:
 			lsbArray = array.array(
@@ -1106,7 +1106,7 @@ class WOFF2HmtxTable(getTableClass("hmtx")):
 			)
 			if sys.byteorder != "big":
 				lsbArray.byteswap()
-			data += lsbArray.tostring()
+			data += lsbArray.tobytes()
 
 		if hasLeftSideBearingArray:
 			leftSideBearingArray = array.array(
@@ -1118,7 +1118,7 @@ class WOFF2HmtxTable(getTableClass("hmtx")):
 			)
 			if sys.byteorder != "big":
 				leftSideBearingArray.byteswap()
-			data += leftSideBearingArray.tostring()
+			data += leftSideBearingArray.tobytes()
 
 		return data
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ doctest_optionflags =
 	ALLOW_UNICODE
 	ELLIPSIS
 filterwarnings = 
-	ignore:tostring:DeprecationWarning
 	ignore:readPlist:DeprecationWarning:plistlib_test
 	ignore:writePlist:DeprecationWarning:plistlib_test
 	ignore:some_function:DeprecationWarning:fontTools.ufoLib.utils

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ doctest_optionflags =
 	ELLIPSIS
 filterwarnings = 
 	ignore:tostring:DeprecationWarning
-	ignore:fromstring:DeprecationWarning
 	ignore:readPlist:DeprecationWarning:plistlib_test
 	ignore:writePlist:DeprecationWarning:plistlib_test
 	ignore:some_function:DeprecationWarning:fontTools.ufoLib.utils


### PR DESCRIPTION
Closes #868 

- removes pytest array.tostring deprecation warning filter in `setup.cfg`
- removes pytest array.fromstring deprecation warning filter in `setup.cfg`
- refactors array.tostring to array.tobytes across a number of modules
- refactors array.fromstring to array.frombytes across a number of modules

