### PR TITLE
[subset] remap FeatureVariations SubstitutionRecord.FeatureIndex

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -1307,6 +1307,9 @@ def subset_features(self, feature_indices):
 	self.ensureDecompiled()
 	self.SubstitutionRecord = [r for r in self.SubstitutionRecord
 				     if r.FeatureIndex in feature_indices]
+	# remap feature indices
+	for r in self.SubstitutionRecord:
+		r.FeatureIndex = feature_indices.index(r.FeatureIndex)
 	self.SubstitutionCount = len(self.SubstitutionRecord)
 	return bool(self.SubstitutionCount)
 


### PR DESCRIPTION
Fixes #1777

The 'rvrn' feature is being incorrectly dropped because the feature indexes change if some other feature occuring before 'rvrn' is dropped. The feature indexes need to be remapped.

I add a failing test case to show the issue, then I'll follow up with the actual patch.