### PR TITLE
[docs] Reorganise designspaceLib documentation

### DIFF
--- a/Doc/source/designspaceLib/index.rst
+++ b/Doc/source/designspaceLib/index.rst
@@ -1,16 +1,24 @@
-##############
-designspaceLib
-##############
+#######################################################
+designspaceLib: Read, write, and edit designspace files
+#######################################################
 
-MutatorMath started out with its own reader and writer for designspaces.
-Since then the use of designspace has broadened and it would be useful
-to have a reader and writer that are independent of a specific system.
+Implements support for reading and manipulating ``designspace`` files.
+Allows the users to define sources, axes, rules and instances.
 
-.. toctree::
-   :maxdepth: 1
+This documentation covers:
 
-   readme
-   scripting
+-  `Reading a designspace file in Python <#python-api>`_
+-  `The XML structure of a designspace file <#document-xml-structure>`_
+-  `How to create a designspace file in code <#designspacedocument-scripting>`_
+-  `API documentation  <#designspacelib-api>`_
+
+.. include:: readme.rst
+.. include:: scripting.rst
+
+fontTools.designspaceLib
+########################
+
+.. _designspacelib-api:
 
 .. automodule:: fontTools.designspaceLib
    :inherited-members:

--- a/Doc/source/designspaceLib/readme.rst
+++ b/Doc/source/designspaceLib/readme.rst
@@ -1,23 +1,13 @@
-#################################
-DesignSpaceDocument Specification
-#################################
+.. _python-api:
 
-An object to read, write and edit interpolation systems for typefaces. Define sources, axes, rules and instances.
-
--  `The Python API of the objects <#python-api>`_
--  `The document XML structure <#document-xml-structure>`_
-
-
-**********
 Python API
-**********
-
+##########
 
 
 .. _designspacedocument-object:
 
 DesignSpaceDocument object
-==========================
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The DesignSpaceDocument object can read and write ``.designspace`` data.
 It imports the axes, sources and instances to very basic **descriptor**
@@ -46,7 +36,7 @@ all lowercase.
     doc.instances
 
 Attributes
-----------
+""""""""""
 
 -  ``axes``: list of axisDescriptors
 -  ``sources``: list of sourceDescriptors
@@ -60,7 +50,7 @@ Attributes
 -  ``rulesProcessingLast``: This flag indicates whether the substitution rules should be applied before or after other glyph substitution features. False: before, True: after.
 
 Methods
--------
+"""""""
 
 -  ``read(path)``: read a designspace file from ``path``
 -  ``write(path)``: write this designspace to ``path``
@@ -81,14 +71,14 @@ Methods
    location. Returns None if there isn't one.
 -  ``normalizeLocation(aLocation)``: return a dict with normalized axis values.
 -  ``normalize()``: normalize the geometry of this designspace: scale all the
-  locations of all masters and instances to the ``-1 - 0 - 1`` value.
+   locations of all masters and instances to the ``-1 - 0 - 1`` value.
 -  ``loadSourceFonts()``: Ensure SourceDescriptor.font attributes are loaded,
    and return list of fonts.
 -  ``tostring(encoding=None)``: Returns the designspace as a string. Default 
    encoding `utf-8`.
 
 Class Methods
--------------
+"""""""""""""
 - ``fromfile(path)``
 - ``fromstring(string)``
 
@@ -98,10 +88,10 @@ Class Methods
 
 
 SourceDescriptor object
-=======================
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Attributes
-----------
+""""""""""
 
 -  ``filename``: string. A relative path to the source file, **as it is
    in the document**. MutatorMath + Varlib.
@@ -164,13 +154,13 @@ Attributes
 .. _instance-descriptor-object:
 
 InstanceDescriptor object
-=========================
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. attributes-1:
 
 
 Attributes
