### PR TITLE
don't round in fixedToFloat, unless we're dumping floats to XML

### DIFF
--- a/Lib/fontTools/ttLib/tables/F__e_a_t.py
+++ b/Lib/fontTools/ttLib/tables/F__e_a_t.py
@@ -1,5 +1,6 @@
 from fontTools.misc.py23 import *
 from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import floatToFixedToStr
 from fontTools.misc.textTools import safeEval
 from .otBase import BaseTTXConverter
 from . import DefaultTable
@@ -19,6 +20,7 @@ class table_F__e_a_t(DefaultTable.DefaultTable):
 
     def decompile(self, data, ttFont):
         (_, data) = sstruct.unpack2(Feat_hdr_format, data, self)
+        self.version = float(floatToFixedToStr(self.version, precisionBits=16))
         numFeats, = struct.unpack('>H', data[:2])
         data = data[8:]
         allfeats = []

--- a/Lib/fontTools/ttLib/tables/G__l_a_t.py
+++ b/Lib/fontTools/ttLib/tables/G__l_a_t.py
@@ -1,5 +1,6 @@
 from fontTools.misc.py23 import *
 from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import floatToFixedToStr
 from fontTools.misc.textTools import safeEval
 from itertools import *
 from functools import partial
@@ -68,6 +69,7 @@ class table_G__l_a_t(DefaultTable.DefaultTable):
 
     def decompile(self, data, ttFont):
         sstruct.unpack2(Glat_format_0, data, self)
+        self.version = float(floatToFixedToStr(self.version, precisionBits=16))
         if self.version <= 1.9:
             decoder = partial(self.decompileAttributes12,fmt=Glat_format_1_entry)
         elif self.version <= 2.9:   

--- a/Lib/fontTools/ttLib/tables/S__i_l_f.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_f.py
@@ -1,5 +1,6 @@
 from fontTools.misc.py23 import *
 from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import floatToFixedToStr
 from fontTools.misc.textTools import safeEval
 from itertools import *
 from . import DefaultTable
@@ -312,6 +313,7 @@ class table_S__i_l_f(DefaultTable.DefaultTable):
 
     def decompile(self, data, ttFont):
         sstruct.unpack2(Silf_hdr_format, data, self)
+        self.version = float(floatToFixedToStr(self.version, precisionBits=16))
         if self.version >= 5.0:
             (data, self.scheme) = grUtils.decompress(data)
             sstruct.unpack2(Silf_hdr_format_3, data, self)
@@ -390,6 +392,7 @@ class Silf(object):
     def decompile(self, data, ttFont, version=2.0):
         if version >= 3.0 :
             _, data = sstruct.unpack2(Silf_part1_format_v3, data, self)
+            self.ruleVersion = float(floatToFixedToStr(self.ruleVersion, precisionBits=16))
         _, data = sstruct.unpack2(Silf_part1_format, data, self)
         for jlevel in range(self.numJLevels):
             j, data = sstruct.unpack2(Silf_justify_format, data, _Object())

--- a/Lib/fontTools/ttLib/tables/S__i_l_l.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_l.py
@@ -1,5 +1,6 @@
 from fontTools.misc.py23 import *
 from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import floatToFixedToStr
 from fontTools.misc.textTools import safeEval
 from . import DefaultTable
 from . import grUtils
@@ -18,6 +19,7 @@ class table_S__i_l_l(DefaultTable.DefaultTable):
 
     def decompile(self, data, ttFont):
         (_, data) = sstruct.unpack2(Sill_hdr, data, self)
+        self.version = float(floatToFixedToStr(self.version, precisionBits=16))
         numLangs, = struct.unpack('>H', data[:2])
         data = data[8:]
         maxsetting = 0

--- a/Lib/fontTools/ttLib/tables/_a_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r.py
@@ -1,7 +1,12 @@
 from fontTools.misc.py23 import *
 from fontTools import ttLib
 from fontTools.misc import sstruct
-from fontTools.misc.fixedTools import fixedToFloat, floatToFixed
+from fontTools.misc.fixedTools import (
+    fixedToFloat as fi2fl,
+    floatToFixed as fl2fi,
+    floatToFixedToStr as fl2str,
+    strToFixedToFloat as str2fl,
+)
 from fontTools.misc.textTools import safeEval
 from fontTools.ttLib import TTLibError
 from . import DefaultTable
@@ -46,8 +51,8 @@ class table__a_v_a_r(DefaultTable.DefaultTable):
             mappings = sorted(self.segments[axis].items())
             result.append(struct.pack(">H", len(mappings)))
             for key, value in mappings:
