### PR TITLE
fontBuilder: Allow varLib to use fresh CFF table

### DIFF
--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -506,6 +506,7 @@ class FontBuilder(object):
         fontSet = CFFFontSet()
         fontSet.major = 1
         fontSet.minor = 0
+        fontSet.otFont = self.font
         fontSet.fontNames = [psName]
         fontSet.topDictIndex = TopDictIndex()
 
@@ -520,6 +521,7 @@ class FontBuilder(object):
         topDict = TopDict()
         topDict.charset = self.font.getGlyphOrder()
         topDict.Private = private
+        topDict.GlobalSubrs = fontSet.GlobalSubrs
         for key, value in fontInfo.items():
             setattr(topDict, key, value)
         if "FontMatrix" not in fontInfo:

--- a/Tests/fontBuilder/fontBuilder_test.py
+++ b/Tests/fontBuilder/fontBuilder_test.py
@@ -255,6 +255,19 @@ def test_build_cff2(tmpdir):
     _verifyOutput(outPath)
 
 
+def test_build_cff_to_cff2(tmpdir):
+    fb, _, _ = _setupFontBuilder(False, 1000)
+
+    pen = T2CharStringPen(600, None)
+    drawTestGlyph(pen)
+    charString = pen.getCharString()
+    charStrings = {".notdef": charString, "A": charString, "a": charString, ".null": charString}
+    fb.setupCFF("TestFont", {}, charStrings, {})
+
+    from fontTools.varLib.cff import convertCFFtoCFF2
+    convertCFFtoCFF2(fb.font)
+
+
 def test_setupNameTable_no_mac():
     fb, _, nameStrings = _setupFontBuilder(True)
     fb.setupNameTable(nameStrings, mac=False)


### PR DESCRIPTION
Make sure the CFF table generated by fontBuilder can be used by varLib without having to compile and decompile the table first. This was breaking in converting the CFF table to CFF2 due to some unset attributes.