### PR TITLE
[ttGlyphPen] quantize component.transform to F2Dot14 to normalize bbox

### DIFF
--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -1,6 +1,6 @@
 from fontTools.misc.py23 import *
 from array import array
-from fontTools.misc.fixedTools import MAX_F2DOT14, otRound
+from fontTools.misc.fixedTools import MAX_F2DOT14, otRound, floatToFixedToFloat
 from fontTools.pens.basePen import LoggingPen
 from fontTools.pens.transformPen import TransformPen
 from fontTools.ttLib.tables import ttProgram
@@ -119,7 +119,11 @@ class TTGlyphPen(LoggingPen):
             component = GlyphComponent()
             component.glyphName = glyphName
             component.x, component.y = (otRound(v) for v in transformation[4:])
-            transformation = transformation[:4]
+            # quantize floats to F2Dot14 so we get same values as when decompiled
+            # from a binary glyf table
+            transformation = tuple(
+                floatToFixedToFloat(v, 14) for v in transformation[:4]
+            )
             if transformation != (1, 0, 0, 1):
                 if (self.handleOverflowingTransforms and
                         any(MAX_F2DOT14 < s <= 2 for s in transformation)):

--- a/Tests/pens/ttGlyphPen_test.py
+++ b/Tests/pens/ttGlyphPen_test.py
@@ -264,6 +264,33 @@ class TTGlyphPenTest(TestCase):
         compositeGlyph.recalcBounds(glyphSet)
         self.assertGlyphBoundsEqual(compositeGlyph, (-86, 0, 282, 1))
 
+    def test_scaled_component_bounds(self):
+        glyphSet = {}
+
+        pen = TTGlyphPen(glyphSet)
+        pen.moveTo((-231, 939))
+        pen.lineTo((-55, 939))
+        pen.lineTo((-55, 745))
+        pen.lineTo((-231, 745))
+        pen.closePath()
+        glyphSet["gravecomb"] = gravecomb = pen.glyph()
+
+        pen = TTGlyphPen(glyphSet)
+        pen.moveTo((-278, 939))
+        pen.lineTo((8, 939))
+        pen.lineTo((8, 745))
+        pen.lineTo((-278, 745))
+        pen.closePath()
+        glyphSet["circumflexcomb"] = circumflexcomb = pen.glyph()
+
+        pen = TTGlyphPen(glyphSet)
+        pen.addComponent("circumflexcomb", (1, 0, 0, 1, 0, 0))
+        pen.addComponent("gravecomb", (0.9, 0, 0, 0.9, 198, 180))
+        glyphSet["uni0302_uni0300"] = uni0302_uni0300 = pen.glyph()
+
+        uni0302_uni0300.recalcBounds(glyphSet)
+        self.assertGlyphBoundsEqual(uni0302_uni0300, (-278, 745, 148, 1025))
+
 
 class _TestGlyph(object):
     def __init__(self, glyph):


### PR DESCRIPTION
Fixes https://github.com/googlefonts/fontmake/issues/558

When creating a composite glyph with a scaled component using the TTGlyphPen, the bounding
box coordinates may change depending on whether one computes the bbox *before* compiling, or
*after* decompiling. Before compiling, component.transform holds double precision floats,
but after compiling and decompiling, these are necessarily clamped to F2Dot14 fixed precision.

The TTGlyphPen needs to quantize transform floats to F2Dot14 so that the values don't
change after compilation.

Without this change, it may happen that round-tripping fonts through ttx (which by default
recalcBBoxes) will produce different bounding boxes for composite glyphs that have
scaled or transformed components.