### PR TITLE
[feaLib] Fix handing of duplicate LigatureCaret

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1049,11 +1049,13 @@ class Builder(object):
 
     def add_ligatureCaretByIndex_(self, location, glyphs, carets):
         for glyph in glyphs:
-            self.ligCaretPoints_.setdefault(glyph, set()).update(carets)
+            if glyph not in self.ligCaretPoints_:
+                self.ligCaretPoints_[glyph] = carets
 
     def add_ligatureCaretByPos_(self, location, glyphs, carets):
         for glyph in glyphs:
-            self.ligCaretCoords_.setdefault(glyph, set()).update(carets)
+            if glyph not in self.ligCaretCoords_:
+                self.ligCaretCoords_[glyph] = carets
 
     def add_name_record(self, location, nameID, platformID, platEncID,
                         langID, string):

--- a/Tests/feaLib/data/LigatureCaretByIndex.fea
+++ b/Tests/feaLib/data/LigatureCaretByIndex.fea
@@ -1,10 +1,6 @@
 table GDEF {
     LigatureCaretByIndex [c_t s_t] 11;
 
-    # The OpenType Feature File specification does not define what should
-    # happen when there are multiple LigatureCaretByIndex statements for
-    # the same glyph. Our behavior matches that of Adobe makeotf v2.0.90.
-    # https://github.com/adobe-type-tools/afdko/issues/95
     LigatureCaretByIndex o_f_f_i 66 33;
     LigatureCaretByIndex o_f_f_i 55;
 } GDEF;

--- a/Tests/feaLib/data/LigatureCaretByIndex.ttx
+++ b/Tests/feaLib/data/LigatureCaretByIndex.ttx
@@ -17,14 +17,11 @@
         </CaretValue>
       </LigGlyph>
       <LigGlyph index="1">
-        <!-- CaretCount=3 -->
+        <!-- CaretCount=2 -->
         <CaretValue index="0" Format="2">
           <CaretValuePoint value="33"/>
         </CaretValue>
         <CaretValue index="1" Format="2">
-          <CaretValuePoint value="55"/>
-        </CaretValue>
-        <CaretValue index="2" Format="2">
           <CaretValuePoint value="66"/>
         </CaretValue>
       </LigGlyph>

--- a/Tests/feaLib/data/LigatureCaretByPos.fea
+++ b/Tests/feaLib/data/LigatureCaretByPos.fea
@@ -1,10 +1,6 @@
 table GDEF {
     LigatureCaretByPos [c_h c_k] 500;
 
-    # The OpenType Feature File specification does not define what should
-    # happen when there are multiple LigatureCaretByPos statements for
-    # the same glyph. Our behavior matches that of Adobe makeotf v2.0.90.
-    # https://github.com/adobe-type-tools/afdko/issues/95
     LigatureCaretByPos o_f_f_i 700 300;
     LigatureCaretByPos o_f_f_i 900;
 } GDEF;

--- a/Tests/feaLib/data/LigatureCaretByPos.ttx
+++ b/Tests/feaLib/data/LigatureCaretByPos.ttx
@@ -23,15 +23,12 @@
         </CaretValue>
       </LigGlyph>
       <LigGlyph index="2">
-        <!-- CaretCount=3 -->
+        <!-- CaretCount=2 -->
         <CaretValue index="0" Format="1">
           <Coordinate value="300"/>
         </CaretValue>
         <CaretValue index="1" Format="1">
           <Coordinate value="700"/>
-        </CaretValue>
-        <CaretValue index="2" Format="1">
-          <Coordinate value="900"/>
         </CaretValue>
       </LigGlyph>
     </LigCaretList>


### PR DESCRIPTION
The spec has been updated for a while to allow only one rule per glyph, and makeotf uses the first and ignores the rest.

See https://github.com/adobe-type-tools/afdko/issues/95, and https://github.com/adobe-type-tools/afdko/issues/155