### PR TITLE
[feaLib] Fix AttributeError: 'NoneType' object has no attribute 'getAlternateGlyphs'

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1311,9 +1311,10 @@ class ChainContextSubstBuilder(LookupBuilder):
             if lookups == self.SUBTABLE_BREAK_:
                 continue
             for lookup in lookups:
-                alts = lookup.getAlternateGlyphs()
-                for glyph, replacements in alts.items():
-                    result.setdefault(glyph, set()).update(replacements)
+                if lookup is not None:
+                    alts = lookup.getAlternateGlyphs()
+                    for glyph, replacements in alts.items():
+                        result.setdefault(glyph, set()).update(replacements)
         return result
 
     def find_chainable_single_subst(self, glyphs):

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -71,6 +71,7 @@ class BuilderTest(unittest.TestCase):
         ZeroValue_ChainSinglePos_horizontal ZeroValue_ChainSinglePos_vertical
         PairPosSubtable ChainSubstSubtable ChainPosSubtable LigatureSubtable
         AlternateSubtable MultipleSubstSubtable SingleSubstSubtable
+        aalt_chain_contextual_subst
     """.split()
 
     def __init__(self, methodName):

--- a/Tests/feaLib/data/aalt_chain_contextual_subst.fea
+++ b/Tests/feaLib/data/aalt_chain_contextual_subst.fea
@@ -1,0 +1,20 @@
+# https://github.com/googlefonts/fontmake/issues/648
+
+lookup CNTXT_LIGS {
+    sub f i by f_i;
+    sub c t by c_t;
+} CNTXT_LIGS;
+
+lookup CNTXT_SUB {
+    sub n by n.end;
+    sub s by s.end;
+} CNTXT_SUB;
+
+feature calt {
+    sub [a e i o u] f' lookup CNTXT_LIGS i' n' lookup CNTXT_SUB;
+    sub [a e i o u] c' lookup CNTXT_LIGS t' s' lookup CNTXT_SUB;
+} calt;
+
+feature aalt {
+    feature calt;
+} aalt;

--- a/Tests/feaLib/data/aalt_chain_contextual_subst.ttx
+++ b/Tests/feaLib/data/aalt_chain_contextual_subst.ttx
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="aalt"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="calt"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="3"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=4 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="n" out="n.end"/>
+          <Substitution in="s" out="s.end"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0">
+          <LigatureSet glyph="c">
+            <Ligature components="t" glyph="c_t"/>
+          </LigatureSet>
+          <LigatureSet glyph="f">
+            <Ligature components="i" glyph="f_i"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="n" out="n.end"/>
+          <Substitution in="s" out="s.end"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=2 -->
+        <ChainContextSubst index="0" Format="3">
+          <!-- BacktrackGlyphCount=1 -->
+          <BacktrackCoverage index="0">
+            <Glyph value="a"/>
+            <Glyph value="e"/>
+            <Glyph value="i"/>
+            <Glyph value="o"/>
+            <Glyph value="u"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=3 -->
+          <InputCoverage index="0">
+            <Glyph value="f"/>
+          </InputCoverage>
+          <InputCoverage index="1">
+            <Glyph value="i"/>
+          </InputCoverage>
+          <InputCoverage index="2">
+            <Glyph value="n"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=2 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="1"/>
+          </SubstLookupRecord>
+          <SubstLookupRecord index="1">
+            <SequenceIndex value="2"/>
+            <LookupListIndex value="2"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+        <ChainContextSubst index="1" Format="3">
+          <!-- BacktrackGlyphCount=1 -->
+          <BacktrackCoverage index="0">
+            <Glyph value="a"/>
+            <Glyph value="e"/>
+            <Glyph value="i"/>
+            <Glyph value="o"/>
+            <Glyph value="u"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=3 -->
+          <InputCoverage index="0">
+            <Glyph value="c"/>
+          </InputCoverage>
+          <InputCoverage index="1">
+            <Glyph value="t"/>
+          </InputCoverage>
+          <InputCoverage index="2">
+            <Glyph value="s"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=2 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="1"/>
+          </SubstLookupRecord>
+          <SubstLookupRecord index="1">
+            <SequenceIndex value="2"/>
+            <LookupListIndex value="2"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
this was originally reported in https://github.com/googlefonts/fontmake/issues/648 by @m4rc1e and @vv-monsalve

If you have FEA like the one below, with `aalt` feature referencing another feature that in turn contains some chain contextual substitution lookups, one may get an `AttributeError: 'NoneType' object has no attribute 'getAlternateGlyphs'`: 

```
lookup CNTXT_LIGS {
    sub f i by f_i;
    sub c t by c_t;
} CNTXT_LIGS;

lookup CNTXT_SUB {
    sub n by n.end;
    sub s by s.end;
} CNTXT_SUB;

feature calt {
    sub [a e i o u] f' lookup CNTXT_LIGS i' n' lookup CNTXT_SUB;
    sub [a e i o u] c' lookup CNTXT_LIGS t' s' lookup CNTXT_SUB;
} calt;

feature aalt {
    feature calt;
} aalt;
```

I copied the snippet above from the [FEA spec](http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#5fi-specifying-a-chain-sub-rule-and-marking-sub-runs), and simply added an `aalt` feature block referencing the `calt` feature that has the chain contextual lookups.