### PR TITLE
ufoLib: Clean up legacy code

### DIFF
--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from copy import deepcopy
+from os import fsdecode
 import logging
 import zipfile
 import enum
@@ -20,7 +21,7 @@ from fontTools.ufoLib.validators import *
 from fontTools.ufoLib.filenames import userNameToFileName
 from fontTools.ufoLib.converters import convertUFO1OrUFO2KerningToUFO3Kerning
 from fontTools.ufoLib.errors import UFOLibError
-from fontTools.ufoLib.utils import datetimeAsTimestamp, fsdecode, numberTypes
+from fontTools.ufoLib.utils import numberTypes
 
 """
 A library for importing .ufo files and their descendants.
@@ -120,7 +121,7 @@ class _UFOBaseIO:
 		except (fs.errors.MissingInfoNamespace, fs.errors.ResourceNotFound):
 			return None
 		else:
-			return datetimeAsTimestamp(dt)
+			return dt.timestamp()
 
 	def _getPlist(self, fileName, default=None):
 		"""

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -1323,8 +1323,6 @@ class UFOWriter(UFOReader):
 			for layerName in layerOrder:
 				if layerName is None:
 					layerName = DEFAULT_LAYER_NAME
-				else:
-					layerName = tostr(layerName)
 				newOrder.append(layerName)
 			layerOrder = newOrder
 		else:

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -671,7 +671,7 @@ class UFOReader(_UFOBaseIO):
 
 	def getCharacterMapping(self, layerName=None, validate=None):
 		"""
-		Return a dictionary that maps str values (ints) to
+		Return a dictionary that maps unicode values (ints) to
 		lists of glyph names.
 		"""
 		if validate is None:

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -1,4 +1,3 @@
-import sys
 import os
 from copy import deepcopy
 from os import fsdecode

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -15,7 +15,7 @@ import fs.osfs
 import fs.zipfs
 import fs.tempfs
 import fs.tools
-from fontTools.misc.py23 import basestring, unicode, tounicode
+from fontTools.misc.py23 import tostr
 from fontTools.misc import plistlib
 from fontTools.ufoLib.validators import *
 from fontTools.ufoLib.filenames import userNameToFileName
@@ -205,7 +205,7 @@ class UFOReader(_UFOBaseIO):
 		if hasattr(path, "__fspath__"):  # support os.PathLike objects
 			path = path.__fspath__()
 
-		if isinstance(path, basestring):
+		if isinstance(path, str):
 			structure = _sniffFileStructure(path)
 			try:
 				if structure is UFOFileStructure.ZIP:
@@ -252,7 +252,7 @@ class UFOReader(_UFOBaseIO):
 				path = filesystem.getsyspath("/")
 			except fs.errors.NoSysPath:
 				# network or in-memory FS may not map to the local one
-				path = unicode(filesystem)
+				path = str(filesystem)
 			# when user passed an already initialized fs instance, it is her
 			# responsibility to close it, thus UFOReader.close/__exit__ are no-op
 			self._shouldClose = False
@@ -324,12 +324,12 @@ class UFOReader(_UFOBaseIO):
 				if not isinstance(groups, dict):
 					raise UFOLibError(invalidFormatMessage)
 				for groupName, glyphList in groups.items():
-					if not isinstance(groupName, basestring):
+					if not isinstance(groupName, str):
 						raise UFOLibError(invalidFormatMessage)
 					elif not isinstance(glyphList, list):
 						raise UFOLibError(invalidFormatMessage)
 					for glyphName in glyphList:
