### PR TITLE
Add missing pen documentation

### DIFF
--- a/Doc/source/pens/cu2quPen.rst
+++ b/Doc/source/pens/cu2quPen.rst
@@ -1,0 +1,8 @@
+########
+cu2quPen
+########
+
+.. automodule:: fontTools.pens.cu2quPen
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/pens/index.rst
+++ b/Doc/source/pens/index.rst
@@ -9,13 +9,16 @@ pens
    basePen
    boundsPen
    cocoaPen
+   cu2quPen
    filterPen
    momentsPen
    perimeterPen
    pointInsidePen
+   pointPen
    qtPen
    recordingPen
    reverseContourPen
+   roundingPen
    statisticsPen
    svgPathPen
    t2CharStringPen

--- a/Doc/source/pens/pointPen.rst
+++ b/Doc/source/pens/pointPen.rst
@@ -1,0 +1,8 @@
+########
+pointPen
+########
+
+.. automodule:: fontTools.pens.pointPen
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/pens/roundingPen.rst
+++ b/Doc/source/pens/roundingPen.rst
@@ -1,0 +1,8 @@
+###########
+roundingPen
+###########
+
+.. automodule:: fontTools.pens.roundingPen
+   :inherited-members:
+   :members:
+   :undoc-members:


### PR DESCRIPTION
This fell off the truck :)

Ignore reportLabPen for now, as reportlab is a missing dependency usually.