-----------
+""""""""""
 
 -  ``filename``: string. Relative path to the instance file, **as it is
    in the document**. The file may or may not exist. MutatorMath.
@@ -210,7 +200,7 @@ Attributes
 -  ``lib``: dict. Custom data associated with this instance.
 
 Methods
--------
+"""""""
 
 These methods give easier access to the localised names.
 
@@ -224,7 +214,7 @@ These methods give easier access to the localised names.
 -  ``getStyleMapFamilyName(languageCode="en")``
 
 Example
--------
+"""""""
 
 .. code:: python
 
@@ -251,7 +241,7 @@ Example
 .. _axis-descriptor-object:
 
 AxisDescriptor object
-=====================
+^^^^^^^^^^^^^^^^^^^^^
 
 -  ``tag``: string. Four letter tag for this axis. Some might be
    registered at the `OpenType
@@ -288,7 +278,7 @@ AxisDescriptor object
     a1.map = [(1.0, 10.0), (400.0, 66.0), (1000.0, 990.0)]
 
 RuleDescriptor object
-=====================
+^^^^^^^^^^^^^^^^^^^^^
 
 -  ``name``: string. Unique name for this rule. Can be used to
    reference this rule data.
@@ -299,12 +289,12 @@ RuleDescriptor object
 -  Each substitution is stored as tuples of glyphnames, e.g. ("a", "a.alt").
 
 Evaluating rules
-----------------
-    
--  ``evaluateRule(rule, location)``: Return True if any of the rule's conditionsets 
+""""""""""""""""
+
+-  ``evaluateRule(rule, location)``: Return True if any of the rule's conditionsets
    matches the given location.
 -  ``evaluateConditions(conditions, location)``: Return True if all the conditions
-   matches the given location. 
+   matches the given location.
 -  ``processRules(rules, location, glyphNames)``: Apply all the rules to the list
    of glyphNames. Return a new list of glyphNames with substitutions applied.
 
@@ -320,7 +310,7 @@ Evaluating rules
 .. _subclassing-descriptors:
 
 Subclassing descriptors
-=======================
+^^^^^^^^^^^^^^^^^^^^^^^
 
 The DesignSpaceDocument can take subclassed Reader and Writer objects.
 This allows you to work with your own descriptors. You could subclass
@@ -343,9 +333,8 @@ descriptor does not need to be a subclass.
 
     myDoc = DesignSpaceDocument(KeyedDocReader, KeyedDocWriter)
 
-**********************
-Document xml structure
-**********************
+Document XML structure
+######################
 
 -  The ``axes`` element contains one or more ``axis`` elements.
 -  The ``sources`` element contains one or more ``source`` elements.
@@ -383,7 +372,7 @@ Document xml structure
 .. 1-axis-element:
 
 1. axis element
-===============
+^^^^^^^^^^^^^^^
 
 -  Define a single axis
 -  Child element of ``axes``
@@ -391,7 +380,7 @@ Document xml structure
 .. attributes-2:
 
 Attributes
-----------
+""""""""""
 
 -  ``name``: required, string. Name of the axis that is used in the
    location elements.
@@ -410,7 +399,7 @@ Attributes
 .. 11-labelname-element:
 
 1.1 labelname element
-=====================
+^^^^^^^^^^^^^^^^^^^^^
 
 -  Defines a human readable name for UI use.
 -  Optional for non-registered axis names.
@@ -420,20 +409,20 @@ Attributes
 .. attributes-3:
 
 Attributes
-----------
+""""""""""
 
 -  ``xml:lang``: required, string. `XML language
    definition <https://www.w3.org/International/questions/qa-when-xmllang.en>`__
 
 Value
------
+"""""
 
 -  The natural language name of this axis.
 
 .. example-2:
 
 Example
--------
+"""""""
 
 .. code:: xml
 
@@ -443,7 +432,7 @@ Example
 .. 12-map-element:
 
 1.2 map element
-===============
+^^^^^^^^^^^^^^^
 
 -  Defines a single node in a series of input value (user space coordinate)
    to output value (designspace coordinate) pairs.
@@ -453,7 +442,7 @@ Example
 .. example-3:
 
 Example
--------
+"""""""
 
 .. code:: xml
 
@@ -462,7 +451,7 @@ Example
     <map input="1000.0" output="990.0" />
 
 Example of all axis elements together:
---------------------------------------
+""""""""""""""""""""""""""""""""""""""
 
 .. code:: xml
 
@@ -481,7 +470,7 @@ Example of all axis elements together:
 .. 2-location-element:
 
 2. location element
-===================
+^^^^^^^^^^^^^^^^^^^
 
 -  Defines a coordinate in the design space.
 -  Dictionary of axisname: axisvalue
@@ -490,14 +479,14 @@ Example of all axis elements together:
 .. 21-dimension-element:
 
 2.1 dimension element
-=====================
+^^^^^^^^^^^^^^^^^^^^^
 
 -  Child element of ``location``
 
 .. attributes-4:
 
 Attributes
-----------
+""""""""""
 
 -  ``name``: required, string. Name of the axis.
 -  ``xvalue``: required, number. The value on this axis.
