### PR TITLE
[ttLib.table._m_e_t_a] if data happens to be ascii, emit comment in TTX

### DIFF
--- a/Lib/fontTools/ttLib/tables/_m_e_t_a.py
+++ b/Lib/fontTools/ttLib/tables/_m_e_t_a.py
@@ -85,7 +85,11 @@ class table__m_e_t_a(DefaultTable.DefaultTable):
             else:
                 writer.begintag("hexdata", tag=tag)
                 writer.newline()
-                writer.dumphex(self.data[tag])
+                data = self.data[tag]
+                if min(data) >= 0x20 and max(data) <= 0x7E:
+                    writer.comment("ascii: " + data.decode("ascii"))
+                    writer.newline()
+                writer.dumphex(data)
                 writer.endtag("hexdata")
                 writer.newline()
 

--- a/Tests/ttLib/tables/_m_e_t_a_test.py
+++ b/Tests/ttLib/tables/_m_e_t_a_test.py
@@ -58,6 +58,19 @@ class MetaTableTest(unittest.TestCase):
             '</hexdata>'
         ], [line.strip() for line in xml.splitlines()][1:])
 
+    def test_toXML_ascii_data(self):
+        table = table__m_e_t_a()
+        table.data["TEST"] = b"Hello!"
+        writer = XMLWriter(BytesIO())
+        table.toXML(writer, {"meta": table})
+        xml = writer.file.getvalue().decode("utf-8")
+        self.assertEqual([
+            '<hexdata tag="TEST">',
+                '<!-- ascii: Hello! -->',
+                '48656c6c 6f21',
+            '</hexdata>'
+        ], [line.strip() for line in xml.splitlines()][1:])
+
     def test_fromXML(self):
         table = table__m_e_t_a()
         for name, attrs, content in parseXML(


### PR DESCRIPTION
I work on a project where an ascii string is stored in a private `meta` key. For us it would be practical if we could see the ascii contents as a comment string in the TTX output.

This PR checks whether the data could be interpreted as ascii (and does not contain special characters < `0x20`), and emits a comment with the contents decoded from ascii.

Maybe this is a bit too specific, so I won't be heartbroken if this gets rejected.