### PR TITLE
[varLib] optionally disable CFF2 specialization

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -1010,7 +1010,7 @@ class MasterFinder(object):
 
 def main(args=None):
 	"""Build a variable font from a designspace file and masters"""
-	from argparse import ArgumentParser
+	from argparse import ArgumentParser, SUPPRESS
 	from fontTools import configLogger
 
 	parser = ArgumentParser(prog='varLib', description = main.__doc__)
@@ -1034,7 +1034,17 @@ def main(args=None):
 		'--disable-iup',
 		dest='optimize',
 		action='store_false',
-		help='do not perform IUP optimization'
+		# hidden from -h (replaced by --no-optimize), kept for backward compat
+		help=SUPPRESS,
+	)
+	parser.add_argument(
+		'--no-optimize',
+		dest='optimize',
+		action='store_false',
+		help=(
+			'do not perform IUP optimization on gvar, or specialization of'
+			' CFF2 charstrings'
+		),
 	)
 	parser.add_argument(
 		'--master-finder',

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -686,7 +686,7 @@ _DesignSpaceData = namedtuple(
 )
 
 
-def _add_CFF2(varFont, model, master_fonts):
+def _add_CFF2(varFont, model, master_fonts, optimize=True):
 	from .cff import merge_region_fonts
 	glyphOrder = varFont.getGlyphOrder()
 	if "CFF2" not in varFont:
@@ -694,7 +694,9 @@ def _add_CFF2(varFont, model, master_fonts):
 		convertCFFtoCFF2(varFont)
 	ordered_fonts_list = model.reorderMasters(master_fonts, model.reverseMapping)
 	# re-ordering the master list simplifies building the CFF2 data item lists.
-	merge_region_fonts(varFont, model, ordered_fonts_list, glyphOrder)
+	merge_region_fonts(
+		varFont, model, ordered_fonts_list, glyphOrder, optimize=optimize
+	)
 
 
 def load_designspace(designspace):
@@ -919,7 +921,7 @@ def build(designspace, master_finder=lambda s:s, exclude=[], optimize=True):
 	if 'GSUB' not in exclude and ds.rules:
 		_add_GSUB_feature_variations(vf, ds.axes, ds.internal_axis_supports, ds.rules, ds.rulesProcessingLast)
 	if 'CFF2' not in exclude and ('CFF ' in vf or 'CFF2' in vf):
-		_add_CFF2(vf, model, master_fonts)
+		_add_CFF2(vf, model, master_fonts, optimize=optimize)
 		if "post" in vf:
 			# set 'post' to format 2 to keep the glyph names dropped from CFF2
 			post = vf["post"]

--- a/Lib/fontTools/varLib/cff.py
+++ b/Lib/fontTools/varLib/cff.py
@@ -317,14 +317,16 @@ def getfd_map(varFont, fonts_list):
 
 
 CVarData = namedtuple('CVarData', 'varDataList masterSupports vsindex_dict')
-def merge_region_fonts(varFont, model, ordered_fonts_list, glyphOrder):
+def merge_region_fonts(varFont, model, ordered_fonts_list, glyphOrder, optimize=True):
 	topDict = varFont['CFF2'].cff.topDictIndex[0]
 	top_dicts = [topDict] + [
 					_cff_or_cff2(ttFont).cff.topDictIndex[0]
 					for ttFont in ordered_fonts_list[1:]
 					]
 	num_masters = len(model.mapping)
-	cvData = merge_charstrings(glyphOrder, num_masters, top_dicts, model)
+	cvData = merge_charstrings(
+		glyphOrder, num_masters, top_dicts, model, optimize=optimize
+	)
 	fd_map = getfd_map(varFont, ordered_fonts_list)
 	merge_PrivateDicts(top_dicts, cvData.vsindex_dict, model, fd_map)
 	addCFFVarStore(varFont, model, cvData.varDataList,
@@ -350,7 +352,7 @@ def _add_new_vsindex(model, key, masterSupports, vsindex_dict,
 	varDataList.append(var_data)
 	return vsindex
 
-def merge_charstrings(glyphOrder, num_masters, top_dicts, masterModel):
+def merge_charstrings(glyphOrder, num_masters, top_dicts, masterModel, optimize=True):
 
 	vsindex_dict = {}
 	vsindex_by_key = {}
@@ -386,7 +388,7 @@ def merge_charstrings(glyphOrder, num_masters, top_dicts, masterModel):
 		new_cs = var_pen.getCharString(
 			private=default_charstring.private,
 			globalSubrs=default_charstring.globalSubrs,
-			var_model=model, optimize=True)
+			var_model=model, optimize=optimize)
 		default_charstrings[gname] = new_cs
 
 		if (not var_pen.seen_moveto) or ('blend' not in new_cs.program):

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -457,6 +457,26 @@ class BuildTest(unittest.TestCase):
         expected_ttx_path = self.get_test_output('BuildMain.ttx')
         self.expect_ttx(varfont, expected_ttx_path, tables)
 
+    def test_varlib_main_otf_no_optimize(self):
+        ds_path = self.get_test_input("TestCFF2.designspace")
+        ttx_dir = self.get_test_input("master_cff2")
+
+        self.temp_dir()
+        otf_dir = os.path.join(self.tempdir, 'master_otf_interpolatable')
+        os.makedirs(otf_dir)
+        for path in self.get_file_list(ttx_dir, ".ttx", "TestCFF2_"):
+            self.compile_font(path, ".otf", otf_dir)
+
+        finder = f"{self.tempdir}/master_otf_interpolatable/{{stem}}.otf"
+        varLib_main([ds_path, "--master-finder", finder, "--no-optimize"])
+        varfont_path = os.path.splitext(ds_copy)[0] + '-VF.otf'
+        self.assertTrue(os.path.exists(varfont_path))
+
+        # varfont = TTFont(varfont_path)
+        # tables = ["fvar", "CFF2"]
+        # expected_ttx_path = self.get_test_output("BuildTestCFF2.ttx")
+        # self.expect_ttx(varfont, expected_ttx_path, tables)
+
     def test_varlib_build_from_ds_object_in_memory_ttfonts(self):
         ds_path = self.get_test_input("Build.designspace")
         ttx_dir = self.get_test_input("master_ttx_interpolatable_ttf")


### PR DESCRIPTION
in ufo2ft we have options to disable subroutinization and specialization of CFF charstrings. `varLib.build` always runs the specializer on CFF2 variable font. I'd like to make that optional by reusing the 
`optimize=True` parameter that `varLib.build` already takes.
This PR does that.

However, as soon as I try to build a non-specialized CFF2-VF, I encounter this issue #1975, as you can also see from the failing test run on CI.

```
AssertionError: CFF2 CharStrings must not have an initial width value
```

I honestly don't know how to fix this, any help is appreciated.