### PR TITLE
Fix composite instructions for empty program

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -789,7 +789,8 @@ class Glyph(object):
 		haveInstructions = 0
 		for i in range(len(self.components)):
 			if i == lastcomponent:
-				haveInstructions = hasattr(self, "program")
+				# Only set haveInstructions if the program is non-zero
+				haveInstructions = hasattr(self, "program") and self.program
 				more = 0
 			compo = self.components[i]
 			data = data + compo.compile(more, haveInstructions, glyfTable)

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -677,6 +677,13 @@ class Glyph(object):
 			haveInstructions = haveInstructions | haveInstr
 			self.components.append(component)
 		if haveInstructions:
+			if not data:
+				log.warning(
+					"Composite glyph flags announce presence of instructions, but there are none. %s",
+					[c.glyphName for c in self.components]
+				)
+				return
+
 			numInstructions, = struct.unpack(">h", data[:2])
 			data = data[2:]
 			self.program = ttProgram.Program()


### PR DESCRIPTION
I found a problem when a composite has a glyph program which is empty.

When I generate a PDF via InDesign, which contains a subset of such font, composite glyphs with empty programs still have the "WE_HAVE_INSTRUCTIONS" flag set, but there is no instruction data to decompile. This causes the affected glyphs to disappear from the PDF text, and make Adobe Reader show a warning about damaged fonts.

This patch makes sure the flag is only set if there actually is a non-empty glyph program.

It also adds a warning on decompilation of a broken font extracted from such PDF (instead of failing decompilation).