### PR TITLE
[Sphinx docs] indent line breaks in lists

### DIFF
--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -152,7 +152,9 @@ For example:
 This command will install fonttools, as well as the optional dependencies that
 are required to unlock the extra features named "ufo", etc.
 
-Optional dependencies are detailed by module in the list below.
+.. note::
+
+    Optional dependencies are detailed by module in the list below with the ``Extra`` setting that automates ``pip`` dependency installation when this is supported.
 
 
 
@@ -169,11 +171,9 @@ The module exports a ElementTree-like API for reading/writing XML files, and all
 
 Package for reading and writing UFO source files; it requires:
 
-* `fs <https://pypi.org/pypi/fs>`__: (aka ``pyfilesystem2``) filesystem
-abstraction layer.
+* `fs <https://pypi.org/pypi/fs>`__: (aka ``pyfilesystem2``) filesystem abstraction layer.
 
-* `enum34 <https://pypi.org/pypi/enum34>`__: backport for the built-in ``enum``
-module (only required on Python < 3.4).
+* `enum34 <https://pypi.org/pypi/enum34>`__: backport for the built-in ``enum`` module (only required on Python < 3.4).
 
 *Extra:* ``ufo``
 
@@ -183,8 +183,7 @@ module (only required on Python < 3.4).
 
 Module to compress/decompress WOFF 2.0 web fonts; it requires:
 
-* `brotli <https://pypi.python.org/pypi/Brotli>`__: Python bindings of
-the Brotli compression library.
+* `brotli <https://pypi.python.org/pypi/Brotli>`__: Python bindings of the Brotli compression library.
 
 *Extra:* ``woff``
 
@@ -197,10 +196,9 @@ with ``ttx`` we use the ``unicodedata`` module in the Standard Library.
 The version included in there varies between different Python versions.
 To use the latest available data, you can install:
 
-* `unicodedata2 <https://pypi.python.org/pypi/unicodedata2>`__:
-``unicodedata`` backport for Python 2.7 and 3.x updated to the latest
-Unicode version 12.0. Note this is not necessary if you use Python 3.8
-as the latter already comes with an up-to-date ``unicodedata``.
+* `unicodedata2 <https://pypi.python.org/pypi/unicodedata2>`__: ``unicodedata`` backport for Python 2.7
+  and 3.x updated to the latest Unicode version 12.0. Note this is not necessary if you use Python 3.8
+  as the latter already comes with an up-to-date ``unicodedata``.
 
 *Extra:* ``unicode``
 
@@ -213,11 +211,10 @@ It requires one of the following packages in order to solve the so-called
 "minimum weight perfect matching problem in bipartite graphs", or
 the Assignment problem:
 
-* `scipy <https://pypi.python.org/pypi/scipy>`__: the Scientific Library
-for Python, which internally uses `NumPy <https://pypi.python.org/pypi/numpy>`__
-arrays and hence is very fast;
-* `munkres <https://pypi.python.org/pypi/munkres>`__: a pure-Python
-module that implements the Hungarian or Kuhn-Munkres algorithm.
+* `scipy <https://pypi.python.org/pypi/scipy>`__: the Scientific Library for Python, which internally
+  uses `NumPy <https://pypi.python.org/pypi/numpy>`__ arrays and hence is very fast;
+* `munkres <https://pypi.python.org/pypi/munkres>`__: a pure-Python module that implements the Hungarian
+  or Kuhn-Munkres algorithm.
 
 *Extra:* ``interpolatable``
 
@@ -237,8 +234,7 @@ Module for visualizing DesignSpaceDocument and resulting VariationModel.
 
 Advanced module for symbolic font statistics analysis; it requires:
 
-* `sympy <https://pypi.python.org/pypi/sympy>`__: the Python library for
-symbolic mathematics.
+* `sympy <https://pypi.python.org/pypi/sympy>`__: the Python library for symbolic mathematics.
 
 *Extra:* ``symfont``
 
@@ -250,8 +246,8 @@ To get the file creator and type of Macintosh PostScript Type 1 fonts
 on Python 3 you need to install the following module, as the old ``MacOS``
 module is no longer included in Mac Python:
 
-* `xattr <https://pypi.python.org/pypi/xattr>`__: Python wrapper for
-extended filesystem attributes (macOS platform only).
+* `xattr <https://pypi.python.org/pypi/xattr>`__: Python wrapper for extended filesystem attributes
+  (macOS platform only).
 
 *Extra:* ``type1``
 
@@ -261,8 +257,8 @@ extended filesystem attributes (macOS platform only).
 
 Pen for drawing glyphs with Cocoa ``NSBezierPath``, requires:
 
-* `PyObjC <https://pypi.python.org/pypi/pyobjc>`__: the bridge between
-Python and the Objective-C runtime (macOS platform only).
+* `PyObjC <https://pypi.python.org/pypi/pyobjc>`__: the bridge between Python and the Objective-C
+  runtime (macOS platform only).
 
 
 :py:mod:`fontTools.pens.qtPen`
@@ -270,8 +266,8 @@ Python and the Objective-C runtime (macOS platform only).
 
 Pen for drawing glyphs with Qt's ``QPainterPath``, requires:
 
-* `PyQt5 <https://pypi.python.org/pypi/PyQt5>`__: Python bindings for
-the Qt cross platform UI and application toolkit.
+* `PyQt5 <https://pypi.python.org/pypi/PyQt5>`__: Python bindings for the Qt cross platform UI and
+  application toolkit.
 
 
 :py:mod:`fontTools.pens.reportLabPen`
@@ -279,8 +275,8 @@ the Qt cross platform UI and application toolkit.
 
 Pen to drawing glyphs as PNG images, requires:
 
-* `reportlab <https://pypi.python.org/pypi/reportlab>`__: Python toolkit
-for generating PDFs and graphics.
+* `reportlab <https://pypi.python.org/pypi/reportlab>`__: Python toolkit for generating PDFs and
+  graphics.
 
 
 Testing


### PR DESCRIPTION
Sphinx doesn't like the list item line break formatting that is used in the README.rst file (#1888).  This is a Sphinx doc formatting PR for list items on the home page of the RTD documentation.