### PR TITLE
[ttLib.glyf] make glyph.draw() skip final lineTo()

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1198,7 +1198,10 @@ class Glyph(object):
 				while contour:
 					nextOnCurve = cFlags.index(1) + 1
 					if nextOnCurve == 1:
-						pen.lineTo(contour[0])
+						# Skip a final lineTo(), as it is implied by
+						# pen.closePath()
+						if len(contour) > 1:
+							pen.lineTo(contour[0])
 					else:
 						pen.qCurveTo(*contour[:nextOnCurve])
 					contour = contour[nextOnCurve:]

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -3,6 +3,7 @@ from fontTools.misc.fixedTools import otRound
 from fontTools.misc.testTools import getXML, parseXML
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.pens.recordingPen import RecordingPen, RecordingPointPen
+from fontTools.pens.pointPen import PointToSegmentPen
 from fontTools.ttLib import TTFont, newTable, TTLibError
 from fontTools.ttLib.tables._g_l_y_f import (
     GlyphCoordinates,
@@ -326,6 +327,16 @@ class glyfTableTest(unittest.TestCase):
             ('addPoint', ((983, 0), 'line', False, None), {}),
         ]
         self.assertEqual(pen.value[:len(expected)], expected)
+
+    def test_draw_vs_drawpoints(self):
+        font = TTFont(sfntVersion="\x00\x01\x00\x00")
+        font.importXML(GLYF_TTX)
+        glyfTable = font['glyf']
+        pen1 = RecordingPen()
+        pen2 = RecordingPen()
+        glyfTable["glyph00003"].draw(pen1, glyfTable)
+        glyfTable["glyph00003"].drawPoints(PointToSegmentPen(pen2), glyfTable)
+        self.assertEqual(pen1.value, pen2.value)
 
 
 class GlyphComponentTest:

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -301,13 +301,11 @@ class glyfTableTest(unittest.TestCase):
                     ('lineTo', ((591, 1193),)),
                     ('lineTo', ((199, 0),)),
                     ('lineTo', ((12, 0),)),
-                    ('lineTo', ((501, 1430),)),
                     ('closePath', ()),
                     ('moveTo', ((249, 514),)),
                     ('lineTo', ((935, 514),)),
                     ('lineTo', ((935, 352),)),
                     ('lineTo', ((249, 352),)),
-                    ('lineTo', ((249, 514),)),
                     ('closePath', ())]
         self.assertEqual(pen.value, expected)
 


### PR DESCRIPTION
In glyphs from the `glyf` table, glyph.draw() has always emitted a final `pen.lineTo()` back to the first point. This is redundant.

However, this may be a breaking change for client code, so I'm not sure it's wise to do this.