### PR TITLE
EBLC: fix padding length calculation for Format 3 IndexSubTable

### DIFF
--- a/Lib/fontTools/ttLib/tables/E_B_L_C_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_L_C_.py
@@ -482,7 +482,7 @@ def _createOffsetArrayIndexSubTableMixin(formatStringForDataType):
 			dataList = [EblcIndexSubTable.compile(self, ttFont)]
 			dataList += [struct.pack(dataFormat, offsetValue) for offsetValue in offsetArray]
 			# Take care of any padding issues. Only occurs in format 3.
-			if offsetDataSize * len(dataList) % 4 != 0:
+			if offsetDataSize * len(offsetArray) % 4 != 0:
 				dataList.append(struct.pack(dataFormat, 0))
 			return bytesjoin(dataList)
 

--- a/Tests/ttLib/tables/C_B_L_C_test.py
+++ b/Tests/ttLib/tables/C_B_L_C_test.py
@@ -1,0 +1,80 @@
+import base64
+import io
+import os
+
+from fontTools.misc.testTools import getXML
+from fontTools.ttLib import TTFont
+
+
+DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
+
+# This is a subset from NotoColorEmoji.ttf which contains an IndexTable format=3
+INDEX_FORMAT_3_TTX = os.path.join(DATA_DIR, "NotoColorEmoji.subset.index_format_3.ttx")
+# The CLBC table was compiled with Harfbuzz' hb-subset and contains the correct padding
+CBLC_INDEX_FORMAT_3 = base64.b64decode(
+    "AAMAAAAAAAEAAAA4AAAALAAAAAIAAAAAZeWIAAAAAAAAAAAAZeWIAAAAAAAAAAAAAAEAA"
+    "21tIAEAAQACAAAAEAADAAMAAAAgAAMAEQAAAAQAAAOmEQ0AAAADABEAABERAAAIUg=="
+)
+
+
+def test_compile_decompile_index_table_format_3():
+    font = TTFont()
+    font.importXML(INDEX_FORMAT_3_TTX)
+    buf = io.BytesIO()
+    font.save(buf)
+    buf.seek(0)
+    font = TTFont(buf)
+
+    assert font.reader["CBLC"] == CBLC_INDEX_FORMAT_3
+
+    assert getXML(font["CBLC"].toXML, font) == [
+        '<header version="3.0"/>',
+        '<strike index="0">',
+        "  <bitmapSizeTable>",
+        '    <sbitLineMetrics direction="hori">',
+        '      <ascender value="101"/>',
+        '      <descender value="-27"/>',
+        '      <widthMax value="136"/>',
+        '      <caretSlopeNumerator value="0"/>',
+        '      <caretSlopeDenominator value="0"/>',
+        '      <caretOffset value="0"/>',
+        '      <minOriginSB value="0"/>',
+        '      <minAdvanceSB value="0"/>',
+        '      <maxBeforeBL value="0"/>',
+        '      <minAfterBL value="0"/>',
+        '      <pad1 value="0"/>',
+        '      <pad2 value="0"/>',
+        "    </sbitLineMetrics>",
+        '    <sbitLineMetrics direction="vert">',
+        '      <ascender value="101"/>',
+        '      <descender value="-27"/>',
+        '      <widthMax value="136"/>',
+        '      <caretSlopeNumerator value="0"/>',
+        '      <caretSlopeDenominator value="0"/>',
+        '      <caretOffset value="0"/>',
+        '      <minOriginSB value="0"/>',
+        '      <minAdvanceSB value="0"/>',
+        '      <maxBeforeBL value="0"/>',
+        '      <minAfterBL value="0"/>',
+        '      <pad1 value="0"/>',
+        '      <pad2 value="0"/>',
+        "    </sbitLineMetrics>",
+        '    <colorRef value="0"/>',
+        '    <startGlyphIndex value="1"/>',
+        '    <endGlyphIndex value="3"/>',
+        '    <ppemX value="109"/>',
+        '    <ppemY value="109"/>',
+        '    <bitDepth value="32"/>',
+        '    <flags value="1"/>',
+        "  </bitmapSizeTable>",
+        "  <!-- GlyphIds are written but not read. The firstGlyphIndex and",
+        "       lastGlyphIndex values will be recalculated by the compiler. -->",
+        '  <eblc_index_sub_table_3 imageFormat="17" firstGlyphIndex="1" lastGlyphIndex="2">',
+        '    <glyphLoc id="1" name="eight"/>',
+        '    <glyphLoc id="2" name="registered"/>',
+        "  </eblc_index_sub_table_3>",
+        '  <eblc_index_sub_table_3 imageFormat="17" firstGlyphIndex="3" lastGlyphIndex="3">',
+        '    <glyphLoc id="3" name="uni2049"/>',
+        "  </eblc_index_sub_table_3>",
+        "</strike>",
+    ]

