### PR TITLE
glifLib: ignore xml <!-- comments --> when parsing GLIF files with lxml

### DIFF
--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -852,7 +852,11 @@ def validateLayerInfoVersion3Data(infoData):
 # -----------------
 
 def _glifTreeFromFile(aFile):
-	root = etree.parse(aFile).getroot()
+	if etree._have_lxml:
+		tree = etree.parse(aFile, parser=etree.XMLParser(remove_comments=True))
+	else:
+		tree = etree.parse(aFile)
+	root = tree.getroot()
 	if root.tag != "glyph":
 		raise GlifLibError("The GLIF is not properly formatted.")
 	if root.text and root.text.strip() != '':
@@ -862,7 +866,10 @@ def _glifTreeFromFile(aFile):
 
 def _glifTreeFromString(aString):
 	data = tobytes(aString, encoding="utf-8")
-	root = etree.fromstring(data)
+	if etree._have_lxml:
+		root = etree.fromstring(data, parser=etree.XMLParser(remove_comments=True))
+	else:
+		root = etree.fromstring(data)
 	if root.tag != "glyph":
 		raise GlifLibError("The GLIF is not properly formatted.")
 	if root.text and root.text.strip() != '':

--- a/Tests/ufoLib/glifLib_test.py
+++ b/Tests/ufoLib/glifLib_test.py
@@ -161,3 +161,21 @@ class ReadWriteFuncTest(unittest.TestCase):
 	def testXmlDeclaration(self):
 		s = writeGlyphToString("a", _Glyph())
 		self.assertTrue(s.startswith(XML_DECLARATION % "UTF-8"))
+
+
+def test_parse_xml_remove_comments():
+	s = b"""<?xml version='1.0' encoding='UTF-8'?>
+	<!-- a comment -->
+	<glyph name="A" format="2">
+		<advance width="1290"/>
+		<unicode hex="0041"/>
+		<!-- another comment -->
+	</glyph>
+	"""
+
+	g = _Glyph()
+	readGlyphFromString(s, g)
+
+	assert g.name == "A"
+	assert g.width == 1290
+	assert g.unicodes == [0x0041]


### PR DESCRIPTION
Fixes #1784 