### PR TITLE
[varLib] Allow feature variations to be active across the entire space

### DIFF
--- a/Lib/fontTools/varLib/featureVars.py
+++ b/Lib/fontTools/varLib/featureVars.py
@@ -136,7 +136,11 @@ def overlayFeatureVariations(conditionalSubstitutions):
                     remainder = hashdict(remainder)
                     newMap[remainder] = newMap.get(remainder, 0) | rank
         boxMap = newMap
-    del boxMap[hashdict()]
+    # Delete initMapInit from boxMap. Need to test for `0` explicitly because there
+    # could be an actual user-defined rule that applies to the entire space, which
+    # would be `1`.
+    if boxMap[hashdict()] == 0:
+        del boxMap[hashdict()]
 
     # Generate output
     items = []

--- a/Lib/fontTools/varLib/featureVars.py
+++ b/Lib/fontTools/varLib/featureVars.py
@@ -82,6 +82,7 @@ def overlayFeatureVariations(conditionalSubstitutions):
     ...     ([{"wght": (0.5, 1.0)}], {"dollar": "dollar.rvrn"}),
     ...     ([{"wght": (0.5, 1.0)}], {"dollar": "dollar.rvrn"}),
     ...     ([{"wdth": (0.5, 1.0)}], {"cent": "cent.rvrn"}),
+    ...     ([{"wght": (0.5, 1.0), "wdth": (-1, 1.0)}], {"dollar": "dollar.rvrn"}),
     ... ]
     >>> from pprint import pprint
     >>> pprint(overlayFeatureVariations(condSubst))
@@ -136,16 +137,14 @@ def overlayFeatureVariations(conditionalSubstitutions):
                     remainder = hashdict(remainder)
                     newMap[remainder] = newMap.get(remainder, 0) | rank
         boxMap = newMap
-    # Delete initMapInit from boxMap. Need to test for `0` explicitly because there
-    # could be an actual user-defined rule that applies to the entire space, which
-    # would be `1`.
-    if boxMap[hashdict()] == 0:
-        del boxMap[hashdict()]
 
     # Generate output
     items = []
     for box,rank in sorted(boxMap.items(),
                            key=(lambda BoxAndRank: -popCount(BoxAndRank[1]))):
+        # Skip the initial entire-space box only if no layers apply.
+        if rank == 0:
+            continue
         substsList = []
         i = 0
         while rank:

--- a/Lib/fontTools/varLib/featureVars.py
+++ b/Lib/fontTools/varLib/featureVars.py
@@ -142,7 +142,7 @@ def overlayFeatureVariations(conditionalSubstitutions):
     items = []
     for box,rank in sorted(boxMap.items(),
                            key=(lambda BoxAndRank: -popCount(BoxAndRank[1]))):
-        # Skip the initial entire-space box only if no layers apply.
+        # Skip any box that doesn't have any substitution.
         if rank == 0:
             continue
         substsList = []

--- a/Tests/varLib/data/FeatureVarsWholeRange.designspace
+++ b/Tests/varLib/data/FeatureVarsWholeRange.designspace
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="3">
+    <axes>
+        <axis default="368.0" maximum="1000.0" minimum="0.0" name="weight" tag="wght" />
+    </axes>
+    <rules processing="last">
+        <rule name="always">
+            <conditionset>
+                <condition name="weight" minimum="0" maximum="1000" />
+            </conditionset>
+            <sub name="uni0024" with="uni0024.nostroke" />
+        </rule>
+    </rules>
+    <sources>
+        <source familyname="Test Family" filename="master_ufo/TestFamily-Master0.ufo" name="master_0" stylename="Master0">
+            <location>
+                <dimension name="weight" xvalue="0" />
+            </location>
+        </source>
+        <source familyname="Test Family" filename="master_ufo/TestFamily-Master1.ufo" name="master_1" stylename="Master1">
+            <lib copy="1" />
+            <groups copy="1" />
+            <info copy="1" />
+            <location>
+                <dimension name="weight" xvalue="368" />
+            </location>
+        </source>
+        <source familyname="Test Family" filename="master_ufo/TestFamily-Master3.ufo" name="master_3" stylename="Master3">
+            <location>
+                <dimension name="weight" xvalue="1000" />
+            </location>
+        </source>
+    </sources>
+</designspace>