@@ -507,7 +496,7 @@ Attributes
 .. example-4:
 
 Example
--------
+"""""""
 
 .. code:: xml
 
@@ -519,7 +508,7 @@ Example
 .. 3-source-element:
 
 3. source element
-=================
+^^^^^^^^^^^^^^^^^
 
 -  Defines a single font or layer that contributes to the designspace.
 -  Child element of ``sources``
@@ -528,7 +517,7 @@ Example
 .. attributes-5:
 
 Attributes
-----------
+""""""""""
 
 -  ``familyname``: optional, string. The family name of the source font.
    While this could be extracted from the font data itself, it can be
@@ -545,11 +534,12 @@ Attributes
 .. 31-lib-element:
 
 3.1 lib element
-===============
+^^^^^^^^^^^^^^^
 
 There are two meanings for the ``lib`` element:
 
 1. Source lib
+
     -  Example: ``<lib copy="1" />``
     -  Child element of ``source``
     -  Defines if the instances can inherit the data in the lib of this
@@ -557,6 +547,7 @@ There are two meanings for the ``lib`` element:
     -  MutatorMath only
 
 2. Document and instance lib
+
     - Example:
 
       .. code:: xml
@@ -576,7 +567,7 @@ There are two meanings for the ``lib`` element:
 .. 32-info-element:
 
 3.2 info element
-================
+^^^^^^^^^^^^^^^^
 
 -  ``<info copy="1" />``
 -  Child element of ``source``
@@ -587,7 +578,7 @@ There are two meanings for the ``lib`` element:
 .. 33-features-element:
 
 3.3 features element
-====================
+^^^^^^^^^^^^^^^^^^^^
 
 -  ``<features copy="1" />``
 -  Defines if the instances can inherit opentype feature text from this
@@ -598,7 +589,7 @@ There are two meanings for the ``lib`` element:
 .. 34-glyph-element:
 
 3.4 glyph element
-=================
+^^^^^^^^^^^^^^^^^
 
 -  Can appear in ``source`` as well as in ``instance`` elements.
 -  In a ``source`` element this states if a glyph is to be excluded from
@@ -608,7 +599,7 @@ There are two meanings for the ``lib`` element:
 .. attributes-6:
 
 Attributes
-----------
+""""""""""
 
 -  ``mute``: optional attribute, number 1 or 0. Indicate if this glyph
    should be ignored as a master.
@@ -618,7 +609,7 @@ Attributes
 .. 35-kerning-element:
 
 3.5 kerning element
-===================
+^^^^^^^^^^^^^^^^^^^
 
 -  ``<kerning mute="1" />``
 -  Can appear in ``source`` as well as in ``instance`` elements.
@@ -626,7 +617,7 @@ Attributes
 .. attributes-7:
 
 Attributes
-----------
+""""""""""
 
 -  ``mute``: required attribute, number 1 or 0. Indicate if the kerning
    data from this source is to be excluded from the calculation.
@@ -637,7 +628,7 @@ Attributes
 .. example-5:
 
 Example
--------
+"""""""
 
 .. code:: xml
 
@@ -656,7 +647,7 @@ Example
 .. 4-instance-element:
 
 4. instance element
-===================
+^^^^^^^^^^^^^^^^^^^
 
 -  Defines a single font that can be calculated with the designspace.
 -  Child element of ``instances``
@@ -670,7 +661,7 @@ Example
 .. attributes-8:
 
 Attributes
-----------
+""""""""""
 
 -  ``familyname``: required, string. The family name of the instance
    font. Corresponds with ``font.info.familyName``
