### PR TITLE
Remove workaround (#1381)

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -325,7 +325,6 @@ def _add_gvar(font, masterModel, master_ttfs, tolerance=0.5, optimize=True):
 
     for glyph in font.getGlyphOrder():
         log.debug("building gvar for glyph '%s'", glyph)
-        isComposite = glyf[glyph].isComposite()
 
         allData = [
             m.glyf._getCoordinatesAndControls(glyph, m.hMetrics, m.vMetrics)
@@ -363,7 +362,7 @@ def _add_gvar(font, masterModel, master_ttfs, tolerance=0.5, optimize=True):
         endPts = control.endPts
 
         for i, (delta, support) in enumerate(zip(deltas[1:], supports[1:])):
-            if all(v == 0 for v in delta.array) and not isComposite:
+            if all(v == 0 for v in delta.array):
                 continue
             var = TupleVariation(support, delta)
             if optimize:

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -372,16 +372,6 @@ def _add_gvar(font, masterModel, master_ttfs, tolerance=0.5, optimize=True):
                 )
 
                 if None in delta_opt:
-                    """In composite glyphs, there should be one 0 entry
-                    to make sure the gvar entry is written to the font.
-
-                    This is to work around an issue with macOS 10.14 and can be
-                    removed once the behaviour of macOS is changed.
-
-                    https://github.com/fonttools/fonttools/issues/1381
-                    """
-                    if all(d is None for d in delta_opt):
-                        delta_opt = [(0, 0)] + [None] * (len(delta_opt) - 1)
                     # Use "optimized" version only if smaller...
                     var_opt = TupleVariation(support, delta_opt)
 

--- a/Tests/varLib/data/test_results/BuildGvarCompositeExplicitDelta.ttx
+++ b/Tests/varLib/data/test_results/BuildGvarCompositeExplicitDelta.ttx
@@ -176,17 +176,6 @@
         <delta pt="35" x="0" y="0"/>
       </tuple>
     </glyphVariations>
-    <glyphVariations glyph="odieresis">
-      <tuple>
-        <coord axis="slnt" value="-1.0"/>
-        <delta pt="0" x="0" y="0"/>
-        <delta pt="1" x="0" y="0"/>
-        <delta pt="2" x="0" y="0"/>
-        <delta pt="3" x="0" y="0"/>
-        <delta pt="4" x="0" y="0"/>
-        <delta pt="5" x="0" y="0"/>
-      </tuple>
-    </glyphVariations>
     <glyphVariations glyph="uni0308">
       <tuple>
         <coord axis="slnt" value="-1.0"/>

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -339,10 +339,7 @@ class BuildTest(unittest.TestCase):
 
     def test_varlib_gvar_explicit_delta(self):
         """The variable font contains a composite glyph odieresis which does not
-        need a gvar entry, because all its deltas are 0, but it must be added
-        anyway to work around an issue with macOS 10.14.
-
-        https://github.com/fonttools/fonttools/issues/1381
+        need a gvar entry.
         """
         test_name = "BuildGvarCompositeExplicitDelta"
         self._run_varlib_build_test(


### PR DESCRIPTION
Apparently the macOS bug has been fixed. I'm not sure when, but in 10.14.6 the workaround introduced in #1381 is not needed anymore. Can anybody confirm?