### PR TITLE
[feaLib] Explicitly look outside UFO for includes

### DIFF
--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -232,12 +232,8 @@ class IncludingLexer(object):
                                           fname_location)
                 try:
                     self.lexers_.append(self.make_lexer_(path))
-                except IOError as err:
-                    # FileNotFoundError does not exist on Python < 3.3
-                    import errno
-                    if err.errno == errno.ENOENT:
-                        raise IncludedFeaNotFound(fname_token, fname_location)
-                    raise  # pragma: no cover
+                except FileNotFoundError as err:
+                    raise IncludedFeaNotFound(fname_token, fname_location) from err
             else:
                 return (token_type, token, location)
         raise StopIteration()

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -201,14 +201,14 @@ class IncludingLexer(object):
     2. relative to the top-level include file
     3. relative to the parent include file
 
-    We only support 1 and 2.
+    We only support 1 (via includeDir) and 2.
     """
 
-    def __init__(self, featurefile, *, include_dir=None):
+    def __init__(self, featurefile, *, includeDir=None):
         """Initializes an IncludingLexer.
 
         Behavior:
-            If include_dir is passed, it will be used to determine the top-level
+            If includeDir is passed, it will be used to determine the top-level
             include directory to use for all encountered include statements. If it is
             not passed, ``os.path.dirname(featurefile)`` will be considered the
             include directory.
@@ -216,7 +216,7 @@ class IncludingLexer(object):
 
         self.lexers_ = [self.make_lexer_(featurefile)]
         self.featurefilepath = self.lexers_[0].filename_
-        self.include_dir = include_dir
+        self.includeDir = includeDir
 
     def __iter__(self):
         return self
@@ -242,8 +242,8 @@ class IncludingLexer(object):
                 if os.path.isabs(fname_token):
                     path = fname_token
                 else:
-                    if self.include_dir is not None:
-                        curpath = self.include_dir
+                    if self.includeDir is not None:
+                        curpath = self.includeDir
                     elif self.featurefilepath is not None:
                         curpath = os.path.dirname(self.featurefilepath)
                     else:

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -190,9 +190,33 @@ class Lexer(object):
 
 
 class IncludingLexer(object):
-    def __init__(self, featurefile):
+    """A Lexer that follows include statements.
+
+    The OpenType feature file specification states that due to
+    historical reasons, relative imports should be resolved in this 
+    order:
+
+    1. If the source font is UFO format, then relative to the UFO's
+       font directory
+    2. relative to the top-level include file
+    3. relative to the parent include file
+
+    We only support 1 and 2.
+    """
+
+    def __init__(self, featurefile, *, include_dir=None):
+        """Initializes an IncludingLexer.
+
+        Behavior:
+            If include_dir is passed, it will be used to determine the top-level
+            include directory to use for all encountered include statements. If it is
+            not passed, ``os.path.dirname(featurefile)`` will be considered the
+            include directory.
+        """
+
         self.lexers_ = [self.make_lexer_(featurefile)]
         self.featurefilepath = self.lexers_[0].filename_
+        self.include_dir = include_dir
 
     def __iter__(self):
         return self
@@ -218,7 +242,9 @@ class IncludingLexer(object):
                 if os.path.isabs(fname_token):
                     path = fname_token
                 else:
-                    if self.featurefilepath is not None:
+                    if self.include_dir is not None:
+                        curpath = self.include_dir
+                    elif self.featurefilepath is not None:
                         curpath = os.path.dirname(self.featurefilepath)
                     else:
                         # if the IncludingLexer was initialized from an in-memory

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -39,7 +39,7 @@ class Parser(object):
     CV_FEATURE_TAGS = {"cv%02d" % i for i in range(1, 99+1)}
 
     def __init__(self, featurefile, glyphNames=(), followIncludes=True,
-                 include_dir=None, **kwargs):
+                 includeDir=None, **kwargs):
 
         if "glyphMap" in kwargs:
             from fontTools.misc.loggingTools import deprecateArgument
@@ -66,7 +66,7 @@ class Parser(object):
         self.cur_comments_ = []
         self.next_token_location_ = None
         lexerClass = IncludingLexer if followIncludes else NonIncludingLexer
