### PR TITLE
subset: fix AttributeError while subsetting Context{Subst,Pos} Format 3

### DIFF
--- a/LICENSE.external
+++ b/LICENSE.external
@@ -26,6 +26,10 @@ XITS font project
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.
 
+Iosevka
+  Copyright (c) 2015-2020 Belleve Invis (belleve@typeof.net).
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
 This license is copied below, and is also available with a FAQ at:
 http://scripts.sil.org/OFL
 

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -894,6 +894,8 @@ def __subset_classify_context(self):
 				self.ClassDef = 'InputClassDef' if Chain else 'ClassDef'
 				self.ClassDefIndex = 1 if Chain else 0
 				self.Input = 'Input' if Chain else 'Class'
+			elif Format == 3:
+				self.Input = 'InputCoverage' if Chain else 'Coverage'
 
 	if self.Format not in [1, 2, 3]:
 		return None	# Don't shoot the messenger; let it go
@@ -976,6 +978,7 @@ def closure_glyphs(self, s, cur_glyphs):
 		if not all(x.intersect(s.glyphs) for x in c.RuleData(self)):
 			return []
 		r = self
+		input_coverages = getattr(r, c.Input)
 		chaos = set()
 		for ll in getattr(r, c.LookupRecord):
 			if not ll: continue
@@ -987,11 +990,11 @@ def closure_glyphs(self, s, cur_glyphs):
 				if seqi == 0:
 					pos_glyphs = frozenset(cur_glyphs)
 				else:
-					pos_glyphs = frozenset(r.InputCoverage[seqi].intersect_glyphs(s.glyphs))
+					pos_glyphs = frozenset(input_coverages[seqi].intersect_glyphs(s.glyphs))
 			lookup = s.table.LookupList.Lookup[ll.LookupListIndex]
 			chaos.add(seqi)
 			if lookup.may_have_non_1to1():
-				chaos.update(range(seqi, len(r.InputCoverage)+1))
+				chaos.update(range(seqi, len(input_coverages)+1))
 			lookup.closure_glyphs(s, cur_glyphs=pos_glyphs)
 	else:
 		assert 0, "unknown format: %s" % self.Format

