### PR TITLE
Use Python3 inheritance style for super.___init__

### DIFF
--- a/Lib/fontTools/cu2qu/errors.py
+++ b/Lib/fontTools/cu2qu/errors.py
@@ -19,7 +19,7 @@ class Error(Exception):
 class ApproxNotFoundError(Error):
     def __init__(self, curve):
         message = "no approximation found: %s" % curve
-        super(Error, self).__init__(message)
+        super().__init__(message)
         self.curve = curve
 
 

--- a/Lib/fontTools/varLib/cff.py
+++ b/Lib/fontTools/varLib/cff.py
@@ -453,7 +453,7 @@ class MergeOutlineExtractor(CFFToCFF2OutlineExtractor):
 
 	def __init__(self, pen, localSubrs, globalSubrs,
 			nominalWidthX, defaultWidthX, private=None):
-		super(CFFToCFF2OutlineExtractor, self).__init__(pen, localSubrs,
+		super().__init__(pen, localSubrs,
 			globalSubrs, nominalWidthX, defaultWidthX, private)
 
 	def countHints(self):
@@ -507,9 +507,7 @@ class CFF2CharStringMergePen(T2CharStringPen):
 	def __init__(
 				self, default_commands, glyphName, num_masters, master_idx,
 				roundTolerance=0.5):
-		super(
-			CFF2CharStringMergePen,
-			self).__init__(
+		super().__init__(
 							width=None,
 							glyphSet=None, CFF2=True,
 							roundTolerance=roundTolerance)


### PR DESCRIPTION
Avoids cases where super() argument is not enclosing class: https://help.semmle.com/wiki/display/PYTHON/First+argument+to+super%28%29+is+not+enclosing+class