### PR TITLE
[glyf] compile empty table as 1 null byte to make OTS and Windows happy

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -122,6 +122,12 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 			ttFont['loca'].set(locations)
 		if 'maxp' in ttFont:
 			ttFont['maxp'].numGlyphs = len(self.glyphs)
+		if not data:
+		# As a special case when all glyph in the font are empty, add a zero byte
+		# to the table, so that OTS doesn’t reject it, and to make the table work
+		# on Windows as well.
+		# See https://github.com/khaledhosny/ots/issues/52
+			data = b"\0"
 		return data
 
 	def toXML(self, writer, ttFont, splitGlyphs=False):


### PR DESCRIPTION
OTS rejects fonts with empty tables, and Windows considers the font file invalid if a table is empty.
See discussion https://github.com/khaledhosny/ots/issues/52
When a glyf table is empty (e.g. all glyphs are zero contours) we compile it as a single zero byte `b'\x00'`, which will make it pass OTS.

Fixes https://github.com/fonttools/fonttools/issues/899

