### PR TITLE
Make calling the subsetter possible with file-like objects

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2771,7 +2771,7 @@ def usage():
 	print("Try pyftsubset --help for more information.\n", file=sys.stderr)
 
 @timer("make one with everything (TOTAL TIME)")
-def main(args=None):
+def main(args=None, outfile=None):
 	from os.path import splitext
 	from fontTools import configLogger
 
@@ -2781,6 +2781,10 @@ def main(args=None):
 	if '--help' in args:
 		print(__doc__)
 		return 0
+
+	fontfile = args[0]
+	args = args[1:]
+
 
 	options = Options()
 	try:
@@ -2795,7 +2799,7 @@ def main(args=None):
 		print("ERROR:", e, file=sys.stderr)
 		return 2
 
-	if len(args) < 2:
+	if len(args) < 1:
 		usage()
 		return 1
 
@@ -2805,11 +2809,7 @@ def main(args=None):
 	else:
 		timer.logger.disabled = True
 
-	fontfile = args[0]
-	args = args[1:]
-
 	subsetter = Subsetter(options=options)
-	outfile = None
 	glyphs = []
 	gids = []
 	unicodes = []


### PR DESCRIPTION
Currently to call the subsetter as a library, the easiest way I found is to call main passing it a list of arguments. 

If it will be used as a step in a pipeline, it would be nice if it does not have to deal with actual files on disk. I found that it is possible to pass a file-like object for the input font as the first item in the argument list, but you cannot do the same with the output font, since all the rest of the arguments are treated as strings. 

This pull request makes it possible to have another file-like object as the output font. This is an extra parameter (named outfile) to main. If outfile is not passed in, everything will work as before, but if it is passed in, the output will be written to that file-like object (for example an `io.BytesIO()` from the standard library).