### PR TITLE
[docs] Reorganise colorLib docs

### DIFF
--- a/Doc/source/colorLib/builder.rst
+++ b/Doc/source/colorLib/builder.rst
@@ -1,8 +1,0 @@
-#######
-builder
-#######
-
-.. automodule:: fontTools.colorLib.builder
-   :inherited-members:
-   :members:
-   :undoc-members:

--- a/Doc/source/colorLib/errors.rst
+++ b/Doc/source/colorLib/errors.rst
@@ -1,8 +1,0 @@
-######
-errors
-######
-
-.. automodule:: fontTools.colorLib.errors
-   :inherited-members:
-   :members:
-   :undoc-members:

--- a/Doc/source/colorLib/index.rst
+++ b/Doc/source/colorLib/index.rst
@@ -1,14 +1,11 @@
-########
-colorLib
-########
+#####################################################
+colorLib.builder: Build COLR/CPAL tables from scratch
+#####################################################
 
-.. toctree::
-   :maxdepth: 1
+.. automodule:: fontTools.colorLib.builder
+   :members: buildCPAL, buildCOLR, populateCOLRv0
 
-   builder
-   errors
-
-.. automodule:: fontTools.colorLib
+.. autoclass:: fontTools.colorLib.builder.ColorPaletteType
    :inherited-members:
    :members:
    :undoc-members:

--- a/Lib/fontTools/colorLib/builder.py
+++ b/Lib/fontTools/colorLib/builder.py
@@ -1,3 +1,7 @@
+"""
+colorLib.builder: Build COLR/CPAL tables from scratch
+
+"""
 import collections
 import copy
 import enum


### PR DESCRIPTION
Does not add any new documentation (there is already some documentation for user-facing functions). It just makes colorLib.builder the top-level documentation entry, because that’s the part the user needs to care about.