### PR TITLE
[ttLib.name] Fix findMultilingualName()

### DIFF
--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -222,8 +222,11 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 		# Collect matching name IDs
 		matchingNames = dict()
 		for name in self.names:
-			key = (name.string, name.platformID,
-			       name.platEncID, name.langID)
+			try:
+				key = (name.toUnicode(), name.platformID,
+				       name.platEncID, name.langID)
+			except UnicodeDecodeError:
+				continue
 			if key in reqNameSet:
 				nameSet = matchingNames.setdefault(name.nameID, set())
 				nameSet.add(key)

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -166,6 +166,20 @@ class NameTableTest(unittest.TestCase):
 		self.assertEqual(nameID, table.findMultilingualName(namesSubSet))
 		self.assertEqual(None, table.findMultilingualName(namesSuperSet))
 
+	def test_findMultilingualName_compiled(self):
+		table = table__n_a_m_e()
+		names, namesSubSet, namesSuperSet = self._get_test_names()
+		nameID = table.addMultilingualName(names)
+		assert nameID is not None
+		# After compile/decompile, name.string is a bytes sequence, which
+		# findMultilingualName() should also handle
+		data = table.compile(None)
+		table = table__n_a_m_e()
+		table.decompile(data, None)
+		self.assertEqual(nameID, table.findMultilingualName(names))
+		self.assertEqual(nameID, table.findMultilingualName(namesSubSet))
+		self.assertEqual(None, table.findMultilingualName(namesSuperSet))
+
 	def test_addMultilingualNameReuse(self):
 		table = table__n_a_m_e()
 		names, namesSubSet, namesSuperSet = self._get_test_names()

--- a/Tests/varLib/data/test_results/BuildTestCFF2.ttx
+++ b/Tests/varLib/data/test_results/BuildTestCFF2.ttx
@@ -27,31 +27,31 @@
 
     <!-- Regular -->
     <!-- PostScript: TestCFF2Roman-Regular -->
-    <NamedInstance flags="0x0" postscriptNameID="262" subfamilyNameID="261">
+    <NamedInstance flags="0x0" postscriptNameID="261" subfamilyNameID="2">
       <coord axis="wght" value="400.0"/>
     </NamedInstance>
 
     <!-- Medium -->
     <!-- PostScript: TestCFF2Roman-Medium -->
-    <NamedInstance flags="0x0" postscriptNameID="264" subfamilyNameID="263">
+    <NamedInstance flags="0x0" postscriptNameID="263" subfamilyNameID="262">
       <coord axis="wght" value="500.0"/>
     </NamedInstance>
 
     <!-- Semibold -->
     <!-- PostScript: TestCFF2Roman-Semibold -->
-    <NamedInstance flags="0x0" postscriptNameID="266" subfamilyNameID="265">
+    <NamedInstance flags="0x0" postscriptNameID="265" subfamilyNameID="264">
       <coord axis="wght" value="600.0"/>
     </NamedInstance>
 
     <!-- Bold -->
     <!-- PostScript: TestCFF2Roman-Bold -->
-    <NamedInstance flags="0x0" postscriptNameID="268" subfamilyNameID="267">
+    <NamedInstance flags="0x0" postscriptNameID="267" subfamilyNameID="266">
       <coord axis="wght" value="700.0"/>
     </NamedInstance>
 
     <!-- Black -->
     <!-- PostScript: TestCFF2Roman-Black -->
-    <NamedInstance flags="0x0" postscriptNameID="270" subfamilyNameID="269">
+    <NamedInstance flags="0x0" postscriptNameID="269" subfamilyNameID="268">
       <coord axis="wght" value="900.0"/>
     </NamedInstance>
   </fvar>


### PR DESCRIPTION
When reading from binary, `name.string` may be an encoded bytes sequence. Previously, `findMultilingualName()` would fail to match these with the requested input.

Calling `toUnicode()` before we compare to the requested string fixes this.