### PR TITLE
ttGlyphPen must round float coordinates and offsets

### DIFF
--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -1,6 +1,6 @@
 from fontTools.misc.py23 import *
 from array import array
-from fontTools.misc.fixedTools import MAX_F2DOT14
+from fontTools.misc.fixedTools import MAX_F2DOT14, otRound
 from fontTools.pens.basePen import LoggingPen
 from fontTools.pens.transformPen import TransformPen
 from fontTools.ttLib.tables import ttProgram
@@ -118,7 +118,7 @@ class TTGlyphPen(LoggingPen):
 
             component = GlyphComponent()
             component.glyphName = glyphName
-            component.x, component.y = transformation[4:]
+            component.x, component.y = (otRound(v) for v in transformation[4:])
             transformation = transformation[:4]
             if transformation != (1, 0, 0, 1):
                 if (self.handleOverflowingTransforms and
@@ -138,6 +138,7 @@ class TTGlyphPen(LoggingPen):
 
         glyph = Glyph()
         glyph.coordinates = GlyphCoordinates(self.points)
+        glyph.coordinates.toInt()
         glyph.endPtsOfContours = self.endPts
         glyph.flags = array("B", self.types)
         self.init()

--- a/Tests/pens/ttGlyphPen_test.py
+++ b/Tests/pens/ttGlyphPen_test.py
@@ -239,6 +239,31 @@ class TTGlyphPenTest(TestCase):
         with self.assertRaises(struct.error):
             compositeGlyph.compile({'a': baseGlyph})
 
+    def assertGlyphBoundsEqual(self, glyph, bounds):
+        self.assertEqual((glyph.xMin, glyph.yMin, glyph.xMax, glyph.yMax), bounds)
+
+    def test_round_float_coordinates_and_component_offsets(self):
+        glyphSet = {}
+        pen = TTGlyphPen(glyphSet)
+
+        pen.moveTo((0, 0))
+        pen.lineTo((0, 1))
+        pen.lineTo((367.6, 0))
+        pen.closePath()
+        simpleGlyph = pen.glyph()
+
+        simpleGlyph.recalcBounds(glyphSet)
+        self.assertGlyphBoundsEqual(simpleGlyph, (0, 0, 368, 1))
+
+        componentName = 'a'
+        glyphSet[componentName] = simpleGlyph
+
+        pen.addComponent(componentName, (1, 0, 0, 1, -86.4, 0))
+        compositeGlyph = pen.glyph()
+
+        compositeGlyph.recalcBounds(glyphSet)
+        self.assertGlyphBoundsEqual(compositeGlyph, (-86, 0, 282, 1))
+
 
 class _TestGlyph(object):
     def __init__(self, glyph):


### PR DESCRIPTION
otherwise the computed glyph xMin, yMin, xMax and yMax bounds can be computed incorrectly.

https://github.com/googlefonts/fontmake/issues/593

See the failing test.