### PR TITLE
[name] Handle duplicate name records with different `string` types

### DIFF
--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -459,22 +459,36 @@ class NameRecord(object):
 		if type(self) != type(other):
 			return NotImplemented
 
-		# implemented so that list.sort() sorts according to the spec.
-		selfTuple = (
-			getattr(self, "platformID", None),
-			getattr(self, "platEncID", None),
-			getattr(self, "langID", None),
-			getattr(self, "nameID", None),
-			getattr(self, "string", None),
-		)
-		otherTuple = (
-			getattr(other, "platformID", None),
-			getattr(other, "platEncID", None),
-			getattr(other, "langID", None),
-			getattr(other, "nameID", None),
-			getattr(other, "string", None),
-		)
-		return selfTuple < otherTuple
+		try:
+			# implemented so that list.sort() sorts according to the spec.
+			selfTuple = (
+				getattr(self, "platformID", None),
+				getattr(self, "platEncID", None),
+				getattr(self, "langID", None),
+				getattr(self, "nameID", None),
+				self.toBytes(),
+			)
+			otherTuple = (
+				getattr(other, "platformID", None),
+				getattr(other, "platEncID", None),
+				getattr(other, "langID", None),
+				getattr(other, "nameID", None),
+				other.toBytes(),
+			)
+			return selfTuple < otherTuple
+		except UnicodeEncodeError:
+			# This can only be reached if all IDs are identical but the strings
+			# can't be encoded for their platform encoding.
+			logging.warning(
+				"The name table contains multiple entries for platformID %d, "
+				"platEncID %d, langID %d, nameID %d with strings that cannot be "
+				"properly encoded.",
+				getattr(self, "platformID", None),
+				getattr(self, "platEncID", None),
+				getattr(self, "langID", None),
+				getattr(self, "nameID", None),
+			)
+			return NotImplemented
 
 	def __repr__(self):
 		return "<NameRecord NameID=%d; PlatformID=%d; LanguageID=%d>" % (

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -462,32 +462,28 @@ class NameRecord(object):
 		try:
 			# implemented so that list.sort() sorts according to the spec.
 			selfTuple = (
-				getattr(self, "platformID", None),
-				getattr(self, "platEncID", None),
-				getattr(self, "langID", None),
-				getattr(self, "nameID", None),
+				self.platformID,
+				self.platEncID,
+				self.langID,
+				self.nameID,
 				self.toBytes(),
 			)
 			otherTuple = (
-				getattr(other, "platformID", None),
-				getattr(other, "platEncID", None),
-				getattr(other, "langID", None),
-				getattr(other, "nameID", None),
+				other.platformID,
+				other.platEncID,
+				other.langID,
+				other.nameID,
 				other.toBytes(),
 			)
 			return selfTuple < otherTuple
-		except UnicodeEncodeError:
-			# This can only be reached if all IDs are identical but the strings
-			# can't be encoded for their platform encoding.
-			logging.warning(
-				"The name table contains multiple entries for platformID %d, "
-				"platEncID %d, langID %d, nameID %d with strings that cannot be "
-				"properly encoded.",
-				getattr(self, "platformID", None),
-				getattr(self, "platEncID", None),
-				getattr(self, "langID", None),
-				getattr(self, "nameID", None),
-			)
+		except (UnicodeEncodeError, AttributeError):
+			# This can only happen for
+			# 1) an object that is not a NameRecord, or
+			# 2) an unlikely incomplete NameRecord object which has not been
+			#    fully populated, or
+			# 3) when all IDs are identical but the strings can't be encoded
+			#    for their platform encoding.
+			# In all cases it is best to return NotImplemented.
 			return NotImplemented
 
 	def __repr__(self):

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -70,12 +70,8 @@ class NameTableTest(unittest.TestCase):
 			makeName("Test寬", 25, 1, 0, 0),
 			makeName("Test鬆鬆", 25, 1, 0, 0),
 		]
-		with CapturingLogHandler(log, "WARNING") as captor:
-			with self.assertRaises(TypeError):
-				table.names.sort()
-		self.assertTrue(
-			all("cannot be properly encoded" in r.msg for r in captor.records)
-		)
+		with self.assertRaises(TypeError):
+			table.names.sort()
 
 	def test_addName(self):
 		table = table__n_a_m_e()

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -53,6 +53,30 @@ class NameTableTest(unittest.TestCase):
 		with self.assertRaises(TypeError):
 			table.setName(1.000, 5, 1, 0, 0)
 
+	def test_names_sort_bytes_str(self):
+		# Corner case: If a user appends a name record directly to `names`, the
+		# `__lt__` method on NameRecord may run into duplicate name records where
+		# one `string` is a str and the other one bytes, leading to an exception.
+		table = table__n_a_m_e()
+		table.names = [
+			makeName("Test", 25, 3, 1, 0x409),
+			makeName("Test".encode("utf-16be"), 25, 3, 1, 0x409),
+		]
+		table.compile(None)
+
+	def test_names_sort_bytes_str_encoding_error(self):
+		table = table__n_a_m_e()
+		table.names = [
+			makeName("Test寬", 25, 1, 0, 0),
+			makeName("Test鬆鬆", 25, 1, 0, 0),
+		]
+		with CapturingLogHandler(log, "WARNING") as captor:
+			with self.assertRaises(TypeError):
+				table.names.sort()
+		self.assertTrue(
+			all("cannot be properly encoded" in r.msg for r in captor.records)
+		)
+
 	def test_addName(self):
 		table = table__n_a_m_e()
 		nameIDs = []


### PR DESCRIPTION
Found this one when I tried to add a name ID 25 string (type `str`) to a font that already had one (type `bytes`) and overlooked the `setName` method. Turns out there is no sanitization when you append name records manually to the `names` list.