-						if not isinstance(glyphName, basestring):
+						if not isinstance(glyphName, str):
 							raise UFOLibError(invalidFormatMessage)
 			self._upConvertedKerningData = dict(
 				kerning={},
@@ -366,7 +366,7 @@ class UFOReader(_UFOBaseIO):
 		The path must be relative to the UFO path.
 		Returns None if the file does not exist.
 		By default the file is opened in binary mode (reads bytes).
-		If encoding is passed, the file is opened in text mode (reads unicode).
+		If encoding is passed, the file is opened in text mode (reads str).
 
 		Note: The caller is responsible for closing the open file.
 		"""
@@ -572,7 +572,7 @@ class UFOReader(_UFOBaseIO):
 
 	def readFeatures(self):
 		"""
-		Read features.fea. Return a unicode string.
+		Read features.fea. Return a string.
 		The returned string is empty if the file is missing.
 		"""
 		try:
@@ -672,7 +672,7 @@ class UFOReader(_UFOBaseIO):
 
 	def getCharacterMapping(self, layerName=None, validate=None):
 		"""
-		Return a dictionary that maps unicode values (ints) to
+		Return a dictionary that maps str values (ints) to
 		lists of glyph names.
 		"""
 		if validate is None:
@@ -829,7 +829,7 @@ class UFOWriter(UFOReader):
 		if hasattr(path, "__fspath__"):  # support os.PathLike objects
 			path = path.__fspath__()
 
-		if isinstance(path, basestring):
+		if isinstance(path, str):
 			# normalize path by removing trailing or double slashes
 			path = os.path.normpath(path)
 			havePreviousFile = os.path.exists(path)
@@ -909,7 +909,7 @@ class UFOWriter(UFOReader):
 				path = filesystem.getsyspath("/")
 			except fs.errors.NoSysPath:
 				# network or in-memory FS may not map to the local one
-				path = unicode(filesystem)
+				path = str(filesystem)
 			# if passed an FS object, always use 'package' structure
 			if structure and structure is not UFOFileStructure.PACKAGE:
 				import warnings
@@ -1241,9 +1241,9 @@ class UFOWriter(UFOReader):
 					raise UFOLibError(invalidFormatMessage)
 				if not len(pair) == 2:
 					raise UFOLibError(invalidFormatMessage)
-				if not isinstance(pair[0], basestring):
+				if not isinstance(pair[0], str):
 					raise UFOLibError(invalidFormatMessage)
-				if not isinstance(pair[1], basestring):
+				if not isinstance(pair[1], str):
 					raise UFOLibError(invalidFormatMessage)
 				if not isinstance(value, numberTypes):
 					raise UFOLibError(invalidFormatMessage)
@@ -1301,7 +1301,7 @@ class UFOWriter(UFOReader):
 		if self._formatVersion == 1:
 			raise UFOLibError("features.fea is not allowed in UFO Format Version 1.")
 		if validate:
-			if not isinstance(features, basestring):
+			if not isinstance(features, str):
 				raise UFOLibError("The features are not text.")
 		if features:
 			self.writeBytesToPath(FEATURES_FILENAME, features.encode("utf8"))
@@ -1325,7 +1325,7 @@ class UFOWriter(UFOReader):
 				if layerName is None:
 					layerName = DEFAULT_LAYER_NAME
 				else:
-					layerName = tounicode(layerName)
+					layerName = tostr(layerName)
 				newOrder.append(layerName)
 			layerOrder = newOrder
 		else:
@@ -1439,9 +1439,9 @@ class UFOWriter(UFOReader):
 				# not caching this could be slightly expensive,
 				# but caching it will be cumbersome
 				existing = {d.lower() for d in self.layerContents.values()}
-				if not isinstance(layerName, unicode):
+				if not isinstance(layerName, str):
 					try:
-						layerName = unicode(layerName)
+						layerName = str(layerName)
 					except UnicodeDecodeError:
 						raise UFOLibError("The specified layer name is not a Unicode string.")
 				directory = userNameToFileName(layerName, existing=existing, prefix="glyphs.")
@@ -1587,7 +1587,7 @@ UFOReaderWriter = UFOWriter
 
 
 def _sniffFileStructure(ufo_path):
-	"""Return UFOFileStructure.ZIP if the UFO at path 'ufo_path' (basestring)
+	"""Return UFOFileStructure.ZIP if the UFO at path 'ufo_path' (str)
 	is a zip file, else return UFOFileStructure.PACKAGE if 'ufo_path' is a
 	directory.
 	Raise UFOLibError if it is a file with unknown structure, or if the path
@@ -1775,23 +1775,23 @@ fontInfoAttributesVersion1 = {
 }
 
 fontInfoAttributesVersion2ValueData = {
-	"familyName"							: dict(type=basestring),
-	"styleName"								: dict(type=basestring),
-	"styleMapFamilyName"					: dict(type=basestring),
-	"styleMapStyleName"						: dict(type=basestring, valueValidator=fontInfoStyleMapStyleNameValidator),
+	"familyName"							: dict(type=str),
+	"styleName"								: dict(type=str),
+	"styleMapFamilyName"					: dict(type=str),
+	"styleMapStyleName"						: dict(type=str, valueValidator=fontInfoStyleMapStyleNameValidator),
 	"versionMajor"							: dict(type=int),
 	"versionMinor"							: dict(type=int),
 	"year"									: dict(type=int),
-	"copyright"								: dict(type=basestring),
-	"trademark"								: dict(type=basestring),
+	"copyright"								: dict(type=str),
+	"trademark"								: dict(type=str),
 	"unitsPerEm"							: dict(type=(int, float)),
 	"descender"								: dict(type=(int, float)),
 	"xHeight"								: dict(type=(int, float)),
 	"capHeight"								: dict(type=(int, float)),
 	"ascender"								: dict(type=(int, float)),
 	"italicAngle"							: dict(type=(float, int)),
-	"note"									: dict(type=basestring),
-	"openTypeHeadCreated"					: dict(type=basestring, valueValidator=fontInfoOpenTypeHeadCreatedValidator),
+	"note"									: dict(type=str),
+	"openTypeHeadCreated"					: dict(type=str, valueValidator=fontInfoOpenTypeHeadCreatedValidator),
 	"openTypeHeadLowestRecPPEM"				: dict(type=(int, float)),
 	"openTypeHeadFlags"						: dict(type="integerList", valueValidator=genericIntListValidator, valueOptions=fontInfoOpenTypeHeadFlagsOptions),
 	"openTypeHheaAscender"					: dict(type=(int, float)),
@@ -1800,25 +1800,25 @@ fontInfoAttributesVersion2ValueData = {
 	"openTypeHheaCaretSlopeRise"			: dict(type=int),
 	"openTypeHheaCaretSlopeRun"				: dict(type=int),
 	"openTypeHheaCaretOffset"				: dict(type=(int, float)),
-	"openTypeNameDesigner"					: dict(type=basestring),
-	"openTypeNameDesignerURL"				: dict(type=basestring),
-	"openTypeNameManufacturer"				: dict(type=basestring),
-	"openTypeNameManufacturerURL"			: dict(type=basestring),
-	"openTypeNameLicense"					: dict(type=basestring),
-	"openTypeNameLicenseURL"				: dict(type=basestring),
-	"openTypeNameVersion"					: dict(type=basestring),
-	"openTypeNameUniqueID"					: dict(type=basestring),
-	"openTypeNameDescription"				: dict(type=basestring),
-	"openTypeNamePreferredFamilyName"		: dict(type=basestring),
-	"openTypeNamePreferredSubfamilyName"	: dict(type=basestring),
-	"openTypeNameCompatibleFullName"		: dict(type=basestring),
-	"openTypeNameSampleText"				: dict(type=basestring),
-	"openTypeNameWWSFamilyName"				: dict(type=basestring),
-	"openTypeNameWWSSubfamilyName"			: dict(type=basestring),
+	"openTypeNameDesigner"					: dict(type=str),
+	"openTypeNameDesignerURL"				: dict(type=str),
+	"openTypeNameManufacturer"				: dict(type=str),
+	"openTypeNameManufacturerURL"			: dict(type=str),
+	"openTypeNameLicense"					: dict(type=str),
+	"openTypeNameLicenseURL"				: dict(type=str),
+	"openTypeNameVersion"					: dict(type=str),
+	"openTypeNameUniqueID"					: dict(type=str),
+	"openTypeNameDescription"				: dict(type=str),
+	"openTypeNamePreferredFamilyName"		: dict(type=str),
+	"openTypeNamePreferredSubfamilyName"	: dict(type=str),
+	"openTypeNameCompatibleFullName"		: dict(type=str),
+	"openTypeNameSampleText"				: dict(type=str),
+	"openTypeNameWWSFamilyName"				: dict(type=str),
+	"openTypeNameWWSSubfamilyName"			: dict(type=str),
 	"openTypeOS2WidthClass"					: dict(type=int, valueValidator=fontInfoOpenTypeOS2WidthClassValidator),
 	"openTypeOS2WeightClass"				: dict(type=int, valueValidator=fontInfoOpenTypeOS2WeightClassValidator),
 	"openTypeOS2Selection"					: dict(type="integerList", valueValidator=genericIntListValidator, valueOptions=fontInfoOpenTypeOS2SelectionOptions),
-	"openTypeOS2VendorID"					: dict(type=basestring),
+	"openTypeOS2VendorID"					: dict(type=str),
 	"openTypeOS2Panose"						: dict(type="integerList", valueValidator=fontInfoVersion2OpenTypeOS2PanoseValidator),
 	"openTypeOS2FamilyClass"				: dict(type="integerList", valueValidator=fontInfoOpenTypeOS2FamilyClassValidator),
 	"openTypeOS2UnicodeRanges"				: dict(type="integerList", valueValidator=genericIntListValidator, valueOptions=fontInfoOpenTypeOS2UnicodeRangesOptions),
@@ -1845,8 +1845,8 @@ fontInfoAttributesVersion2ValueData = {
 	"openTypeVheaCaretSlopeRise"			: dict(type=int),
 	"openTypeVheaCaretSlopeRun"				: dict(type=int),
 	"openTypeVheaCaretOffset"				: dict(type=(int, float)),
-	"postscriptFontName"					: dict(type=basestring),
-	"postscriptFullName"					: dict(type=basestring),
+	"postscriptFontName"					: dict(type=str),
+	"postscriptFullName"					: dict(type=str),
 	"postscriptSlantAngle"					: dict(type=(float, int)),
 	"postscriptUniqueID"					: dict(type=int),
 	"postscriptUnderlineThickness"			: dict(type=(int, float)),
@@ -1864,11 +1864,11 @@ fontInfoAttributesVersion2ValueData = {
 	"postscriptForceBold"					: dict(type=bool),
 	"postscriptDefaultWidthX"				: dict(type=(int, float)),
 	"postscriptNominalWidthX"				: dict(type=(int, float)),
-	"postscriptWeightName"					: dict(type=basestring),
-	"postscriptDefaultCharacter"			: dict(type=basestring),
+	"postscriptWeightName"					: dict(type=str),
+	"postscriptDefaultCharacter"			: dict(type=str),
 	"postscriptWindowsCharacterSet"			: dict(type=int, valueValidator=fontInfoPostscriptWindowsCharacterSetValidator),
 	"macintoshFONDFamilyID"					: dict(type=int),
-	"macintoshFONDName"						: dict(type=basestring),
+	"macintoshFONDName"						: dict(type=str),
 }
 fontInfoAttributesVersion2 = set(fontInfoAttributesVersion2ValueData.keys())
 

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -1668,7 +1668,7 @@ def validateInfoVersion2Data(infoData):
 	for attr, value in list(infoData.items()):
 		isValidValue = validateFontInfoVersion2ValueForAttribute(attr, value)
 		if not isValidValue:
-			raise UFOLibError(f"Invalid value for attribute {attr} ({repr(value)}).")
+			raise UFOLibError(f"Invalid value for attribute {attr} ({value!r}).")
 		else:
 			validInfoData[attr] = value
 	return validInfoData
@@ -1712,7 +1712,7 @@ def validateInfoVersion3Data(infoData):
 	for attr, value in list(infoData.items()):
 		isValidValue = validateFontInfoVersion3ValueForAttribute(attr, value)
 		if not isValidValue:
-			raise UFOLibError(f"Invalid value for attribute {attr} ({repr(value)}).")
+			raise UFOLibError(f"Invalid value for attribute {attr} ({value!r}).")
 		else:
 			validInfoData[attr] = value
 	return validInfoData
@@ -2042,17 +2042,17 @@ def convertFontInfoValueForAttributeFromVersion1ToVersion2(attr, value):
 		if attr == "fontStyle":
 			v = _fontStyle1To2.get(value)
 			if v is None:
-				raise UFOLibError(f"Cannot convert value ({repr(value)}) for attribute {attr}.")
+				raise UFOLibError(f"Cannot convert value ({value!r}) for attribute {attr}.")
 			value = v
 		elif attr == "widthName":
 			v = _widthName1To2.get(value)
 			if v is None:
-				raise UFOLibError(f"Cannot convert value ({repr(value)}) for attribute {attr}.")
+				raise UFOLibError(f"Cannot convert value ({value!r}) for attribute {attr}.")
 			value = v
 		elif attr == "msCharSet":
 			v = _msCharSet1To2.get(value)
 			if v is None:
-				raise UFOLibError(f"Cannot convert value ({repr(value)}) for attribute {attr}.")
+				raise UFOLibError(f"Cannot convert value ({value!r}) for attribute {attr}.")
 			value = v
 	attr = fontInfoAttributesVersion1To2.get(attr, attr)
 	return attr, value
@@ -2087,7 +2087,7 @@ def _convertFontInfoDataVersion1ToVersion2(data):
 			continue
 		# catch values that can't be converted
 		if value is None:
-			raise UFOLibError(f"Cannot convert value ({repr(value)}) for attribute {newAttr}.")
+			raise UFOLibError(f"Cannot convert value ({value!r}) for attribute {newAttr}.")
 		# store
 		converted[newAttr] = newValue
 	return converted
@@ -2101,7 +2101,7 @@ def _convertFontInfoDataVersion2ToVersion1(data):
 			continue
 		# catch values that can't be converted
 		if value is None:
-			raise UFOLibError(f"Cannot convert value ({repr(value)}) for attribute {newAttr}.")
+			raise UFOLibError(f"Cannot convert value ({value!r}) for attribute {newAttr}.")
 		# store
 		converted[newAttr] = newValue
 	return converted

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -1436,11 +1436,6 @@ class UFOWriter(UFOReader):
 				# not caching this could be slightly expensive,
 				# but caching it will be cumbersome
 				existing = {d.lower() for d in self.layerContents.values()}
-				if not isinstance(layerName, str):
-					try:
-						layerName = str(layerName)
-					except UnicodeDecodeError:
-						raise UFOLibError("The specified layer name is not a Unicode string.")
 				directory = userNameToFileName(layerName, existing=existing, prefix="glyphs.")
 		# make the directory
 		glyphSubFS = self.fs.makedir(directory, recreate=True)

--- a/Lib/fontTools/ufoLib/filenames.py
+++ b/Lib/fontTools/ufoLib/filenames.py
@@ -15,7 +15,7 @@ class NameTranslationError(Exception):
 	pass
 
 
-def userNameToFileName(userName, existing=[], prefix="", suffix=""):
+def userNameToFileName(userName: str, existing=[], prefix="", suffix=""):
 	"""
 	existing should be a case-insensitive list
 	of all existing file names.

--- a/Lib/fontTools/ufoLib/filenames.py
+++ b/Lib/fontTools/ufoLib/filenames.py
@@ -2,8 +2,6 @@
 User name to file name conversion.
 This was taken form the UFO 3 spec.
 """
-from fontTools.misc.py23 import basestring, unicode
-
 
 illegalCharacters = r"\" * + / : < > ? [ \ ] | \0".split(" ")
 illegalCharacters += [chr(i) for i in range(1, 32)]
@@ -67,9 +65,9 @@ def userNameToFileName(userName, existing=[], prefix="", suffix=""):
 	>>> userNameToFileName("alt.con") == "alt._con"
 	True
 	"""
-	# the incoming name must be a unicode string
-	if not isinstance(userName, unicode):
-		raise ValueError("The value for userName must be a unicode string.")
+	# the incoming name must be a string
+	if not isinstance(userName, str):
+		raise ValueError("The value for userName must be a string.")
 	# establish the prefix and suffix lengths
 	prefixLength = len(prefix)
 	suffixLength = len(suffix)

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -622,8 +622,8 @@ def _writeGlyphToBytes(
 
 def writeGlyphToString(glyphName, glyphObject=None, drawPointsFunc=None, formatVersion=2, validate=True):
 	"""
-	Return .glif data for a glyph as a Unicode string (`unicode` in py2, `str`
-	in py3). The XML declaration's encoding is always set to "UTF-8".
+	Return .glif data for a glyph as a string. The XML declaration's
+	encoding is always set to "UTF-8".
 	The 'glyphObject' argument can be any kind of object (even None);
 	the writeGlyphToString() method will attempt to get the following
 	attributes from it:

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 glifLib.py -- Generic module for reading and writing the .glif format.
 
@@ -59,7 +58,7 @@ supportedGLIFFormatVersions = [1, 2]
 # Simple Glyph
 # ------------
 
-class Glyph(object):
+class Glyph:
 
 	"""
 	Minimal glyph object. It has no glyph attributes until either
@@ -852,7 +851,7 @@ def validateLayerInfoVersion3Data(infoData):
 			raise GlifLibError("Unknown attribute %s." % attr)
 		isValidValue = validateLayerInfoVersion3ValueForAttribute(attr, value)
 		if not isValidValue:
-			raise GlifLibError("Invalid value for attribute %s (%s)." % (attr, repr(value)))
+			raise GlifLibError(f"Invalid value for attribute {attr} ({repr(value)}).")
 	return infoData
 
 # -----------------
@@ -1072,13 +1071,13 @@ def _readImage(glyphObject, image, validate):
 # GLIF to PointPen
 # ----------------
 
-contourAttributesFormat2 = set(["identifier"])
-componentAttributesFormat1 = set(["base", "xScale", "xyScale", "yxScale", "yScale", "xOffset", "yOffset"])
-componentAttributesFormat2 = componentAttributesFormat1 | set(["identifier"])
-pointAttributesFormat1 = set(["x", "y", "type", "smooth", "name"])
-pointAttributesFormat2 = pointAttributesFormat1 | set(["identifier"])
-pointSmoothOptions = set(("no", "yes"))
-pointTypeOptions = set(["move", "line", "offcurve", "curve", "qcurve"])
+contourAttributesFormat2 = {"identifier"}
+componentAttributesFormat1 = {"base", "xScale", "xyScale", "yxScale", "yScale", "xOffset", "yOffset"}
+componentAttributesFormat2 = componentAttributesFormat1 | {"identifier"}
+pointAttributesFormat1 = {"x", "y", "type", "smooth", "name"}
+pointAttributesFormat2 = pointAttributesFormat1 | {"identifier"}
+pointSmoothOptions = {"no", "yes"}
+pointTypeOptions = {"move", "line", "offcurve", "curve", "qcurve"}
 
 # format 1
 
@@ -1388,7 +1387,7 @@ def _number(s):
 
 class _DoneParsing(Exception): pass
 
-class _BaseParser(object):
+class _BaseParser:
 
 	def __init__(self):
 		self._elementStack = []
@@ -1422,7 +1421,7 @@ class _FetchUnicodesParser(_BaseParser):
 
 	def __init__(self):
 		self.unicodes = []
-		super(_FetchUnicodesParser, self).__init__()
+		super().__init__()
 
 	def startElementHandler(self, name, attrs):
 		if name == "unicode" and self._elementStack and self._elementStack[-1] == "glyph":
@@ -1434,7 +1433,7 @@ class _FetchUnicodesParser(_BaseParser):
 						self.unicodes.append(value)
 				except ValueError:
 					pass
-		super(_FetchUnicodesParser, self).startElementHandler(name, attrs)
+		super().startElementHandler(name, attrs)
 
 # image
 
@@ -1453,13 +1452,13 @@ class _FetchImageFileNameParser(_BaseParser):
 
 	def __init__(self):
 		self.fileName = None
-		super(_FetchImageFileNameParser, self).__init__()
+		super().__init__()
 
 	def startElementHandler(self, name, attrs):
 		if name == "image" and self._elementStack and self._elementStack[-1] == "glyph":
 			self.fileName = attrs.get("fileName")
 			raise _DoneParsing
-		super(_FetchImageFileNameParser, self).startElementHandler(name, attrs)
+		super().startElementHandler(name, attrs)
 
 # component references
 
@@ -1478,19 +1477,19 @@ class _FetchComponentBasesParser(_BaseParser):
 
 	def __init__(self):
 		self.bases = []
-		super(_FetchComponentBasesParser, self).__init__()
+		super().__init__()
 
 	def startElementHandler(self, name, attrs):
 		if name == "component" and self._elementStack and self._elementStack[-1] == "outline":
 			base = attrs.get("base")
 			if base is not None:
 				self.bases.append(base)
-		super(_FetchComponentBasesParser, self).startElementHandler(name, attrs)
+		super().startElementHandler(name, attrs)
 
 	def endElementHandler(self, name):
 		if name == "outline":
 			raise _DoneParsing
-		super(_FetchComponentBasesParser, self).endElementHandler(name)
+		super().endElementHandler(name)
 
 # --------------
 # GLIF Point Pen

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -17,7 +17,7 @@ import fs.base
 import fs.errors
 import fs.osfs
 import fs.path
-from fontTools.misc.py23 import tobytes, tostr
+from fontTools.misc.py23 import tobytes
 from fontTools.misc import plistlib
 from fontTools.pens.pointPen import AbstractPointPen, PointToSegmentPen
 from fontTools.ufoLib.errors import GlifLibError

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -851,7 +851,7 @@ def validateLayerInfoVersion3Data(infoData):
 			raise GlifLibError("Unknown attribute %s." % attr)
 		isValidValue = validateLayerInfoVersion3ValueForAttribute(attr, value)
 		if not isValidValue:
-			raise GlifLibError(f"Invalid value for attribute {attr} ({repr(value)}).")
+			raise GlifLibError(f"Invalid value for attribute {attr} ({value!r}).")
 	return infoData
 
 # -----------------

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -33,7 +33,7 @@ from fontTools.ufoLib.validators import (
 )
 from fontTools.misc import etree
 from fontTools.ufoLib import _UFOBaseIO
-from fontTools.ufoLib.utils import integerTypes, numberTypes
+from fontTools.ufoLib.utils import numberTypes
 
 
 __all__ = [
@@ -681,11 +681,11 @@ def _writeAdvance(glyphObject, element, validate):
 
 def _writeUnicodes(glyphObject, element, validate):
 	unicodes = getattr(glyphObject, "unicodes", None)
-	if validate and isinstance(unicodes, integerTypes):
+	if validate and isinstance(unicodes, int):
 		unicodes = [unicodes]
 	seen = set()
 	for code in unicodes:
-		if validate and not isinstance(code, integerTypes):
+		if validate and not isinstance(code, int):
 			raise GlifLibError("unicode values must be int")
 		if code in seen:
 			continue

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -17,7 +17,7 @@ import fs.base
 import fs.errors
 import fs.osfs
 import fs.path
-from fontTools.misc.py23 import basestring, unicode, tobytes, tounicode
+from fontTools.misc.py23 import tobytes, tostr
 from fontTools.misc import plistlib
 from fontTools.pens.pointPen import AbstractPointPen, PointToSegmentPen
 from fontTools.ufoLib.errors import GlifLibError
@@ -127,7 +127,7 @@ class GlyphSet(_UFOBaseIO):
 		"""
 		if ufoFormatVersion not in supportedUFOFormatVersions:
 			raise GlifLibError("Unsupported UFO format version: %s" % ufoFormatVersion)
-		if isinstance(path, basestring):
+		if isinstance(path, str):
 			try:
 				filesystem = fs.osfs.OSFS(path)
 			except fs.errors.CreateFailed:
@@ -149,7 +149,7 @@ class GlyphSet(_UFOBaseIO):
 			path = filesystem.getsyspath("/")
 		except fs.errors.NoSysPath:
 			# network or in-memory FS may not map to the local one
-			path = unicode(filesystem)
+			path = str(filesystem)
 		# 'dirName' is kept for backward compatibility only, but it's DEPRECATED
 		# as it's not guaranteed that it maps to an existing OSFS directory.
 		# Client could use the FS api via the `self.fs` attribute instead.
@@ -185,9 +185,9 @@ class GlyphSet(_UFOBaseIO):
 				invalidFormat = True
 			else:
 				for name, fileName in contents.items():
-					if not isinstance(name, basestring):
+					if not isinstance(name, str):
 						invalidFormat = True
-					if not isinstance(fileName, basestring):
+					if not isinstance(fileName, str):
 						invalidFormat = True
 					elif not self.fs.exists(fileName):
 						raise GlifLibError(
@@ -521,9 +521,9 @@ def glyphNameToFileName(glyphName, existingFileNames):
 	"""
 	if existingFileNames is None:
 		existingFileNames = []
-	if not isinstance(glyphName, unicode):
+	if not isinstance(glyphName, str):
 		try:
-			new = unicode(glyphName)
+			new = str(glyphName)
 			glyphName = new
 		except UnicodeDecodeError:
 			pass
@@ -576,7 +576,7 @@ def _writeGlyphToBytes(
 		formatVersion=2, validate=True):
 	"""Return .glif data for a glyph as a UTF-8 encoded bytes string."""
 	# start
-	if validate and not isinstance(glyphName, basestring):
+	if validate and not isinstance(glyphName, str):
 		raise GlifLibError("The glyph name is not properly formatted.")
 	if validate and len(glyphName) == 0:
 		raise GlifLibError("The glyph name is empty.")
@@ -695,12 +695,12 @@ def _writeUnicodes(glyphObject, element, validate):
 
 def _writeNote(glyphObject, element, validate):
 	note = getattr(glyphObject, "note", None)
-	if validate and not isinstance(note, basestring):
-		raise GlifLibError("note attribute must be str or unicode")
+	if validate and not isinstance(note, str):
+		raise GlifLibError("note attribute must be str")
 	note = note.strip()
 	note = "\n" + note + "\n"
-	# ensure text is unicode, if it's bytes decode as ASCII
-	etree.SubElement(element, "note").text = tounicode(note)
+	# ensure text is str, if it's bytes decode as ASCII
+	etree.SubElement(element, "note").text = note
 
 def _writeImage(glyphObject, element, validate):
 	image = getattr(glyphObject, "image", None)
@@ -805,7 +805,7 @@ def _writeLib(glyphObject, element, validate):
 # -----------------------
 
 layerInfoVersion3ValueData = {
-	"color"			: dict(type=basestring, valueValidator=colorValidator),
+	"color"			: dict(type=str, valueValidator=colorValidator),
 	"lib"			: dict(type=dict, valueValidator=genericTypeValidator)
 }
 

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -521,12 +521,6 @@ def glyphNameToFileName(glyphName, existingFileNames):
 	"""
 	if existingFileNames is None:
 		existingFileNames = []
-	if not isinstance(glyphName, str):
-		try:
-			new = str(glyphName)
-			glyphName = new
-		except UnicodeDecodeError:
-			pass
 	return userNameToFileName(glyphName, existing=existingFileNames, suffix=".glif")
 
 # -----------------------

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -699,7 +699,6 @@ def _writeNote(glyphObject, element, validate):
 		raise GlifLibError("note attribute must be str")
 	note = note.strip()
 	note = "\n" + note + "\n"
-	# ensure text is str, if it's bytes decode as ASCII
 	etree.SubElement(element, "note").text = note
 
 def _writeImage(glyphObject, element, validate):

--- a/Lib/fontTools/ufoLib/plistlib.py
+++ b/Lib/fontTools/ufoLib/plistlib.py
@@ -12,7 +12,7 @@ from fontTools.ufoLib.utils import deprecated
 @deprecated("Use 'fontTools.misc.plistlib.load' instead")
 def readPlist(path_or_file):
     did_open = False
-    if isinstance(path_or_file, basestring):
+    if isinstance(path_or_file, str):
         path_or_file = open(path_or_file, "rb")
         did_open = True
     try:
@@ -25,7 +25,7 @@ def readPlist(path_or_file):
 @deprecated("Use 'fontTools.misc.plistlib.dump' instead")
 def writePlist(value, path_or_file):
     did_open = False
-    if isinstance(path_or_file, basestring):
+    if isinstance(path_or_file, str):
         path_or_file = open(path_or_file, "wb")
         did_open = True
     try:

--- a/Lib/fontTools/ufoLib/plistlib.py
+++ b/Lib/fontTools/ufoLib/plistlib.py
@@ -2,7 +2,7 @@
 for the old ufoLib.plistlib module, which was moved to fontTools.misc.plistlib.
 Please use the latter instead.
 """
-from fontTools.misc.plistlib import *
+from fontTools.misc.plistlib import dump, dumps, load, loads, tobytes
 
 # The following functions were part of the old py2-like ufoLib.plistlib API.
 # They are kept only for backward compatiblity.

--- a/Lib/fontTools/ufoLib/utils.py
+++ b/Lib/fontTools/ufoLib/utils.py
@@ -1,50 +1,12 @@
 """The module contains miscellaneous helpers.
 It's not considered part of the public ufoLib API.
 """
-import sys
 import warnings
 import functools
-from datetime import datetime
-from fontTools.misc.py23 import tounicode
 
 
-if hasattr(datetime, "timestamp"):  # python >= 3.3
-
-    def datetimeAsTimestamp(dt):
-        return dt.timestamp()
-
-else:
-    from datetime import tzinfo, timedelta
-
-    ZERO = timedelta(0)
-
-    class UTC(tzinfo):
-
-        def utcoffset(self, dt):
-            return ZERO
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def dst(self, dt):
-            return ZERO
-
-    utc = UTC()
-
-    EPOCH = datetime.fromtimestamp(0, tz=utc)
-
-    def datetimeAsTimestamp(dt):
-        return (dt - EPOCH).total_seconds()
-
-
-# TODO: should import from fontTools.misc.py23
-try:
-	long = long
-except NameError:
-	long = int
-
-integerTypes = (int, long)
-numberTypes = (int, float, long)
+integerTypes = int
+numberTypes = (int, float)
 
 
 def deprecated(msg=""):
@@ -73,10 +35,6 @@ def deprecated(msg=""):
         return wrapper
 
     return deprecated_decorator
-
-
-def fsdecode(path, encoding=sys.getfilesystemencoding()):
-    return tounicode(path, encoding=encoding)
 
 
 if __name__ == "__main__":

--- a/Lib/fontTools/ufoLib/utils.py
+++ b/Lib/fontTools/ufoLib/utils.py
@@ -5,7 +5,6 @@ import warnings
 import functools
 
 
-integerTypes = int
 numberTypes = (int, float)
 
 

--- a/Lib/fontTools/ufoLib/utils.py
+++ b/Lib/fontTools/ufoLib/utils.py
@@ -64,7 +64,7 @@ def deprecated(msg=""):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             warnings.warn(
-                "{} function is a deprecated. {}".format(func.__name__, msg),
+                f"{func.__name__} function is a deprecated. {msg}",
                 category=DeprecationWarning,
                 stacklevel=2,
             )

--- a/Lib/fontTools/ufoLib/validators.py
+++ b/Lib/fontTools/ufoLib/validators.py
@@ -6,7 +6,7 @@ import fs.base
 import fs.osfs
 
 from collections.abc import Mapping
-from fontTools.ufoLib.utils import integerTypes, numberTypes
+from fontTools.ufoLib.utils import numberTypes
 
 
 # -------
@@ -42,7 +42,7 @@ def genericIntListValidator(values, validValues):
 	if valuesSet - validValuesSet:
 		return False
 	for value in values:
-		if not isinstance(value, integerTypes):
+		if not isinstance(value, int):
 			return False
 	return True
 
@@ -50,7 +50,7 @@ def genericNonNegativeIntValidator(value):
 	"""
 	Generic. (Added at version 3.)
 	"""
-	if not isinstance(value, integerTypes):
+	if not isinstance(value, int):
 		return False
 	if value < 0:
 		return False
@@ -207,7 +207,7 @@ def fontInfoOpenTypeOS2WeightClassValidator(value):
 	"""
 	Version 2+.
 	"""
-	if not isinstance(value, integerTypes):
+	if not isinstance(value, int):
 		return False
 	if value < 0:
 		return False
@@ -217,7 +217,7 @@ def fontInfoOpenTypeOS2WidthClassValidator(value):
 	"""
 	Version 2+.
 	"""
-	if not isinstance(value, integerTypes):
+	if not isinstance(value, int):
 		return False
 	if value < 1:
 		return False
@@ -234,7 +234,7 @@ def fontInfoVersion2OpenTypeOS2PanoseValidator(values):
 	if len(values) != 10:
 		return False
 	for value in values:
-		if not isinstance(value, integerTypes):
+		if not isinstance(value, int):
 			return False
 	# XXX further validation?
 	return True
@@ -248,7 +248,7 @@ def fontInfoVersion3OpenTypeOS2PanoseValidator(values):
 	if len(values) != 10:
 		return False
 	for value in values:
-		if not isinstance(value, integerTypes):
+		if not isinstance(value, int):
 			return False
 		if value < 0:
 			return False
@@ -264,7 +264,7 @@ def fontInfoOpenTypeOS2FamilyClassValidator(values):
 	if len(values) != 2:
 		return False
 	for value in values:
-		if not isinstance(value, integerTypes):
+		if not isinstance(value, int):
 			return False
 	classID, subclassID = values
 	if classID < 0 or classID > 14:

--- a/Lib/fontTools/ufoLib/validators.py
+++ b/Lib/fontTools/ufoLib/validators.py
@@ -5,12 +5,7 @@ from io import open
 import fs.base
 import fs.osfs
 
-try:
-    from collections.abc import Mapping  # python >= 3.3
-except ImportError:
-    from collections import Mapping
-
-from fontTools.misc.py23 import basestring
+from collections.abc import Mapping
 from fontTools.ufoLib.utils import integerTypes, numberTypes
 
 
@@ -142,7 +137,7 @@ def fontInfoOpenTypeHeadCreatedValidator(value):
 	Version 2+.
 	"""
 	# format: 0000/00/00 00:00:00
-	if not isinstance(value, basestring):
+	if not isinstance(value, str):
 		return False
 	# basic formatting
 	if not len(value) == 19:
@@ -202,7 +197,7 @@ def fontInfoOpenTypeNameRecordsValidator(value):
 	"""
 	if not isinstance(value, list):
 		return False
-	dictPrototype = dict(nameID=(int, True), platformID=(int, True), encodingID=(int, True), languageID=(int, True), string=(basestring, True))
+	dictPrototype = dict(nameID=(int, True), platformID=(int, True), encodingID=(int, True), languageID=(int, True), string=(str, True))
 	for nameRecord in value:
 		if not genericDictValidator(nameRecord, dictPrototype):
 			return False
@@ -334,7 +329,7 @@ def fontInfoWOFFMetadataUniqueIDValidator(value):
 	"""
 	Version 3+.
 	"""
-	dictPrototype = dict(id=(basestring, True))
+	dictPrototype = dict(id=(str, True))
 	if not genericDictValidator(value, dictPrototype):
 		return False
 	return True
@@ -343,7 +338,7 @@ def fontInfoWOFFMetadataVendorValidator(value):
 	"""
 	Version 3+.
 	"""
-	dictPrototype = {"name" : (basestring, True), "url" : (basestring, False), "dir" : (basestring, False), "class" : (basestring, False)}
+	dictPrototype = {"name" : (str, True), "url" : (str, False), "dir" : (str, False), "class" : (str, False)}
 	if not genericDictValidator(value, dictPrototype):
 		return False
 	if "dir" in value and value.get("dir") not in ("ltr", "rtl"):
@@ -359,7 +354,7 @@ def fontInfoWOFFMetadataCreditsValidator(value):
 		return False
 	if not len(value["credits"]):
 		return False
-	dictPrototype = {"name" : (basestring, True), "url" : (basestring, False), "role" : (basestring, False), "dir" : (basestring, False), "class" : (basestring, False)}
+	dictPrototype = {"name" : (str, True), "url" : (str, False), "role" : (str, False), "dir" : (str, False), "class" : (str, False)}
 	for credit in value["credits"]:
 		if not genericDictValidator(credit, dictPrototype):
 			return False
@@ -371,7 +366,7 @@ def fontInfoWOFFMetadataDescriptionValidator(value):
 	"""
 	Version 3+.
 	"""
-	dictPrototype = dict(url=(basestring, False), text=(list, True))
+	dictPrototype = dict(url=(str, False), text=(list, True))
 	if not genericDictValidator(value, dictPrototype):
 		return False
 	for text in value["text"]:
@@ -383,7 +378,7 @@ def fontInfoWOFFMetadataLicenseValidator(value):
 	"""
 	Version 3+.
 	"""
-	dictPrototype = dict(url=(basestring, False), text=(list, False), id=(basestring, False))
+	dictPrototype = dict(url=(str, False), text=(list, False), id=(str, False))
 	if not genericDictValidator(value, dictPrototype):
 		return False
 	if "text" in value:
@@ -420,7 +415,7 @@ def fontInfoWOFFMetadataLicenseeValidator(value):
 	"""
 	Version 3+.
 	"""
-	dictPrototype = {"name" : (basestring, True), "dir" : (basestring, False), "class" : (basestring, False)}
+	dictPrototype = {"name" : (str, True), "dir" : (str, False), "class" : (str, False)}
 	if not genericDictValidator(value, dictPrototype):
 		return False
 	if "dir" in value and value.get("dir") not in ("ltr", "rtl"):
@@ -431,7 +426,7 @@ def fontInfoWOFFMetadataTextValue(value):
 	"""
 	Version 3+.
 	"""
-	dictPrototype = {"text" : (basestring, True), "language" : (basestring, False), "dir" : (basestring, False), "class" : (basestring, False)}
+	dictPrototype = {"text" : (str, True), "language" : (str, False), "dir" : (str, False), "class" : (str, False)}
 	if not genericDictValidator(value, dictPrototype):
 		return False
 	if "dir" in value and value.get("dir") not in ("ltr", "rtl"):
@@ -455,7 +450,7 @@ def fontInfoWOFFMetadataExtensionValidator(value):
 	"""
 	Version 3+.
 	"""
-	dictPrototype = dict(names=(list, False), items=(list, True), id=(basestring, False))
+	dictPrototype = dict(names=(list, False), items=(list, True), id=(str, False))
 	if not genericDictValidator(value, dictPrototype):
 		return False
 	if "names" in value:
@@ -471,7 +466,7 @@ def fontInfoWOFFMetadataExtensionItemValidator(value):
 	"""
 	Version 3+.
 	"""
-	dictPrototype = dict(id=(basestring, False), names=(list, True), values=(list, True))
+	dictPrototype = dict(id=(str, False), names=(list, True), values=(list, True))
 	if not genericDictValidator(value, dictPrototype):
 		return False
 	for name in value["names"]:
@@ -486,7 +481,7 @@ def fontInfoWOFFMetadataExtensionNameValidator(value):
 	"""
 	Version 3+.
 	"""
-	dictPrototype = {"text" : (basestring, True), "language" : (basestring, False), "dir" : (basestring, False), "class" : (basestring, False)}
+	dictPrototype = {"text" : (str, True), "language" : (str, False), "dir" : (str, False), "class" : (str, False)}
 	if not genericDictValidator(value, dictPrototype):
 		return False
 	if "dir" in value and value.get("dir") not in ("ltr", "rtl"):
@@ -497,7 +492,7 @@ def fontInfoWOFFMetadataExtensionValueValidator(value):
 	"""
 	Version 3+.
 	"""
-	dictPrototype = {"text" : (basestring, True), "language" : (basestring, False), "dir" : (basestring, False), "class" : (basestring, False)}
+	dictPrototype = {"text" : (str, True), "language" : (str, False), "dir" : (str, False), "class" : (str, False)}
 	if not genericDictValidator(value, dictPrototype):
 		return False
 	if "dir" in value and value.get("dir") not in ("ltr", "rtl"):
@@ -528,7 +523,7 @@ def guidelinesValidator(value, identifiers=None):
 
 _guidelineDictPrototype = dict(
 	x=((int, float), False), y=((int, float), False), angle=((int, float), False),
-	name=(basestring, False), color=(basestring, False), identifier=(basestring, False)
+	name=(str, False), color=(str, False), identifier=(str, False)
 )
 
 def guidelineValidator(value):
@@ -590,8 +585,8 @@ def anchorsValidator(value, identifiers=None):
 
 _anchorDictPrototype = dict(
 	x=((int, float), False), y=((int, float), False),
-	name=(basestring, False), color=(basestring, False),
-	identifier=(basestring, False)
+	name=(str, False), color=(str, False),
+	identifier=(str, False)
 )
 
 def anchorValidator(value):
@@ -632,7 +627,7 @@ def identifierValidator(value):
 	"""
 	validCharactersMin = 0x20
 	validCharactersMax = 0x7E
-	if not isinstance(value, basestring):
+	if not isinstance(value, str):
 		return False
 	if not value:
 		return False
@@ -691,7 +686,7 @@ def colorValidator(value):
 	>>> colorValidator("1, 1, 1, 1")
 	True
 	"""
-	if not isinstance(value, basestring):
+	if not isinstance(value, str):
 		return False
 	parts = value.split(",")
 	if len(parts) != 4:
@@ -725,11 +720,11 @@ def colorValidator(value):
 pngSignature = b"\x89PNG\r\n\x1a\n"
 
 _imageDictPrototype = dict(
-	fileName=(basestring, True),
+	fileName=(str, True),
 	xScale=((int, float), False), xyScale=((int, float), False),
 	yxScale=((int, float), False), yScale=((int, float), False),
 	xOffset=((int, float), False), yOffset=((int, float), False),
-	color=(basestring, False)
+	color=(str, False)
 )
 
 def imageValidator(value):
@@ -796,7 +791,7 @@ def layerContentsValidator(value, ufoPathOrFileSystem):
 		if not len(entry) == 2:
 			return False, bogusFileMessage
 		for i in entry:
-			if not isinstance(i, basestring):
+			if not isinstance(i, str):
 				return False, bogusFileMessage
 		layerName, directoryName = entry
 		# check directory naming
@@ -880,7 +875,7 @@ def groupsValidator(value):
 	firstSideMapping = {}
 	secondSideMapping = {}
 	for groupName, glyphList in value.items():
-		if not isinstance(groupName, (basestring)):
+		if not isinstance(groupName, (str)):
 			return False, bogusFormatMessage
 		if not isinstance(glyphList, (list, tuple)):
 			return False, bogusFormatMessage
@@ -898,7 +893,7 @@ def groupsValidator(value):
 			else:
 				d = secondSideMapping
 			for glyphName in glyphList:
-				if not isinstance(glyphName, basestring):
+				if not isinstance(glyphName, str):
 					return False, "The group data %s contains an invalid member." % groupName
 				if glyphName in d:
 					return False, "The glyph \"%s\" occurs in too many kerning groups." % glyphName
@@ -936,12 +931,12 @@ def kerningValidator(data):
 	if not isinstance(data, Mapping):
 		return False, bogusFormatMessage
 	for first, secondDict in data.items():
-		if not isinstance(first, basestring):
+		if not isinstance(first, str):
 			return False, bogusFormatMessage
 		elif not isinstance(secondDict, Mapping):
 			return False, bogusFormatMessage
 		for second, value in secondDict.items():
-			if not isinstance(second, basestring):
+			if not isinstance(second, str):
 				return False, bogusFormatMessage
 			elif not isinstance(value, numberTypes):
 				return False, bogusFormatMessage
@@ -982,7 +977,7 @@ def fontLibValidator(value):
 	>>> valid
 	False
 	>>> print(msg)
-	The lib key is not properly formatted: expected basestring, found int: 1
+	The lib key is not properly formatted: expected str, found int: 1
 
 	>>> lib = {"public.glyphOrder" : "hello"}
 	>>> valid, msg = fontLibValidator(lib)
@@ -996,15 +991,15 @@ def fontLibValidator(value):
 	>>> valid
 	False
 	>>> print(msg)  # doctest: +ELLIPSIS
-	public.glyphOrder is not properly formatted: expected basestring,...
+	public.glyphOrder is not properly formatted: expected str,...
 	"""
 	if not isDictEnough(value):
 		reason = "expected a dictionary, found %s" % type(value).__name__
 		return False, _bogusLibFormatMessage % reason
 	for key, value in value.items():
-		if not isinstance(key, basestring):
+		if not isinstance(key, str):
 			return False, (
-				"The lib key is not properly formatted: expected basestring, found %s: %r" %
+				"The lib key is not properly formatted: expected str, found %s: %r" %
 				(type(key).__name__, key))
 		# public.glyphOrder
 		if key == "public.glyphOrder":
@@ -1013,8 +1008,8 @@ def fontLibValidator(value):
 				reason = "expected list or tuple, found %s" % type(value).__name__
 				return False, bogusGlyphOrderMessage % reason
 			for glyphName in value:
-				if not isinstance(glyphName, basestring):
-					reason = "expected basestring, found %s" % type(glyphName).__name__
+				if not isinstance(glyphName, str):
+					reason = "expected str, found %s" % type(glyphName).__name__
 					return False, bogusGlyphOrderMessage % reason
 	return True, None
 
@@ -1050,7 +1045,7 @@ def glyphLibValidator(value):
 		reason = "expected a dictionary, found %s" % type(value).__name__
 		return False, _bogusLibFormatMessage % reason
 	for key, value in value.items():
-		if not isinstance(key, basestring):
+		if not isinstance(key, str):
 			reason = "key (%s) should be a string" % key
 			return False, _bogusLibFormatMessage % reason
 		# public.markColor

--- a/Tests/ufoLib/GLIF1_test.py
+++ b/Tests/ufoLib/GLIF1_test.py
@@ -3,10 +3,6 @@ from fontTools.ufoLib.glifLib import GlifLibError, readGlyphFromString, writeGly
 from .testSupport import Glyph, stripText
 from itertools import islice
 
-try:
-	basestring
-except NameError:
-	basestring = str
 # ----------
 # Test Cases
 # ----------
@@ -14,9 +10,9 @@ except NameError:
 class TestGLIF1(unittest.TestCase):
 
 	def assertEqual(self, first, second, msg=None):
-		if isinstance(first, basestring):
+		if isinstance(first, str):
 			first = stripText(first)
-		if isinstance(second, basestring):
+		if isinstance(second, str):
 			second = stripText(second)
 		return super().assertEqual(first, second, msg=msg)
 

--- a/Tests/ufoLib/GLIF1_test.py
+++ b/Tests/ufoLib/GLIF1_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 from fontTools.ufoLib.glifLib import GlifLibError, readGlyphFromString, writeGlyphToString
 from .testSupport import Glyph, stripText
@@ -19,7 +18,7 @@ class TestGLIF1(unittest.TestCase):
 			first = stripText(first)
 		if isinstance(second, basestring):
 			second = stripText(second)
-		return super(TestGLIF1, self).assertEqual(first, second, msg=msg)
+		return super().assertEqual(first, second, msg=msg)
 
 	def pyToGLIF(self, py):
 		py = stripText(py)

--- a/Tests/ufoLib/GLIF2_test.py
+++ b/Tests/ufoLib/GLIF2_test.py
@@ -3,10 +3,6 @@ from fontTools.ufoLib.glifLib import GlifLibError, readGlyphFromString, writeGly
 from .testSupport import Glyph, stripText
 from itertools import islice
 
-try:
-	basestring
-except NameError:
-	basestring = str
 # ----------
 # Test Cases
 # ----------
@@ -14,9 +10,9 @@ except NameError:
 class TestGLIF2(unittest.TestCase):
 
 	def assertEqual(self, first, second, msg=None):
-		if isinstance(first, basestring):
+		if isinstance(first, str):
 			first = stripText(first)
-		if isinstance(second, basestring):
+		if isinstance(second, str):
 			second = stripText(second)
 		return super().assertEqual(first, second, msg=msg)
 

--- a/Tests/ufoLib/GLIF2_test.py
+++ b/Tests/ufoLib/GLIF2_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 from fontTools.ufoLib.glifLib import GlifLibError, readGlyphFromString, writeGlyphToString
 from .testSupport import Glyph, stripText
@@ -19,7 +18,7 @@ class TestGLIF2(unittest.TestCase):
 			first = stripText(first)
 		if isinstance(second, basestring):
 			second = stripText(second)
-		return super(TestGLIF2, self).assertEqual(first, second, msg=msg)
+		return super().assertEqual(first, second, msg=msg)
 
 	def pyToGLIF(self, py):
 		py = stripText(py)

--- a/Tests/ufoLib/UFO1_test.py
+++ b/Tests/ufoLib/UFO1_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import shutil
 import unittest
@@ -9,7 +8,7 @@ from fontTools.ufoLib import plistlib
 from .testSupport import fontInfoVersion1, fontInfoVersion2
 
 
-class TestInfoObject(object): pass
+class TestInfoObject: pass
 
 
 class ReadFontInfoVersion1TestCase(unittest.TestCase):

--- a/Tests/ufoLib/UFO2_test.py
+++ b/Tests/ufoLib/UFO2_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import shutil
 import unittest
@@ -9,7 +8,7 @@ from fontTools.ufoLib import plistlib
 from .testSupport import fontInfoVersion2
 
 
-class TestInfoObject(object): pass
+class TestInfoObject: pass
 
 
 class ReadFontInfoVersion2TestCase(unittest.TestCase):

--- a/Tests/ufoLib/UFO3_test.py
+++ b/Tests/ufoLib/UFO3_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import shutil
 import unittest
@@ -11,7 +10,7 @@ from fontTools.misc import plistlib
 from .testSupport import fontInfoVersion3
 
 
-class TestInfoObject(object): pass
+class TestInfoObject: pass
 
 
 # --------------
@@ -4310,7 +4309,7 @@ class UFO3WriteDataTestCase(unittest.TestCase):
 # layerinfo.plist
 # ---------------
 
-class TestLayerInfoObject(object):
+class TestLayerInfoObject:
 
 	color = guidelines = lib = None
 

--- a/Tests/ufoLib/UFO3_test.py
+++ b/Tests/ufoLib/UFO3_test.py
@@ -3,7 +3,6 @@ import shutil
 import unittest
 import tempfile
 from io import open
-from fontTools.misc.py23 import unicode
 from fontTools.ufoLib import UFOReader, UFOWriter, UFOLibError
 from fontTools.ufoLib.glifLib import GlifLibError
 from fontTools.misc import plistlib
@@ -4151,7 +4150,7 @@ class UFO3WriteLayersTestCase(unittest.TestCase):
 		]
 		self.assertEqual(expected, result)
 		for layerName, directory in result:
-			assert isinstance(layerName, unicode)
+			assert isinstance(layerName, str)
 
 # -----
 # /data

--- a/Tests/ufoLib/UFO3_test.py
+++ b/Tests/ufoLib/UFO3_test.py
@@ -4105,16 +4105,14 @@ class UFO3WriteLayersTestCase(unittest.TestCase):
 		self.makeUFO()
 		writer = UFOWriter(self.ufoPath)
 		writer.deleteGlyphSet("public.default")
+		writer.writeLayerContents(["layer 1", "layer 2"])
 		# directories
 		path = os.path.join(self.ufoPath, "glyphs")
-		exists = os.path.exists(path)
-		self.assertEqual(False, exists)
+		self.assertEqual(False, os.path.exists(path))
 		path = os.path.join(self.ufoPath, "glyphs.layer 1")
-		exists = os.path.exists(path)
-		self.assertEqual(True, exists)
+		self.assertEqual(True, os.path.exists(path))
 		path = os.path.join(self.ufoPath, "glyphs.layer 2")
-		exists = os.path.exists(path)
-		self.assertEqual(True, exists)
+		self.assertEqual(True, os.path.exists(path))
 		# layer contents
 		path = os.path.join(self.ufoPath, "layercontents.plist")
 		with open(path, "rb") as f:
@@ -4124,7 +4122,7 @@ class UFO3WriteLayersTestCase(unittest.TestCase):
 
 	# remove unknown layer
 
-	def testRemoveDefaultLayer(self):
+	def testRemoveDefaultLayer2(self):
 		self.makeUFO()
 		writer = UFOWriter(self.ufoPath)
 		self.assertRaises(UFOLibError, writer.deleteGlyphSet, "does not exist")

--- a/Tests/ufoLib/UFO3_test.py
+++ b/Tests/ufoLib/UFO3_test.py
@@ -4138,8 +4138,7 @@ class UFO3WriteLayersTestCase(unittest.TestCase):
 			]
 		)
 		writer = UFOWriter(self.ufoPath)
-		# if passed bytes string, it'll be decoded to ASCII unicode string
-		writer.writeLayerContents(["public.default", "layer 2", b"layer 1"])
+		writer.writeLayerContents(["public.default", "layer 2", "layer 1"])
 		path = os.path.join(self.ufoPath, "layercontents.plist")
 		with open(path, "rb") as f:
 			result = plistlib.load(f)
@@ -4149,7 +4148,7 @@ class UFO3WriteLayersTestCase(unittest.TestCase):
 			["layer 1", "glyphs.layer 1"],
 		]
 		self.assertEqual(expected, result)
-		for layerName, directory in result:
+		for layerName, _ in result:
 			assert isinstance(layerName, str)
 
 # -----

--- a/Tests/ufoLib/UFOConversion_test.py
+++ b/Tests/ufoLib/UFOConversion_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import shutil
 import unittest
@@ -121,7 +120,7 @@ class ConversionFunctionsTestCase(unittest.TestCase):
 # kerning up conversion
 # ---------------------
 
-class TestInfoObject(object): pass
+class TestInfoObject: pass
 
 
 class KerningUpConversionTestCase(unittest.TestCase):

--- a/Tests/ufoLib/UFOZ_test.py
+++ b/Tests/ufoLib/UFOZ_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from fontTools.misc.py23 import tostr
 from fontTools.ufoLib import UFOReader, UFOWriter, UFOFileStructure
 from fontTools.ufoLib.errors import UFOLibError, GlifLibError
@@ -38,7 +37,7 @@ def testufoz():
         yield tmp.getsyspath(TEST_UFOZ)
 
 
-class TestUFOZ(object):
+class TestUFOZ:
 
     def test_read(self, testufoz):
         with UFOReader(testufoz) as reader:
@@ -54,7 +53,7 @@ class TestUFOZ(object):
 
 def test_pathlike(testufo):
 
-    class PathLike(object):
+    class PathLike:
 
         def __init__(self, s):
             self._path = s
@@ -84,7 +83,7 @@ def memufo():
     return m
 
 
-class TestMemoryFS(object):
+class TestMemoryFS:
 
     def test_init_reader(self, memufo):
         with UFOReader(memufo) as reader:

--- a/Tests/ufoLib/glifLib_test.py
+++ b/Tests/ufoLib/glifLib_test.py
@@ -138,7 +138,7 @@ class FileNameTests(unittest.TestCase):
 		self.assertEqual(glyphNameToFileName("alt.con", None), "alt._con.glif")
 
 
-class _Glyph(object):
+class _Glyph:
 	pass
 
 

--- a/Tests/ufoLib/testSupport.py
+++ b/Tests/ufoLib/testSupport.py
@@ -21,7 +21,7 @@ def getDemoFontGlyphSetPath():
 
 # GLIF test tools
 
-class Glyph(object):
+class Glyph:
 
 	def __init__(self):
 		self.name = None
@@ -39,11 +39,11 @@ class Glyph(object):
 		args = _listToString(args)
 		kwargs = _dictToString(kwargs)
 		if args and kwargs:
-			return "pointPen.%s(*%s, **%s)" % (command, args, kwargs)
+			return f"pointPen.{command}(*{args}, **{kwargs})"
 		elif len(args):
-			return "pointPen.%s(*%s)" % (command, args)
+			return f"pointPen.{command}(*{args})"
 		elif len(kwargs):
-			return "pointPen.%s(**%s)" % (command, kwargs)
+			return f"pointPen.{command}(**{kwargs})"
 		else:
 			return "pointPen.%s()" % command
 
@@ -104,7 +104,7 @@ def _dictToString(d):
 			value = repr(value)
 		elif isinstance(value, basestring):
 			value = "\"%s\"" % value
-		text.append("%s : %s" % (key, value))
+		text.append(f"{key} : {value}")
 	if not text:
 		return ""
 	return "{%s}" % ", ".join(text)

--- a/Tests/ufoLib/testSupport.py
+++ b/Tests/ufoLib/testSupport.py
@@ -3,10 +3,6 @@
 import os
 from fontTools.ufoLib.utils import numberTypes
 
-try:
-	basestring
-except NameError:
-	basestring = str
 
 def getDemoFontPath():
 	"""Return the path to Data/DemoFont.ufo/."""
@@ -102,7 +98,7 @@ def _dictToString(d):
 			value = _tupleToString(value)
 		elif isinstance(value, numberTypes):
 			value = repr(value)
-		elif isinstance(value, basestring):
+		elif isinstance(value, str):
 			value = "\"%s\"" % value
 		text.append(f"{key} : {value}")
 	if not text:
@@ -120,7 +116,7 @@ def _listToString(l):
 			value = _tupleToString(value)
 		elif isinstance(value, numberTypes):
 			value = repr(value)
-		elif isinstance(value, basestring):
+		elif isinstance(value, str):
 			value = "\"%s\"" % value
 		text.append(value)
 	if not text:
@@ -138,7 +134,7 @@ def _tupleToString(t):
 			value = _tupleToString(value)
 		elif isinstance(value, numberTypes):
 			value = repr(value)
-		elif isinstance(value, basestring):
+		elif isinstance(value, str):
 			value = "\"%s\"" % value
 		text.append(value)
 	if not text:


### PR DESCRIPTION
Use Python 3.6+ syntax, remove redundant code.