--- a/Tests/ttLib/tables/data/NotoColorEmoji.subset.index_format_3.ttx
+++ b/Tests/ttLib/tables/data/NotoColorEmoji.subset.index_format_3.ttx
@@ -1,0 +1,705 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.44">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="eight"/>
+    <GlyphID id="2" name="registered"/>
+    <GlyphID id="3" name="uni2049"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="2.011"/>
+    <checkSumAdjustment value="0x73631d70"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00001011"/>
+    <unitsPerEm value="2048"/>
+    <created value="Wed May 22 20:00:43 2013"/>
+    <modified value="Thu Jan 30 14:31:14 2020"/>
+    <xMin value="0"/>
+    <yMin value="-500"/>
+    <xMax value="2550"/>
+    <yMax value="1900"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="8"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1900"/>
+    <descent value="-500"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="2550"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="0"/>
+    <xMaxExtent value="2550"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="1"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="4"/>
+    <maxPoints value="8"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="2"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="1"/>
+    <maxFunctionDefs value="1"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="64"/>
+    <maxSizeOfInstructions value="46"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="2550"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="1331"/>
+    <ySubscriptYSize value="1433"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="286"/>
+    <ySuperscriptXSize value="1331"/>
+    <ySuperscriptYSize value="1433"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="983"/>
+    <yStrikeoutSize value="102"/>
+    <yStrikeoutPosition value="530"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="6"/>
+      <bProportion value="9"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="GOOG"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="56"/>
+    <usLastCharIndex value="8265"/>
+    <sTypoAscender value="1900"/>
+    <sTypoDescender value="-500"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1900"/>
+    <usWinDescent value="500"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="0"/>
+    <sCapHeight value="1900"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="1"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="2550" lsb="0"/>
+    <mtx name="eight" width="2550" lsb="0"/>
+    <mtx name="registered" width="2550" lsb="0"/>
+    <mtx name="uni2049" width="2550" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_14 platformID="0" platEncID="5">
+      <map uv="0x38" uvs="0xfe0f"/>
+      <map uv="0xae" uvs="0xfe0f"/>
+      <map uv="0x2049" uvs="0xfe0f"/>
+    </cmap_format_14>
+    <cmap_format_12 platformID="3" platEncID="10" format="12" reserved="0" length="52" language="0" nGroups="3">
+      <map code="0x38" name="eight"/><!-- DIGIT EIGHT -->
+      <map code="0xae" name="registered"/><!-- REGISTERED SIGN -->
+      <map code="0x2049" name="uni2049"/><!-- EXCLAMATION QUESTION MARK -->
+    </cmap_format_12>
+  </cmap>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2013 Google Inc.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Noto Color Emoji
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      Noto Color Emoji
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Noto Color Emoji
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 2.011;GOOG;noto-emoji:20180424; pistol
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      NotoColorEmoji
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-1244"/>
+    <underlineThickness value="131"/>
+    <isFixedPitch value="1"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
+
+  <CBDT>
+    <header version="3.0"/>
+    <strikedata index="0">
+      <cbdt_bitmap_format_17 name="registered">
+        <SmallGlyphMetrics>
+          <height value="128"/>
+          <width value="136"/>
+          <BearingX value="0"/>
+          <BearingY value="101"/>
+          <Advance value="136"/>
+        </SmallGlyphMetrics>
+        <rawimagedata>
+          89504e47 0d0a1a0a 0000000d 49484452
+          00000088 00000080 08030000 00e737d1
+          0d000000 ff504c54 454c6971 74747475
+          75757878 78777777 7b7b7b7e 7e7e6868
+          68787878 79797977 77777777 77787878
+          6969697b 7b7b7777 77737373 6f6f6f6c
+          6c6c6767 67787878 6a6a6a64 64646161
+          617d7d7d 7a7a7a60 60607575 75797979
+          6666665e 5e5e7171 716e6e6e 6565655c
+          5c5c5a5a 5a6c6c6c 58585857 57577373
+          73555555 53535352 52526e6e 6e505050
+          4e4e4e6b 6b6b4c4c 4c666666 4b4b4b66
+          66666565 65494949 65656547 47474646
+          465b5b5b 4444445a 5a5a4242 42606060
+          5757573f 3f3f6060 60575757 3d3d3d58
+          58583a3a 3a5c5c5c 5d5d5d39 39393737
+          37353535 33333353 53535252 52525252
+          2f2f2f52 52524f4f 4f2b2b2b 28282825
+          25252323 23212121 f9766a48 00000050
+          74524e53 00406180 bfefff20 9fcf508e
+          df30ffff ffffffff 10ffffff ffffffff
+          afffffff ffffffff 70ffffef ffffff80
+          ffffc0ff 8fffefa4 ffdfffff 50ff10ff
+          c162ff80 40ffa7ff d6efffff ffff8fdb
+          7fffefbf 08ff47de 00000bbe 49444154
+          7801ecd5 d77eab30 0c067033 dcb0629b
+          8d11a381 aef77fc2 23b70c93 09745c9d
+          ff5533ac 7e96941f e4bfff7e 8d615ab6
+          4d9f26d4 b62dd320 7fea603a eed30dae
+          631ec89f f0fce0e9 81c0f7c8 2f3bfaf3
+          30181761 144fa250 70360fca 3f925f93
+          98d34078 9866f915 591af269 4866f23b
+          312c5a7c 9222cdcb 3bf254c8 e213b592
+          5f8bc144 5cae100b f63b5186 181c7bb1
+          529ef221 0af93946 50281097 9bc45028
+          81f15353 a976c5d0 a2543f32 1f8f1648
+          d6cd2eb5 2c10f5be df0ebf40 2cbaf63f
+          a210a098 0084d1b5 b4112b90 ffcda61c
+          dc0241d6 9c89435e 5cc5c38b 301914c8
+          3d7c6b4b e9b576c4 2d2bee60 6d7cad29
+          d420bb99 0cf1653b f267c906 d4f62dcf
+          1878966f 533690cf f9b2299c 2193ec64
+          31d4968d e624d897 407fc8ea 8fe5807d
+          11a74653 b60c5964 1787a168 39ed2185
+          7fbcf75c 1cb240b6 1c0f7276 e788bb59
+          13b24fce c3611bea 2c0a9b6e 16ef4ca2
+          6ac9ac9b a592216a 252b1f4d 0cc9b49b
+          65724f12 4b95c9bb 492ef418 eba308bd
+          86dcbe27 e6598e5a 32541dc8 06878a21
+          59eb49b6 fe760c89 b4b94412 05c6f687
+          a544913e 1db4a1cc 814a29e3 794b8544
+          4e42364b 1c89c4bc b331bea4 87d5c75d
+          29b5356b 409d36c9 2ea6ba13 cc49527c
+          e9aebd92 affad98f 4ad58fe0 88350379
+          07b52bcb bb72d7a3 3a25ca7e a4a6ec93
+          553c75b2 9b72f0af 3b24b65c 21f0bdab
+          fde55392 4eddcb5b 35187a71 cec65e3a
+          7225ea1f ce0ada17 37a36b86 53a9455d
+          e4705487 d5a8b3fc b6380d85 1c386751
+          9c4512b5 b0d5ba5f 6edb8f5a d50f822c
+          2979d33f d0652948 85be9005 7b5974d5
+          6f38e01c bad741ca 397793a1 54d4af91
+          4752b193 e59e60a1 f475d001 e70179c0
+          c213f578 22e77822 19ef94f6 eb349144
+          f4b84812 60a9fc75 50e30beb d1a6722e
+          f4e4586f 631094c3 459223d5 3b2db070
+          f2b021e5 db20c417 e63865ce e3d7d5fa
+          673cba4c 62e23be1 58b97cd4 92e45dfb
+          f609bfed 903d4150 346cd7cc c1774eda
+          1ddf937b 0d0180e6 e3cbab00 08123dc8
+          db166acf fde59a00 88d7a178 0300d6bd
+          86003c7f 0c520030 c8ad20fd 29d4a531
+          0e74a9c5 2406d118 00908ed5 9f01eeb4
+          c4d41ad2 01404526 3640fd31 eb045c88
+          f0a8a607 009be82a 00e8b496 98e41657
+          6bc83f52 ca43c759 1c8ac2c0 163205c9
+          258e2524 c7941448 4fa6effc efff5c7b
+          b35c6106 dfb059f6 53733807 fbb3cd8c
+          00e59814 c16b23c8 601987c1 236d89d7
+          60db3992 87e00609 bca9dd81 e025b622
+          b95b23bf eef6b70e bf3f372a ba72acc0
+          76e27d82 05a61ac6 4940f304 5f535537
+          28bc435a 4474ae0d 897f7bee 9b4898c3
+          fb06152e 5081e653 40033589 b5a53b10
+          5ac4a56e 99eb8659 f9f32b79 f48e6489
+          4ba026c1 2363acc0 9681f1b4 2f52b7a0
+          08f5b18b da61fb9b 9ec2b406 c302c68f
+          f4cd30c6 db29189b 043d91d9 90084e01
+          2685ab49 f777834c 18b335c2 19a3efe6
+          196c370d 57dbf0a7 08631d11 c5182932
+          5d33265d 4d33d63b fdf07aea b8089cfa
+          73401013 9d6111fa 54adab95 30e5f06e
+          63ea82e1 798d1d0b a7e68b60 0880c816
+          037fc755 5babf060 7ba698d6 904681cf
+          c45ab56b 28adb589 27a20745 1098bc74
+          3d5f2481 a94b5c46 593ba1fe ad5aabb1
+          31b3b67f 7bbfb729 4e714364 6d6dea7a
+          b06ad8bf 1b6b6798 6a6ba97f ae84ea08
+          11ec1122 f4c113b7 0b4feb7d 030ca3c1
+          05e47891 089ee132 b51f030b 6b332cac
+          a010fb0b a4840879 ae832231 3c5bb90d
+          2f823e5b ce25e605 e7eb8010 d9b7d022
+          6e197247 c89af302 73c9b93f cd81f319
+          e69af303 11cf3126 674022ce f9aead2d
+          e117b590 c67c060b f97996cd 8f0d26cb
+          4e2345a0 a65c6d4e 2d74ca32 830bcdb3
+          cccfd759 563891ed 8027d540 1eb37616
+          ac4dfc6f c0891459 b6f67221 448d390c
+          1f478924 b01bb16f 5b7bd08a 7c59981e
+          0b350cff 4524f444 84e86c35 17624b79
+          c09b956b 95f033f6 5ae11d22 e7867122
+          d39300f4 d1a18438 04a4082e 3456e4dc
+          a285b874 2bd370f1 22aea467 c70a7e47
+          ff592486 679bd77f 38c230a1 445e5b36
+          82022bc8 f540de02 5a042b3b fa44ba22
+          2129e248 0541ba7f eda0f19b 1f10d950
+          224aa91d e630f445 942a5f3b 94aac76c
+          797ced17 0e012502 01767630 1c2be2d8
+          7539bff6 a86092cb 74acc87b c32d91f7
+          fb291590 04b744b0 754b64ff d100c34f
+          4264f971 2faf7305 4401c927 44d8db53
+          2217a52a ccb552db ff23b2cf 490f64ab
+          94c66205 d7e7e507 29575f0d a9942732
+          be8f4202 9724b8c1 49ca149b 2b290f94
+          48817949 e41057f7 79ec2470 f82ba0c0
+          994aa7ec 8b6c9d68 0d1b1a2f a2e1ed45
+          709b8b94 b53bfaad 972fa4cc bf1b8eb0
+          a59810f9 be0b7839 1af08821 3f623597
+          d2570ea1 f04ece45 8bec2ac7 7b4f241c
+          108920c7 e63b5d35 c6ecb191 1af3d217
+          31a6fe76 bc42a5c3 a613cddc cb142fc6
+          a4d8dcc3 9b44e397 5baa32e6 ad9fe679
+          5744e73f d9bb6809 3f07be91 37632a6c
+          d6c6fca2 54f3bcc0 c619e64a 86447650
+          787b796a 8028d75f 3f242f71 708304ca
+          672c1679 4e9ddddf 8456c792 eb2010f4
+          4da77785 2a0e1c98 924b72ce 56708e9b
+          feff7b5e d72e3028 d9fddeee 4a9aeea6
+          67c0612f 84280f7f 9042cc6a 4184181c
+          3c8c1041 2f199486 8b53c1d5 06664248
+          cb2bc1db b71d673c 9f5a4e22 c4fa5510
+          12e2180e 13d23957 53c1e53a d6422441
+          e0e80d67 0ecea91e 64d419a4 58a0cfd2
+          574b0d79 fb3beb89 2373b72d 53d307de
+          9b6523c8 d98383f0 e6f4b9bc e9dc9c25
+          efcc4157 f7bfeab6 b15629ae 8b4a1029
+          8320b194 d5d95fa4 942bae8f 24134214
+          b04d83b4 59c79baf 948e55b2 930f327e
+          11a48056 1d9840d0 9f7a0d1c f1b874bd
+          4ab9e83a d1815902 5ad119a4 df6838c3
+          12092a41 236bafe7 b84c3a28 29675daf
+          f160be79 6d243ba5 c6578fbe 52f5c95f
+          94525b66 8c713b6b 1b486e17 58e1baf3
+          abc24d29 0ad6ba47 9520535e 26690629
+          ee4ae973 85a26a9b 1381d277 7552ead6
+          ebc21ee2 dc124b5c 5faa411e 1e1c8491
+          419032e5 a0d149d1 185a69ed 735cefb9
+          d4d255e2 9c069596 765a4f9f 1e89d61c
+          c4e1a2b5 ce99b3c2 ed25ac9f 6038e056
+          38660b8e 1097d6e8 6cb4be15 4190392f
+          928641b8 0dadcdb5 42d25950 bea17cb6
+          b552571c 5abd92b0 a5e5fb20 8c0c8211
+          931ea475 70cc96a8 ae8291f2 405e8c84
+          5bdabb20 c6ac3e3c 5263dafa b918634a
+          6695b8dd f9f307b3 f4f97620 3c126362
+          67742663 eeffda82 0c10a443 4d4fa68d
+          90e464df 1a50a2b3 2bc4c6f0 40da7184
+          761bb674 2b7c904f 8f6a1046 06c18869
+          cfc4982f 7b40c261 6d0deb3b 01053d9c
+          62ee9320 c8865718 358d7873 0ecc5b61
+          6f7c8eb9 737d105c 7bef7082 6410b46e
+          ad2e4463 5e8088f6 adeae84e 147f78de
+          98e862db a8999e7a 6f812529 779a8f94
+          febcf6f8 fb704f4b dcb4bd3d 5bdedcf1
+          1e84c0d6 32f5f172 6bf90e05 9aea5f2b
+          4976452f 8ae338b1 5f1256b8 feee92ef
+          501c1f7e 799b04d7 51afd855 725cfb44
+          7c525f21 838ee7f8 808e704e 7ee20a3a
+          471bdd2b bc1f9c0f 42670fde 18dcfe6f
+          af5e7694 85a1008e 9f1d2b5e 83585342
+          4c8cdc02 2975a2f4 4a19bff7 7f96ef94
+          4174eee0 e8ace647 5c68da93 bf674306
+          b3481cb0 356747ea 1710828c 2e6c059f
+          0a6d7421 2154789d 1ecd995f a784798a
+          273c5c1a 235e1ee1 4b6c058c ab68f024
+          832fafeb 2e1a28ce a0b2be43 4cc372fc
+          8afb9d29 f07faa36 67228e10 2f60b182
+          472816e6 acf6eb0c 603616a1 8399e411
+          520c1662 2a42b999 1c22b468 4c851748
+          6b267b12 211ec002 018f10d9 9b49eba7
+          54b0885e ad56a475 1391ac90 d505cc54
+          68bb4289 709396e0 0f1a16e2 bee4e8cc
+          f8385793 29657606 a99d9b46 1cfd000e
+          8b71821a 77617232 e00cbec1 3819e4c6
+          5d34c35d 801b4b6a 77456cc9 40c9103e
+          154a4506 5be1aed4 b776204d 50eeaeb5
+          2979a178 15c03b41 c5157991 b6ee5a4e
+          90861b55 0425a2bf 664a4a46 b6933a63
+          28c44fa6 6567c988 96a6bf26 12822ab8
+          19b3ebf5 9aeefbd7 da92aebf 40cbb67f
+          6defcf5b 063f10a8 35dab9fe 0d516fd7
+          1fdad6a2 7fc3edd6 4805f023 85a4283e
+          f4ef8943 9da67492 a6f541f4 ef1d628a
+          64013f95 598a36e6 f9266643 91cde00e
+          0a4ebddc dc909153 8f17701f 4cc55e6e
+          4e8b983c f61483fb d136f652 f17c9ae9
+          59a4b167 35dc5531 a6248dfb 37836b92
+          31a3807b c39464b0 6bcce9ab 88936976
+          c9e01119 5e51a964 541e4dff 51446f8e
+          65325255 010f134a 9b9c6dcb a615ceeb
+          1d126d53 26132b43 78b04caa cd3794cc
+          e0570415 ff346678 2dff2aa6 75d7d9cd
+          c4769dd6 0cfefc79 94ff183d 2a93948d
+          64820000 00004945 4e44ae42 6082
+        </rawimagedata>
+      </cbdt_bitmap_format_17>
+      <cbdt_bitmap_format_17 name="eight">
+        <SmallGlyphMetrics>
+          <height value="128"/>
+          <width value="136"/>
+          <BearingX value="0"/>
+          <BearingY value="101"/>
+          <Advance value="136"/>
+        </SmallGlyphMetrics>
+        <rawimagedata>
+          89504e47 0d0a1a0a 0000000d 49484452
+          00000088 00000080 08030000 00e737d1
+          0d000000 36504c54 454c6971 40404040
+          40404040 40404040 40404071 7171c3c3
+          c3dfdfdf efefeff4 f4f4fafa fad0d0d0
+          f8f8f8b6 b6b6e7e7 e7909090 a6a6a6ad
+          4143d100 00001274 524e5300 0a131e29
+          3340739e c8dfff84 f266b34d 59e71538
+          bc000003 04494441 547801ed 9ac1b29d
+          200c860b f02902a2 beffcb76 3a3d73ab
+          a15e4f17 c959946f ed8cbf49 0249cc8f
+          c1603018 0c0683c1 6030b0c7 f910232f
+          620cde7d 44458874 c460adc5 456e88ce
+          5ec634a7 25971779 49f3642c 25005097
+          d2b15400 828d8e08 5073f92b 6b028856
+          3a5a2eb7 e406441b 1da97c4b 02a2858e
+          ad3cb04d ea4a82d0 71c3a21d b1eece2f
+          920d70ba 8e99cb5b ccaacef1 30e5f216
+          eb045ed3 20a93b37 e61df639 ad7dea44
+          c50899d6 ee752fa6 d49bc4e9 a54cbdbe
+          ece0c47c 155921e8 79662967 1a10bdfb
+          559944a4 caace71b a0f38b3f 994b0490
+          9a6f1c34 190527e3 0719414d 2b6fbc30
+          fe266c1f c5a19bb4 822408db cfe085d0
+          6623447c f10e4e9e ffe2c289 26490374
+          c1bc7e5e 887ce07f 102282f5 d9355659
+          b3839342 4cb2c6c3 fc2fe95b c1ab5dbe
+          0f075a6f 311522e4 72e27ac4 7b71c467
+          c0a80c48 9c947820 c932c0aa 30aad732
+          e0d02b8c 04519864 9d3971ac 7aa5a2c0
+          21a2a4a4 e9a654cc 80576d27 f6b59c59
+          b7b9c121 8be7f580 a8dc60b5 37db1a54
+          c7241ea8 e5910a78 fde6b7ad 0fcd55b3
+          18d60460 5fca372c bba20ea1 847a6b94
+          5cb1d1e1 7930c9b6 03380b1d d31b1323
+          bcbe8e23 9707f204 78751d6b 79643d74
+          bde3a48e 4f2989bd 8e9c5a83 36a72c94
+          68cef37c 77e72d8d 2f5a36bb f5ba7e3f
+          7161331a 1979d8bb 1b85f0bb 300a208b
+          955dcb24 7db70fd1 5dfe586c b2b8b628
+          e2f3a576 160312cd 625196ce b5fbe0d8
+          3f11f45b df1570bd cd54e612 cf438767
+          ad2a21b2 f79ded73 77ac3eca 9bc13f75
+          c74d5f88 7c897c66 083116f2 744878a8
+          e642b6e7 ac5113b2 cb6b5ebe 05c8327d
+          f57f09b4 ce24415e cf80c174 7301bcb0
+          199b3ce2 2d7e1b55 e4e88a26 1f081675
+          d17afcd9 18713ed2 8d2cb42a 2360e99a
+          6d313292 bed36a7a 5bdf5e22 4746fad3
+          3c072cfd c6480338 eaf63287 c86f2d93
+          1ce56d0e d5f126b5 bc49d26c f5bc3c29
+          eed980f0 a9ad0da1 23daefb1 98e9104a
+          ead330af 9aecf6bc 37cc8b46 c3bc762b
+          6569669b 681e803d e5d291d3 0180375d
+          cd63afd7 15c1ba83 b239242e 708bf502
+          a70ff410 fca7166b f9e2338b b583c160
+          30180c06 83c160f0 13e55b78 1b5bd5fd
+          5a000000 0049454e 44ae4260 82
+        </rawimagedata>
+      </cbdt_bitmap_format_17>
+      <cbdt_bitmap_format_17 name="uni2049">
+        <SmallGlyphMetrics>
+          <height value="128"/>
+          <width value="136"/>
+          <BearingX value="0"/>
+          <BearingY value="101"/>
+          <Advance value="136"/>
+        </SmallGlyphMetrics>
+        <rawimagedata>
+          89504e47 0d0a1a0a 0000000d 49484452
+          00000088 00000080 08030000 00e737d1
+          0d000001 3b504c54 454c6971 d73b3bd9
+          4141da44 44d94141 d94242d5 3737d83f
+          3fd84040 d94040d9 4141d941 41d53838
+          d13030d8 3f3fee4a 4af74d4d e34545eb
+          4747ff50 50fe5050 fe4e4eda 4242fe4f
+          4ffb4747 d94040d3 3434fd4c 4ce14040
+          f34747fc 4b4bd83e 3eeb4242 fb4949fa
+          4545d639 39d02e2e dc3a3aef 3f3fd333
+          33f94343 d43737f8 4141f740 40ed3939
+          e13434d3 3434cf2b 2bf63e3e f53c3cd2
+          3131f439 39d02c2c cc2626d0 2d2df337
+          37f23535 e83030cf 2b2bf132 32ce2929
+          dd2b2bcb 2222f030 30cb2323 d42525cd
+          2626ef2d 2dc81d1d c31313cb 2222eb25
+          25ee2929 c81b1bdb 2121c91f 1fec2525
+          ea2222eb 2424c71a 1ac10c0c c61919c0
+          0a0ac00a 0ac20c0c c10c0cd1 0b0bda0c
+          0cc00a0a e10c0cc1 0808be06 06df0909
+          cb0202de 0606d403 03bc0202 dc0303b9
+          0000b800 00da0101 b80000b9 0000b800
+          00b70000 fbff4a1d 00000068 74524e53
+          0040cfff df583080 afbfef8f 10209fff
+          ffffffff ffffffff ffff70ff ffffffff
+          ffffffff 60ffffef ffffffff ffffffbf
+          ffffffff 9fd5ffff ffffffff ffff80ff
+          8fffffff ef40ffff ffbfffff ffffffff
+          a0ff50df ff8fffff 8fffffff ffffffff
+          ffffdf9f ff50ff8f 9e461cce 00000655
+          49444154 7801ec96 e9e2e22a 0c476ff7
+          55812254 dcfabfef ff929320 636b6c71
+          c3d98fdf f0977808 a8fdef1f ff788128
+          4e6e48b3 7b557956 94553d56 c4555344
+          ed3b1e59 328bcf64 95954e81 1237d9cb
+          2269324b ba946fb3 2af151af f3d744a0
+          96710283 c5d5bc46 719985e8 189b9430
+          7171a9b2 1745b824 7058cc7d 1a827179
+          0be79d70 2a513891 b96b9d3a 8b8d5c04
+          a78934ed c744dae6 ac31492b 3e833c1f
+          529a7f48 64156b00 34b81f6c c6120d3c
+          7953a0e2 56041649 2caf612d 614b6320
+          6c843509 2f821ebe 7110140c c59a0417
+          b11e5dbf d928fe20 ea691314 d910a848
+          6b3dfc16 0437933c ac486c3d 36923f07
+          54a56d48 9102ef47 3f734b7b c63a21ec
+          4f6ccf29 b2c79934 0f8ba45a b39e702d
+          92a387ea a949dfe9 291da32e 4a8a670e
+          a79a1161 30d3ab84 e654830b 4d49ae55
+          94b41baa de1419eb 236d1357 26dbef1a
+          55d514f8 60a22d82 13153c9c 28944865
+          8c564a49 b5e5eea5 943640dd 8c9fb1da
+          c506d05c f131266d 70fda888 319d2274
+          c65c4472 e3025272 47af5123 bb79d23b
+          9b8c833b 77326d18 9106baef ad08771b
+          e5e851ce b45f1b9b e5e34014 87a52c8c
+          486a8c50 167749e4 c14ce74d 4d84cd21
+          0a398073 10113c99 e3dea2e0 fced9bcb
+          e75eda34 de26f4c6 224c3f2e b2274c44
+          0a9cb643 49789da0 73bcd4ac ad8d1198
+          430d2b82 67138510 29b1f3c5 449db798
+          2f35436f c3210749 87366617 4224a56f
+          fbbf906d 4df3c298 e62191c6 18e111b1
+          873ee1e8 ff1ae07d 3d2cf5f2 53cc8888
+          cbae231c 35e95bfb da655040 45d27744
+          0a27320c 43779c70 1806ef06 5750703c
+          4d38c2c2 6322c370 3811e0d3 5004a987
+          1bfc77ef 5322d940 895b6fbf 7818bec2
+          8ba0493c 4ca9d7c4 8352bd23 f23fc18a
+          bc088a4c 7bfd13f9 65446a10 d94ef87a
+          46644b78 43a4c5af 2f11a9be 114717ba
+          11c34010 40b74cee 89a10ca6 630ef9ff
+          3fac7315 d99b8241 ca8d78a5 993c3951
+          cd0b340b 217cee93 6d8da29a 2752ca4f
+          96372915 e5e54e4a cdb71eb3 21389d50
+          5ecea57c f6a70cb6 2e8f0051 a81a7fea
+          594a4b47 80dc48a9 c77eb494 a378c898
+          251ba2d0 7cf7970c 9f1a0622 ec0f0f72
+          4e9190c9 64c22138 6541ae51 34c183e0
+          f0383ce4 113d3df5 a327132b 12205396
+          3c889a20 337fc7e0 70454343 2e2d6ac6
+          9f99c984 0721c1ea 6910e698 07330b5c
+          144567b9 5c9a5910 83934876 a034efcd
+          aca81492 e358042b eb094e97 89907590
+          68087384 2b1aa72b 4a83ccc3 89394ea5
+          8ed922f1 c7144098 6313e4b0 614532a4
+          3f52ec40 2e694808 1cdbedb6 e7c04d51
+          5a50e110 9cca1c5b e4913220 bb202910
+          f1ede07d 644f8342 4455e060 59fdb814
+          5baeeb7a d104996f 71cb7060 8b4f2dea
+          ba8aebee f1cd2d73 d4dc5104 594555d5
+          c1d1963b 4a21f716 1f9db77e 921d0cd2
+          068985a0 597741b3 2b70d0ca 390e712e
+          06f2e878 b373c89e 068608eb 5cdd777c
+          1143c74a 0ac25014 865359b1 2f604d6f
+          2305eb05 f50a27c8 d1d57dff 9759ab4d
+          120b329b ccf20fed c97c97ad 290639a4
+          41f622d2 1ebcda4f 11a9cddf 2122dd21
+          a8135986 5412efd2 1d4521bd 881ca395
+          9cccff43 9ad7ece8 d5cad22a e1b4f331
+          2805b251 d53618a9 ea471e44 35829c55
+          fb8495fa 9b8bba51 06e4e297 04d9a976
+          fea8531d aa321057 0a442388 aaeecd0a
+          90118075 8ba905b0 c9850031 045882d4
+          0026af0e 684c01c8 14e420cb 2337d917
+          825cdc97 00d94510 00f52a7f e40accde
+          c202d864 43c81842 2e411af2 176227db
+          91340520 b8f9d904 08c9bb37 99c9abc9
+          6d24790b 421ac4ba 8a416c10 c9716134
+          909c5d24 4f45205f 410990fe 1137e643
+          5eafdc83 129ead9a c8d19b22 90d977cc
+          49f7d5cf abeb399a fcaae1f1 5e6556a8
+          7f77f466 95b6c377 d090e9f8 698f0e76
+          1c048130 8e73da5b 1f8b3b11 4b5b953a
+          8222efff 043b241b 56d9c334 0e7be377
+          2bc9ff8b 50869b3c b889a669 9a0b3aa5
+          7ba455c7 6f18a4ee 332d990d c3bd3f51
+          179abba8 40f58979 20437c09 aba13c7b
+          645e3fcc 47abcf61 188e0dfe 7c0a2699
+          361fafec 91563ba2 19c77138 36031e48
+          c1a30f9b 7955d76f 281ddec5 bc4e0c1e
+          7564339d 900d49e1 e5a6025e 4f5d69b8
+          ff8c9d0a 16df996a de05aa21 e193ceef
+          c28c87b5 1b1200fc 1dc5c3af 0bcdbf7c
+          c88d6896 02e34388 d1ca0dc9 01d8a560
+          015ced86 e401c6a5 300278aa 590b5443
+          da420876 3db178b4 d56e682e 0498d783
+          194270f5 1b920c79 356f86ed 422305d3
+          9e566d7e e3b4e9c9 26c6187e 9b803f77
+          c1e62302 3b230b11 f98f9b24 377c7b3c
+          d9990d83 74317392 df306cde 45e4fc56
+          af691a86 6f38d2f4 13a054ea b3000000
+          0049454e 44ae4260 82 
+        </rawimagedata>
+      </cbdt_bitmap_format_17>
+    </strikedata>
+  </CBDT>
+
+  <CBLC>
+    <header version="3.0"/>
+    <strike index="0">
+      <bitmapSizeTable>
+        <sbitLineMetrics direction="hori">
+          <ascender value="101"/>
+          <descender value="-27"/>
+          <widthMax value="136"/>
+          <caretSlopeNumerator value="0"/>
+          <caretSlopeDenominator value="0"/>
+          <caretOffset value="0"/>
+          <minOriginSB value="0"/>
+          <minAdvanceSB value="0"/>
+          <maxBeforeBL value="0"/>
+          <minAfterBL value="0"/>
+          <pad1 value="0"/>
+          <pad2 value="0"/>
+        </sbitLineMetrics>
+        <sbitLineMetrics direction="vert">
+          <ascender value="101"/>
+          <descender value="-27"/>
+          <widthMax value="136"/>
+          <caretSlopeNumerator value="0"/>
+          <caretSlopeDenominator value="0"/>
+          <caretOffset value="0"/>
+          <minOriginSB value="0"/>
+          <minAdvanceSB value="0"/>
+          <maxBeforeBL value="0"/>
+          <minAfterBL value="0"/>
+          <pad1 value="0"/>
+          <pad2 value="0"/>
+        </sbitLineMetrics>
+        <colorRef value="0"/>
+        <startGlyphIndex value="1"/>
+        <endGlyphIndex value="3"/>
+        <ppemX value="109"/>
+        <ppemY value="109"/>
+        <bitDepth value="32"/>
+        <flags value="1"/>
+      </bitmapSizeTable>
+      <!-- GlyphIds are written but not read. The firstGlyphIndex and
+           lastGlyphIndex values will be recalculated by the compiler. -->
+      <eblc_index_sub_table_3 imageFormat="17" firstGlyphIndex="1" lastGlyphIndex="2">
+        <glyphLoc id="1" name="eight"/>
+        <glyphLoc id="2" name="registered"/>
+      </eblc_index_sub_table_3>
+      <eblc_index_sub_table_3 imageFormat="17" firstGlyphIndex="3" lastGlyphIndex="3">
+        <glyphLoc id="3" name="uni2049"/>
+      </eblc_index_sub_table_3>
+    </strike>
+  </CBLC>
+
+  <vhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1275"/>
+    <descent value="-1275"/>
+    <lineGap value="0"/>
+    <advanceHeightMax value="2500"/>
+    <minTopSideBearing value="0"/>
+    <minBottomSideBearing value="0"/>
+    <yMaxExtent value="2400"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="1"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="2500" tsb="0"/>
+    <mtx name="eight" height="2500" tsb="0"/>
+    <mtx name="registered" height="2500" tsb="0"/>
+    <mtx name="uni2049" height="2500" tsb="0"/>
+  </vmtx>
+
+</ttFont>


### PR DESCRIPTION
Fixes #1817

Ideally we should add a test for this. Currently, the only test that has to do with CBLC/EBLC is for the subset module. The Tests/subset/data/google_color.ttx file however only has format 1 index subtable.
I need to make a test font or modify the existing one.

/cc @ckitagawa-work
