### PR TITLE
[voltLib] Handle ALL and NONE in PROCESS_MARKS

### DIFF
--- a/Lib/fontTools/voltLib/parser.py
+++ b/Lib/fontTools/voltLib/parser.py
@@ -215,13 +215,16 @@ class Parser(object):
             if self.next_token_ == "MARK_GLYPH_SET":
                 self.advance_lexer_()
                 mark_glyph_set = self.expect_string_()
-            elif self.next_token_type_ == Lexer.STRING:
-                process_marks = self.expect_string_()
             elif self.next_token_ == "ALL":
                 self.advance_lexer_()
+            elif self.next_token_ == "NONE":
+                self.advance_lexer_()
+                process_marks = False
+            elif self.next_token_type_ == Lexer.STRING:
+                process_marks = self.expect_string_()
             else:
                 raise VoltLibError(
-                    "Expected ALL, MARK_GLYPH_SET or an ID. "
+                    "Expected ALL, NONE, MARK_GLYPH_SET or an ID. "
                     "Got %s" % (self.next_token_type_),
                     location)
         elif self.next_token_ == "SKIP_MARKS":

--- a/Tests/voltLib/parser_test.py
+++ b/Tests/voltLib/parser_test.py
@@ -663,6 +663,58 @@ class ParserTest(unittest.TestCase):
             (lookup.name, lookup.process_base),
             ("SomeSub", True))
 
+    def test_substitution_process_marks(self):
+        [group, lookup] = self.parse(
+            'DEF_GROUP "SomeMarks" ENUM GLYPH "marka" GLYPH "markb" '
+            'END_ENUM END_GROUP\n'
+            'DEF_LOOKUP "SomeSub" PROCESS_BASE PROCESS_MARKS "SomeMarks" '
+            'AS_SUBSTITUTION\n'
+            'SUB GLYPH "A" WITH GLYPH "A.c2sc"\n'
+            'END_SUB\n'
+            'END_SUBSTITUTION'
+        ).statements
+        self.assertEqual(
+            (lookup.name, lookup.process_marks),
+            ("SomeSub", 'SomeMarks'))
+
+    def test_substitution_process_marks_all(self):
+        [lookup] = self.parse(
+            'DEF_LOOKUP "SomeSub" PROCESS_BASE PROCESS_MARKS "ALL" '
+            'AS_SUBSTITUTION\n'
+            'SUB GLYPH "A" WITH GLYPH "A.c2sc"\n'
+            'END_SUB\n'
+            'END_SUBSTITUTION'
+        ).statements
+        self.assertEqual(
+            (lookup.name, lookup.process_marks),
+            ("SomeSub", True))
+
+    def test_substitution_process_marks_none(self):
+        [lookup] = self.parse(
+            'DEF_LOOKUP "SomeSub" PROCESS_BASE PROCESS_MARKS "NONE" '
+            'AS_SUBSTITUTION\n'
+            'SUB GLYPH "A" WITH GLYPH "A.c2sc"\n'
+            'END_SUB\n'
+            'END_SUBSTITUTION'
+        ).statements
+        self.assertEqual(
+            (lookup.name, lookup.process_marks),
+            ("SomeSub", False))
+
+    def test_substitution_process_marks_bad(self):
+        with self.assertRaisesRegex(
+                VoltLibError,
+                'Expected ALL, NONE, MARK_GLYPH_SET or an ID'):
+            self.parse(
+                'DEF_GROUP "SomeMarks" ENUM GLYPH "marka" GLYPH "markb" '
+                'END_ENUM END_GROUP\n'
+                'DEF_LOOKUP "SomeSub" PROCESS_BASE PROCESS_MARKS SomeMarks '
+                'AS_SUBSTITUTION\n'
+                'SUB GLYPH "A" WITH GLYPH "A.c2sc"\n'
+                'END_SUB\n'
+                'END_SUBSTITUTION'
+            )
+
     def test_substitution_skip_marks(self):
         [group, lookup] = self.parse(
             'DEF_GROUP "SomeMarks" ENUM GLYPH "marka" GLYPH "markb" '


### PR DESCRIPTION
Both were treated as group names, as `NONE` was not checked at all and code for `ALL` was never reached.