### PR TITLE
tox: add skip_missing_interpreters=true

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -7,7 +7,7 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     source .venv/bin/activate
 fi
 
-tox
+tox --skip-missing-interpreters false
 
 # re-run all the XML-related tests, this time without lxml but using the
 # built-in ElementTree library.
@@ -17,4 +17,4 @@ else
     # strip additional tox envs after the comma, add -nolxml factor
     TOXENV="${TOXENV%,*}-nolxml"
 fi
-tox -e $TOXENV -- Tests/ufoLib Tests/misc/etree_test.py Tests/misc/plistlib_test.py
+tox --skip-missing-interpreters false -e $TOXENV -- Tests/ufoLib Tests/misc/etree_test.py Tests/misc/plistlib_test.py

--- a/Doc/source/developer.rst
+++ b/Doc/source/developer.rst
@@ -50,9 +50,9 @@ environments::
 
 .. note::
 
-    When you run ``tox`` without arguments, the tests are executed for all the environments listed in the ``tox.ini`` ``envlist``. The current Python interpreters defined for tox testing must be available on your system ``PATH``.
+    When you run ``tox`` without arguments, the tests are executed for all the environments listed in the ``tox.ini`` ``envlist``. The Python versions that are not available on your system ``PATH`` will be skipped.
 
-You can specify a different testing environment list via the ``-e`` option, or the ``TOXENV`` environment variable::
+You can specify a specific testing environment list via the ``-e`` option, or the ``TOXENV`` environment variable::
 
     tox -e py36
     TOXENV="py36-cov,htmlcov" tox

--- a/Doc/source/developer.rst
+++ b/Doc/source/developer.rst
@@ -52,7 +52,7 @@ environments::
 
     When you run ``tox`` without arguments, the tests are executed for all the environments listed in the ``tox.ini`` ``envlist``. The Python versions that are not available on your system ``PATH`` will be skipped.
 
-You can specify a specific testing environment list via the ``-e`` option, or the ``TOXENV`` environment variable::
+You can specify a particular testing environment list via the ``-e`` option, or the ``TOXENV`` environment variable::
 
     tox -e py36
     TOXENV="py36-cov,htmlcov" tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 minversion = 3.0
 envlist = py3{6,7,8}-cov, htmlcov
+skip_missing_interpreters=true
 
 [testenv]
 setenv =


### PR DESCRIPTION
https://tox.readthedocs.io/en/latest/config.html#conf-skip_missing_interpreters

Runing `tox` with no options runs the tests agaist all the python
environments that are listed inside the `tox.ini`'s `envlist` (currently 3.6, 3.7 and 3.8).

Before this change, if any of these requested versions was not available, tox would exit with an error. Now it will simply continue (with a warning).

This can be useful when on a developer box, one might only have a subset of all our supported interpreters installed. We don’t want to mark the build as failed because of it.

Note that on the CI I am passing the opposite command line switch that overrides this setting, because there I want to make sure none of the specified interpreters is skipped.

This simplifies running the test suite. It's now simply `pip install tox && tox`. This will run against any of the python versions >= 3.6 that you happen to have installed locally.