### PR TITLE
add RoundingPen, a filter pen to round coordinates and component offsets

### DIFF
--- a/Lib/fontTools/pens/roundingPen.py
+++ b/Lib/fontTools/pens/roundingPen.py
@@ -1,0 +1,56 @@
+from fontTools.misc.fixedTools import otRound
+from fontTools.misc.transform import Transform
+from fontTools.pens.filterPen import FilterPen
+
+
+class RoundingPen(FilterPen):
+    """
+    Filter pen that rounds point coordinates and component XY offsets to integer.
+
+    >>> from fontTools.pens.recordingPen import RecordingPen
+    >>> recpen = RecordingPen()
+    >>> roundpen = RoundingPen(recpen)
+    >>> roundpen.moveTo((0.4, 0.6))
+    >>> roundpen.lineTo((1.6, 2.5))
+    >>> roundpen.qCurveTo((2.4, 4.6), (3.3, 5.7), (4.9, 6.1))
+    >>> roundpen.curveTo((6.4, 8.6), (7.3, 9.7), (8.9, 10.1))
+    >>> roundpen.addComponent("a", (1.5, 0, 0, 1.5, 10.5, -10.5))
+    >>> recpen.value == [
+    ...     ('moveTo', ((0, 1),)),
+    ...     ('lineTo', ((2, 3),)),
+    ...     ('qCurveTo', ((2, 5), (3, 6), (5, 6))),
+    ...     ('curveTo', ((6, 9), (7, 10), (9, 10))),
+    ...     ('addComponent', ('a', (1.5, 0, 0, 1.5, 11, -10))),
+    ... ]
+    True
+    """
+
+    def __init__(self, outPen, roundFunc=otRound):
+        super().__init__(outPen)
+        self.roundFunc = roundFunc
+
+    def moveTo(self, pt):
+        self._outPen.moveTo((self.roundFunc(pt[0]), self.roundFunc(pt[1])))
+
+    def lineTo(self, pt):
+        self._outPen.lineTo((self.roundFunc(pt[0]), self.roundFunc(pt[1])))
+
+    def curveTo(self, *points):
+        self._outPen.curveTo(
+            *((self.roundFunc(x), self.roundFunc(y)) for x, y in points)
+        )
+
+    def qCurveTo(self, *points):
+        self._outPen.qCurveTo(
+            *((self.roundFunc(x), self.roundFunc(y)) for x, y in points)
+        )
+
+    def addComponent(self, glyphName, transformation):
+        self._outPen.addComponent(
+            glyphName,
+            Transform(
+                *transformation[:4],
+                self.roundFunc(transformation[4]),
+                self.roundFunc(transformation[5]),
+            ),
+        )


### PR DESCRIPTION
I'd like to use this in ufo2ft to make sure we compile same OTF regardless of whether UFO contains float coordinates or not.