### PR TITLE
[feaLib] Raise exception when GSUB statement doesn't match a rule.

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -827,7 +827,13 @@ class Parser(object):
                 location)
 
         # GSUB lookup type 6: Chaining contextual substitution.
-        assert len(new) == 0, new
+        if len(new) != 0:
+            raise FeatureLibError(
+                'This is not a valid substitution. If attempting contextual '
+                'substitution, remember to mark the input sequence with a "\'"',
+                location
+            )
+
         rule = self.ast.ChainContextSubstStatement(
             old_prefix, old, old_suffix, lookups, location=location)
         return rule

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -826,14 +826,15 @@ class Parser(object):
                 'is not supported',
                 location)
 
-        # GSUB lookup type 6: Chaining contextual substitution.
+        # If there are remaining glyphs to parse, this is an invalid GSUB statement
         if len(new) != 0:
             raise FeatureLibError(
-                'This is not a valid substitution. If attempting contextual '
-                'substitution, remember to mark the input sequence with a "\'"',
+                'This is an invalid GSUB statement. Make sure your statement '
+                'follows the format of one of the GSUB rules.',
                 location
             )
 
+        # GSUB lookup type 6: Chaining contextual substitution.
         rule = self.ast.ChainContextSubstStatement(
             old_prefix, old, old_suffix, lookups, location=location)
         return rule

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -829,8 +829,7 @@ class Parser(object):
         # If there are remaining glyphs to parse, this is an invalid GSUB statement
         if len(new) != 0:
             raise FeatureLibError(
-                'This is an invalid GSUB statement. Make sure your statement '
-                'follows the format of one of the GSUB rules.',
+                'Invalid substitution statement',
                 location
             )
 

--- a/Tests/feaLib/data/GSUB_error.fea
+++ b/Tests/feaLib/data/GSUB_error.fea
@@ -1,0 +1,13 @@
+# Trigger a parser error in the function parse_substitute_ in order to improve the error message.
+# Note that this is not a valid substitution, this test is made to trigger an error.
+
+languagesystem latn dflt;
+
+@base = [a e];
+@accents = [acute grave];
+
+feature abvs {
+    lookup lookup1 {
+        sub @base @accents by @base;
+    } lookup1;
+} abvs;

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1502,6 +1502,13 @@ class ParserTest(unittest.TestCase):
             FeatureLibError,
             'Expected "by", "from" or explicit lookup references',
             self.parse, "feature liga {substitute f f i;} liga;")
+    
+    def test_substitute_missing_input_sequence(self):
+        self.assertRaisesRegex(
+            FeatureLibError,
+            "This is not a valid substitution. If attempting contextual ",
+            Parser(self.getpath("GSUB_error.fea"), GLYPHNAMES).parse
+        )
 
     def test_subtable(self):
         doc = self.parse("feature test {subtable;} test;")

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1506,7 +1506,7 @@ class ParserTest(unittest.TestCase):
     def test_substitute_invalid_statement(self):
         self.assertRaisesRegex(
             FeatureLibError,
-            "This is an invalid GSUB statement. Make sure your statement ",
+            "Invalid substitution statement",
             Parser(self.getpath("GSUB_error.fea"), GLYPHNAMES).parse
         )
 

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1503,10 +1503,10 @@ class ParserTest(unittest.TestCase):
             'Expected "by", "from" or explicit lookup references',
             self.parse, "feature liga {substitute f f i;} liga;")
     
-    def test_substitute_missing_input_sequence(self):
+    def test_substitute_invalid_statement(self):
         self.assertRaisesRegex(
             FeatureLibError,
-            "This is not a valid substitution. If attempting contextual ",
+            "This is an invalid GSUB statement. Make sure your statement ",
             Parser(self.getpath("GSUB_error.fea"), GLYPHNAMES).parse
         )
 


### PR DESCRIPTION
Raise an exception when a substitute statement doesn't match any of the GSUB lookup rules. Add tests that trigger and test said exception.