### PR TITLE
[ttLib.glyf] Fix flag bug in glyph.drawPoints()

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1230,7 +1230,7 @@ class Glyph(object):
 			# Start with the appropriate segment type based on the final segment
 			segmentType = "line" if cFlags[-1] == 1 else "qcurve"
 			for i, pt in enumerate(contour):
-				if cFlags[i] == 1:
+				if cFlags[i] & flagOnCurve == 1:
 					pen.addPoint(pt, segmentType=segmentType)
 					segmentType = "line"
 				else:


### PR DESCRIPTION
The glyph.drawPoints() method had the same bug as glyph.draw(), as reported in #1771. This fixes that, too, and adds a test for it.