### PR TITLE
PointToSegmentPen: preserve duplicate last point

### DIFF
--- a/Tests/pens/reverseContourPen_test.py
+++ b/Tests/pens/reverseContourPen_test.py
@@ -278,6 +278,26 @@ TEST_DATA = [
             ('lineTo', ((848, 348),)),  # the duplicate point is kept
             ('closePath', ())
         ]
+    ),
+    # Test case from https://github.com/googlefonts/fontmake/issues/572
+    # An additional closing lineTo is required to disambiguate a duplicate
+    # point at the end of a contour from the implied closing line.
+    (
+        [
+            ('moveTo', ((0, 651),)),
+            ('lineTo', ((0, 101),)),
+            ('lineTo', ((0, 101),)),
+            ('lineTo', ((0, 651),)),
+            ('lineTo', ((0, 651),)),
+            ('closePath', ())
+        ],
+        [
+            ('moveTo', ((0, 651),)),
+            ('lineTo', ((0, 651),)),
+            ('lineTo', ((0, 101),)),
+            ('lineTo', ((0, 101),)),
+            ('closePath', ())
+        ]
     )
 ]
 


### PR DESCRIPTION
The PointToSegmentPen translates between PointPen and (Segment)Pen protocol.

In the SegmentPen protocol, closed contours always imply a final 'lineTo' segment from the last oncurve point to the starting point.
So the PointToSegmentPen omits the final 'lineTo' segment for closed contours -- unless the option 'outputImpliedClosingLine' is True (it is False by default, and defcon.Glyph.draw method initializes the
converter pen without this option).

However, if the last oncurve point is on a "line" segment and has same coordinates as the starting point of a closed contour, the converter pen must always output the closing 'lineTo' explicitly (regardless of the value of the 'outputImpliedClosingLine' option) in order to disambiguate this case from the implied closing 'lineTo'.

If it doesn't do that, a duplicate 'line' point at the end of a closed contour gets lost in the conversion.

See https://github.com/googlefonts/fontmake/issues/572.