### PR TITLE
enforce VarStore RegionAxisCount == fvar.AxisCount

### DIFF
--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -498,6 +498,11 @@ class OTTableWriter(object):
 		return OverflowErrorRecord( (self.tableTag, LookupListIndex, SubTableIndex, itemName, itemIndex) )
 
 
+class LiteralCount(int):
+	"""A count value that should be taken literally, rather than recomputed on compile."""
+	pass
+
+
 class CountReference(object):
 	"""A reference to a Count value, not a count of references."""
 	def __init__(self, table, name, size=None, value=None):
@@ -690,8 +695,12 @@ class BaseTable(object):
 				# table. We will later store it here.
 				# We add a reference: by the time the data is assembled
 				# the Count value will be filled in.
-				ref = writer.writeCountReference(table, conv.name, conv.staticSize)
-				table[conv.name] = None
+				if not isinstance(value, LiteralCount):
+					# we ignore the current count value since it's being recomputed,
+					# unless this is a LiteralCount, which is assumed to be already correct.
+					value = None
+				ref = writer.writeCountReference(table, conv.name, conv.staticSize, value)
+				table[conv.name] = value
 				if conv.isPropagated:
 					writer[conv.name] = ref
 			elif conv.isLookupType:

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -498,7 +498,7 @@ class OTTableWriter(object):
 		return OverflowErrorRecord( (self.tableTag, LookupListIndex, SubTableIndex, itemName, itemIndex) )
 
 
-class LiteralCount(int):
+class StaticCount(int):
 	"""A count value that should be taken literally, rather than recomputed on compile."""
 	pass
 
@@ -695,9 +695,9 @@ class BaseTable(object):
 				# table. We will later store it here.
 				# We add a reference: by the time the data is assembled
 				# the Count value will be filled in.
-				if not isinstance(value, LiteralCount):
+				if not isinstance(value, StaticCount):
 					# we ignore the current count value since it's being recomputed,
-					# unless this is a LiteralCount, which is assumed to be already correct.
+					# unless this is of type StaticCount, which is assumed to be correct.
 					value = None
 				ref = writer.writeCountReference(table, conv.name, conv.staticSize, value)
 				table[conv.name] = value

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -7,7 +7,7 @@ converter objects from otConverters.py.
 """
 from fontTools.misc.py23 import *
 from fontTools.misc.textTools import pad, safeEval
-from .otBase import BaseTable, FormatSwitchingBaseTable, ValueRecord
+from .otBase import BaseTable, FormatSwitchingBaseTable, ValueRecord, LiteralCount
 import logging
 import struct
 
@@ -685,6 +685,22 @@ class VarIdxMap(BaseTable):
 		inner = safeEval(attrs['inner'])
 		assert inner <= 0xFFFF
 		mapping[glyph] = (outer << 16) | inner
+
+
+class VarRegionList(BaseTable):
+
+	def preWrite(self, font):
+		# The OT spec says VarStore.VarRegionList.RegionAxisCount should always
+		# be equal to the fvar.axisCount, and OTS < v8.0.0 enforces this rule
+		# even when the VarRegionList is empty. We can't treat RegionAxisCount
+		# like a normal propagated count (== len(Region[i].VarRegionAxis)),
+		# otherwise it would default to 0 if VarRegionList is empty.
+		# Thus, we force it to always be equal to fvar.axisCount.
+		# https://github.com/khaledhosny/ots/pull/192
+		fvarTable = font.get("fvar")
+		if fvarTable:
+			self.RegionAxisCount = LiteralCount(len(fvarTable.axes))
+		return self.__dict__.copy()
 
 
 class SingleSubst(FormatSwitchingBaseTable):

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -7,7 +7,7 @@ converter objects from otConverters.py.
 """
 from fontTools.misc.py23 import *
 from fontTools.misc.textTools import pad, safeEval
-from .otBase import BaseTable, FormatSwitchingBaseTable, ValueRecord, StaticCount
+from .otBase import BaseTable, FormatSwitchingBaseTable, ValueRecord, CountReference
 import logging
 import struct
 
@@ -699,8 +699,11 @@ class VarRegionList(BaseTable):
 		# https://github.com/khaledhosny/ots/pull/192
 		fvarTable = font.get("fvar")
 		if fvarTable:
