### PR TITLE
[feaLib] Hide traceback by default on command line

### DIFF
--- a/Lib/fontTools/feaLib/__main__.py
+++ b/Lib/fontTools/feaLib/__main__.py
@@ -1,6 +1,7 @@
 from fontTools.misc.py23 import *
 from fontTools.ttLib import TTFont
 from fontTools.feaLib.builder import addOpenTypeFeatures, Builder
+from fontTools.feaLib.error import FeatureLibError
 from fontTools import configLogger
 from fontTools.misc.cliTools import makeOutputFileName
 import sys
@@ -27,6 +28,9 @@ def main(args=None):
     parser.add_argument(
         "-v", "--verbose", help="increase the logger verbosity. Multiple -v "
         "options are allowed.", action="count", default=0)
+    parser.add_argument(
+        "--traceback", help="show traceback for exceptions.",
+        action="store_true")
     options = parser.parse_args(args)
 
     levels = ["WARNING", "INFO", "DEBUG"]
@@ -36,7 +40,12 @@ def main(args=None):
     log.info("Compiling features to '%s'" % (output_font))
 
     font = TTFont(options.input_font)
-    addOpenTypeFeatures(font, options.input_fea, tables=options.tables)
+    try:
+        addOpenTypeFeatures(font, options.input_fea, tables=options.tables)
+    except FeatureLibError as e:
+        if options.traceback:
+            raise
+        log.error(e)
     font.save(output_font)
 
 


### PR DESCRIPTION
Makes the command line tool a little nicer to use. Adds `--traceback` option to show them when needed.