-                fixedKey = floatToFixed(key, 14)
-                fixedValue = floatToFixed(value, 14)
+                fixedKey = fl2fi(key, 14)
+                fixedValue = fl2fi(value, 14)
                 result.append(struct.pack(">hh", fixedKey, fixedValue))
         return bytesjoin(result)
 
@@ -66,7 +71,7 @@ class table__a_v_a_r(DefaultTable.DefaultTable):
             pos = pos + 2
             for _ in range(numPairs):
                 fromValue, toValue = struct.unpack(">hh", data[pos:pos+4])
-                segments[fixedToFloat(fromValue, 14)] = fixedToFloat(toValue, 14)
+                segments[fi2fl(fromValue, 14)] = fi2fl(toValue, 14)
                 pos = pos + 4
 
     def toXML(self, writer, ttFont):
@@ -75,10 +80,8 @@ class table__a_v_a_r(DefaultTable.DefaultTable):
             writer.begintag("segment", axis=axis)
             writer.newline()
             for key, value in sorted(self.segments[axis].items()):
-                # roundtrip float -> fixed -> float to normalize TTX output
-                # as dumped after decompiling or straight from varLib
-                key = fixedToFloat(floatToFixed(key, 14), 14)
-                value = fixedToFloat(floatToFixed(value, 14), 14)
+                key = fl2str(key, 14)
+                value = fl2str(value, 14)
                 writer.simpletag("mapping", **{"from": key, "to": value})
                 writer.newline()
             writer.endtag("segment")
@@ -92,8 +95,8 @@ class table__a_v_a_r(DefaultTable.DefaultTable):
                 if isinstance(element, tuple):
                     elementName, elementAttrs, _ = element
                     if elementName == "mapping":
-                        fromValue = safeEval(elementAttrs["from"])
-                        toValue = safeEval(elementAttrs["to"])
+                        fromValue = str2fl(elementAttrs["from"], 14)
+                        toValue = str2fl(elementAttrs["to"], 14)
                         if fromValue in segment:
                             log.warning("duplicate entry for %s in axis '%s'",
                                         fromValue, axis)

--- a/Lib/fontTools/ttLib/tables/_f_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_f_v_a_r.py
@@ -1,6 +1,11 @@
 from fontTools.misc.py23 import *
 from fontTools.misc import sstruct
-from fontTools.misc.fixedTools import fixedToFloat, floatToFixed
+from fontTools.misc.fixedTools import (
+    fixedToFloat as fi2fl,
+    floatToFixed as fl2fi,
+    floatToFixedToStr as fl2str,
+    strToFixedToFloat as str2fl,
+)
 from fontTools.misc.textTools import safeEval, num2binary, binary2num
 from fontTools.ttLib import TTLibError
 from . import DefaultTable
@@ -129,9 +134,9 @@ class Axis(object):
         writer.newline()
         for tag, value in [("AxisTag", self.axisTag),
                            ("Flags", "0x%X" % self.flags),
-                           ("MinValue", str(self.minValue)),
-                           ("DefaultValue", str(self.defaultValue)),
-                           ("MaxValue", str(self.maxValue)),
+                           ("MinValue", fl2str(self.minValue, 16)),
+                           ("DefaultValue", fl2str(self.defaultValue, 16)),
+                           ("MaxValue", fl2str(self.maxValue, 16)),
                            ("AxisNameID", str(self.axisNameID))]:
             writer.begintag(tag)
             writer.write(value)
@@ -148,7 +153,11 @@ class Axis(object):
                 self.axisTag = Tag(value)
             elif tag in {"Flags", "MinValue", "DefaultValue", "MaxValue",
                          "AxisNameID"}:
-                setattr(self, tag[0].lower() + tag[1:], safeEval(value))
+                setattr(
+                    self,
+                    tag[0].lower() + tag[1:],
+                    str2fl(value, 16) if tag.endswith("Value") else safeEval(value)
+                )
 
 
 class NamedInstance(object):
@@ -161,7 +170,7 @@ class NamedInstance(object):
     def compile(self, axisTags, includePostScriptName):
         result = [sstruct.pack(FVAR_INSTANCE_FORMAT, self)]
         for axis in axisTags:
-            fixedCoord = floatToFixed(self.coordinates[axis], 16)
+            fixedCoord = fl2fi(self.coordinates[axis], 16)
             result.append(struct.pack(">l", fixedCoord))
         if includePostScriptName:
             result.append(struct.pack(">H", self.postscriptNameID))
@@ -172,7 +181,7 @@ class NamedInstance(object):
         pos = sstruct.calcsize(FVAR_INSTANCE_FORMAT)
         for axis in axisTags:
             value = struct.unpack(">l", data[pos : pos + 4])[0]