-			self.RegionAxisCount = StaticCount(len(fvarTable.axes))
-		return self.__dict__.copy()
+			self.RegionAxisCount = len(fvarTable.axes)
+		return {
+			**self.__dict__,
+			"RegionAxisCount": CountReference(self.__dict__, "RegionAxisCount")
+		}
 
 
 class SingleSubst(FormatSwitchingBaseTable):

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -7,7 +7,7 @@ converter objects from otConverters.py.
 """
 from fontTools.misc.py23 import *
 from fontTools.misc.textTools import pad, safeEval
-from .otBase import BaseTable, FormatSwitchingBaseTable, ValueRecord, LiteralCount
+from .otBase import BaseTable, FormatSwitchingBaseTable, ValueRecord, StaticCount
 import logging
 import struct
 
@@ -699,7 +699,7 @@ class VarRegionList(BaseTable):
 		# https://github.com/khaledhosny/ots/pull/192
 		fvarTable = font.get("fvar")
 		if fvarTable:
-			self.RegionAxisCount = LiteralCount(len(fvarTable.axes))
+			self.RegionAxisCount = StaticCount(len(fvarTable.axes))
 		return self.__dict__.copy()
 
 

--- a/Tests/varLib/data/SingleMaster.designspace
+++ b/Tests/varLib/data/SingleMaster.designspace
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="3">
+    <axes>
+        <axis default="400" maximum="400" minimum="400" name="weight" tag="wght" />
+    </axes>
+    <sources>
+        <source familyname="Test Family" filename="master_ufo/TestFamily-Master0.ufo" name="master_0">
+            <location>
+                <dimension name="weight" xvalue="400" />
+            </location>
+        </source>
+    </sources>
+</designspace>

--- a/Tests/varLib/data/test_results/SingleMaster.ttx
+++ b/Tests/varLib/data/test_results/SingleMaster.ttx
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.0">
+
+  <GDEF>
+    <Version value="0x00010003"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="uni0024" class="1"/>
+      <ClassDef glyph="uni0024.nostroke" class="1"/>
+      <ClassDef glyph="uni0041" class="1"/>
+      <ClassDef glyph="uni0061" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=0 -->
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=6 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+        <Item index="1" value="[]"/>
+        <Item index="2" value="[]"/>
+        <Item index="3" value="[]"/>
+        <Item index="4" value="[]"/>
+        <Item index="5" value="[]"/>
+      </VarData>
+    </VarStore>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=1 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisOrdering value="0"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=0 -->
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
+
+  <fvar>
+
+    <!-- Weight -->
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>400.0</MinValue>
+      <DefaultValue>400.0</DefaultValue>
+      <MaxValue>400.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+  </fvar>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Test Family
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      Version 1.001;ADBO;Test Family Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Test Family
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.001
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      TestFamily-Master0
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Frank Grießhammer
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      Master 0
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+  </name>
+
+</ttFont>

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -584,6 +584,15 @@ class BuildTest(unittest.TestCase):
         self.expect_ttx(varfont, expected_ttx_path, tables)
         self.check_ttx_dump(varfont, expected_ttx_path, tables, suffix)
 
+    def test_varlib_build_single_master(self):
+        self._run_varlib_build_test(
+            designspace_name='SingleMaster',
+            font_name='TestFamily',
+            tables=['GDEF', 'HVAR', 'MVAR', 'STAT', 'fvar', 'cvar', 'gvar', 'name'],
+            expected_ttx_name='SingleMaster',
+            save_before_dump=True,
+        )
+
     def test_kerning_merging(self):
         """Test the correct merging of class-based pair kerning.
 


### PR DESCRIPTION
... even when the ItemVariationStore contains no Regions and thus we can't take the length of their VarRegionAxis arrays.

This is to appease older versions of OTS (< 8.0.0) which blindly enforce this rule and reject a VF that has, e.g., an empty HVAR table with no regions when the HVAR.VarStore.VarRegionList.RegionAxisCount != fvar.AxisCount.

Fixes https://github.com/fonttools/fonttools/issues/1670

Related:
https://github.com/fonttools/fonttools/pull/1671
https://github.com/googlefonts/fontmake/issues/565
https://github.com/khaledhosny/ots/pull/192