### PR TITLE
[feaLib lexer tests] Compare realpath against realpath

### DIFF
--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -223,7 +223,7 @@ class IncludingLexerTest(unittest.TestCase):
             # an in-memory stream, so it will use the current working
             # directory to resolve relative include statements
             lexer = IncludingLexer(UnicodeIO("include(included.fea);"))
-            files = set(loc[0] for _, _, loc in lexer)
+            files = set(os.path.realpath(loc[0]) for _, _, loc in lexer)
             expected = os.path.realpath(included.name)
             self.assertIn(expected, files)
         finally:


### PR DESCRIPTION
On Windows, tests may be run in the user's temp directory, so the previous code may compare `C:\Users\nikolaus.waxweiler\` against `C:\Users\NIKOLA~1.WAX\`.