### PR TITLE
Use non-localized date parsing to fix #1838

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,11 @@ cache:
   - directories:
     - $HOME/.pyenv_cache
 
+addons:
+  apt:
+    packages:
+      - language-pack-de
+
 before_install:
   - source ./.travis/before_install.sh
 

--- a/Lib/fontTools/misc/timeTools.py
+++ b/Lib/fontTools/misc/timeTools.py
@@ -4,6 +4,7 @@
 from fontTools.misc.py23 import *
 import os
 import time
+from datetime import datetime, timezone
 import calendar
 
 
@@ -44,7 +45,12 @@ def timestampToString(value):
 	return asctime(time.gmtime(max(0, value + epoch_diff)))
 
 def timestampFromString(value):
-	return calendar.timegm(time.strptime(value)) - epoch_diff
+	wkday, mnth = value[:7].split()
+	t = datetime.strptime(value[7:], ' %d %H:%M:%S %Y')
+	t = t.replace(month=MONTHNAMES.index(mnth), tzinfo=timezone.utc)
+	wkday_idx = DAYNAMES.index(wkday)
+	assert t.weekday() == wkday_idx, '"' + value + '" has inconsistent weekday'
+	return int(t.timestamp()) - epoch_diff
 
 def timestampNow():
 	# https://reproducible-builds.org/specs/source-date-epoch/

--- a/Tests/misc/timeTools_test.py
+++ b/Tests/misc/timeTools_test.py
@@ -1,7 +1,8 @@
 from fontTools.misc.py23 import *
-from fontTools.misc.timeTools import asctime, timestampNow, epoch_diff
+from fontTools.misc.timeTools import asctime, timestampNow, timestampToString, timestampFromString, epoch_diff
 import os
 import time
+import locale
 import pytest
 
 
@@ -21,3 +22,17 @@ def test_source_date_epoch():
 
     del os.environ["SOURCE_DATE_EPOCH"]
     assert timestampNow() + epoch_diff != 150687315
+
+
+# test for issue #1838
+def test_date_parsing_with_locale():
+    l = locale.getlocale(locale.LC_TIME)
+    try:
+        locale.setlocale(locale.LC_TIME, 'de_DE.utf8')
+    except locale.Error:
+        pytest.skip("Locale de_DE not available")
+
+    try:
+        assert timestampFromString(timestampToString(timestampNow()))
+    finally:
+        locale.setlocale(locale.LC_TIME, l)


### PR DESCRIPTION
This commit uses non-localized date parsing in [`fontTools.misc.timeTools.timestampFromString`](https://github.com/fonttools/fonttools/blob/51bff6cf6a08976c831aa5c9e8c901fac7e61dea/Lib/fontTools/misc/timeTools.py#L46). This is consistent with the opposite function `fontTools.misc.timeTools.timestampToString`, which also uses a non-localized date format.

This function is used when importing a font from XML using [`fontTools.ttLib.TTFont.importXML`](https://github.com/fonttools/fonttools/blob/51bff6cf6a08976c831aa5c9e8c901fac7e61dea/Lib/fontTools/ttLib/ttFont.py#L318) via [`fontTools.ttLib.tables.table__h_e_a_d.fromXML`](https://github.com/fonttools/fonttools/blob/51bff6cf6a08976c831aa5c9e8c901fac7e61dea/Lib/fontTools/ttLib/tables/_h_e_a_d.py#L107)

Depending on the LC_TIME locale setting, the parsing of the created and modified dates of a font might fail, as described in #1838. This fix provides simple code to parse the date string with a fixed format, defined by [`fontTools.misc.timeTools.asctime`](https://github.com/fonttools/fonttools/blob/51bff6cf6a08976c831aa5c9e8c901fac7e61dea/Lib/fontTools/misc/timeTools.py#L17). The parsing is now independent of the LC_TIME locale setting.