@@ -689,7 +680,7 @@ Attributes
    with ``styleMapStyleName``
 
 Example for varlib
-------------------
+^^^^^^^^^^^^^^^^^^
 
 .. code:: xml
 
@@ -711,7 +702,7 @@ Example for varlib
 .. 41-glyphs-element:
 
 4.1 glyphs element
-==================
+^^^^^^^^^^^^^^^^^^
 
 -  Container for ``glyph`` elements.
 -  Optional
@@ -720,7 +711,7 @@ Example for varlib
 .. 42-glyph-element:
 
 4.2 glyph element
-=================
+^^^^^^^^^^^^^^^^^
 
 -  Child element of ``glyphs``
 -  May contain a ``location`` element.
@@ -728,7 +719,7 @@ Example for varlib
 .. attributes-9:
 
 Attributes
-----------
+""""""""""
 
 -  ``name``: string. The name of the glyph.
 -  ``unicode``: string. Unicode values for this glyph, in hexadecimal.
@@ -739,14 +730,14 @@ Attributes
 .. 421-note-element:
 
 4.2.1 note element
-==================
+^^^^^^^^^^^^^^^^^^
 
 -  String. The value corresponds to glyph.note in UFO.
 
 .. 422-masters-element:
 
 4.2.2 masters element
-=====================
+^^^^^^^^^^^^^^^^^^^^^
 
 -  Container for ``master`` elements
 -  These ``master`` elements define an alternative set of glyph masters
@@ -755,12 +746,12 @@ Attributes
 .. 4221-master-element:
 
 4.2.2.1 master element
-======================
+^^^^^^^^^^^^^^^^^^^^^^
 
 -  Defines a single alternative master for this glyph.
 
 4.3 Localised names for instances
-=================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Localised names for instances can be included with these simple elements
 with an ``xml:lang`` attribute:
@@ -774,7 +765,7 @@ with an ``xml:lang`` attribute:
 .. example-6:
 
 Example
--------
+"""""""
 
 .. code:: xml
 
@@ -789,7 +780,7 @@ Example
 .. attributes-10:
 
 Attributes
-----------
+""""""""""
 
 -  ``glyphname``: the name of the alternate master glyph.
 -  ``source``: the identifier name of the source this master glyph needs
@@ -798,7 +789,7 @@ Attributes
 .. example-7:
 
 Example
--------
+"""""""
 
 .. code:: xml
 
@@ -838,7 +829,7 @@ Example
 .. 50-rules-element:
 
 5.0 rules element
-=================
+^^^^^^^^^^^^^^^^^
 
 -  Container for ``rule`` elements
 -  The rules are evaluated in this order.
@@ -851,7 +842,7 @@ glyphname pairs: the glyphs that need to be substituted. For a rule to be trigge
 
 
 Attributes
-----------
+""""""""""
 
 -  ``processing``: flag, optional. Valid values are [``first``, ``last``]. This flag indicates whether the substitution rules should be applied before or after other glyph substitution features.
 -  If no ``processing`` attribute is given, interpret as ``first``.
@@ -859,7 +850,7 @@ Attributes
 .. 51-rule-element:
 
 5.1 rule element
-================
+^^^^^^^^^^^^^^^^
 
 -  Defines a named rule.
 -  Each ``rule`` element contains one or more ``conditionset`` elements.
@@ -873,14 +864,14 @@ Attributes
 .. attributes-11:
 
 Attributes
-----------
+""""""""""
 
 -  ``name``: optional, string. A unique name that can be used to
    identify this rule if it needs to be referenced elsewhere. The name
    is not important for compiling variable fonts.
 
 5.1.1 conditionset element
-=======================
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -  Child element of ``rule``
 -  Contains one or more ``condition`` elements.
@@ -888,7 +879,7 @@ Attributes
 .. 512-condition-element:
 
 5.1.2 condition element
-=======================
+^^^^^^^^^^^^^^^^^^^^^^^
 
 -  Child element of ``conditionset``
 -  Between the ``minimum`` and ``maximum`` this condition is ``True``.
