### PR TITLE
[varLib] revert to always build gvar, even if empty

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -234,13 +234,11 @@ def _add_gvar(font, masterModel, master_ttfs, tolerance=0.5, optimize=True):
 
 	log.info("Generating gvar")
 	assert "gvar" not in font
-
+	gvar = font["gvar"] = newTable('gvar')
 	glyf = font['glyf']
 
 	# use hhea.ascent of base master as default vertical origin when vmtx is missing
 	baseAscent = font['hhea'].ascent
-
-	variations = {}
 	for glyph in font.getGlyphOrder():
 
 		isComposite = glyf[glyph].isComposite()
@@ -260,6 +258,7 @@ def _add_gvar(font, masterModel, master_ttfs, tolerance=0.5, optimize=True):
 		del allControls
 
 		# Update gvar
+		gvar.variations[glyph] = []
 		deltas = model.getDeltas(allCoords)
 		supports = model.supports
 		assert len(deltas) == len(supports)
@@ -298,13 +297,7 @@ def _add_gvar(font, masterModel, master_ttfs, tolerance=0.5, optimize=True):
 					if optimized_len < unoptimized_len:
 						var = var_opt
 
-			variations.setdefault(glyph, []).append(var)
-
-	if variations:
-		gvar = font["gvar"] = newTable('gvar')
-		gvar.version = 1
-		gvar.reserved = 0
-		gvar.variations = {g: variations.get(g, []) for g in font.getGlyphOrder()}
+			gvar.variations[glyph].append(var)
 
 
 def _remove_TTHinting(font):

--- a/Tests/varLib/data/test_results/SingleMaster.ttx
+++ b/Tests/varLib/data/test_results/SingleMaster.ttx
@@ -62,6 +62,11 @@
     </Axis>
   </fvar>
 
+  <gvar>
+    <version value="1"/>
+    <reserved value="0"/>
+  </gvar>
+
   <name>
     <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Weight


### PR DESCRIPTION
turns out gvar is required by OT spec for VF with TrueType outlines:
see https://github.com/fonttools/fonttools/issues/1855#issuecomment-598769956

Fixes https://github.com/fonttools/fonttools/issues/1855