-            self.coordinates[axis] = fixedToFloat(value, 16)
+            self.coordinates[axis] = fi2fl(value, 16)
             pos += 4
         if pos + 2 <= len(data):
           self.postscriptNameID = struct.unpack(">H", data[pos : pos + 2])[0]
@@ -199,7 +208,7 @@ class NamedInstance(object):
         writer.newline()
         for axis in ttFont["fvar"].axes:
             writer.simpletag("coord", axis=axis.axisTag,
-                             value=self.coordinates[axis.axisTag])
+                             value=fl2str(self.coordinates[axis.axisTag], 16))
             writer.newline()
         writer.endtag("NamedInstance")
         writer.newline()
@@ -215,4 +224,5 @@ class NamedInstance(object):
 
         for tag, elementAttrs, _ in filter(lambda t: type(t) is tuple, content):
             if tag == "coord":
-                self.coordinates[elementAttrs["axis"]] = safeEval(elementAttrs["value"])
+                value = str2fl(elementAttrs["value"], 16)
+                self.coordinates[elementAttrs["axis"]] = value

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -11,6 +11,8 @@ from fontTools.misc.bezierTools import calcQuadraticBounds
 from fontTools.misc.fixedTools import (
 	fixedToFloat as fi2fl,
 	floatToFixed as fl2fi,
+	floatToFixedToStr as fl2str,
+	strToFixedToFloat as str2fl,
 	otRound,
 )
 from numbers import Number
@@ -1365,15 +1367,18 @@ class GlyphComponent(object):
 			transform = self.transform
 			if transform[0][1] or transform[1][0]:
 				attrs = attrs + [
-						("scalex", transform[0][0]), ("scale01", transform[0][1]),
-						("scale10", transform[1][0]), ("scaley", transform[1][1]),
-						]
+					("scalex", fl2str(transform[0][0], 14)),
+					("scale01", fl2str(transform[0][1], 14)),
+					("scale10", fl2str(transform[1][0], 14)),
+					("scaley", fl2str(transform[1][1], 14)),
+				]
 			elif transform[0][0] != transform[1][1]:
 				attrs = attrs + [
-						("scalex", transform[0][0]), ("scaley", transform[1][1]),
-						]
+					("scalex", fl2str(transform[0][0], 14)),
+					("scaley", fl2str(transform[1][1], 14)),
+				]
 			else:
-				attrs = attrs + [("scale", transform[0][0])]
+				attrs = attrs + [("scale", fl2str(transform[0][0], 14))]
 		attrs = attrs + [("flags", hex(self.flags))]
 		writer.simpletag("component", attrs)
 		writer.newline()
@@ -1387,17 +1392,17 @@ class GlyphComponent(object):
 			self.x = safeEval(attrs["x"])
 			self.y = safeEval(attrs["y"])
 		if "scale01" in attrs:
-			scalex = safeEval(attrs["scalex"])
-			scale01 = safeEval(attrs["scale01"])
-			scale10 = safeEval(attrs["scale10"])
-			scaley = safeEval(attrs["scaley"])
+			scalex = str2fl(attrs["scalex"], 14)
+			scale01 = str2fl(attrs["scale01"], 14)
+			scale10 = str2fl(attrs["scale10"], 14)
+			scaley = str2fl(attrs["scaley"], 14)
 			self.transform = [[scalex, scale01], [scale10, scaley]]
 		elif "scalex" in attrs:
-			scalex = safeEval(attrs["scalex"])
-			scaley = safeEval(attrs["scaley"])
+			scalex = str2fl(attrs["scalex"], 14)
+			scaley = str2fl(attrs["scaley"], 14)
 			self.transform = [[scalex, 0], [0, scaley]]
 		elif "scale" in attrs:
-			scale = safeEval(attrs["scale"])
+			scale = str2fl(attrs["scale"], 14)
 			self.transform = [[scale, 0], [0, scale]]
 		self.flags = safeEval(attrs["flags"])
 

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k.py
@@ -1,6 +1,11 @@
 from fontTools.misc.py23 import *
 from fontTools.misc import sstruct
-from fontTools.misc.fixedTools import fixedToFloat as fi2fl, floatToFixed as fl2fi
+from fontTools.misc.fixedTools import (
+	fixedToFloat as fi2fl,
+	floatToFixed as fl2fi,
+	floatToFixedToStr as fl2str,
+	strToFixedToFloat as str2fl,
+)
 from fontTools.misc.textTools import safeEval
 from fontTools.ttLib import TTLibError
 from . import DefaultTable