@@ -900,7 +891,7 @@ Attributes
 .. attributes-12:
 
 Attributes
-----------
+""""""""""
 
 -  ``name``: string, required. Must match one of the defined ``axis``
    name attributes.
@@ -910,7 +901,7 @@ Attributes
 .. 513-sub-element:
 
 5.1.3 sub element
-=================
+^^^^^^^^^^^^^^^^^
 
 -  Child element of ``rule``.
 -  Defines which glyph to replace when the rule evaluates to **True**.
@@ -921,7 +912,7 @@ Axis values in Conditions are in designspace coordinates.
 .. attributes-13:
 
 Attributes
-----------
+""""""""""
 
 -  ``name``: string, required. The name of the glyph this rule looks
    for.
@@ -931,7 +922,7 @@ Attributes
 .. example-8:
 
 Example
--------
+"""""""
 
 Example with an implied ``conditionset``. Here the conditions are not
 contained in a conditionset. 
@@ -957,8 +948,8 @@ Example with ``conditionsets``. All conditions in a conditionset must be true.
                 <condition minimum="50" maximum="100" name="width" />
             </conditionset>
             <conditionset>
-                <condition ... />
-                <condition ... />
+                <condition  />
+                <condition  />
             </conditionset>
             <sub name="dollar" with="dollar.alt"/>
         </rule>
@@ -966,11 +957,11 @@ Example with ``conditionsets``. All conditions in a conditionset must be true.
 
 .. 6-notes:
 
-6 Notes
-=======
+Notes
+^^^^^
 
 Paths and filenames
--------------------
+"""""""""""""""""""
 
 A designspace file needs to store many references to UFO files.
 
@@ -1049,7 +1040,7 @@ method prepares the paths as follows:
    for filename based on the path and the document path.
 
 Recommendation for editors
---------------------------
+""""""""""""""""""""""""""
 
 -  If you want to explicitly set the **filename** attribute, leave the
    path attribute empty.
@@ -1060,11 +1051,11 @@ Recommendation for editors
 
 .. 7-common-lib-key-registry:
 
-7 Common Lib Key Registry
-=========================
+Common Lib Key Registry
+^^^^^^^^^^^^^^^^^^^^^^^
 
 public.skipExportGlyphs
------------------------
+"""""""""""""""""""""""
 
 This lib key works the same as the UFO lib key with the same name. The
 difference is that applications using a Designspace as the corner stone of the
@@ -1076,56 +1067,57 @@ UFOs says.
 .. 8-implementation-and-differences:
 
 
-8 Implementation and differences
-================================
+Implementation and differences
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The designspace format has gone through considerable development. 
+The designspace format has gone through considerable development.
 
  -  the format was originally written for MutatorMath.
- -  the format is now also used in fontTools.varlib.
+ -  the format is now also used in ``fontTools.varLib``.
  -  not all values are be required by all implementations.
 
-8.1 Varlib vs. MutatorMath
---------------------------
+8.1 varLib vs. MutatorMath
+""""""""""""""""""""""""""
 
-There are some differences between the way MutatorMath and fontTools.varlib handle designspaces.
+There are some differences between the way MutatorMath and
+``fontTools.varLib`` handle designspaces.
 
- -  Varlib does not support anisotropic interpolations.
+ -  ``varLib`` does not support anisotropic interpolations.
  -  MutatorMath will extrapolate over the boundaries of
-    the axes. Varlib can not (at the moment).
- -  Varlib requires much less data to define an instance than
+    the axes. ``varLib`` can not (at the moment).
+ -  ``varLib`` requires much less data to define an instance than
     MutatorMath.
- -  The goals of Varlib and MutatorMath are different, so not all
+ -  The goals of ``varLib`` and MutatorMath are different, so not all
     attributes are always needed.
 
 8.2 Older versions
-------------------
+""""""""""""""""""
 
 -  In some implementations that preceed Variable Fonts, the `copyInfo`
    flag in a source indicated the source was to be treated as the default.
    This is no longer compatible with the assumption that the default font
    is located on the default value of each axis.
 -  Older implementations did not require axis records to be present in
-   the designspace file. The axis extremes for instance were generated 
+   the designspace file. The axis extremes for instance were generated
    from the locations used in the sources. This is no longer possible.
 
 8.3 Rules and generating static UFO instances
----------------------------------------------
+"""""""""""""""""""""""""""""""""""""""""""""
 
 When making instances as UFOs from a designspace with rules, it can
