### PR TITLE
[feaLib.ast] Restore compatibility with 4.9.0

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -617,16 +617,24 @@ class ChainContextPosStatement(Statement):
     ``prefix``, ``glyphs``, and ``suffix`` should be lists of
     `glyph-containing objects`_ .
 
-    ``lookups`` should be a list of lists containing :class:`LookupBlock`
-    statements. The length of the outer list should equal to the length of
-    ``glyphs``; the inner lists can be of variable length. Where there is no
-    chaining lookup at the given glyph position, the entry in ``lookups``
-    should be ``None``."""
+    ``lookups`` should be a list of elements representing what lookups
+    to apply at each glyph position. Each element should be a
+    :class:`LookupBlock` to apply a single chaining lookup at the given
+    position, a list of :class:`LookupBlock`\ s to apply multiple
+    lookups, or ``None`` to apply no lookup. The length of the outer
+    list should equal the length of ``glyphs``; the inner lists can be
+    of variable length."""
 
     def __init__(self, prefix, glyphs, suffix, lookups, location=None):
         Statement.__init__(self, location)
         self.prefix, self.glyphs, self.suffix = prefix, glyphs, suffix
-        self.lookups = lookups
+        self.lookups = list(lookups)
+        for i, lookup in enumerate(lookups):
+            if lookup:
+                try:
+                    (_ for _ in lookup)
+                except TypeError:
+                    self.lookups[i] = [lookup]
 
     def build(self, builder):
         """Calls the builder's ``add_chain_context_pos`` callback."""
@@ -662,14 +670,24 @@ class ChainContextSubstStatement(Statement):
     ``prefix``, ``glyphs``, and ``suffix`` should be lists of
     `glyph-containing objects`_ .
 
-    ``lookups`` should be a list of :class:`LookupBlock` statements, with
-    length equal to the length of ``glyphs``. Where there is no chaining
-    lookup at the given glyph position, the entry in ``lookups`` should be
-    ``None``."""
+    ``lookups`` should be a list of elements representing what lookups
+    to apply at each glyph position. Each element should be a
+    :class:`LookupBlock` to apply a single chaining lookup at the given
+    position, a list of :class:`LookupBlock`\ s to apply multiple
+    lookups, or ``None`` to apply no lookup. The length of the outer
+    list should equal the length of ``glyphs``; the inner lists can be
+    of variable length."""
+
     def __init__(self, prefix, glyphs, suffix, lookups, location=None):
         Statement.__init__(self, location)
         self.prefix, self.glyphs, self.suffix = prefix, glyphs, suffix
-        self.lookups = lookups
+        self.lookups = list(lookups)
+        for i, lookup in enumerate(lookups):
+            if lookup:
+                try:
+                    (_ for _ in lookup)
+                except TypeError:
+                    self.lookups[i] = [lookup]
 
     def build(self, builder):
         """Calls the builder's ``add_chain_context_subst`` callback."""

--- a/README.rst
+++ b/README.rst
@@ -201,15 +201,15 @@ In alphabetical order:
 
 Olivier Berten, Samyak Bhuta, Erik van Blokland, Petr van Blokland,
 Jelle Bosma, Sascha Brawer, Tom Byrer, Frédéric Coiffier, Vincent
-Connare, Dave Crossland, Simon Daniels, Peter Dekkers, Behdad Esfahbod,
-Behnam Esfahbod, Hannes Famira, Sam Fishman, Matt Fontaine, Yannis
-Haralambous, Greg Hitchcock, Jeremie Hornus, Khaled Hosny, John Hudson,
-Denis Moyogo Jacquerye, Jack Jansen, Tom Kacvinsky, Jens Kutilek,
-Antoine Leca, Werner Lemberg, Tal Leming, Peter Lofting, Cosimo Lupo,
-Masaya Nakamura, Dave Opstad, Laurence Penney, Roozbeh Pournader, Garret
-Rieger, Read Roberts, Guido van Rossum, Just van Rossum, Andreas Seidel,
-Georg Seifert, Chris Simpkins, Miguel Sousa, Adam Twardoch, Adrien Tétar, Vitaly Volkov,
-Paul Wise.
+Connare, David Corbett, Dave Crossland, Simon Daniels, Peter Dekkers,
+Behdad Esfahbod, Behnam Esfahbod, Hannes Famira, Sam Fishman, Matt
+Fontaine, Yannis Haralambous, Greg Hitchcock, Jeremie Hornus, Khaled
+Hosny, John Hudson, Denis Moyogo Jacquerye, Jack Jansen, Tom Kacvinsky,
+Jens Kutilek, Antoine Leca, Werner Lemberg, Tal Leming, Peter Lofting,
+Cosimo Lupo, Masaya Nakamura, Dave Opstad, Laurence Penney, Roozbeh
+Pournader, Garret Rieger, Read Roberts, Guido van Rossum, Just van
+Rossum, Andreas Seidel, Georg Seifert, Chris Simpkins, Miguel Sousa,
+Adam Twardoch, Adrien Tétar, Vitaly Volkov, Paul Wise.
 
 Copyrights
 ~~~~~~~~~~


### PR DESCRIPTION
Version 4.10.0 broke `feaLib.ast.ChainContextPosStatement` and `ChainContextSubstStatement`. Previously each of these classes had a `lookups` field that was a list of lookups. #1905 changed it to a list of lists of lookups. For compatibility, it should treat a lookup within the outer list as if it were a list of a single entry.

In 4.9.0, and once again with my fix, this script:
```python3
#!/usr/bin/env python3

from fontTools.feaLib.ast import (
    ChainContextSubstStatement,
    GlyphName,
    LookupBlock,
)

print(ChainContextSubstStatement(
    [],
    [GlyphName('x')],
    [],
    [LookupBlock('dummy')],
))
```
printed this:
```
sub x' lookup dummy;
```
In 4.10.0, it prints this:
```
Traceback (most recent call last):
  File "./bug.py", line 13, in <module>
    [LookupBlock('dummy')],
  File "/usr/local/lib/python3.7/site-packages/fontTools/feaLib/ast.py", line 128, in __str__
    return self.asFea()
  File "/usr/local/lib/python3.7/site-packages/fontTools/feaLib/ast.py", line 690, in asFea
    for lu in self.lookups[i]:
TypeError: 'LookupBlock' object is not iterable
```

Please merge this, or something similar, and release 4.10.1.