--- a/Tests/varLib/data/FeatureVarsWholeRangeEmpty.designspace
+++ b/Tests/varLib/data/FeatureVarsWholeRangeEmpty.designspace
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="3">
+    <axes>
+        <axis default="368.0" maximum="1000.0" minimum="0.0" name="weight" tag="wght" />
+    </axes>
+    <rules processing="last">
+        <rule name="always">
+            <conditionset>
+            </conditionset>
+            <sub name="uni0024" with="uni0024.nostroke" />
+        </rule>
+    </rules>
+    <sources>
+        <source familyname="Test Family" filename="master_ufo/TestFamily-Master0.ufo" name="master_0" stylename="Master0">
+            <location>
+                <dimension name="weight" xvalue="0" />
+            </location>
+        </source>
+        <source familyname="Test Family" filename="master_ufo/TestFamily-Master1.ufo" name="master_1" stylename="Master1">
+            <lib copy="1" />
+            <groups copy="1" />
+            <info copy="1" />
+            <location>
+                <dimension name="weight" xvalue="368" />
+            </location>
+        </source>
+        <source familyname="Test Family" filename="master_ufo/TestFamily-Master3.ufo" name="master_3" stylename="Master3">
+            <location>
+                <dimension name="weight" xvalue="1000" />
+            </location>
+        </source>
+    </sources>
+</designspace>

--- a/Tests/varLib/data/test_results/FeatureVarsWholeRange.ttx
+++ b/Tests/varLib/data/test_results/FeatureVarsWholeRange.ttx
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.9">
+
+  <fvar>
+
+    <!-- Weight -->
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>0.0</MinValue>
+      <DefaultValue>368.0</DefaultValue>
+      <MaxValue>1000.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+  </fvar>
+
+  <GSUB>
+    <Version value="0x00010001"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="rclt"/>
+        <Feature>
+          <!-- LookupCount=0 -->
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="uni0024" out="uni0024.nostroke"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+    <FeatureVariations>
+      <Version value="0x00010000"/>
+      <!-- FeatureVariationCount=1 -->
+      <FeatureVariationRecord index="0">
+        <ConditionSet>
+          <!-- ConditionCount=0 -->
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="0"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="0"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+    </FeatureVariations>
+  </GSUB>
+
+</ttFont>

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -219,11 +219,23 @@ class BuildTest(unittest.TestCase):
         )
 
     def test_varlib_build_feature_variations_whole_range(self):
-        """Designspace file contains <rules> element, used to build
-        GSUB FeatureVariations table.
+        """Designspace file contains <rules> element specifying the entire design
+        space, used to build GSUB FeatureVariations table.
         """
         self._run_varlib_build_test(
             designspace_name="FeatureVarsWholeRange",
+            font_name="TestFamily",
+            tables=["fvar", "GSUB"],
+            expected_ttx_name="FeatureVarsWholeRange",
+            save_before_dump=True,
+        )
+
+    def test_varlib_build_feature_variations_whole_range_empty(self):
+        """Designspace file contains <rules> element without a condition, specifying
+        the entire design space, used to build GSUB FeatureVariations table.
+        """
+        self._run_varlib_build_test(
+            designspace_name="FeatureVarsWholeRangeEmpty",
             font_name="TestFamily",
             tables=["fvar", "GSUB"],
             expected_ttx_name="FeatureVarsWholeRange",

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -218,6 +218,18 @@ class BuildTest(unittest.TestCase):
             save_before_dump=True,
         )
 
+    def test_varlib_build_feature_variations_whole_range(self):
+        """Designspace file contains <rules> element, used to build
+        GSUB FeatureVariations table.
+        """
+        self._run_varlib_build_test(
+            designspace_name="FeatureVarsWholeRange",
+            font_name="TestFamily",
+            tables=["fvar", "GSUB"],
+            expected_ttx_name="FeatureVarsWholeRange",
+            save_before_dump=True,
+        )
+
     def test_varlib_build_feature_variations_with_existing_rclt(self):
         """Designspace file contains <rules> element, used to build GSUB
         FeatureVariations table. <rules> is specified to do its OT processing


### PR DESCRIPTION
Original use case: A VF containing weight and italic axes with a subordinate VF containing only a weight axis of the italic forms. Some Cyrillic glyphs need to be swapped out for special italic forms for some languages like Macedonian. The solution we settled on requires that the special forms are substituted across the entire weight axis range, which varLib filtered out before.