### PR TITLE
[feaLib] Warning instead of error for duplicate identical substitutions

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -917,8 +917,8 @@ class Builder(object):
                 if to_glyph == lookup.mapping[from_glyph]:
                     log.info(
                         'Removing duplicate single substitution from glyph'
-                        ' "%s" to "%s" at %s:%i:%i' %
-                        (from_glyph, to_glyph, *location),
+                        ' "%s" to "%s" at %s:%i:%i',
+                        from_glyph, to_glyph, *location,
                     )
                 else:
                     raise FeatureLibError(

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -914,10 +914,19 @@ class Builder(object):
         lookup = self.get_lookup_(location, SingleSubstBuilder)
         for (from_glyph, to_glyph) in mapping.items():
             if from_glyph in lookup.mapping:
-                raise FeatureLibError(
-                    'Already defined rule for replacing glyph "%s" by "%s"' %
-                    (from_glyph, lookup.mapping[from_glyph]),
-                    location)
+                if to_glyph == lookup.mapping[from_glyph]:
+                    # log warning?
+                    # FDK logs "[NOTE] Removing duplicate single substitution in 'xxxx' feature: from_glyph, to_glyph" in this case
+                    log.info(FeatureLibError(
+                        'Removing duplicate single substitution for glyph "%s" by "%s"' %
+                        (from_glyph, to_glyph),
+                        location
+                    ))
+                else:
+                    raise FeatureLibError(
+                        'Already defined rule for replacing glyph "%s" by "%s"' %
+                        (from_glyph, lookup.mapping[from_glyph]),
+                        location)
             lookup.mapping[from_glyph] = to_glyph
 
     def add_single_subst_chained_(self, location, prefix, suffix, mapping):

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -915,13 +915,11 @@ class Builder(object):
         for (from_glyph, to_glyph) in mapping.items():
             if from_glyph in lookup.mapping:
                 if to_glyph == lookup.mapping[from_glyph]:
-                    # log warning?
-                    # FDK logs "[NOTE] Removing duplicate single substitution in 'xxxx' feature: from_glyph, to_glyph" in this case
-                    log.info(FeatureLibError(
-                        'Removing duplicate single substitution for glyph "%s" by "%s"' %
-                        (from_glyph, to_glyph),
-                        location
-                    ))
+                    log.info(
+                        'Removing duplicate single substitution from glyph'
+                        ' "%s" to "%s" at %s:%i:%i' %
+                        (from_glyph, to_glyph, *location),
+                    )
                 else:
                     raise FeatureLibError(
                         'Already defined rule for replacing glyph "%s" by "%s"' %

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -187,6 +187,17 @@ class BuilderTest(unittest.TestCase):
             "    sub A from [A.alt1 A.alt2];"
             "} test;")
 
+    def test_singleSubst_multipleIdenticalSubstitutionsForSameGlyph_info(self):
+        logger = logging.getLogger("fontTools.feaLib.builder")
+        with CapturingLogHandler(logger, "INFO") as captor:
+            self.build(
+                "feature test {"
+                "    sub A by A.sc;"
+                "    sub B by B.sc;"
+                "    sub A by A.sc;"
+                "} test;")
+        captor.assertRegex('Removing duplicate single substitution from glyph "A" to "A.sc"')
+
     def test_multipleSubst_multipleSubstitutionsForSameGlyph(self):
         self.assertRaisesRegex(
             FeatureLibError,


### PR DESCRIPTION
We have lots of source files which contain substitutions that do nothing or are duplicated because classes are reused for different features. Those fail compilation with feaLib currently.

 I think if an identical substitution is added to a feature, it could be ignored instead of raising an error. The problem is only when a duplicate source glyph would introduce an ambiguity, i.e. the code would demand to replace one glyph with two different target glyphs.

Example:

```
@fig = [one two three Euro];
@figOldstyle = [one.osf two.osf Euro];
@figSC = [one.sc two.sc Euro.sc];

feature onum {
  sub @fig by @figOldstyle;
} onum;

feature c2sc {
  sub @fig by @figSC;
  sub @figOldstyle by @figSC; # <-- adds sub Euro by Euro.sc; again
} cs2c;
```

Which is equal to:

```
feature onum {
  sub [one two three Euro] by [one.osf two.osf Euro];
} onum;

feature c2sc {
  sub [one two three Euro] by [one.sc two.sc Euro.sc];
  sub [one.osf two.osf Euro] by [one.sc two.sc Euro.sc]; # <-- adds sub Euro by Euro.sc; again
} cs2c;
```

Adobe FDK logs an info in this situation and continues compilation.