### PR TITLE
Annotate LookupFlag ttx dump

### DIFF
--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1569,6 +1569,19 @@ class VarDataValue(BaseConverter):
 	def xmlRead(self, attrs, content, font):
 		return safeEval(attrs["value"])
 
+class LookupFlag(UShort):
+	def xmlWrite(self, xmlWriter, font, value, name, attrs):
+		xmlWriter.simpletag(name, attrs + [("value", value)])
+		if value > 0:
+			flags = []
+			if value & 0x01: flags.append("rightToLeft")
+			if value & 0x02: flags.append("ignoreBaseGlyphs")
+			if value & 0x04: flags.append("ignoreLigatures")
+			if value & 0x08: flags.append("ignoreMarks")
+			if value & 0x10: flags.append("useMarkFilteringSet")
+			if value & 0xff00: flags.append("markAttachmentType")
+			xmlWriter.comment(" ".join(flags))
+		xmlWriter.newline()
 
 converterMapping = {
 	# type		class
@@ -1595,6 +1608,7 @@ converterMapping = {
 	"DeltaValue":	DeltaValue,
 	"VarIdxMapValue":	VarIdxMapValue,
 	"VarDataValue":	VarDataValue,
+	"LookupFlag": LookupFlag,
 
 	# AAT
 	"CIDGlyphMap":	CIDGlyphMap,

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1579,7 +1579,7 @@ class LookupFlag(UShort):
 			if value & 0x04: flags.append("ignoreLigatures")
 			if value & 0x08: flags.append("ignoreMarks")
 			if value & 0x10: flags.append("useMarkFilteringSet")
-			if value & 0xff00: flags.append("markAttachmentType")
+			if value & 0xff00: flags.append("markAttachmentType[%i]" % (value >> 8))
 			xmlWriter.comment(" ".join(flags))
 		xmlWriter.newline()
 

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1572,14 +1572,14 @@ class VarDataValue(BaseConverter):
 class LookupFlag(UShort):
 	def xmlWrite(self, xmlWriter, font, value, name, attrs):
 		xmlWriter.simpletag(name, attrs + [("value", value)])
-		if value > 0:
-			flags = []
-			if value & 0x01: flags.append("rightToLeft")
-			if value & 0x02: flags.append("ignoreBaseGlyphs")
-			if value & 0x04: flags.append("ignoreLigatures")
-			if value & 0x08: flags.append("ignoreMarks")
-			if value & 0x10: flags.append("useMarkFilteringSet")
-			if value & 0xff00: flags.append("markAttachmentType[%i]" % (value >> 8))
+		flags = []
+		if value & 0x01: flags.append("rightToLeft")
+		if value & 0x02: flags.append("ignoreBaseGlyphs")
+		if value & 0x04: flags.append("ignoreLigatures")
+		if value & 0x08: flags.append("ignoreMarks")
+		if value & 0x10: flags.append("useMarkFilteringSet")
+		if value & 0xff00: flags.append("markAttachmentType[%i]" % (value >> 8))
+		if flags:
 			xmlWriter.comment(" ".join(flags))
 		xmlWriter.newline()
 

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -87,7 +87,7 @@ otData = [
 
 	('Lookup', [
 		('uint16', 'LookupType', None, None, 'Different enumerations for GSUB and GPOS'),
-		('uint16', 'LookupFlag', None, None, 'Lookup qualifiers'),
+		('LookupFlag', 'LookupFlag', None, None, 'Lookup qualifiers'),
 		('uint16', 'SubTableCount', None, None, 'Number of SubTables for this lookup'),
 		('Offset', 'SubTable', 'SubTableCount', 0, 'Array of offsets to SubTables-from beginning of Lookup table'),
 		('uint16', 'MarkFilteringSet', None, 'LookupFlag & 0x0010', 'If set, indicates that the lookup table structure is followed by a MarkFilteringSet field. The layout engine skips over all mark glyphs not in the mark filtering set indicated.'),

--- a/Tests/feaLib/data/lookupflag.ttx
+++ b/Tests/feaLib/data/lookupflag.ttx
@@ -263,7 +263,7 @@
       </Lookup>
       <Lookup index="14">
         <LookupType value="1"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -275,7 +275,7 @@
       </Lookup>
       <Lookup index="15">
         <LookupType value="1"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -311,7 +311,7 @@
       </Lookup>
       <Lookup index="18">
         <LookupType value="1"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -323,7 +323,7 @@
       </Lookup>
       <Lookup index="19">
         <LookupType value="1"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -347,7 +347,7 @@
       </Lookup>
       <Lookup index="21">
         <LookupType value="1"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>

--- a/Tests/feaLib/data/lookupflag.ttx
+++ b/Tests/feaLib/data/lookupflag.ttx
@@ -151,7 +151,7 @@
       </Lookup>
       <Lookup index="5">
         <LookupType value="1"/>
-        <LookupFlag value="256"/><!-- markAttachmentType -->
+        <LookupFlag value="256"/><!-- markAttachmentType[1] -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -163,7 +163,7 @@
       </Lookup>
       <Lookup index="6">
         <LookupType value="1"/>
-        <LookupFlag value="512"/><!-- markAttachmentType -->
+        <LookupFlag value="512"/><!-- markAttachmentType[2] -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -175,7 +175,7 @@
       </Lookup>
       <Lookup index="7">
         <LookupType value="1"/>
-        <LookupFlag value="260"/><!-- ignoreLigatures markAttachmentType -->
+        <LookupFlag value="260"/><!-- ignoreLigatures markAttachmentType[1] -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -251,7 +251,7 @@
       </Lookup>
       <Lookup index="13">
         <LookupType value="1"/>
-        <LookupFlag value="768"/><!-- markAttachmentType -->
+        <LookupFlag value="768"/><!-- markAttachmentType[3] -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>

--- a/Tests/feaLib/data/lookupflag.ttx
+++ b/Tests/feaLib/data/lookupflag.ttx
@@ -91,7 +91,7 @@
       <!-- LookupCount=22 -->
       <Lookup index="0">
         <LookupType value="1"/>
-        <LookupFlag value="1"/>
+        <LookupFlag value="1"/><!-- rightToLeft -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -103,7 +103,7 @@
       </Lookup>
       <Lookup index="1">
         <LookupType value="1"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -115,7 +115,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="1"/>
-        <LookupFlag value="4"/>
+        <LookupFlag value="4"/><!-- ignoreLigatures -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -127,7 +127,7 @@
       </Lookup>
       <Lookup index="3">
         <LookupType value="1"/>
-        <LookupFlag value="7"/>
+        <LookupFlag value="7"/><!-- rightToLeft ignoreBaseGlyphs ignoreLigatures -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -139,7 +139,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="1"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -151,7 +151,7 @@
       </Lookup>
       <Lookup index="5">
         <LookupType value="1"/>
-        <LookupFlag value="256"/>
+        <LookupFlag value="256"/><!-- markAttachmentType -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -163,7 +163,7 @@
       </Lookup>
       <Lookup index="6">
         <LookupType value="1"/>
-        <LookupFlag value="512"/>
+        <LookupFlag value="512"/><!-- markAttachmentType -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -175,7 +175,7 @@
       </Lookup>
       <Lookup index="7">
         <LookupType value="1"/>
-        <LookupFlag value="260"/>
+        <LookupFlag value="260"/><!-- ignoreLigatures markAttachmentType -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -187,7 +187,7 @@
       </Lookup>
       <Lookup index="8">
         <LookupType value="1"/>
-        <LookupFlag value="16"/>
+        <LookupFlag value="16"/><!-- useMarkFilteringSet -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -200,7 +200,7 @@
       </Lookup>
       <Lookup index="9">
         <LookupType value="1"/>
-        <LookupFlag value="16"/>
+        <LookupFlag value="16"/><!-- useMarkFilteringSet -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -213,7 +213,7 @@
       </Lookup>
       <Lookup index="10">
         <LookupType value="1"/>
-        <LookupFlag value="20"/>
+        <LookupFlag value="20"/><!-- ignoreLigatures useMarkFilteringSet -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -238,7 +238,7 @@
       </Lookup>
       <Lookup index="12">
         <LookupType value="1"/>
-        <LookupFlag value="16"/>
+        <LookupFlag value="16"/><!-- useMarkFilteringSet -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>
@@ -251,7 +251,7 @@
       </Lookup>
       <Lookup index="13">
         <LookupType value="1"/>
-        <LookupFlag value="768"/>
+        <LookupFlag value="768"/><!-- markAttachmentType -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage>

--- a/Tests/feaLib/data/spec5fi2.ttx
+++ b/Tests/feaLib/data/spec5fi2.ttx
@@ -31,7 +31,7 @@
       <!-- LookupCount=2 -->
       <Lookup index="0">
         <LookupType value="6"/>
-        <LookupFlag value="7"/>
+        <LookupFlag value="7"/><!-- rightToLeft ignoreBaseGlyphs ignoreLigatures -->
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="3">
           <!-- BacktrackGlyphCount=1 -->
@@ -54,7 +54,7 @@
       </Lookup>
       <Lookup index="1">
         <LookupType value="1"/>
-        <LookupFlag value="7"/>
+        <LookupFlag value="7"/><!-- rightToLeft ignoreBaseGlyphs ignoreLigatures -->
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
           <Substitution in="d" out="d.alt"/>

--- a/Tests/mtiLib/data/mti/chained-glyph.ttx.GPOS
+++ b/Tests/mtiLib/data/mti/chained-glyph.ttx.GPOS
@@ -5,7 +5,7 @@
     <!-- LookupCount=2 -->
     <Lookup index="0">
       <LookupType value="8"/>
-      <LookupFlag value="512"/><!-- markAttachmentType -->
+      <LookupFlag value="512"/><!-- markAttachmentType[2] -->
       <!-- SubTableCount=1 -->
       <ChainContextPos index="0" Format="1">
         <Coverage Format="1">

--- a/Tests/mtiLib/data/mti/chained-glyph.ttx.GPOS
+++ b/Tests/mtiLib/data/mti/chained-glyph.ttx.GPOS
@@ -5,7 +5,7 @@
     <!-- LookupCount=2 -->
     <Lookup index="0">
       <LookupType value="8"/>
-      <LookupFlag value="512"/>
+      <LookupFlag value="512"/><!-- markAttachmentType -->
       <!-- SubTableCount=1 -->
       <ChainContextPos index="0" Format="1">
         <Coverage Format="1">

--- a/Tests/mtiLib/data/mti/chained-glyph.ttx.GSUB
+++ b/Tests/mtiLib/data/mti/chained-glyph.ttx.GSUB
@@ -5,7 +5,7 @@
     <!-- LookupCount=2 -->
     <Lookup index="0">
       <LookupType value="6"/>
-      <LookupFlag value="512"/>
+      <LookupFlag value="512"/><!-- markAttachmentType -->
       <!-- SubTableCount=1 -->
       <ChainContextSubst index="0" Format="1">
         <Coverage Format="1">

--- a/Tests/mtiLib/data/mti/chained-glyph.ttx.GSUB
+++ b/Tests/mtiLib/data/mti/chained-glyph.ttx.GSUB
@@ -5,7 +5,7 @@
     <!-- LookupCount=2 -->
     <Lookup index="0">
       <LookupType value="6"/>
-      <LookupFlag value="512"/><!-- markAttachmentType -->
+      <LookupFlag value="512"/><!-- markAttachmentType[2] -->
       <!-- SubTableCount=1 -->
       <ChainContextSubst index="0" Format="1">
         <Coverage Format="1">

--- a/Tests/mtiLib/data/mti/gsubreversechanined.ttx.GSUB
+++ b/Tests/mtiLib/data/mti/gsubreversechanined.ttx.GSUB
@@ -5,7 +5,7 @@
     <!-- LookupCount=1 -->
     <Lookup index="0">
       <LookupType value="8"/>
-      <LookupFlag value="9"/>
+      <LookupFlag value="9"/><!-- rightToLeft ignoreMarks -->
       <!-- SubTableCount=3 -->
       <ReverseChainSingleSubst index="0" Format="1">
         <Coverage Format="2">

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -470,7 +470,7 @@ class BuilderTest(object):
         assert getXML(lookup.toXML) == [
             "<Lookup>",
             '  <LookupType value="1"/>',
-            '  <LookupFlag value="7"/>',
+            '  <LookupFlag value="7"/><!-- rightToLeft ignoreBaseGlyphs ignoreLigatures -->',
             "  <!-- SubTableCount=2 -->",
             '  <SingleSubst index="0">',
             '    <Substitution in="one" out="two"/>',
@@ -524,7 +524,7 @@ class BuilderTest(object):
         assert getXML(lookup.toXML) == [
             "<Lookup>",
             '  <LookupType value="1"/>',
-            '  <LookupFlag value="17"/>',
+            '  <LookupFlag value="17"/><!-- rightToLeft useMarkFilteringSet -->',
             "  <!-- SubTableCount=1 -->",
             '  <SingleSubst index="0">',
             '    <Substitution in="one" out="two"/>',

--- a/Tests/otlLib/data/gsub_51.ttx
+++ b/Tests/otlLib/data/gsub_51.ttx
@@ -105,7 +105,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/otlLib/data/gsub_52.ttx
+++ b/Tests/otlLib/data/gsub_52.ttx
@@ -105,7 +105,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gpos1_1_lookupflag_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos1_1_lookupflag_f1.ttx.GPOS
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="1"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos1_2_font2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos1_2_font2.ttx.GPOS
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="1"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <SinglePos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos2_1_lookupflag_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos2_1_lookupflag_f1.ttx.GPOS
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos2_1_lookupflag_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos2_1_lookupflag_f2.ttx.GPOS
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos2_2_font2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos2_2_font2.ttx.GPOS
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos2_2_font3.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos2_2_font3.ttx.GPOS
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos3_font2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos3_font2.ttx.GPOS
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="3"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <CursivePos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos3_font3.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos3_font3.ttx.GPOS
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="3"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <CursivePos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos4_lookupflag_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos4_lookupflag_f1.ttx.GPOS
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <MarkBasePos index="0" Format="1">
           <MarkCoverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos4_lookupflag_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos4_lookupflag_f2.ttx.GPOS
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <MarkBasePos index="0" Format="1">
           <MarkCoverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos5_font1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gpos5_font1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g30">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining1_boundary_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining1_boundary_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining1_boundary_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining1_boundary_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining1_boundary_f3.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining1_boundary_f3.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining1_boundary_f4.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining1_boundary_f4.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining1_lookupflag_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining1_lookupflag_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">
@@ -97,7 +97,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="8"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ChainContextPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining1_multiple_subrules_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining1_multiple_subrules_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining1_multiple_subrules_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining1_multiple_subrules_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining1_next_glyph_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining1_next_glyph_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining1_simple_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining1_simple_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining1_simple_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining1_simple_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining1_successive_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining1_successive_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining2_boundary_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining2_boundary_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining2_boundary_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining2_boundary_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining2_boundary_f3.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining2_boundary_f3.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining2_boundary_f4.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining2_boundary_f4.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining2_lookupflag_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining2_lookupflag_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">
@@ -97,7 +97,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="8"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ChainContextPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining2_multiple_subrules_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining2_multiple_subrules_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining2_multiple_subrules_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining2_multiple_subrules_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining2_next_glyph_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining2_next_glyph_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining2_simple_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining2_simple_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining2_simple_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining2_simple_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining2_successive_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining2_successive_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining3_boundary_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining3_boundary_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining3_boundary_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining3_boundary_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining3_boundary_f3.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining3_boundary_f3.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining3_boundary_f4.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining3_boundary_f4.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining3_lookupflag_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining3_lookupflag_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">
@@ -97,7 +97,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="8"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ChainContextPos index="0" Format="3">
           <!-- BacktrackGlyphCount=2 -->

--- a/Tests/ttLib/tables/data/aots/gpos_chaining3_next_glyph_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining3_next_glyph_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining3_simple_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining3_simple_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining3_simple_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining3_simple_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_chaining3_successive_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_chaining3_successive_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context1_boundary_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context1_boundary_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context1_boundary_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context1_boundary_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context1_expansion_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context1_expansion_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context1_lookupflag_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context1_lookupflag_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">
@@ -97,7 +97,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="7"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context1_lookupflag_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context1_lookupflag_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">
@@ -97,7 +97,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="7"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context1_multiple_subrules_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context1_multiple_subrules_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context1_multiple_subrules_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context1_multiple_subrules_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context1_next_glyph_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context1_next_glyph_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context1_simple_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context1_simple_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context1_simple_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context1_simple_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context1_successive_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context1_successive_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_boundary_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_boundary_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_boundary_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_boundary_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_classes_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_classes_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_classes_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_classes_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_expansion_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_expansion_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_lookupflag_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_lookupflag_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">
@@ -97,7 +97,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="7"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_lookupflag_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_lookupflag_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">
@@ -97,7 +97,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="7"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_multiple_subrules_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_multiple_subrules_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_multiple_subrules_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_multiple_subrules_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_next_glyph_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_next_glyph_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_simple_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_simple_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_simple_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_simple_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context2_successive_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context2_successive_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context3_boundary_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context3_boundary_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context3_boundary_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context3_boundary_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context3_lookupflag_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context3_lookupflag_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">
@@ -97,7 +97,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="7"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextPos index="0" Format="3">
           <!-- GlyphCount=3 -->

--- a/Tests/ttLib/tables/data/aots/gpos_context3_lookupflag_f2.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context3_lookupflag_f2.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">
@@ -97,7 +97,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="7"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextPos index="0" Format="3">
           <!-- GlyphCount=3 -->

--- a/Tests/ttLib/tables/data/aots/gpos_context3_next_glyph_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context3_next_glyph_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context3_simple_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context3_simple_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gpos_context3_successive_f1.ttx.GPOS
+++ b/Tests/ttLib/tables/data/aots/gpos_context3_successive_f1.ttx.GPOS
@@ -72,7 +72,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gsub1_1_lookupflag_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub1_1_lookupflag_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="1"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <SingleSubst index="0" Format="1">
           <Substitution in="g18" out="g23"/>

--- a/Tests/ttLib/tables/data/aots/gsub1_2_lookupflag_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub1_2_lookupflag_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="1"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <SingleSubst index="0" Format="2">
           <Substitution in="g18" out="g22"/>

--- a/Tests/ttLib/tables/data/aots/gsub2_1_lookupflag_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub2_1_lookupflag_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <MultipleSubst index="0" Format="1">
           <Substitution in="g18" out="g20,g21"/>

--- a/Tests/ttLib/tables/data/aots/gsub3_1_lookupflag_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub3_1_lookupflag_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="3"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <AlternateSubst index="0" Format="1">
           <AlternateSet glyph="g18">

--- a/Tests/ttLib/tables/data/aots/gsub4_1_lookupflag_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub4_1_lookupflag_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g18">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining1_boundary_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining1_boundary_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining1_boundary_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining1_boundary_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining1_boundary_f3.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining1_boundary_f3.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining1_boundary_f4.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining1_boundary_f4.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining1_lookupflag_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining1_lookupflag_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">
@@ -76,7 +76,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="6"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining1_multiple_subrules_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining1_multiple_subrules_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining1_multiple_subrules_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining1_multiple_subrules_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining1_next_glyph_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining1_next_glyph_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining1_simple_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining1_simple_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining1_simple_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining1_simple_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining1_successive_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining1_successive_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining2_boundary_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining2_boundary_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining2_boundary_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining2_boundary_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining2_boundary_f3.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining2_boundary_f3.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining2_boundary_f4.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining2_boundary_f4.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining2_lookupflag_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining2_lookupflag_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">
@@ -76,7 +76,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="6"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining2_multiple_subrules_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining2_multiple_subrules_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining2_multiple_subrules_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining2_multiple_subrules_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining2_next_glyph_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining2_next_glyph_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining2_simple_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining2_simple_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining2_simple_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining2_simple_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining2_successive_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining2_successive_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining3_boundary_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining3_boundary_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining3_boundary_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining3_boundary_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining3_boundary_f3.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining3_boundary_f3.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining3_boundary_f4.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining3_boundary_f4.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining3_lookupflag_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining3_lookupflag_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">
@@ -76,7 +76,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="6"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ChainContextSubst index="0" Format="3">
           <!-- BacktrackGlyphCount=2 -->

--- a/Tests/ttLib/tables/data/aots/gsub_chaining3_next_glyph_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining3_next_glyph_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining3_simple_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining3_simple_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining3_simple_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining3_simple_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_chaining3_successive_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_chaining3_successive_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context1_boundary_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context1_boundary_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context1_boundary_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context1_boundary_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context1_expansion_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context1_expansion_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context1_lookupflag_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context1_lookupflag_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">
@@ -76,7 +76,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="5"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextSubst index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gsub_context1_lookupflag_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context1_lookupflag_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">
@@ -76,7 +76,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="5"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextSubst index="0" Format="1">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gsub_context1_multiple_subrules_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context1_multiple_subrules_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context1_multiple_subrules_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context1_multiple_subrules_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context1_next_glyph_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context1_next_glyph_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context1_simple_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context1_simple_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context1_simple_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context1_simple_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context1_successive_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context1_successive_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_boundary_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_boundary_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_boundary_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_boundary_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_classes_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_classes_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_classes_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_classes_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_expansion_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_expansion_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_lookupflag_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_lookupflag_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">
@@ -76,7 +76,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="5"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextSubst index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_lookupflag_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_lookupflag_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">
@@ -76,7 +76,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="5"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextSubst index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_multiple_subrules_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_multiple_subrules_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_multiple_subrules_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_multiple_subrules_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_next_glyph_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_next_glyph_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_simple_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_simple_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_simple_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_simple_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context2_successive_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context2_successive_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context3_boundary_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context3_boundary_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context3_boundary_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context3_boundary_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context3_lookupflag_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context3_lookupflag_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">
@@ -76,7 +76,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="5"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextSubst index="0" Format="3">
           <!-- GlyphCount=3 -->

--- a/Tests/ttLib/tables/data/aots/gsub_context3_lookupflag_f2.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context3_lookupflag_f2.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">
@@ -76,7 +76,7 @@
       </Lookup>
       <Lookup index="4">
         <LookupType value="5"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <ContextSubst index="0" Format="3">
           <!-- GlyphCount=3 -->

--- a/Tests/ttLib/tables/data/aots/gsub_context3_next_glyph_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context3_next_glyph_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context3_simple_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context3_simple_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/gsub_context3_successive_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/gsub_context3_successive_f1.ttx.GSUB
@@ -58,7 +58,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g21">

--- a/Tests/ttLib/tables/data/aots/lookupflag_ignore_attach_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/lookupflag_ignore_attach_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <LookupFlag value="512"/>
+        <LookupFlag value="512"/><!-- markAttachmentType -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g11">

--- a/Tests/ttLib/tables/data/aots/lookupflag_ignore_attach_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/lookupflag_ignore_attach_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <LookupFlag value="512"/><!-- markAttachmentType -->
+        <LookupFlag value="512"/><!-- markAttachmentType[2] -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g11">

--- a/Tests/ttLib/tables/data/aots/lookupflag_ignore_base_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/lookupflag_ignore_base_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <LookupFlag value="2"/>
+        <LookupFlag value="2"/><!-- ignoreBaseGlyphs -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g18">

--- a/Tests/ttLib/tables/data/aots/lookupflag_ignore_combination_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/lookupflag_ignore_combination_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <LookupFlag value="514"/>
+        <LookupFlag value="514"/><!-- ignoreBaseGlyphs markAttachmentType -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g18">

--- a/Tests/ttLib/tables/data/aots/lookupflag_ignore_combination_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/lookupflag_ignore_combination_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <LookupFlag value="514"/><!-- ignoreBaseGlyphs markAttachmentType -->
+        <LookupFlag value="514"/><!-- ignoreBaseGlyphs markAttachmentType[2] -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g18">

--- a/Tests/ttLib/tables/data/aots/lookupflag_ignore_ligatures_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/lookupflag_ignore_ligatures_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <LookupFlag value="4"/>
+        <LookupFlag value="4"/><!-- ignoreLigatures -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g18">

--- a/Tests/ttLib/tables/data/aots/lookupflag_ignore_marks_f1.ttx.GSUB
+++ b/Tests/ttLib/tables/data/aots/lookupflag_ignore_marks_f1.ttx.GSUB
@@ -31,7 +31,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="4"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <LigatureSubst index="0" Format="1">
           <LigatureSet glyph="g18">

--- a/Tests/varLib/data/PartialInstancerTest2-VF.ttx
+++ b/Tests/varLib/data/PartialInstancerTest2-VF.ttx
@@ -649,7 +649,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_kerning_merging/0.ttx
+++ b/Tests/varLib/data/master_kerning_merging/0.ttx
@@ -263,7 +263,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_kerning_merging/1.ttx
+++ b/Tests/varLib/data/master_kerning_merging/1.ttx
@@ -257,7 +257,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_kerning_merging/2.ttx
+++ b/Tests/varLib/data/master_kerning_merging/2.ttx
@@ -263,7 +263,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Bold.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Bold.ttx
@@ -477,7 +477,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Condensed.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Condensed.ttx
@@ -483,7 +483,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedBold.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedBold.ttx
@@ -483,7 +483,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedLight.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedLight.ttx
@@ -483,7 +483,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedSemiBold.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-CondensedSemiBold.ttx
@@ -483,7 +483,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Light.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Light.ttx
@@ -483,7 +483,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Regular.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-Regular.ttx
@@ -477,7 +477,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-SemiBold.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily3-SemiBold.ttx
@@ -483,7 +483,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily4-Italic15.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily4-Italic15.ttx
@@ -624,7 +624,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="6"/>
-        <LookupFlag value="16"/>
+        <LookupFlag value="16"/><!-- useMarkFilteringSet -->
         <!-- SubTableCount=1 -->
         <MarkMarkPos index="0" Format="1">
           <Mark1Coverage Format="1">

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily4-Regular.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/TestFamily4-Regular.ttx
@@ -618,7 +618,7 @@
       </Lookup>
       <Lookup index="2">
         <LookupType value="6"/>
-        <LookupFlag value="16"/>
+        <LookupFlag value="16"/><!-- useMarkFilteringSet -->
         <!-- SubTableCount=1 -->
         <MarkMarkPos index="0" Format="1">
           <Mark1Coverage Format="1">

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-100,100.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-100,100.ttx
@@ -417,7 +417,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-100,62.5.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-100,62.5.ttx
@@ -417,7 +417,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-400,100.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-400,100.ttx
@@ -411,7 +411,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-400,62.5.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-400,62.5.ttx
@@ -417,7 +417,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-900,100.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-900,100.ttx
@@ -417,7 +417,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">

--- a/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-900,62.5.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest2-VF-instance-900,62.5.ttx
@@ -417,7 +417,7 @@
       <!-- LookupCount=1 -->
       <Lookup index="0">
         <LookupType value="2"/>
-        <LookupFlag value="8"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
         <!-- SubTableCount=1 -->
         <PairPos index="0" Format="2">
           <Coverage Format="1">


### PR DESCRIPTION
This is a cosmetic improvement to the TTX dumps which helps the user by explaining what bits are set in a LookupFlag and what they mean.