### PR TITLE
[varLib.instancer] implement restricting axis ranges (aka L3) 

### DIFF
--- a/Lib/fontTools/misc/fixedTools.py
+++ b/Lib/fontTools/misc/fixedTools.py
@@ -21,6 +21,11 @@ __all__ = [
 ]
 
 
+# the max value that can still fit in an F2Dot14:
+# 1.99993896484375
+MAX_F2DOT14 = 0x7FFF / (1 << 14)
+
+
 def otRound(value):
 	"""Round float value to nearest integer towards +Infinity.
 	For fractional values of 0.5 and higher, take the next higher integer;

--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -1,5 +1,6 @@
 from fontTools.misc.py23 import *
 from array import array
+from fontTools.misc.fixedTools import MAX_F2DOT14
 from fontTools.pens.basePen import LoggingPen
 from fontTools.pens.transformPen import TransformPen
 from fontTools.ttLib.tables import ttProgram
@@ -9,11 +10,6 @@ from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 
 
 __all__ = ["TTGlyphPen"]
-
-
-# the max value that can still fit in an F2Dot14:
-# 1.99993896484375
-MAX_F2DOT14 = 0x7FFF / (1 << 14)
 
 
 class TTGlyphPen(LoggingPen):

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -733,10 +733,6 @@ def _limitFeatureVariationConditionRange(condition, axisRange):
             newValue = 0
         values[i] = newValue
 
-    # TODO(anthrotype): Is (0,0) condition supposed to be applied ever? Ask Behdad
-    # if not any(values):
-    #     return
-
     return AxisRange(*values)
 
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -4,16 +4,17 @@ The module exports an `instantiateVariableFont` function and CLI that allow to
 create full instances (i.e. static fonts) from variable fonts, as well as "partial"
 variable fonts that only contain a subset of the original variation space.
 
-For example, if you wish to pin the width axis to a given location while keeping
-the rest of the axes, you can do:
+For example, if you wish to pin the width axis to a given location while also
+restricting the weight axis to 400..700 range, you can do:
 
-$ fonttools varLib.instancer ./NotoSans-VF.ttf wdth=85
+$ fonttools varLib.instancer ./NotoSans-VF.ttf wdth=85 wght=400:700
 
 See `fonttools varLib.instancer --help` for more info on the CLI options.
 
 The module's entry point is the `instantiateVariableFont` function, which takes
-a TTFont object and a dict specifying a location along either some or all the axes,
-and returns a new TTFont representing respectively a partial or a full instance.
+a TTFont object and a dict specifying either axis coodinates or (min, max) ranges,
+and returns a new TTFont representing either a partial VF, or full instance if all
+the VF axes were given an explicit coordinate.
 
 E.g. here's how to pin the wght axis at a given location in a wght+wdth variable
 font, keeping only the deltas associated with the wdth axis:
@@ -50,7 +51,7 @@ Note that, unlike varLib.mutator, when an axis is not mentioned in the input
 location, the varLib.instancer will keep the axis and the corresponding deltas,
 whereas mutator implicitly drops the axis at its default coordinate.
 
-The module currently supports only the first two "levels" of partial instancing,
+The module currently supports only the first three "levels" of partial instancing,
 with the rest planned to be implemented in the future, namely:
 L1) dropping one or more axes while leaving the default tables unmodified;
 L2) dropping one or more axes while pinning them at non-default locations;

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -158,10 +158,10 @@ def instantiateTupleVariationStore(
         axisLimits, rangeType=NormalizedAxisRange
     )
 
+    newVariations = variations
+
     if pinnedLocation:
         newVariations = pinTupleVariationAxes(variations, pinnedLocation)
-    else:
-        newVariations = variations
 
     if axisRanges:
         newVariations = limitTupleVariationAxisRanges(newVariations, axisRanges)
@@ -871,6 +871,8 @@ def _isValidAvarSegmentMap(axisTag, segmentMap):
 
 
 def instantiateAvar(varfont, axisLimits):
+    # 'axisLimits' dict must contain user-space (non-normalized) coordinates.
+
     location, axisRanges = splitAxisLocationAndRanges(axisLimits)
 
     segments = varfont["avar"].segments
@@ -887,6 +889,12 @@ def instantiateAvar(varfont, axisLimits):
         if axis in segments:
             del segments[axis]
 
+    # First compute the default normalization for axisRanges coordinates: i.e.
+    # min = -1.0, default = 0, max = +1.0, and in between values interpolated linearly,
+    # without using the avar table's mappings.
+    # Then, for each axis' SegmentMap, if we are restricting its, compute the new
+    # mappings by dividing the key/value pairs by the desired new min/max values,
+    # dropping any mappings that fall outside the restricted range.
     normalizedRanges = normalizeAxisLimits(varfont, axisRanges, usingAvar=False)
     newSegments = {}
     for axisTag, mapping in segments.items():

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -467,8 +467,6 @@ def _instantiateVHVAR(varfont, axisLimits, tableFields):
                 _remapVarIdxMap(
                     vhvar, tableFields.vOrigMapping, varIndexMapping, glyphOrder
                 )
-    else:
-        del varfont[tableTag]
 
 
 def instantiateHVAR(varfont, location):

--- a/Tests/varLib/data/PartialInstancerTest2-VF.ttx
+++ b/Tests/varLib/data/PartialInstancerTest2-VF.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.41">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.0">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -14,16 +14,16 @@
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
     <fontRevision value="2.001"/>
-    <checkSumAdjustment value="0x6b1f158e"/>
+    <checkSumAdjustment value="0x605c3e60"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000011"/>
     <unitsPerEm value="1000"/>
     <created value="Tue Mar 15 19:50:39 2016"/>
-    <modified value="Tue May 21 16:23:19 2019"/>
-    <xMin value="-621"/>
-    <yMin value="-389"/>
-    <xMax value="2800"/>
-    <yMax value="1067"/>
+    <modified value="Thu Oct 17 14:43:10 2019"/>
+    <xMin value="0"/>
+    <yMin value="0"/>
+    <xMax value="638"/>
+    <yMax value="944"/>
     <macStyle value="00000000 00000000"/>
     <lowestRecPPEM value="6"/>
     <fontDirectionHint value="2"/>
@@ -36,10 +36,10 @@
     <ascent value="1069"/>
     <descent value="-293"/>
     <lineGap value="0"/>
-    <advanceWidthMax value="2840"/>
-    <minLeftSideBearing value="-621"/>
-    <minRightSideBearing value="-620"/>
-    <xMaxExtent value="2800"/>
+    <advanceWidthMax value="639"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="1"/>
+    <xMaxExtent value="638"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
@@ -55,10 +55,10 @@
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="0x10000"/>
     <numGlyphs value="5"/>
-    <maxPoints value="202"/>
-    <maxContours value="24"/>
-    <maxCompositePoints value="315"/>
-    <maxCompositeContours value="21"/>
+    <maxPoints value="19"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="32"/>
+    <maxCompositeContours value="3"/>
     <maxZones value="1"/>
     <maxTwilightPoints value="0"/>
     <maxStorage value="0"/>
@@ -66,8 +66,8 @@
     <maxInstructionDefs value="0"/>
     <maxStackElements value="0"/>
     <maxSizeOfInstructions value="0"/>
-    <maxComponentElements value="8"/>
-    <maxComponentDepth value="8"/>
+    <maxComponentElements value="2"/>
+    <maxComponentDepth value="1"/>
   </maxp>
 
   <OS_2>
@@ -107,8 +107,8 @@
     <ulUnicodeRange4 value="00000000 00010000 00000000 00000000"/>
     <achVendID value="GOOG"/>
     <fsSelection value="00000001 01000000"/>
-    <usFirstCharIndex value="0"/>
-    <usLastCharIndex value="65533"/>
+    <usFirstCharIndex value="65"/>
+    <usLastCharIndex value="192"/>
     <sTypoAscender value="1069"/>
     <sTypoDescender value="-293"/>
     <sTypoLineGap value="0"/>
@@ -1037,15 +1037,104 @@
       <Axis index="0">
         <AxisTag value="wght"/>
         <AxisNameID value="256"/>  <!-- Weight -->
-        <AxisOrdering value="0"/>
+        <AxisOrdering value="1"/>
       </Axis>
       <Axis index="1">
         <AxisTag value="wdth"/>
         <AxisNameID value="257"/>  <!-- Width -->
-        <AxisOrdering value="1"/>
+        <AxisOrdering value="0"/>
       </Axis>
     </DesignAxisRecord>
-    <!-- AxisValueCount=0 -->
+    <!-- AxisValueCount=13 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="258"/>  <!-- Thin -->
+        <Value value="100.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="259"/>  <!-- ExtraLight -->
+        <Value value="200.0"/>
+      </AxisValue>
+      <AxisValue index="2" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="260"/>  <!-- Light -->
+        <Value value="300.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="3">
+        <AxisIndex value="0"/>
+        <Flags value="2"/>
+        <ValueNameID value="261"/>  <!-- Regular -->
+        <Value value="400.0"/>
+        <LinkedValue value="700.0"/>
+      </AxisValue>
+      <AxisValue index="4" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="262"/>  <!-- Medium -->
+        <Value value="500.0"/>
+      </AxisValue>
+      <AxisValue index="5" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="263"/>  <!-- SemiBold -->
+        <Value value="600.0"/>
+      </AxisValue>
+      <AxisValue index="6" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="264"/>  <!-- Bold -->
+        <Value value="700.0"/>
+      </AxisValue>
+      <AxisValue index="7" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="265"/>  <!-- ExtraBold -->
+        <Value value="800.0"/>
+      </AxisValue>
+      <AxisValue index="8" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="266"/>  <!-- Black -->
+        <Value value="900.0"/>
+      </AxisValue>
+      <AxisValue index="9" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="2"/>
+        <ValueNameID value="261"/>  <!-- Regular -->
+        <NominalValue value="100.0"/>
+        <RangeMinValue value="93.75"/>
+        <RangeMaxValue value="100.0"/>
+      </AxisValue>
+      <AxisValue index="10" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="270"/>  <!-- SemiCondensed -->
+        <NominalValue value="87.5"/>
+        <RangeMinValue value="81.25"/>
+        <RangeMaxValue value="93.75"/>
+      </AxisValue>
+      <AxisValue index="11" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="279"/>  <!-- Condensed -->
+        <NominalValue value="75.0"/>
+        <RangeMinValue value="68.75"/>
+        <RangeMaxValue value="81.25"/>
+      </AxisValue>
+      <AxisValue index="12" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="288"/>  <!-- ExtraCondensed -->
+        <NominalValue value="62.5"/>
+        <RangeMinValue value="62.5"/>
+        <RangeMaxValue value="68.75"/>
+      </AxisValue>
+    </AxisValueArray>
     <ElidedFallbackNameID value="2"/>  <!-- Regular -->
   </STAT>
 

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-100,100.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-100,100.ttx
@@ -14,12 +14,12 @@
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
     <fontRevision value="2.001"/>
-    <checkSumAdjustment value="0x982d27a8"/>
+    <checkSumAdjustment value="0x90f1c28"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000011"/>
     <unitsPerEm value="1000"/>
     <created value="Tue Mar 15 19:50:39 2016"/>
-    <modified value="Tue May 21 16:23:19 2019"/>
+    <modified value="Thu Oct 17 14:43:10 2019"/>
     <xMin value="0"/>
     <yMin value="0"/>
     <xMax value="577"/>
@@ -238,6 +238,18 @@
   </glyf>
 
   <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Thin
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
     <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
       Copyright 2015 Google Inc. All Rights Reserved.
     </namerecord>
@@ -282,6 +294,18 @@
     </namerecord>
     <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
       http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      Thin
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      Regular
     </namerecord>
   </name>
 
@@ -480,5 +504,41 @@
       <!-- LookupCount=0 -->
     </LookupList>
   </GSUB>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=2 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="257"/>  <!-- Width -->
+        <AxisOrdering value="0"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=2 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="258"/>  <!-- Thin -->
+        <Value value="100.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="2"/>
+        <ValueNameID value="261"/>  <!-- Regular -->
+        <NominalValue value="100.0"/>
+        <RangeMinValue value="93.75"/>
+        <RangeMaxValue value="100.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
 
 </ttFont>

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-100,62.5.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-100,62.5.ttx
@@ -14,12 +14,12 @@
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
     <fontRevision value="2.001"/>
-    <checkSumAdjustment value="0x1d4f3a2e"/>
+    <checkSumAdjustment value="0x31525751"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000011"/>
     <unitsPerEm value="1000"/>
     <created value="Tue Mar 15 19:50:39 2016"/>
-    <modified value="Tue May 21 16:23:19 2019"/>
+    <modified value="Thu Oct 17 14:43:10 2019"/>
     <xMin value="0"/>
     <yMin value="0"/>
     <xMax value="496"/>
@@ -238,6 +238,18 @@
   </glyf>
 
   <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Thin
+    </namerecord>
+    <namerecord nameID="288" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      ExtraCondensed
+    </namerecord>
     <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
       Copyright 2015 Google Inc. All Rights Reserved.
     </namerecord>
@@ -282,6 +294,18 @@
     </namerecord>
     <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
       http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      Thin
+    </namerecord>
+    <namerecord nameID="288" platformID="3" platEncID="1" langID="0x409">
+      ExtraCondensed
     </namerecord>
   </name>
 
@@ -480,5 +504,41 @@
       <!-- LookupCount=0 -->
     </LookupList>
   </GSUB>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=2 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="257"/>  <!-- Width -->
+        <AxisOrdering value="0"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=2 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="258"/>  <!-- Thin -->
+        <Value value="100.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="288"/>  <!-- ExtraCondensed -->
+        <NominalValue value="62.5"/>
+        <RangeMinValue value="62.5"/>
+        <RangeMaxValue value="68.75"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
 
 </ttFont>

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-400,100.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-400,100.ttx
@@ -14,12 +14,12 @@
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
     <fontRevision value="2.001"/>
-    <checkSumAdjustment value="0xf43664b4"/>
+    <checkSumAdjustment value="0x4b2d3480"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000011"/>
     <unitsPerEm value="1000"/>
     <created value="Tue Mar 15 19:50:39 2016"/>
-    <modified value="Tue May 21 16:23:19 2019"/>
+    <modified value="Thu Oct 17 14:43:10 2019"/>
     <xMin value="0"/>
     <yMin value="0"/>
     <xMax value="638"/>
@@ -238,6 +238,15 @@
   </glyf>
 
   <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
     <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
       Copyright 2015 Google Inc. All Rights Reserved.
     </namerecord>
@@ -282,6 +291,15 @@
     </namerecord>
     <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
       http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      Regular
     </namerecord>
   </name>
 
@@ -480,5 +498,42 @@
       <!-- LookupCount=0 -->
     </LookupList>
   </GSUB>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=2 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="257"/>  <!-- Width -->
+        <AxisOrdering value="0"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=2 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="3">
+        <AxisIndex value="0"/>
+        <Flags value="2"/>
+        <ValueNameID value="261"/>  <!-- Regular -->
+        <Value value="400.0"/>
+        <LinkedValue value="700.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="2"/>
+        <ValueNameID value="261"/>  <!-- Regular -->
+        <NominalValue value="100.0"/>
+        <RangeMinValue value="93.75"/>
+        <RangeMaxValue value="100.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
 
 </ttFont>

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-400,62.5.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-400,62.5.ttx
@@ -14,12 +14,12 @@
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
     <fontRevision value="2.001"/>
-    <checkSumAdjustment value="0xd9290bac"/>
+    <checkSumAdjustment value="0x39ab2622"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000011"/>
     <unitsPerEm value="1000"/>
     <created value="Tue Mar 15 19:50:39 2016"/>
-    <modified value="Tue May 21 16:23:19 2019"/>
+    <modified value="Thu Oct 17 14:43:10 2019"/>
     <xMin value="0"/>
     <yMin value="0"/>
     <xMax value="496"/>
@@ -238,6 +238,18 @@
   </glyf>
 
   <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="288" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      ExtraCondensed
+    </namerecord>
     <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
       Copyright 2015 Google Inc. All Rights Reserved.
     </namerecord>
@@ -282,6 +294,18 @@
     </namerecord>
     <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
       http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="288" platformID="3" platEncID="1" langID="0x409">
+      ExtraCondensed
     </namerecord>
   </name>
 
@@ -480,5 +504,42 @@
       <!-- LookupCount=0 -->
     </LookupList>
   </GSUB>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=2 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="257"/>  <!-- Width -->
+        <AxisOrdering value="0"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=2 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="3">
+        <AxisIndex value="0"/>
+        <Flags value="2"/>
+        <ValueNameID value="261"/>  <!-- Regular -->
+        <Value value="400.0"/>
+        <LinkedValue value="700.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="288"/>  <!-- ExtraCondensed -->
+        <NominalValue value="62.5"/>
+        <RangeMinValue value="62.5"/>
+        <RangeMaxValue value="68.75"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
 
 </ttFont>

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-900,100.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-900,100.ttx
@@ -14,12 +14,12 @@
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
     <fontRevision value="2.001"/>
-    <checkSumAdjustment value="0xa514fda"/>
+    <checkSumAdjustment value="0x7b5e7903"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000011"/>
     <unitsPerEm value="1000"/>
     <created value="Tue Mar 15 19:50:39 2016"/>
-    <modified value="Tue May 21 16:23:19 2019"/>
+    <modified value="Thu Oct 17 14:43:10 2019"/>
     <xMin value="0"/>
     <yMin value="0"/>
     <xMax value="726"/>
@@ -238,6 +238,18 @@
   </glyf>
 
   <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="261" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="266" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Black
+    </namerecord>
     <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
       Copyright 2015 Google Inc. All Rights Reserved.
     </namerecord>
@@ -282,6 +294,18 @@
     </namerecord>
     <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
       http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      Black
     </namerecord>
   </name>
 
@@ -480,5 +504,41 @@
       <!-- LookupCount=0 -->
     </LookupList>
   </GSUB>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=2 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="257"/>  <!-- Width -->
+        <AxisOrdering value="0"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=2 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="266"/>  <!-- Black -->
+        <Value value="900.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="2"/>
+        <ValueNameID value="261"/>  <!-- Regular -->
+        <NominalValue value="100.0"/>
+        <RangeMinValue value="93.75"/>
+        <RangeMaxValue value="100.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
 
 </ttFont>

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-900,62.5.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-900,62.5.ttx
@@ -14,12 +14,12 @@
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
     <fontRevision value="2.001"/>
-    <checkSumAdjustment value="0xc8e8b846"/>
+    <checkSumAdjustment value="0x7f9149e4"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000011"/>
     <unitsPerEm value="1000"/>
     <created value="Tue Mar 15 19:50:39 2016"/>
-    <modified value="Tue May 21 16:23:19 2019"/>
+    <modified value="Thu Oct 17 14:43:10 2019"/>
     <xMin value="0"/>
     <yMin value="0"/>
     <xMax value="574"/>
@@ -238,6 +238,18 @@
   </glyf>
 
   <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Width
+    </namerecord>
+    <namerecord nameID="266" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Black
+    </namerecord>
+    <namerecord nameID="288" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      ExtraCondensed
+    </namerecord>
     <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
       Copyright 2015 Google Inc. All Rights Reserved.
     </namerecord>
@@ -282,6 +294,18 @@
     </namerecord>
     <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
       http://scripts.sil.org/OFL
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Width
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      Black
+    </namerecord>
+    <namerecord nameID="288" platformID="3" platEncID="1" langID="0x409">
+      ExtraCondensed
     </namerecord>
   </name>
 
@@ -480,5 +504,41 @@
       <!-- LookupCount=0 -->
     </LookupList>
   </GSUB>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=2 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisOrdering value="1"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="wdth"/>
+        <AxisNameID value="257"/>  <!-- Width -->
+        <AxisOrdering value="0"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=2 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="266"/>  <!-- Black -->
+        <Value value="900.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="2">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="288"/>  <!-- ExtraCondensed -->
+        <NominalValue value="62.5"/>
+        <RangeMinValue value="62.5"/>
+        <RangeMaxValue value="68.75"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
 
 </ttFont>

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -382,6 +382,26 @@ class InstantiateHVARTest(object):
 
         assert "HVAR" not in varfont
 
+    def test_partial_instance_keep_empty_table(self, varfont):
+        # Append an additional dummy axis to fvar, for which the current HVAR table
+        # in our test 'varfont' contains no variation data.
+        # Instancing the other two wght and wdth axes should leave HVAR table empty,
+        # to signal there are variations to the glyph's advance widths.
+        fvar = varfont["fvar"]
+        axis = _f_v_a_r.Axis()
+        axis.axisTag = "TEST"
+        fvar.axes.append(axis)
+
+        instancer.instantiateHVAR(varfont, {"wght": 0, "wdth": 0})
+
+        assert "HVAR" in varfont
+
+        varStore = varfont["HVAR"].table.VarStore
+
+        assert varStore.VarRegionList.RegionCount == 0
+        assert not varStore.VarRegionList.Region
+        assert varStore.VarRegionList.RegionAxisCount == 1
+
 
 class InstantiateItemVariationStoreTest(object):
     def test_VarRegion_get_support(self):

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1852,6 +1852,11 @@ def test_normalizeAxisLimits_tuple(varfont):
     assert normalized == {"wght": (-1.0, 0)}
 
 
+def test_normalizeAxisLimits_unsupported_range(varfont):
+    with pytest.raises(NotImplementedError, match="Unsupported range"):
+        instancer.normalizeAxisLimits(varfont, {"wght": (401, 700)})
+
+
 def test_normalizeAxisLimits_no_avar(varfont):
     del varfont["avar"]
 

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1,4 +1,5 @@
 from fontTools.misc.py23 import *
+from fontTools.misc.fixedTools import floatToFixedToFloat
 from fontTools import ttLib
 from fontTools import designspaceLib
 from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
@@ -493,32 +494,39 @@ class TupleVarStoreAdapterTest(object):
             [TupleVariation({"wdth": (-1.0, -1.0, 0)}, [-12, 8])],
         ]
 
-    def test_dropAxes(self):
+    def test_rebuildRegions(self):
         regions = [
             {"wght": (-1.0, -1.0, 0)},
             {"wght": (0.0, 1.0, 1.0)},
             {"wdth": (-1.0, -1.0, 0)},
-            {"opsz": (0.0, 1.0, 1.0)},
             {"wght": (-1.0, -1.0, 0), "wdth": (-1.0, -1.0, 0)},
-            {"wght": (0, 0.5, 1.0), "wdth": (-1.0, -1.0, 0)},
-            {"wght": (0.5, 1.0, 1.0), "wdth": (-1.0, -1.0, 0)},
+            {"wght": (0, 1.0, 1.0), "wdth": (-1.0, -1.0, 0)},
         ]
-        axisOrder = ["wght", "wdth", "opsz"]
-        adapter = instancer._TupleVarStoreAdapter(regions, axisOrder, [], itemCounts=[])
+        axisOrder = ["wght", "wdth"]
+        variations = []
+        for region in regions:
+            variations.append(TupleVariation(region, [100]))
+        tupleVarData = [variations[:3], variations[3:]]
+        adapter = instancer._TupleVarStoreAdapter(
+            regions, axisOrder, tupleVarData, itemCounts=[1, 1]
+        )
 
-        adapter.dropAxes({"wdth"})
+        adapter.rebuildRegions()
+
+        assert adapter.regions == regions
+
+        del tupleVarData[0][2]
+        tupleVarData[1][0].axes = {"wght": (-1.0, -0.5, 0)}
+        tupleVarData[1][1].axes = {"wght": (0, 0.5, 1.0)}
+
+        adapter.rebuildRegions()
 
         assert adapter.regions == [
             {"wght": (-1.0, -1.0, 0)},
             {"wght": (0.0, 1.0, 1.0)},
-            {"opsz": (0.0, 1.0, 1.0)},
-            {"wght": (0.0, 0.5, 1.0)},
-            {"wght": (0.5, 1.0, 1.0)},
+            {"wght": (-1.0, -0.5, 0)},
+            {"wght": (0, 0.5, 1.0)},
         ]
-
-        adapter.dropAxes({"wght", "opsz"})
-
-        assert adapter.regions == []
 
     def test_roundtrip(self, fvarAxes):
         regions = [
@@ -924,6 +932,208 @@ class InstantiateAvarTest(object):
 
         assert "avar" not in varfont
 
+    @staticmethod
+    def quantizeF2Dot14Floats(mapping):
+        return {
+            floatToFixedToFloat(k, 14): floatToFixedToFloat(v, 14)
+            for k, v in mapping.items()
+        }
+
+    # the following values come from NotoSans-VF.ttf
+    DFLT_WGHT_MAPPING = {
+        -1.0: -1.0,
+        -0.6667: -0.7969,
+        -0.3333: -0.5,
+        0: 0,
+        0.2: 0.18,
+        0.4: 0.38,
+        0.6: 0.61,
+        0.8: 0.79,
+        1.0: 1.0,
+    }
+
+    DFLT_WDTH_MAPPING = {-1.0: -1.0, -0.6667: -0.7, -0.3333: -0.36664, 0: 0, 1.0: 1.0}
+
+    @pytest.fixture
+    def varfont(self):
+        fvarAxes = ("wght", (100, 400, 900)), ("wdth", (62.5, 100, 100))
+        avarSegments = {
+            "wght": self.quantizeF2Dot14Floats(self.DFLT_WGHT_MAPPING),
+            "wdth": self.quantizeF2Dot14Floats(self.DFLT_WDTH_MAPPING),
+        }
+        varfont = ttLib.TTFont()
+        varfont["name"] = ttLib.newTable("name")
+        varLib._add_fvar(varfont, _makeDSAxesDict(fvarAxes), instances=())
+        avar = varfont["avar"] = ttLib.newTable("avar")
+        avar.segments = avarSegments
+        return varfont
+
+    @pytest.mark.parametrize(
+        "axisLimits, expectedSegments",
+        [
+            pytest.param(
+                {"wght": (100, 900)},
+                {"wght": DFLT_WGHT_MAPPING, "wdth": DFLT_WDTH_MAPPING},
+                id="wght=100:900",
+            ),
+            pytest.param(
+                {"wght": (400, 900)},
+                {
+                    "wght": {
+                        -1.0: -1.0,
+                        0: 0,
+                        0.2: 0.18,
+                        0.4: 0.38,
+                        0.6: 0.61,
+                        0.8: 0.79,
+                        1.0: 1.0,
+                    },
+                    "wdth": DFLT_WDTH_MAPPING,
+                },
+                id="wght=400:900",
+            ),
+            pytest.param(
+                {"wght": (100, 400)},
+                {
+                    "wght": {
+                        -1.0: -1.0,
+                        -0.6667: -0.7969,
+                        -0.3333: -0.5,
+                        0: 0,
+                        1.0: 1.0,
+                    },
+                    "wdth": DFLT_WDTH_MAPPING,
+                },
+                id="wght=100:400",
+            ),
+            pytest.param(
+                {"wght": (400, 800)},
+                {
+                    "wght": {
+                        -1.0: -1.0,
+                        0: 0,
+                        0.25: 0.22784,
+                        0.50006: 0.48103,
+                        0.75: 0.77214,
+                        1.0: 1.0,
+                    },
+                    "wdth": DFLT_WDTH_MAPPING,
+                },
+                id="wght=400:800",
+            ),
+            pytest.param(
+                {"wght": (400, 700)},
+                {
+                    "wght": {
+                        -1.0: -1.0,
+                        0: 0,
+                        0.3334: 0.2951,
+                        0.66675: 0.623,
+                        1.0: 1.0,
+                    },
+                    "wdth": DFLT_WDTH_MAPPING,
+                },
+                id="wght=400:700",
+            ),
+            pytest.param(
+                {"wght": (400, 600)},
+                {
+                    "wght": {-1.0: -1.0, 0: 0, 0.5: 0.47363, 1.0: 1.0},
+                    "wdth": DFLT_WDTH_MAPPING,
+                },
+                id="wght=400:600",
+            ),
+            pytest.param(
+                {"wdth": (62.5, 100)},
+                {
+                    "wght": DFLT_WGHT_MAPPING,
+                    "wdth": {
+                        -1.0: -1.0,
+                        -0.6667: -0.7,
+                        -0.3333: -0.36664,
+                        0: 0,
+                        1.0: 1.0,
+                    },
+                },
+                id="wdth=62.5:100",
+            ),
+            pytest.param(
+                {"wdth": (70, 100)},
+                {
+                    "wght": DFLT_WGHT_MAPPING,
+                    "wdth": {
+                        -1.0: -1.0,
+                        -0.8334: -0.85364,
+                        -0.4166: -0.44714,
+                        0: 0,
+                        1.0: 1.0,
+                    },
+                },
+                id="wdth=70:100",
+            ),
+            pytest.param(
+                {"wdth": (75, 100)},
+                {
+                    "wght": DFLT_WGHT_MAPPING,
+                    "wdth": {-1.0: -1.0, -0.49994: -0.52374, 0: 0, 1.0: 1.0},
+                },
+                id="wdth=75:100",
+            ),
+            pytest.param(
+                {"wdth": (77, 100)},
+                {
+                    "wght": DFLT_WGHT_MAPPING,
+                    "wdth": {-1.0: -1.0, -0.54346: -0.56696, 0: 0, 1.0: 1.0},
+                },
+                id="wdth=77:100",
+            ),
+            pytest.param(
+                {"wdth": (87.5, 100)},
+                {"wght": DFLT_WGHT_MAPPING, "wdth": {-1.0: -1.0, 0: 0, 1.0: 1.0}},
+                id="wdth=87.5:100",
+            ),
+        ],
+    )
+    def test_limit_axes(self, varfont, axisLimits, expectedSegments):
+        instancer.instantiateAvar(varfont, axisLimits)
+
+        newSegments = varfont["avar"].segments
+        expectedSegments = {
+            axisTag: self.quantizeF2Dot14Floats(mapping)
+            for axisTag, mapping in expectedSegments.items()
+        }
+        assert newSegments == expectedSegments
+
+    @pytest.mark.parametrize(
+        "invalidSegmentMap",
+        [
+            pytest.param({0.5: 0.5}, id="missing-required-maps-1"),
+            pytest.param({-1.0: -1.0, 1.0: 1.0}, id="missing-required-maps-2"),
+            pytest.param(
+                {-1.0: -1.0, 0: 0, 0.5: 0.5, 0.6: 0.4, 1.0: 1.0},
+                id="retrograde-value-maps",
+            ),
+        ],
+    )
+    def test_drop_invalid_segment_map(self, varfont, invalidSegmentMap, caplog):
+        varfont["avar"].segments["wght"] = invalidSegmentMap
+
+        with caplog.at_level(logging.WARNING, logger="fontTools.varLib.instancer"):
+            instancer.instantiateAvar(varfont, {"wght": (100, 400)})
+
+        assert "Invalid avar" in caplog.text
+        assert "wght" not in varfont["avar"].segments
+
+    def test_isValidAvarSegmentMap(self):
+        assert instancer._isValidAvarSegmentMap("FOOO", {})
+        assert instancer._isValidAvarSegmentMap("FOOO", {-1.0: -1.0, 0: 0, 1.0: 1.0})
+        assert instancer._isValidAvarSegmentMap(
+            "FOOO", {-1.0: -1.0, 0: 0, 0.5: 0.5, 1.0: 1.0}
+        )
+        assert instancer._isValidAvarSegmentMap(
+            "FOOO", {-1.0: -1.0, 0: 0, 0.5: 0.5, 0.7: 0.5, 1.0: 1.0}
+        )
+
 
 class InstantiateFvarTest(object):
     @pytest.mark.parametrize(
@@ -1321,12 +1531,204 @@ class InstantiateFeatureVariationsTest(object):
         assert rec1.ConditionSet.ConditionTable[0].Format == 2
 
 
+class LimitTupleVariationAxisRangesTest:
+    def check_limit_single_var_axis_range(self, var, axisTag, axisRange, expected):
+        result = instancer.limitTupleVariationAxisRange(var, axisTag, axisRange)
+        print(result)
+
+        assert len(result) == len(expected)
+        for v1, v2 in zip(result, expected):
+            assert v1.coordinates == pytest.approx(v2.coordinates)
+            assert v1.axes.keys() == v2.axes.keys()
+            for k in v1.axes:
+                p, q = v1.axes[k], v2.axes[k]
+                assert p == pytest.approx(q)
+
+    @pytest.mark.parametrize(
+        "var, axisTag, newMax, expected",
+        [
+            (
+                TupleVariation({"wght": (0.0, 1.0, 1.0)}, [100, 100]),
+                "wdth",
+                0.5,
+                [TupleVariation({"wght": (0.0, 1.0, 1.0)}, [100, 100])],
+            ),
+            (
+                TupleVariation({"wght": (0.0, 1.0, 1.0)}, [100, 100]),
+                "wght",
+                0.5,
+                [TupleVariation({"wght": (0.0, 1.0, 1.0)}, [50, 50])],
+            ),
+            (
+                TupleVariation({"wght": (0.0, 1.0, 1.0)}, [100, 100]),
+                "wght",
+                0.8,
+                [TupleVariation({"wght": (0.0, 1.0, 1.0)}, [80, 80])],
+            ),
+            (
+                TupleVariation({"wght": (0.0, 1.0, 1.0)}, [100, 100]),
+                "wght",
+                1.0,
+                [TupleVariation({"wght": (0.0, 1.0, 1.0)}, [100, 100])],
+            ),
+            (TupleVariation({"wght": (0.0, 1.0, 1.0)}, [100, 100]), "wght", 0.0, []),
+            (TupleVariation({"wght": (0.5, 1.0, 1.0)}, [100, 100]), "wght", 0.4, []),
+            (
+                TupleVariation({"wght": (0.0, 0.5, 1.0)}, [100, 100]),
+                "wght",
+                0.5,
+                [TupleVariation({"wght": (0.0, 1.0, 1.0)}, [100, 100])],
+            ),
+            (
+                TupleVariation({"wght": (0.0, 0.5, 1.0)}, [100, 100]),
+                "wght",
+                0.4,
+                [TupleVariation({"wght": (0.0, 1.0, 1.0)}, [80, 80])],
+            ),
+            (
+                TupleVariation({"wght": (0.0, 0.5, 1.0)}, [100, 100]),
+                "wght",
+                0.6,
+                [TupleVariation({"wght": (0.0, 0.833334, 1.666667)}, [100, 100])],
+            ),
+            (
+                TupleVariation({"wght": (0.0, 0.2, 1.0)}, [100, 100]),
+                "wght",
+                0.4,
+                [
+                    TupleVariation({"wght": (0.0, 0.5, 1.99994)}, [100, 100]),
+                    TupleVariation({"wght": (0.5, 1.0, 1.0)}, [8.33333, 8.33333]),
+                ],
+            ),
+            (
+                TupleVariation({"wght": (0.0, 0.2, 1.0)}, [100, 100]),
+                "wght",
+                0.5,
+                [TupleVariation({"wght": (0.0, 0.4, 1.99994)}, [100, 100])],
+            ),
+            (
+                TupleVariation({"wght": (0.5, 0.5, 1.0)}, [100, 100]),
+                "wght",
+                0.5,
+                [TupleVariation({"wght": (1.0, 1.0, 1.0)}, [100, 100])],
+            ),
+        ],
+    )
+    def test_positive_var(self, var, axisTag, newMax, expected):
+        axisRange = instancer.NormalizedAxisRange(0, newMax)
+        self.check_limit_single_var_axis_range(var, axisTag, axisRange, expected)
+
+    @pytest.mark.parametrize(
+        "var, axisTag, newMin, expected",
+        [
+            (
+                TupleVariation({"wght": (-1.0, -1.0, 0.0)}, [100, 100]),
+                "wdth",
+                -0.5,
+                [TupleVariation({"wght": (-1.0, -1.0, 0.0)}, [100, 100])],
+            ),
+            (
+                TupleVariation({"wght": (-1.0, -1.0, 0.0)}, [100, 100]),
+                "wght",
+                -0.5,
+                [TupleVariation({"wght": (-1.0, -1.0, 0.0)}, [50, 50])],
+            ),
+            (
+                TupleVariation({"wght": (-1.0, -1.0, 0.0)}, [100, 100]),
+                "wght",
+                -0.8,
+                [TupleVariation({"wght": (-1.0, -1.0, 0.0)}, [80, 80])],
+            ),
+            (
+                TupleVariation({"wght": (-1.0, -1.0, 0.0)}, [100, 100]),
+                "wght",
+                -1.0,
+                [TupleVariation({"wght": (-1.0, -1.0, 0.0)}, [100, 100])],
+            ),
+            (TupleVariation({"wght": (-1.0, -1.0, 0.0)}, [100, 100]), "wght", 0.0, []),
+            (
+                TupleVariation({"wght": (-1.0, -1.0, -0.5)}, [100, 100]),
+                "wght",
+                -0.4,
+                [],
+            ),
+            (
+                TupleVariation({"wght": (-1.0, -0.5, 0.0)}, [100, 100]),
+                "wght",
+                -0.5,
+                [TupleVariation({"wght": (-1.0, -1.0, 0.0)}, [100, 100])],
+            ),
+            (
+                TupleVariation({"wght": (-1.0, -0.5, 0.0)}, [100, 100]),
+                "wght",
+                -0.4,
+                [TupleVariation({"wght": (-1.0, -1.0, 0.0)}, [80, 80])],
+            ),
+            (
+                TupleVariation({"wght": (-1.0, -0.5, 0.0)}, [100, 100]),
+                "wght",
+                -0.6,
+                [TupleVariation({"wght": (-1.666667, -0.833334, 0.0)}, [100, 100])],
+            ),
+            (
+                TupleVariation({"wght": (-1.0, -0.2, 0.0)}, [100, 100]),
+                "wght",
+                -0.4,
+                [
+                    TupleVariation({"wght": (-2.0, -0.5, -0.0)}, [100, 100]),
+                    TupleVariation({"wght": (-1.0, -1.0, -0.5)}, [8.33333, 8.33333]),
+                ],
+            ),
+            (
+                TupleVariation({"wght": (-1.0, -0.2, 0.0)}, [100, 100]),
+                "wght",
+                -0.5,
+                [TupleVariation({"wght": (-2.0, -0.4, 0.0)}, [100, 100])],
+            ),
+            (
+                TupleVariation({"wght": (-1.0, -0.5, -0.5)}, [100, 100]),
+                "wght",
+                -0.5,
+                [TupleVariation({"wght": (-1.0, -1.0, -1.0)}, [100, 100])],
+            ),
+        ],
+    )
+    def test_negative_var(self, var, axisTag, newMin, expected):
+        axisRange = instancer.NormalizedAxisRange(newMin, 0)
+        self.check_limit_single_var_axis_range(var, axisTag, axisRange, expected)
+
+
+@pytest.mark.parametrize(
+    "oldRange, newRange, expected",
+    [
+        ((1.0, -1.0), (-1.0, 1.0), None),  # invalid oldRange min > max
+        ((0.6, 1.0), (0, 0.5), None),
+        ((-1.0, -0.6), (-0.5, 0), None),
+        ((0.4, 1.0), (0, 0.5), (0.8, 1.0)),
+        ((-1.0, -0.4), (-0.5, 0), (-1.0, -0.8)),
+        ((0.4, 1.0), (0, 0.4), (1.0, 1.0)),
+        ((-1.0, -0.4), (-0.4, 0), (-1.0, -1.0)),
+        ((-0.5, 0.5), (-0.4, 0.4), (-1.0, 1.0)),
+        ((0, 1.0), (-1.0, 0), (0, 0)),  # or None?
+        ((-1.0, 0), (0, 1.0), (0, 0)),  # or None?
+    ],
+)
+def test_limitFeatureVariationConditionRange(oldRange, newRange, expected):
+    condition = featureVars.buildConditionTable(0, *oldRange)
+
+    result = instancer._limitFeatureVariationConditionRange(
+        condition, instancer.NormalizedAxisRange(*newRange)
+    )
+
+    assert result == expected
+
+
 @pytest.mark.parametrize(
     "limits, expected",
     [
         (["wght=400", "wdth=100"], {"wght": 400, "wdth": 100}),
         (["wght=400:900"], {"wght": (400, 900)}),
-        (["slnt=11.4"], {"slnt": 11.4}),
+        (["slnt=11.4"], {"slnt": pytest.approx(11.399994)}),
         (["ABCD=drop"], {"ABCD": None}),
     ],
 )
@@ -1350,9 +1752,9 @@ def test_normalizeAxisLimits_tuple(varfont):
 def test_normalizeAxisLimits_no_avar(varfont):
     del varfont["avar"]
 
-    normalized = instancer.normalizeAxisLimits(varfont, {"wght": (500, 600)})
+    normalized = instancer.normalizeAxisLimits(varfont, {"wght": (400, 500)})
 
-    assert normalized["wght"] == pytest.approx((0.2, 0.4), 1e-4)
+    assert normalized["wght"] == pytest.approx((0, 0.2), 1e-4)
 
 
 def test_normalizeAxisLimits_missing_from_fvar(varfont):

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1189,7 +1189,7 @@ class InstantiateSTATTest(object):
     @pytest.mark.parametrize(
         "location, expected",
         [
-            ({"wght": 400}, ["Condensed", "Upright"]),
+            ({"wght": 400}, ["Regular", "Condensed", "Upright"]),
             ({"wdth": 100}, ["Thin", "Regular", "Black", "Upright"]),
         ],
     )
@@ -1199,7 +1199,7 @@ class InstantiateSTATTest(object):
         stat = varfont["STAT"].table
         designAxes = {a.AxisTag for a in stat.DesignAxisRecord.Axis}
 
-        assert designAxes == {"wght", "wdth", "ital"}.difference(location)
+        assert designAxes == {"wght", "wdth", "ital"}
 
         name = varfont["name"]
         valueNames = []
@@ -1209,7 +1209,23 @@ class InstantiateSTATTest(object):
 
         assert valueNames == expected
 
-    def test_skip_empty_table(self, varfont):
+    def test_skip_table_no_axis_value_array(self, varfont):
+        varfont["STAT"].table.AxisValueArray = None
+
+        instancer.instantiateSTAT(varfont, {"wght": 100})
+
+        assert len(varfont["STAT"].table.DesignAxisRecord.Axis) == 3
+        assert varfont["STAT"].table.AxisValueArray is None
+
+    def test_skip_table_axis_value_array_empty(self, varfont):
+        varfont["STAT"].table.AxisValueArray.AxisValue = []
+
+        instancer.instantiateSTAT(varfont, {"wght": 100})
+
+        assert len(varfont["STAT"].table.DesignAxisRecord.Axis) == 3
+        assert not varfont["STAT"].table.AxisValueArray.AxisValue
+
+    def test_skip_table_no_design_axes(self, varfont):
         stat = otTables.STAT()
         stat.Version = 0x00010001
         stat.populateDefaults()
@@ -1221,21 +1237,88 @@ class InstantiateSTATTest(object):
 
         assert not varfont["STAT"].table.DesignAxisRecord
 
-    def test_drop_table(self, varfont):
-        stat = otTables.STAT()
-        stat.Version = 0x00010001
-        stat.populateDefaults()
-        stat.DesignAxisRecord = otTables.AxisRecordArray()
-        axis = otTables.AxisRecord()
-        axis.AxisTag = "wght"
-        axis.AxisNameID = 0
-        axis.AxisOrdering = 0
-        stat.DesignAxisRecord.Axis = [axis]
-        varfont["STAT"].table = stat
+    @staticmethod
+    def get_STAT_axis_values(stat):
+        axes = stat.DesignAxisRecord.Axis
+        result = []
+        for axisValue in stat.AxisValueArray.AxisValue:
+            if axisValue.Format == 1:
+                result.append((axes[axisValue.AxisIndex].AxisTag, axisValue.Value))
+            elif axisValue.Format == 3:
+                result.append(
+                    (
+                        axes[axisValue.AxisIndex].AxisTag,
+                        (axisValue.Value, axisValue.LinkedValue),
+                    )
+                )
+            elif axisValue.Format == 2:
+                result.append(
+                    (
+                        axes[axisValue.AxisIndex].AxisTag,
+                        (
+                            axisValue.RangeMinValue,
+                            axisValue.NominalValue,
+                            axisValue.RangeMaxValue,
+                        ),
+                    )
+                )
+            elif axisValue.Format == 4:
+                result.append(
+                    tuple(
+                        (axes[rec.AxisIndex].AxisTag, rec.Value)
+                        for rec in axisValue.AxisValueRecord
+                    )
+                )
+            else:
+                raise AssertionError(axisValue.Format)
+        return result
 
-        instancer.instantiateSTAT(varfont, {"wght": 100})
+    def test_limit_axes(self, varfont2):
+        instancer.instantiateSTAT(varfont2, {"wght": (400, 500), "wdth": (75, 100)})
 
-        assert "STAT" not in varfont
+        assert len(varfont2["STAT"].table.AxisValueArray.AxisValue) == 5
+        assert self.get_STAT_axis_values(varfont2["STAT"].table) == [
+            ("wght", (400.0, 700.0)),
+            ("wght", 500.0),
+            ("wdth", (93.75, 100.0, 100.0)),
+            ("wdth", (81.25, 87.5, 93.75)),
+            ("wdth", (68.75, 75.0, 81.25)),
+        ]
+
+    def test_limit_axis_value_format_4(self, varfont2):
+        stat = varfont2["STAT"].table
+
+        axisValue = otTables.AxisValue()
+        axisValue.Format = 4
+        axisValue.AxisValueRecord = []
+        for tag, value in (("wght", 575), ("wdth", 90)):
+            rec = otTables.AxisValueRecord()
+            rec.AxisIndex = next(
+                i for i, a in enumerate(stat.DesignAxisRecord.Axis) if a.AxisTag == tag
+            )
+            rec.Value = value
+            axisValue.AxisValueRecord.append(rec)
+        stat.AxisValueArray.AxisValue.append(axisValue)
+
+        instancer.instantiateSTAT(varfont2, {"wght": (100, 600)})
+
+        assert axisValue in varfont2["STAT"].table.AxisValueArray.AxisValue
+
+        instancer.instantiateSTAT(varfont2, {"wdth": (62.5, 87.5)})
+
+        assert axisValue not in varfont2["STAT"].table.AxisValueArray.AxisValue
+
+    def test_unknown_axis_value_format(self, varfont2, caplog):
+        stat = varfont2["STAT"].table
+        axisValue = otTables.AxisValue()
+        axisValue.Format = 5
+        stat.AxisValueArray.AxisValue.append(axisValue)
+
+        with caplog.at_level(logging.WARNING, logger="fontTools.varLib.instancer"):
+            instancer.instantiateSTAT(varfont2, {"wght": 400})
+
+        assert "Unknown AxisValue table format (5)" in caplog.text
+        assert axisValue in varfont2["STAT"].table.AxisValueArray.AxisValue
 
 
 def test_pruningUnusedNames(varfont):


### PR DESCRIPTION
This PR adds support for Level-3 partial instacing (as defined in https://github.com/fonttools/fonttools/issues/1537#issuecomment-474983825): i.e. restricting axes min/max coordinates, dropping delta regions that fall completely outside the new limits.

The core method is `limitTupleVariationAxisRange`. This is called for each `{axisTag: (min, max)}` range and for each TupleVariation table, and either drops it entirely if outside the range, or scales the deltas and updates the tent's min/default/max.

The command line tool `fonttools varLib.instancer` now accepts (colon-separated) axis ranges, in addition to single points. E.g. to limit the wght axis between 400:700 and drop-and-pin the wdth axis to 75, you do:

```
$ fonttools varLib.instancer wght=400:700 wdth=75
```