--- a/Tests/subset/data/TestContextSubstFormat3.ttx
+++ b/Tests/subset/data/TestContextSubstFormat3.ttx
@@ -1,0 +1,610 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.9">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="plus"/>
+    <GlyphID id="2" name="glyph00002"/>
+    <GlyphID id="3" name="glyph00003"/>
+    <GlyphID id="4" name="glyph00004"/>
+    <GlyphID id="5" name="glyph00005"/>
+    <GlyphID id="6" name="glyph00006"/>
+    <GlyphID id="7" name="glyph00007"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0xa69ed898"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00001111"/>
+    <unitsPerEm value="1000"/>
+    <created value="Mon Nov 21 06:10:39 2016"/>
+    <modified value="Fri Apr 24 05:31:23 2020"/>
+    <xMin value="-1000"/>
+    <yMin value="-509"/>
+    <xMax value="1135"/>
+    <yMax value="1194"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="8"/>
+    <fontDirectionHint value="0"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="977"/>
+    <descent value="-205"/>
+    <lineGap value="67"/>
+    <advanceWidthMax value="1000"/>
+    <minLeftSideBearing value="-1000"/>
+    <minRightSideBearing value="-1000"/>
+    <xMaxExtent value="1135"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="1"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="240"/>
+    <maxContours value="41"/>
+    <maxCompositePoints value="163"/>
+    <maxCompositeContours value="12"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="4"/>
+    <maxComponentDepth value="3"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="500"/>
+    <usWeightClass value="500"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="665"/>
+    <ySubscriptYSize value="716"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="143"/>
+    <ySuperscriptXSize value="0"/>
+    <ySuperscriptYSize value="0"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="0"/>
+    <yStrikeoutSize value="51"/>
+    <yStrikeoutPosition value="265"/>
+    <sFamilyClass value="2057"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="6"/>
+      <bProportion value="9"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="BE5N"/>
+    <fsSelection value="00000000 11000000"/>
+    <usFirstCharIndex value="43"/>
+    <usLastCharIndex value="43"/>
+    <sTypoAscender value="977"/>
+    <sTypoDescender value="-272"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="977"/>
+    <usWinDescent value="272"/>
+    <ulCodePageRange1 value="00100000 00000000 00000001 00011111"/>
+    <ulCodePageRange2 value="11000100 00000000 00000000 00000000"/>
+    <sxHeight value="530"/>
+    <sCapHeight value="735"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="8"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="57"/>
+    <mtx name="glyph00002" width="500" lsb="57"/>
+    <mtx name="glyph00003" width="500" lsb="57"/>
+    <mtx name="glyph00004" width="500" lsb="-8"/>
+    <mtx name="glyph00005" width="500" lsb="-8"/>
+    <mtx name="glyph00006" width="500" lsb="-8"/>
+    <mtx name="glyph00007" width="500" lsb="-65"/>
+    <mtx name="plus" width="500" lsb="57"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+    </cmap_format_4>
+    <cmap_format_12 platformID="0" platEncID="4" format="12" reserved="0" length="28" language="0" nGroups="1">
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+    </cmap_format_12>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+    </cmap_format_4>
+    <cmap_format_12 platformID="3" platEncID="10" format="12" reserved="0" length="28" language="0" nGroups="1">
+      <map code="0x2b" name="plus"/><!-- PLUS SIGN -->
+    </cmap_format_12>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+
+    <TTGlyph name="glyph00002" xMin="57" yMin="139" xMax="508" yMax="541">
+      <contour>
+        <pt x="203" y="139" on="1"/>
+        <pt x="203" y="298" on="1"/>
+        <pt x="57" y="298" on="1"/>
+        <pt x="57" y="382" on="1"/>
+        <pt x="203" y="382" on="1"/>
+        <pt x="203" y="541" on="1"/>
+        <pt x="297" y="541" on="1"/>
+        <pt x="297" y="382" on="1"/>
+        <pt x="508" y="382" on="1"/>
+        <pt x="508" y="298" on="1"/>
+        <pt x="297" y="298" on="1"/>
+        <pt x="297" y="139" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="glyph00003" xMin="57" yMin="139" xMax="508" yMax="541">
+      <contour>
+        <pt x="260" y="139" on="1"/>
+        <pt x="260" y="298" on="1"/>
+        <pt x="57" y="298" on="1"/>
+        <pt x="57" y="382" on="1"/>
+        <pt x="260" y="382" on="1"/>
+        <pt x="260" y="541" on="1"/>
+        <pt x="354" y="541" on="1"/>
+        <pt x="354" y="382" on="1"/>
+        <pt x="508" y="382" on="1"/>
+        <pt x="508" y="298" on="1"/>
+        <pt x="354" y="298" on="1"/>
+        <pt x="354" y="139" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="glyph00004" xMin="-8" yMin="139" xMax="508" yMax="541">
+      <contour>
+        <pt x="203" y="139" on="1"/>
+        <pt x="203" y="298" on="1"/>
+        <pt x="-8" y="298" on="1"/>
+        <pt x="-8" y="382" on="1"/>
+        <pt x="203" y="382" on="1"/>
+        <pt x="203" y="541" on="1"/>
+        <pt x="297" y="541" on="1"/>
+        <pt x="297" y="382" on="1"/>
+        <pt x="508" y="382" on="1"/>
+        <pt x="508" y="298" on="1"/>
+        <pt x="297" y="298" on="1"/>
+        <pt x="297" y="139" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="glyph00005" xMin="-8" yMin="139" xMax="443" yMax="541">
+      <contour>
+        <pt x="203" y="139" on="1"/>
+        <pt x="203" y="298" on="1"/>
+        <pt x="-8" y="298" on="1"/>
+        <pt x="-8" y="382" on="1"/>
+        <pt x="203" y="382" on="1"/>
+        <pt x="203" y="541" on="1"/>
+        <pt x="297" y="541" on="1"/>
+        <pt x="297" y="382" on="1"/>
+        <pt x="443" y="382" on="1"/>
+        <pt x="443" y="298" on="1"/>
+        <pt x="297" y="298" on="1"/>
+        <pt x="297" y="139" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="glyph00006" xMin="-8" yMin="139" xMax="443" yMax="541">
+      <contour>
+        <pt x="146" y="139" on="1"/>
+        <pt x="146" y="298" on="1"/>
+        <pt x="-8" y="298" on="1"/>
+        <pt x="-8" y="382" on="1"/>
+        <pt x="146" y="382" on="1"/>
+        <pt x="146" y="541" on="1"/>
+        <pt x="240" y="541" on="1"/>
+        <pt x="240" y="382" on="1"/>
+        <pt x="443" y="382" on="1"/>
+        <pt x="443" y="298" on="1"/>
+        <pt x="240" y="298" on="1"/>
+        <pt x="240" y="139" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="glyph00007" xMin="-65" yMin="139" xMax="443" yMax="541">
+      <contour>
+        <pt x="203" y="139" on="1"/>
+        <pt x="203" y="298" on="1"/>
+        <pt x="-65" y="298" on="1"/>
+        <pt x="-65" y="382" on="1"/>
+        <pt x="203" y="382" on="1"/>
+        <pt x="203" y="541" on="1"/>
+        <pt x="297" y="541" on="1"/>
+        <pt x="297" y="382" on="1"/>
+        <pt x="443" y="382" on="1"/>
+        <pt x="443" y="298" on="1"/>
+        <pt x="297" y="298" on="1"/>
+        <pt x="297" y="139" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="plus" xMin="57" yMin="139" xMax="443" yMax="541">
+      <contour>
+        <pt x="203" y="139" on="1"/>
+        <pt x="203" y="298" on="1"/>
+        <pt x="57" y="298" on="1"/>
+        <pt x="57" y="382" on="1"/>
+        <pt x="203" y="382" on="1"/>
+        <pt x="203" y="541" on="1"/>
+        <pt x="297" y="541" on="1"/>
+        <pt x="297" y="382" on="1"/>
+        <pt x="443" y="382" on="1"/>
+        <pt x="443" y="298" on="1"/>
+        <pt x="297" y="298" on="1"/>
+        <pt x="297" y="139" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright (c) 2015-2019 Belleve Invis.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Iosevka Medium
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      Iosevka Medium Version 3.0.0-rc.8
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Iosevka Medium
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 3.0.0-rc.8; ttfautohint (v1.8.3)
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      Iosevka-Medium
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-50"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="1"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="6380"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="1"/>
+  </post>
+
+  <gasp>
+    <gaspRange rangeMaxPPEM="65535" rangeGaspBehavior="15"/>
+  </gasp>
+
+  <GDEF>
+    <Version value="0x00010000"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph=".notdef" class="1"/>
+      <ClassDef glyph="glyph00002" class="1"/>
+      <ClassDef glyph="glyph00003" class="1"/>
+      <ClassDef glyph="glyph00004" class="1"/>
+      <ClassDef glyph="glyph00005" class="1"/>
+      <ClassDef glyph="glyph00006" class="1"/>
+      <ClassDef glyph="glyph00007" class="1"/>
+      <ClassDef glyph="plus" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=4 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="grek"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="3">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="calt"/>
+        <Feature>
+          <!-- LookupCount=2 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=6 -->
+      <Lookup index="0">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="2">
+          <Coverage Format="1">
+            <Glyph value="plus"/>
+          </Coverage>
+          <BacktrackClassDef Format="1">
+            <ClassDef glyph="glyph00005" class="1"/>
+            <ClassDef glyph="glyph00007" class="1"/>
+          </BacktrackClassDef>
+          <InputClassDef Format="1">
+            <ClassDef glyph="plus" class="1"/>
+          </InputClassDef>
+          <LookAheadClassDef Format="2">
+          </LookAheadClassDef>
+          <!-- ChainSubClassSetCount=2 -->
+          <ChainSubClassSet index="0" empty="1"/>
+          <ChainSubClassSet index="1">
+            <!-- ChainSubClassRuleCount=4 -->
+            <ChainSubClassRule index="0">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="1"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="5"/>
+              </SubstLookupRecord>
+            </ChainSubClassRule>
+            <ChainSubClassRule index="1">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=4 -->
+              <Input index="0" value="1"/>
+              <Input index="1" value="1"/>
+              <Input index="2" value="1"/>
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=4 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="4"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="1">
+                <SequenceIndex value="1"/>
+                <LookupListIndex value="3"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="2">
+                <SequenceIndex value="2"/>
+                <LookupListIndex value="3"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="3">
+                <SequenceIndex value="3"/>
+                <LookupListIndex value="2"/>
+              </SubstLookupRecord>
+            </ChainSubClassRule>
+            <ChainSubClassRule index="2">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=3 -->
+              <Input index="0" value="1"/>
+              <Input index="1" value="1"/>
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=3 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="4"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="1">
+                <SequenceIndex value="1"/>
+                <LookupListIndex value="3"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="2">
+                <SequenceIndex value="2"/>
+                <LookupListIndex value="2"/>
+              </SubstLookupRecord>
+            </ChainSubClassRule>
+            <ChainSubClassRule index="3">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=2 -->
+              <Input index="0" value="1"/>
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=2 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="4"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="1">
+                <SequenceIndex value="1"/>
+                <LookupListIndex value="2"/>
+              </SubstLookupRecord>
+            </ChainSubClassRule>
+          </ChainSubClassSet>
+        </ChainContextSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="5"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=2 -->
+        <ContextSubst index="0" Format="3">
+          <!-- GlyphCount=3 -->
+          <!-- SubstCount=2 -->
+          <Coverage index="0" Format="1">
+            <Glyph value="glyph00002"/>
+          </Coverage>
+          <Coverage index="1" Format="1">
+            <Glyph value="glyph00004"/>
+          </Coverage>
+          <Coverage index="2" Format="1">
+            <Glyph value="glyph00005"/>
+          </Coverage>
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="5"/>
+          </SubstLookupRecord>
+          <SubstLookupRecord index="1">
+            <SequenceIndex value="2"/>
+            <LookupListIndex value="5"/>
+          </SubstLookupRecord>
+        </ContextSubst>
+        <ContextSubst index="1" Format="3">
+          <!-- GlyphCount=2 -->
+          <!-- SubstCount=2 -->
+          <Coverage index="0" Format="1">
+            <Glyph value="glyph00002"/>
+          </Coverage>
+          <Coverage index="1" Format="1">
+            <Glyph value="glyph00005"/>
+          </Coverage>
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="5"/>
+          </SubstLookupRecord>
+          <SubstLookupRecord index="1">
+            <SequenceIndex value="1"/>
+            <LookupListIndex value="5"/>
+          </SubstLookupRecord>
+        </ContextSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="plus" out="glyph00005"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="plus" out="glyph00004"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="4">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="plus" out="glyph00002"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="5">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="glyph00002" out="glyph00003"/>
+          <Substitution in="glyph00005" out="glyph00006"/>
+          <Substitution in="plus" out="glyph00007"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -56,7 +56,7 @@ class SubsetTest(unittest.TestCase):
                     lines.append(line.rstrip() + os.linesep)
         return lines
 
