### PR TITLE
tox.ini: pin pytest==5.1.1 to workaround issue with caplog fixture on windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py3{6,7}-cov, htmlcov
 [testenv]
 deps =
     cov: coverage>=4.3
-    pytest
+    pytest==5.1.1
     pytest-randomly
     -rrequirements.txt
 extras =


### PR DESCRIPTION
let's see if this fixes the recent failues on Appveyor CI: e.g. https://ci.appveyor.com/project/fonttools/fonttools/builds/27126458/job/iomtsu4prflws4xu