### PR TITLE
splitMarkBasePos should update MarkRecord.Class values after splitting

### DIFF
--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -1415,6 +1415,7 @@ def splitMarkBasePos(oldSubTable, newSubTable, overflowRecord):
 			oldMarkCoverage.append(glyphName)
 			oldMarkRecords.append(markRecord)
 		else:
+			markRecord.Class -= oldClassCount
 			newMarkCoverage.append(glyphName)
 			newMarkRecords.append(markRecord)
 

--- a/Tests/ttLib/tables/otTables_test.py
+++ b/Tests/ttLib/tables/otTables_test.py
@@ -605,20 +605,87 @@ def test_splitMarkBasePos():
 	ok = otTables.splitMarkBasePos(oldSubTable, newSubTable, overflowRecord=None)
 
 	assert ok
-	assert oldSubTable.Format == newSubTable.Format
-	assert oldSubTable.MarkCoverage.glyphs == [
-		"acutecomb", "gravecomb"
+
+	assert getXML(oldSubTable.toXML) == [
+		'<MarkBasePos Format="1">',
+		'  <MarkCoverage Format="1">',
+		'    <Glyph value="acutecomb"/>',
+		'    <Glyph value="gravecomb"/>',
+		'  </MarkCoverage>',
+		'  <BaseCoverage Format="1">',
+		'    <Glyph value="a"/>',
+		'    <Glyph value="c"/>',
+		'  </BaseCoverage>',
+		'  <!-- ClassCount=1 -->',
+		'  <MarkArray>',
+		'    <!-- MarkCount=2 -->',
+		'    <MarkRecord index="0">',
+		'      <Class value="0"/>',
+		'      <MarkAnchor Format="1">',
+		'        <XCoordinate value="0"/>',
+		'        <YCoordinate value="600"/>',
+		'      </MarkAnchor>',
+		'    </MarkRecord>',
+		'    <MarkRecord index="1">',
+		'      <Class value="0"/>',
+		'      <MarkAnchor Format="1">',
+		'        <XCoordinate value="0"/>',
+		'        <YCoordinate value="590"/>',
+		'      </MarkAnchor>',
+		'    </MarkRecord>',
+		'  </MarkArray>',
+		'  <BaseArray>',
+		'    <!-- BaseCount=2 -->',
+		'    <BaseRecord index="0">',
+		'      <BaseAnchor index="0" Format="1">',
+		'        <XCoordinate value="350"/>',
+		'        <YCoordinate value="500"/>',
+		'      </BaseAnchor>',
+		'    </BaseRecord>',
+		'    <BaseRecord index="1">',
+		'      <BaseAnchor index="0" Format="1">',
+		'        <XCoordinate value="300"/>',
+		'        <YCoordinate value="700"/>',
+		'      </BaseAnchor>',
+		'    </BaseRecord>',
+		'  </BaseArray>',
+		'</MarkBasePos>',
 	]
-	assert newSubTable.MarkCoverage.glyphs == ["cedillacomb"]
-	assert newSubTable.MarkCoverage.Format == 1
-	assert oldSubTable.BaseCoverage.glyphs == newSubTable.BaseCoverage.glyphs
-	assert newSubTable.BaseCoverage.Format == 1
-	assert oldSubTable.ClassCount == newSubTable.ClassCount == 1
-	assert oldSubTable.MarkArray.MarkCount == 2
-	assert newSubTable.MarkArray.MarkCount == 1
-	assert oldSubTable.BaseArray.BaseCount == newSubTable.BaseArray.BaseCount
-	assert newSubTable.BaseArray.BaseRecord[0].BaseAnchor[0] is None
-	assert newSubTable.BaseArray.BaseRecord[1].BaseAnchor[0] == buildAnchor(300, 0)
+
+	assert getXML(newSubTable.toXML) == [
+		'<MarkBasePos Format="1">',
+		'  <MarkCoverage Format="1">',
+		'    <Glyph value="cedillacomb"/>',
+		'  </MarkCoverage>',
+		'  <BaseCoverage Format="1">',
+		'    <Glyph value="a"/>',
+		'    <Glyph value="c"/>',
+		'  </BaseCoverage>',
+		'  <!-- ClassCount=1 -->',
+		'  <MarkArray>',
+		'    <!-- MarkCount=1 -->',
+		'    <MarkRecord index="0">',
+		'      <Class value="0"/>',
+		'      <MarkAnchor Format="1">',
+		'        <XCoordinate value="0"/>',
+		'        <YCoordinate value="0"/>',
+		'      </MarkAnchor>',
+		'    </MarkRecord>',
+		'  </MarkArray>',
+		'  <BaseArray>',
+		'    <!-- BaseCount=2 -->',
+		'    <BaseRecord index="0">',
+		'      <BaseAnchor index="0" empty="1"/>',
+		'    </BaseRecord>',
+		'    <BaseRecord index="1">',
+		'      <BaseAnchor index="0" Format="1">',
+		'        <XCoordinate value="300"/>',
+		'        <YCoordinate value="0"/>',
+		'      </BaseAnchor>',
+		'    </BaseRecord>',
+		'  </BaseArray>',
+		'</MarkBasePos>',
+	]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@marekj and @punchcutter discovered a major bug in the `splitMarkBasePos` function from `fontTools.ttLib.tables.otTables` (which is used when offsets within a MarkToBase subtable overflow uint16 limits).

https://github.com/googlefonts/noto-source/issues/145

The function splits the big subtable into two halves, each containing the same base coverage but only half of the marks.
The problem was that the MarkRecord.Class values of the second subtable were not being updated to match the new (halved) class count. And because the mark class values were out of sync, the base records would end up referencing either wrong or non-existent mark classes...

I added a (failing) test and will push a fix in a following commit.

Overflows in MarkBasePos subtables are rare in static fonts (although they may happen if the font contains loads of marks); they are more frequent when these are merged into variable fonts in fontTools.varLib.
If you are building VFs using fonttools (or fontmake), and you see logging messages like the ones from NotoSerifTibetan-VF:

```
Saving variation font master_ttf_interpolatable/NotoSerifTibetan-VF.ttf
Attempting to fix OTLOffsetOverflowError ('GPOS', 'LookupIndex:', 13, 'SubTableIndex:', None, 'ItemName:', None, 'ItemIndex:', None)
Attempting to fix OTLOffsetOverflowError ('GPOS', 'LookupIndex:', 12, 'SubTableIndex:', 0, 'ItemName:', 'MarkArray.MarkAnchor.XDeviceTable', 'ItemIndex:', None)
Attempting to fix OTLOffsetOverflowError ('GPOS', 'LookupIndex:', 12, 'SubTableIndex:', 0, 'ItemName:', 'MarkArray.MarkAnchor.XDeviceTable', 'ItemIndex:', None)
```

... I suggest that you update fonttools once this bugfix is released and re-build the VFs.

Apologies for any inconvenience.