-be useful to evaluate the rules so that the characterset of the ufo 
+be useful to evaluate the rules so that the characterset of the UFO
 reflects, as much as possible, the state of a variable font when seen
 at the same location. This can be done by some swapping and renaming of
 glyphs.
 
 While useful for proofing or development work, it should be noted that
 swapping and renaming leaves the UFOs with glyphnames that are no longer
-descriptive. For instance, after a swap `dollar.bar` could contain a shape
+descriptive. For instance, after a swap ``dollar.bar`` could contain a shape
 without a bar. Also, when the swapped glyphs are part of other GSUB variations
 it can become complex very quickly. So proceed with caution.
 
- -  Assuming `rulesProcessingLast = True`:
- -  We need to swap the glyphs so that the original shape is still available. 
+ -  Assuming ``rulesProcessingLast = True``:
+ -  We need to swap the glyphs so that the original shape is still available.
     For instance, if a rule swaps ``a`` for ``a.alt``, a glyph
     that references ``a`` in a component would then show the new ``a.alt``.
  -  But that can lead to unexpected results, the two glyphs may have different
@@ -1135,13 +1127,4 @@ it can become complex very quickly. So proceed with caution.
     glyphs in order to preserve their appearance.
  -  The swap function also needs to take care of swapping the names in
     kerning data and any GPOS code.
-
-
-.. 9-this-document
-
-9 This document
-===============
-
--  Changes are to be expected.
-
 

--- a/Doc/source/designspaceLib/scripting.rst
+++ b/Doc/source/designspaceLib/scripting.rst
@@ -1,6 +1,8 @@
-#######################
+
 Scripting a designspace
 #######################
+
+.. _designspacedocument-scripting:
 
 It can be useful to build a designspace with a script rather than
 construct one with an interface like
@@ -10,7 +12,6 @@ construct one with an interface like
 `fontTools.designspaceLib` offers a some tools for building designspaces in
 Python. This document shows an example.
 
-********************************
 Filling-in a DesignSpaceDocument
 ********************************
 
@@ -38,7 +39,7 @@ attributes.
 -  Read about :ref:`subclassing-descriptors`
 
 Make an axis object
-===================
+^^^^^^^^^^^^^^^^^^^
 
 Make a descriptor object and add it to the document.
 
@@ -63,7 +64,7 @@ Make a descriptor object and add it to the document.
    default values of all axes. 
 
 Option: add label names
------------------------
+"""""""""""""""""""""""
 
 The **labelnames** attribute is intended to store localisable, human
 readable names for this axis if this is not an axis that is registered
@@ -80,7 +81,7 @@ authoring software. This, at least, is the place to record it.
     a1.labelNames['en'] = u"Wéíght"
 
 Option: add a map
------------------
+"""""""""""""""""
 
 The **map** attribute is a list of (input, output) mapping values
 intended for `axis variations table of
@@ -91,7 +92,7 @@ OpenType <https://www.microsoft.com/typography/otspec/avar.htm>`__.
     a1.map = [(0.0, 10.0), (401.0, 66.0), (1000.0, 990.0)]
 
 Make a source object
-====================
+^^^^^^^^^^^^^^^^^^^^
 
 A **source** is an object that points to a UFO file. It provides the
 outline geometry, kerning and font.info that we want to work with.
@@ -127,7 +128,7 @@ So go ahead and add another master:
     
 
 Option: exclude glyphs
-----------------------
+""""""""""""""""""""""
 
 By default all glyphs in a source will be processed. If you want to
 exclude certain glyphs, add their names to the ``mutedGlyphNames`` list.
@@ -137,7 +138,7 @@ exclude certain glyphs, add their names to the ``mutedGlyphNames`` list.
     s1.mutedGlyphNames = ["A.test", "A.old"]
 
 Make an instance object
-=======================
+^^^^^^^^^^^^^^^^^^^^^^^
 
 An **instance** is description of a UFO that you want to generate with
 the designspace. For an instance you can define more things. If you want
@@ -165,7 +166,7 @@ and so on. You can also set a path where to generate the instance.
 -  Instances for variable fonts become **named instances**.
 
 Option: add more names
-----------------------
+""""""""""""""""""""""
 
 If you want you can add a PostScript font name, a stylemap familyName
 and a stylemap styleName.