@@ -257,19 +262,19 @@ class TrackTableEntry(MutableMapping):
 		name = ttFont["name"].getDebugName(self.nameIndex)
 		writer.begintag(
 			"trackEntry",
-			(('value', self.track), ('nameIndex', self.nameIndex)))
+			(('value', fl2str(self.track, 16)), ('nameIndex', self.nameIndex)))
 		writer.newline()
 		if name:
 			writer.comment(name)
 			writer.newline()
 		for size, perSizeValue in sorted(self.items()):
-			writer.simpletag("track", size=size, value=perSizeValue)
+			writer.simpletag("track", size=fl2str(size, 16), value=perSizeValue)
 			writer.newline()
 		writer.endtag("trackEntry")
 		writer.newline()
 
 	def fromXML(self, name, attrs, content, ttFont):
-		self.track = safeEval(attrs['value'])
+		self.track = str2fl(attrs['value'], 16)
 		self.nameIndex = safeEval(attrs['nameIndex'])
 		for element in content:
 			if not isinstance(element, tuple):
@@ -277,7 +282,7 @@ class TrackTableEntry(MutableMapping):
 			name, attrs, _ = element
 			if name != 'track':
 				continue
-			size = safeEval(attrs['size'])
+			size = str2fl(attrs['size'], 16)
 			self[size] = safeEval(attrs['value'])
 
 	def __getitem__(self, size):

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1,7 +1,12 @@
 from fontTools.misc.py23 import *
 from fontTools.misc.fixedTools import (
-	fixedToFloat as fi2fl, floatToFixed as fl2fi, ensureVersionIsLong as fi2ve,
-	versionToFixed as ve2fi)
+	fixedToFloat as fi2fl,
+	floatToFixed as fl2fi,
+	floatToFixedToStr as fl2str,
+	strToFixedToFloat as str2fl,
+	ensureVersionIsLong as fi2ve,
+	versionToFixed as ve2fi,
+)
 from fontTools.misc.textTools import pad, safeEval
 from fontTools.ttLib import getSearchRange
 from .otBase import (CountReference, FormatSwitchingBaseTable,
@@ -315,6 +320,11 @@ class Fixed(FloatValue):
 		return  fi2fl(reader.readLong(), 16)
 	def write(self, writer, font, tableDict, value, repeatIndex=None):
 		writer.writeLong(fl2fi(value, 16))
+	def xmlRead(self, attrs, content, font):
+		return str2fl(attrs["value"], 16)
+	def xmlWrite(self, xmlWriter, font, value, name, attrs):
+		xmlWriter.simpletag(name, attrs + [("value", fl2str(value, 16))])
+		xmlWriter.newline()
 
 class F2Dot14(FloatValue):
 	staticSize = 2
@@ -322,6 +332,11 @@ class F2Dot14(FloatValue):
 		return  fi2fl(reader.readShort(), 14)
 	def write(self, writer, font, tableDict, value, repeatIndex=None):
 		writer.writeShort(fl2fi(value, 14))
+	def xmlRead(self, attrs, content, font):
+		return str2fl(attrs["value"], 14)
+	def xmlWrite(self, xmlWriter, font, value, name, attrs):
+		xmlWriter.simpletag(name, attrs + [("value", fl2str(value, 14))])
+		xmlWriter.newline()
 
 class Version(BaseConverter):
 	staticSize = 4

--- a/Tests/misc/fixedTools_test.py
+++ b/Tests/misc/fixedTools_test.py
@@ -1,5 +1,12 @@
 from fontTools.misc.py23 import *
-from fontTools.misc.fixedTools import fixedToFloat, floatToFixed
+from fontTools.misc.fixedTools import (
+    fixedToFloat,
+    floatToFixed,
+    floatToFixedToStr,
+    fixedToStr,
+    strToFixed,
+    strToFixedToFloat,
+)
 import unittest
 
 
@@ -11,18 +18,32 @@ class FixedToolsTest(unittest.TestCase):
                 self.assertEqual(value, floatToFixed(fixedToFloat(value, bits), bits))
 
     def test_fixedToFloat_precision14(self):
-        self.assertEqual(0.8, fixedToFloat(13107, 14))
+        self.assertAlmostEqual(0.7999878, fixedToFloat(13107, 14))
         self.assertEqual(0.0, fixedToFloat(0, 14))
         self.assertEqual(1.0, fixedToFloat(16384, 14))
         self.assertEqual(-1.0, fixedToFloat(-16384, 14))
-        self.assertEqual(0.99994, fixedToFloat(16383, 14))
-        self.assertEqual(-0.99994, fixedToFloat(-16383, 14))
+        self.assertAlmostEqual(0.999939, fixedToFloat(16383, 14))
+        self.assertAlmostEqual(-0.999939, fixedToFloat(-16383, 14))
 
     def test_fixedToFloat_precision6(self):
-        self.assertAlmostEqual(-9.98, fixedToFloat(-639, 6))
+        self.assertAlmostEqual(-9.984375, fixedToFloat(-639, 6))
         self.assertAlmostEqual(-10.0, fixedToFloat(-640, 6))
-        self.assertAlmostEqual(9.98, fixedToFloat(639, 6))
+        self.assertAlmostEqual(9.984375, fixedToFloat(639, 6))
         self.assertAlmostEqual(10.0, fixedToFloat(640, 6))
+
+    def test_fixedToStr_precision14(self):
+        self.assertEqual('0.8', fixedToStr(13107, 14))
+        self.assertEqual('0.0', fixedToStr(0, 14))
+        self.assertEqual('1.0', fixedToStr(16384, 14))
+        self.assertEqual('-1.0', fixedToStr(-16384, 14))
+        self.assertEqual('0.99994', fixedToStr(16383, 14))
+        self.assertEqual('-0.99994', fixedToStr(-16383, 14))
+
+    def test_fixedToStr_precision6(self):
+        self.assertAlmostEqual('-9.98', fixedToStr(-639, 6))
+        self.assertAlmostEqual('-10.0', fixedToStr(-640, 6))
+        self.assertAlmostEqual('9.98', fixedToStr(639, 6))
+        self.assertAlmostEqual('10.0', fixedToStr(640, 6))
 
     def test_floatToFixed_precision14(self):
         self.assertEqual(13107, floatToFixed(0.8, 14))
@@ -31,6 +52,30 @@ class FixedToolsTest(unittest.TestCase):
         self.assertEqual(-16384, floatToFixed(-1.0, 14))
         self.assertEqual(-16384, floatToFixed(-1, 14))
         self.assertEqual(0, floatToFixed(0, 14))
+
+    def test_strToFixed_precision14(self):
+        self.assertEqual(13107, strToFixed('0.8', 14))
+        self.assertEqual(16384, strToFixed('1.0', 14))
+        self.assertEqual(16384, strToFixed('1', 14))
+        self.assertEqual(-16384, strToFixed('-1.0', 14))
+        self.assertEqual(-16384, strToFixed('-1', 14))
+        self.assertEqual(0, strToFixed('0', 14))
+
+    def test_strToFixedToFloat_precision14(self):
+        self.assertAlmostEqual(0.7999878, strToFixedToFloat('0.8', 14))
+        self.assertEqual(0.0, strToFixedToFloat('0', 14))
+        self.assertEqual(1.0, strToFixedToFloat('1.0', 14))
+        self.assertEqual(-1.0, strToFixedToFloat('-1.0', 14))
+        self.assertAlmostEqual(0.999939, strToFixedToFloat('0.99994', 14))
+        self.assertAlmostEqual(-0.999939, strToFixedToFloat('-0.99994', 14))
+
+    def test_floatToFixedToStr_precision14(self):
+        self.assertEqual('0.8', floatToFixedToStr(0.7999878, 14))
+        self.assertEqual('1.0', floatToFixedToStr(1.0, 14))
+        self.assertEqual('1.0', floatToFixedToStr(1, 14))
+        self.assertEqual('-1.0', floatToFixedToStr(-1.0, 14))
+        self.assertEqual('-1.0', floatToFixedToStr(-1, 14))
+        self.assertEqual('0.0', floatToFixedToStr(0, 14))
 
     def test_fixedToFloat_return_float(self):
         value = fixedToFloat(16384, 14)

--- a/Tests/ttLib/tables/_a_v_a_r_test.py
+++ b/Tests/ttLib/tables/_a_v_a_r_test.py
@@ -17,6 +17,17 @@ TEST_DATA = deHexStr(
 
 
 class AxisVariationTableTest(unittest.TestCase):
+    def assertAvarAlmostEqual(self, segments1, segments2):
+        self.assertSetEqual(set(segments1.keys()), set(segments2.keys()))
+        for axisTag, mapping1 in segments1.items():
+            mapping2 = segments2[axisTag]
+            self.assertEqual(len(mapping1), len(mapping2))
+            for (k1, v1), (k2, v2) in zip(
+                sorted(mapping1.items()), sorted(mapping2.items())
+            ):
+                self.assertAlmostEqual(k1, k2)
+                self.assertAlmostEqual(v1, v2)
+
     def test_compile(self):
         avar = table__a_v_a_r()
         avar.segments["wdth"] = {-1.0: -1.0, 0.0: 0.0, 0.3: 0.8, 1.0: 1.0}
@@ -26,8 +37,8 @@ class AxisVariationTableTest(unittest.TestCase):
     def test_decompile(self):
         avar = table__a_v_a_r()
         avar.decompile(TEST_DATA, self.makeFont(["wdth", "wght"]))
-        self.assertEqual({
-            "wdth": {-1.0: -1.0, 0.0: 0.0, 0.3: 0.8, 1.0: 1.0},
+        self.assertAvarAlmostEqual({
+            "wdth": {-1.0: -1.0, 0.0: 0.0, 0.2999878: 0.7999878, 1.0: 1.0},
             "wght": {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}
         }, avar.segments)
 
@@ -38,7 +49,7 @@ class AxisVariationTableTest(unittest.TestCase):
 
     def test_toXML(self):
         avar = table__a_v_a_r()
-        avar.segments["opsz"] = {-1.0: -1.0, 0.0: 0.0, 0.3: 0.8, 1.0: 1.0}
+        avar.segments["opsz"] = {-1.0: -1.0, 0.0: 0.0, 0.2999878: 0.7999878, 1.0: 1.0}
         writer = XMLWriter(BytesIO())
         avar.toXML(writer, self.makeFont(["opsz"]))
         self.assertEqual([
@@ -60,8 +71,10 @@ class AxisVariationTableTest(unittest.TestCase):
                 '    <mapping from="1.0" to="1.0"/>'
                 '</segment>'):
             avar.fromXML(name, attrs, content, ttFont=None)
-        self.assertEqual({"wdth": {-1: -1, 0: 0, 0.7: 0.2, 1.0: 1.0}},
-                         avar.segments)
+        self.assertAvarAlmostEqual(
+            {"wdth": {-1: -1, 0: 0, 0.7000122: 0.2000122, 1.0: 1.0}},
+            avar.segments
+        )
 
     @staticmethod
     def makeFont(axisTags):

--- a/Tests/ttLib/tables/_c_v_a_r_test.py
+++ b/Tests/ttLib/tables/_c_v_a_r_test.py
@@ -51,12 +51,23 @@ CVAR_XML = [
 
 CVAR_VARIATIONS = [
     TupleVariation({"wght": (0.0, 1.0, 1.0)}, [None, None, 3, 1, 4]),
-    TupleVariation({"wght": (-1, -1.0, 0.0), "wdth": (0.0, 0.8, 0.8)},
+    TupleVariation({"wght": (-1, -1.0, 0.0), "wdth": (0.0, 0.7999878, 0.7999878)},
                    [None, None, 9, 7, 8]),
 ]
 
 
 class CVARTableTest(unittest.TestCase):
+    def assertVariationsAlmostEqual(self, variations1, variations2):
+        self.assertEqual(len(variations1), len(variations2))
+        for (v1, v2) in zip(variations1, variations2):
+            self.assertSetEqual(set(v1.axes), set(v2.axes))
+            for axisTag, support1 in v1.axes.items():
+                support2 = v2.axes[axisTag]
+                self.assertEqual(len(support1), len(support2))
+                for s1, s2 in zip(support1, support2):
+                    self.assertAlmostEqual(s1, s2)
+                self.assertEqual(v1.coordinates, v2.coordinates)
+
     def makeFont(self):
         cvt, cvar, fvar = newTable("cvt "), newTable("cvar"), newTable("fvar")
         font = {"cvt ": cvt, "cvar": cvar, "fvar": fvar}
@@ -81,14 +92,14 @@ class CVARTableTest(unittest.TestCase):
         cvar.decompile(CVAR_PRIVATE_POINT_DATA, font)
         self.assertEqual(cvar.majorVersion, 1)
         self.assertEqual(cvar.minorVersion, 0)
-        self.assertEqual(cvar.variations, CVAR_VARIATIONS)
+        self.assertVariationsAlmostEqual(cvar.variations, CVAR_VARIATIONS)
 
     def test_decompile_shared_points(self):
         font, cvar = self.makeFont()
         cvar.decompile(CVAR_DATA, font)
         self.assertEqual(cvar.majorVersion, 1)
         self.assertEqual(cvar.minorVersion, 0)
-        self.assertEqual(cvar.variations, CVAR_VARIATIONS)
+        self.assertVariationsAlmostEqual(cvar.variations, CVAR_VARIATIONS)
 
     def test_fromXML(self):
         font, cvar = self.makeFont()
@@ -96,7 +107,7 @@ class CVARTableTest(unittest.TestCase):
             cvar.fromXML(name, attrs, content, ttFont=font)
         self.assertEqual(cvar.majorVersion, 1)
         self.assertEqual(cvar.minorVersion, 0)
-        self.assertEqual(cvar.variations, CVAR_VARIATIONS)
+        self.assertVariationsAlmostEqual(cvar.variations, CVAR_VARIATIONS)
 
     def test_toXML(self):
         font, cvar = self.makeFont()

--- a/Tests/ttLib/tables/_f_v_a_r_test.py
+++ b/Tests/ttLib/tables/_f_v_a_r_test.py
@@ -119,7 +119,7 @@ class AxisTest(unittest.TestCase):
         self.assertEqual("opsz", axis.axisTag)
         self.assertEqual(345, axis.axisNameID)
         self.assertEqual(-0.5, axis.minValue)
-        self.assertEqual(1.3, axis.defaultValue)
+        self.assertAlmostEqual(1.3000031, axis.defaultValue)
         self.assertEqual(1.5, axis.maxValue)
 
     def test_toXML(self):
@@ -165,6 +165,11 @@ class AxisTest(unittest.TestCase):
 
 
 class NamedInstanceTest(unittest.TestCase):
+    def assertDictAlmostEqual(self, dict1, dict2):
+        self.assertEqual(set(dict1.keys()), set(dict2.keys()))
+        for key in dict1:
+            self.assertAlmostEqual(dict1[key], dict2[key])
+
     def test_compile_withPostScriptName(self):
         inst = NamedInstance()
         inst.subfamilyNameID = 345
@@ -186,14 +191,14 @@ class NamedInstanceTest(unittest.TestCase):
         inst.decompile(FVAR_INSTANCE_DATA_WITH_PSNAME, ["wght", "wdth"])
         self.assertEqual(564, inst.postscriptNameID)
         self.assertEqual(345, inst.subfamilyNameID)
-        self.assertEqual({"wght": 0.7, "wdth": 0.5}, inst.coordinates)
+        self.assertDictAlmostEqual({"wght": 0.6999969, "wdth": 0.5}, inst.coordinates)
 
     def test_decompile_withoutPostScriptName(self):
         inst = NamedInstance()
         inst.decompile(FVAR_INSTANCE_DATA_WITHOUT_PSNAME, ["wght", "wdth"])
         self.assertEqual(0xFFFF, inst.postscriptNameID)
         self.assertEqual(345, inst.subfamilyNameID)
-        self.assertEqual({"wght": 0.7, "wdth": 0.5}, inst.coordinates)
+        self.assertDictAlmostEqual({"wght": 0.6999969, "wdth": 0.5}, inst.coordinates)
 
     def test_toXML_withPostScriptName(self):
         font = MakeFont()
@@ -243,7 +248,7 @@ class NamedInstanceTest(unittest.TestCase):
             inst.fromXML(name, attrs, content, ttFont=MakeFont())
         self.assertEqual(257, inst.postscriptNameID)
         self.assertEqual(345, inst.subfamilyNameID)
-        self.assertEqual({"wght": 0.7, "wdth": 0.5}, inst.coordinates)
+        self.assertDictAlmostEqual({"wght": 0.6999969, "wdth": 0.5}, inst.coordinates)
 
     def test_fromXML_withoutPostScriptName(self):
         inst = NamedInstance()
@@ -255,7 +260,7 @@ class NamedInstanceTest(unittest.TestCase):
             inst.fromXML(name, attrs, content, ttFont=MakeFont())
         self.assertEqual(0x123ABC, inst.flags)
         self.assertEqual(345, inst.subfamilyNameID)
-        self.assertEqual({"wght": 0.7, "wdth": 0.5}, inst.coordinates)
+        self.assertDictAlmostEqual({"wght": 0.6999969, "wdth": 0.5}, inst.coordinates)
 
 
 if __name__ == "__main__":

--- a/Tests/ttLib/tables/_g_v_a_r_test.py
+++ b/Tests/ttLib/tables/_g_v_a_r_test.py
@@ -64,7 +64,7 @@ GVAR_VARIATIONS = {
     ],
     "space": [
         TupleVariation(
-            {"wdth": (0.0, 0.7, 0.7)},
+            {"wdth": (0.0, 0.7000122, 0.7000122)},
             [(1, 11), (2, 22), (3, 33), (4, 44)]),
     ],
     "I": [
@@ -72,7 +72,7 @@ GVAR_VARIATIONS = {
             {"wght": (0.0, 0.5, 1.0)},
             [(3,3), (1,1), (4,4), (1,1), (5,5), (9,9), (2,2), (6,6)]),
         TupleVariation(
-            {"wght": (-1.0, -1.0, 0.0), "wdth": (0.0, 0.8, 0.8)},
+            {"wght": (-1.0, -1.0, 0.0), "wdth": (0.0, 0.7999878, 0.7999878)},
             [(-8,-88), (7,77), None, None, (-4,44), (3,33), (-2,-22), (1,11)]),
     ],
 }
@@ -132,6 +132,20 @@ def hexencode(s):
 
 
 class GVARTableTest(unittest.TestCase):
+	def assertVariationsAlmostEqual(self, vars1, vars2):
+		self.assertSetEqual(set(vars1.keys()), set(vars2.keys()))
+		for glyphName, variations1 in vars1.items():
+			variations2 = vars2[glyphName]
+			self.assertEqual(len(variations1), len(variations2))
+			for (v1, v2) in zip(variations1, variations2):
+				self.assertSetEqual(set(v1.axes), set(v2.axes))
+				for axisTag, support1 in v1.axes.items():
+					support2 = v2.axes[axisTag]
+					self.assertEqual(len(support1), len(support2))
+					for s1, s2 in zip(support1, support2):
+						self.assertAlmostEqual(s1, s2)
+				self.assertEqual(v1.coordinates, v2.coordinates)
+
 	def makeFont(self, variations):
 		glyphs=[".notdef", "space", "I"]
 		Axis = getTableModule("fvar").Axis
@@ -163,7 +177,7 @@ class GVARTableTest(unittest.TestCase):
 	def test_decompile(self):
 		font, gvar = self.makeFont({})
 		gvar.decompile(GVAR_DATA, font)
-		self.assertEqual(gvar.variations, GVAR_VARIATIONS)
+		self.assertVariationsAlmostEqual(gvar.variations, GVAR_VARIATIONS)
 
 	def test_decompile_noVariations(self):
 		font, gvar = self.makeFont({})
@@ -175,8 +189,10 @@ class GVARTableTest(unittest.TestCase):
 		font, gvar = self.makeFont({})
 		for name, attrs, content in parseXML(GVAR_XML):
 			gvar.fromXML(name, attrs, content, ttFont=font)
-		self.assertEqual(gvar.variations,
-                         {g:v for g,v in GVAR_VARIATIONS.items() if v})
+		self.assertVariationsAlmostEqual(
+			gvar.variations,
+			{g:v for g,v in GVAR_VARIATIONS.items() if v}
+		)
 
 	def test_toXML(self):
 		font, gvar = self.makeFont(GVAR_VARIATIONS)

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -336,12 +336,12 @@ class InstantiateHVARTest(object):
                 {"wdth": -1.0},
                 [
                     {"wght": (-1.0, -1.0, 0.0)},
-                    {"wght": (0.0, 0.61, 1.0)},
-                    {"wght": (0.61, 1.0, 1.0)},
+                    {"wght": (0.0, 0.6099854, 1.0)},
+                    {"wght": (0.6099854, 1.0, 1.0)},
                 ],
                 [-11, 31, 51],
             ),
-            ({"wdth": 0}, [{"wght": (0.61, 1.0, 1.0)}], [-4]),
+            ({"wdth": 0}, [{"wght": (0.6099854, 1.0, 1.0)}], [-4]),
         ],
     )
     def test_partial_instance(self, varfont, location, expectedRegions, expectedDeltas):
@@ -353,7 +353,12 @@ class InstantiateHVARTest(object):
 
         regions = varStore.VarRegionList.Region
         fvarAxes = [a for a in varfont["fvar"].axes if a.axisTag not in location]
-        assert [reg.get_support(fvarAxes) for reg in regions] == expectedRegions
+        regionDicts = [reg.get_support(fvarAxes) for reg in regions]
+        assert len(regionDicts) == len(expectedRegions)
+        for region, expectedRegion in zip(regionDicts, expectedRegions):
+            assert region.keys() == expectedRegion.keys()
+            for axisTag, support in region.items():
+                assert support == pytest.approx(expectedRegion[axisTag])
 
         assert len(varStore.VarData) == 1
         assert varStore.VarData[0].ItemCount == 2


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/737

I changed `fixedToFloat` to NOT do any magic, simply return `value / (1 << precisionBits)`
The code of the previous fixedToFloat is now called `fixedToStr`, but returns a string and is used in `toXML` methods to write fixed-point numbers as compact decimal floats.

The function actually used in `toXML` methods is `floatToFixedToStr` (that in turn uses `fixedToStr`), because internally table objects store these fixed-point numbers as floats, not as integers.
But I still kept `fixedToStr` (and `strToFixed`) in `fixedTools` module, even though they are not used directly anywhere.

There is also a corresponding `strToFixedToFloat` that does the reverse and it's equivalent of doing `floatToFixedToFloat(float(string))`. This is used in `fromXML` methods to ensure that the internal un-rounded float values are the same whether a table was decompiled from binary (hence used `fixedToFloat`) or loaded from XML.

I updated all the calling sites accordingly, including `Fixed` and `F2Dot14` types in `otConverters`, fvar, avar, glyf, head, trak, TupleVariations and psCharStrings.

/cc @Lorp