### PR TITLE
[feaLib] Check lookup index in chaining lookups

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1263,6 +1263,9 @@ class ChainContextPosBuilder(LookupBuilder):
             st.PosLookupRecord = []
             for sequenceIndex, l in enumerate(lookups):
                 if l is not None:
+                    if l.lookup_index is None:
+                        raise FeatureLibError('Missing lookup index',
+                            self.location)
                     rec = otTables.PosLookupRecord()
                     rec.SequenceIndex = sequenceIndex
                     rec.LookupListIndex = l.lookup_index
@@ -1310,6 +1313,9 @@ class ChainContextSubstBuilder(LookupBuilder):
             st.SubstLookupRecord = []
             for sequenceIndex, l in enumerate(lookups):
                 if l is not None:
+                    if l.lookup_index is None:
+                        raise FeatureLibError('Missing lookup index',
+                            self.location)
                     rec = otTables.SubstLookupRecord()
                     rec.SequenceIndex = sequenceIndex
                     rec.LookupListIndex = l.lookup_index

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1264,7 +1264,8 @@ class ChainContextPosBuilder(LookupBuilder):
             for sequenceIndex, l in enumerate(lookups):
                 if l is not None:
                     if l.lookup_index is None:
-                        raise FeatureLibError('Missing lookup index',
+                        raise FeatureLibError('Missing index of the specified '
+                            'lookup, might be a substitution lookup',
                             self.location)
                     rec = otTables.PosLookupRecord()
                     rec.SequenceIndex = sequenceIndex
@@ -1314,7 +1315,8 @@ class ChainContextSubstBuilder(LookupBuilder):
             for sequenceIndex, l in enumerate(lookups):
                 if l is not None:
                     if l.lookup_index is None:
-                        raise FeatureLibError('Missing lookup index',
+                        raise FeatureLibError('Missing index of the specified '
+                            'lookup, might be a positioning lookup',
                             self.location)
                     rec = otTables.SubstLookupRecord()
                     rec.SequenceIndex = sequenceIndex

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -433,7 +433,7 @@ class BuilderTest(unittest.TestCase):
     def test_chain_subst_refrences_GPOS_looup(self):
         self.assertRaisesRegex(
             FeatureLibError,
-            "Missing lookup index",
+            "Missing index of the specified lookup, might be a positioning lookup",
             self.build,
             "lookup dummy { pos a 50; } dummy;"
             "feature test {"
@@ -444,7 +444,7 @@ class BuilderTest(unittest.TestCase):
     def test_chain_pos_refrences_GSUB_looup(self):
         self.assertRaisesRegex(
             FeatureLibError,
-            "Missing lookup index",
+            "Missing index of the specified lookup, might be a substitution lookup",
             self.build,
             "lookup dummy { sub a by A; } dummy;"
             "feature test {"

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -430,6 +430,28 @@ class BuilderTest(unittest.TestCase):
             "Lookup blocks cannot be placed inside 'aalt' features",
             self.build, "feature aalt {lookup L {} L;} aalt;")
 
+    def test_chain_subst_refrences_GPOS_looup(self):
+        self.assertRaisesRegex(
+            FeatureLibError,
+            "Missing lookup index",
+            self.build,
+            "lookup dummy { pos a 50; } dummy;"
+            "feature test {"
+            "    sub a' lookup dummy b;"
+            "} test;"
+        )
+
+    def test_chain_pos_refrences_GSUB_looup(self):
+        self.assertRaisesRegex(
+            FeatureLibError,
+            "Missing lookup index",
+            self.build,
+            "lookup dummy { sub a by A; } dummy;"
+            "feature test {"
+            "    pos a' lookup dummy b;"
+            "} test;"
+        )
+
     def test_extensions(self):
         class ast_BaseClass(ast.MarkClass):
             def asFea(self, indent=""):


### PR DESCRIPTION
Raise if `lookup_index` is None, which would happen only of the lookup referenced belongs to the wrong table. The error message needs to be less cryptic, though.

Fixes https://github.com/fonttools/fonttools/issues/1896