-    def expect_ttx(self, font, expected_ttx, tables):
+    def expect_ttx(self, font, expected_ttx, tables=None):
         path = self.temp_path(suffix=".ttx")
         font.saveXML(path, tables=tables)
         actual = self.read_ttx(path)
@@ -731,6 +731,17 @@ class SubsetTest(unittest.TestCase):
         ttf = TTFont(ttf_path)
 
         self.assertEqual(ttf.flavor, None)
+
+    def test_subset_context_subst_format_3(self):
+        # https://github.com/fonttools/fonttools/issues/1879
+        # Test font contains 'calt' feature with Format 3 ContextSubst lookup subtables
+        ttx = self.getpath("TestContextSubstFormat3.ttx")
+        font, fontpath = self.compile_font(ttx, ".ttf")
+        subsetpath = self.temp_path(".ttf")
+        subset.main([fontpath, "--unicodes=*", "--output-file=%s" % subsetpath])
+        subsetfont = TTFont(subsetpath)
+        # check all glyphs are kept via GSUB closure, no changes expected
+        self.expect_ttx(subsetfont, ttx)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/1879

In Format-3 ChainContext subtables, the array of input coverages is under `InputCoverage` attribute, whereas in non-Chain Context Format 3 subtables it is called simply `Coverage`.
