### PR TITLE
Eliminate PDF documentation builds on Read The Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,9 @@ sphinx:
   fail_on_warning: false
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+formats:
+  - htmlzip
+  - epub
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
The [PDF builds on RTD fail with the current docstrings/configuration](https://readthedocs.org/projects/fonttools/builds/10881463/).  This PR transitions to distribution of [static HTML site zip archives](https://fonttools.readthedocs.io/_/downloads/en/latest/htmlzip/) and [ePub](https://fonttools.readthedocs.io/_/downloads/en/latest/epub/) builds for those who want to download pre-built content.  We can troubleshoot this if PDF documentation downloads are useful to anyone.