@@ -177,7 +178,7 @@ and a stylemap styleName.
     i0.styleMapStyleName = "regular"
 
 Option: add glyph specific masters
-----------------------------------
+""""""""""""""""""""""""""""""""""
 
 This bit is not supported by OpenType variable fonts, but it is needed
 for some designspaces intended for generating instances with
@@ -211,37 +212,34 @@ this into something clever.
     # With all of that set up, store it in the instance.
     i4.glyphs['dollar'] = glyphData
 
-******
 Saving
-******
+^^^^^^
 
 .. code:: python
 
     path = "myprototype.designspace"
     doc.write(path)
 
-************************
 Reading old designspaces
-************************
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Old designspace files might not contain ``axes`` definitions. This is
-how you reconstruct the axes from the extremes of the source locations
+how you reconstruct the axes from the extremes of the source locations:
 
 .. code:: python
 
     doc.checkAxes()
 
-This is how you check the default font.
+This is how you check the default font:
 
 .. code:: python
 
     doc.checkDefault()
 
-***********
 Generating?
-***********
+^^^^^^^^^^^
 
-You can generate the UFO's with MutatorMath:
+You can generate the UFOs with MutatorMath:
 
 .. code:: python
 

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -156,18 +156,22 @@ class SourceDescriptor(SimpleDescriptor):
 
 
 class RuleDescriptor(SimpleDescriptor):
-    """<!-- optional: list of substitution rules -->
-    <rules>
-        <rule name="vertical.bars">
-            <conditionset>
-                <condition minimum="250.000000" maximum="750.000000" name="weight"/>
-                <condition minimum="100" name="width"/>
-                <condition minimum="10" maximum="40" name="optical"/>
-            </conditionset>
-            <sub name="cent" with="cent.alt"/>
-            <sub name="dollar" with="dollar.alt"/>
-        </rule>
-    </rules>
+    """Optionally represents a list of substitution rules, e.g.
+
+    .. code-block:: xml
+
+        <rules>
+            <rule name="vertical.bars">
+                <conditionset>
+                    <condition minimum="250.000000" maximum="750.000000" name="weight"/>
+                    <condition minimum="100" name="width"/>
+                    <condition minimum="10" maximum="40" name="optical"/>
+                </conditionset>
+                <sub name="cent" with="cent.alt"/>
+                <sub name="dollar" with="dollar.alt"/>
+            </rule>
+        </rules>
+
     """
     _attrs = ['name', 'conditionSets', 'subs']   # what do we need here
 
@@ -992,9 +996,12 @@ class BaseDocReader(LogMixin):
 
     def readGlyphElement(self, glyphElement, instanceObject):
         """
-        Read the glyph element.
+        Read the glyph element, which could look like either one of these::
+
             <glyph name="b" unicode="0x62"/>
+
             <glyph name="b"/>
+
             <glyph name="b">
                 <master location="location-token-bbb" source="master-token-aaa2"/>
                 <master glyphname="b.alt1" location="location-token-ccc" source="master-token-aaa3"/>
@@ -1002,6 +1009,7 @@ class BaseDocReader(LogMixin):
                     This is an instance from an anisotropic interpolation.
                 </note>
             </glyph>
+
         """
         glyphData = {}
         glyphName = glyphElement.attrib.get('name')


### PR DESCRIPTION
designspaceLib actually has really thorough documentation already! Because of this, I’ve only done light-touch editing (mostly formatting nits) where I’ve seen obvious problems.

The bigger issue with it is that it’s a bit disorganised, and the references to MutatorMath aren’t necessarily helpful. I’ve tried to improve the organising by providing signposting to end-users to portions of the documentation that can help them achieve what they’re trying to do, reorganising it into one page with links so they don’t have to hunt around for things.