### PR TITLE
Get rid of SyntaxWarning with py3.8.

### DIFF
--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -18,7 +18,7 @@ def _make_map(font, chars, gids):
 	cmap = {}
 	glyphOrder = font.getGlyphOrder()
 	for char,gid in zip(chars,gids):
-		if gid is 0:
+		if gid == 0:
 			continue
 		try:
 			name = glyphOrder[gid]


### PR DESCRIPTION
On a clean clone (make sure there are no pycs present yet),
```
python -c 'import fontTools.ttLib.tables._c_m_a_p'
```
results in
```
.../fontTools/ttLib/tables/_c_m_a_p.py:21: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if gid is 0:
```

Fix that.