-        self.lexer_ = lexerClass(featurefile, include_dir=include_dir)
+        self.lexer_ = lexerClass(featurefile, include_dir=includeDir)
         self.advance_lexer_(comments=True)
 
     def parse(self):

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -39,7 +39,7 @@ class Parser(object):
     CV_FEATURE_TAGS = {"cv%02d" % i for i in range(1, 99+1)}
 
     def __init__(self, featurefile, glyphNames=(), followIncludes=True,
-                 **kwargs):
+                 include_dir=None, **kwargs):
 
         if "glyphMap" in kwargs:
             from fontTools.misc.loggingTools import deprecateArgument
@@ -66,7 +66,7 @@ class Parser(object):
         self.cur_comments_ = []
         self.next_token_location_ = None
         lexerClass = IncludingLexer if followIncludes else NonIncludingLexer
-        self.lexer_ = lexerClass(featurefile)
+        self.lexer_ = lexerClass(featurefile, include_dir=include_dir)
         self.advance_lexer_(comments=True)
 
     def parse(self):

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -31,7 +31,9 @@ class Parser(object):
     help to disambiguate ranges from glyph names containing hyphens.)
 
     By default, the parser will follow ``include()`` statements in the feature
-    file. To turn this off, pass ``followIncludes=False``.
+    file. To turn this off, pass ``followIncludes=False``. Pass a directory string as
+    ``includeDir`` to explicitly declare a directory to search included feature files
+    in.
     """
     extensions = {}
     ast = ast
@@ -66,7 +68,7 @@ class Parser(object):
         self.cur_comments_ = []
         self.next_token_location_ = None
         lexerClass = IncludingLexer if followIncludes else NonIncludingLexer
-        self.lexer_ = lexerClass(featurefile, include_dir=includeDir)
+        self.lexer_ = lexerClass(featurefile, includeDir=includeDir)
         self.advance_lexer_(comments=True)
 
     def parse(self):

--- a/Tests/feaLib/data/include/test.fea
+++ b/Tests/feaLib/data/include/test.fea
@@ -1,0 +1,1 @@
+include(../test.fea)

--- a/Tests/feaLib/data/include/test.ufo/features.fea
+++ b/Tests/feaLib/data/include/test.ufo/features.fea
@@ -1,0 +1,1 @@
+include(test.fea)

--- a/Tests/feaLib/data/test.fea
+++ b/Tests/feaLib/data/test.fea
@@ -1,0 +1,1 @@
+# Nothing

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1740,6 +1740,12 @@ class ParserTest(unittest.TestCase):
             doc = self.parse("table %s { ;;; } %s;" % (table, table))
             self.assertEqual(doc.statements[0].statements, [])
 
+    def test_ufo_features_parse_include_dir(self):
+        fea_path = self.getpath("include/test.ufo/features.fea")
+        include_dir = os.path.dirname(os.path.dirname(fea_path))
+        doc = Parser(fea_path, include_dir=include_dir).parse()
+        assert len(doc.statements) == 1 and doc.statements[0].text == "# Nothing"
+
     def parse(self, text, glyphNames=GLYPHNAMES, followIncludes=True):
         featurefile = StringIO(text)
         p = Parser(featurefile, glyphNames, followIncludes=followIncludes)

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1743,7 +1743,7 @@ class ParserTest(unittest.TestCase):
     def test_ufo_features_parse_include_dir(self):
         fea_path = self.getpath("include/test.ufo/features.fea")
         include_dir = os.path.dirname(os.path.dirname(fea_path))
-        doc = Parser(fea_path, include_dir=include_dir).parse()
+        doc = Parser(fea_path, includeDir=include_dir).parse()
         assert len(doc.statements) == 1 and doc.statements[0].text == "# Nothing"
 
     def parse(self, text, glyphNames=GLYPHNAMES, followIncludes=True):


### PR DESCRIPTION
ufo2ft reads a UFO's feature file into a StringIO and sets the `name` attribute to the UFO, not the feature file within: https://github.com/googlefonts/ufo2ft/blob/53dd7c6/Lib/ufo2ft/featureCompiler.py#L34-L40. `IncludingLexer` then uses that attribute to determine where to look for includes.

I want to change ufo2ft to make it point to the actual feature file and change `IncludingLexer` to take an explicit directory to use for includes, so that users get a better error message if something goes wrong. For backwards compatibility, `IncludingLexer` continue handling the `name` attribute as above.