### PR TITLE
[voltLib] Accept DO_NOT_TOUCH_CMAP keyword

### DIFF
--- a/Lib/fontTools/voltLib/parser.py
+++ b/Lib/fontTools/voltLib/parser.py
@@ -12,9 +12,10 @@ PARSE_FUNCS = {
     "GRID_PPEM": "parse_ppem_",
     "PRESENTATION_PPEM": "parse_ppem_",
     "PPOSITIONING_PPEM": "parse_ppem_",
-    "COMPILER_USEEXTENSIONLOOKUPS": "parse_compiler_flag_",
-    "COMPILER_USEPAIRPOSFORMAT2": "parse_compiler_flag_",
+    "COMPILER_USEEXTENSIONLOOKUPS": "parse_noarg_option_",
+    "COMPILER_USEPAIRPOSFORMAT2": "parse_noarg_option_",
     "CMAP_FORMAT": "parse_cmap_format",
+    "DO_NOT_TOUCH_CMAP": "parse_noarg_option_",
 }
 
 
@@ -549,11 +550,11 @@ class Parser(object):
         setting = ast.SettingDefinition(ppem_name, value, location=location)
         return setting
 
-    def parse_compiler_flag_(self):
+    def parse_noarg_option_(self):
         location = self.cur_token_location_
-        flag_name = self.cur_token_
+        name = self.cur_token_
         value = True
-        setting = ast.SettingDefinition(flag_name, value, location=location)
+        setting = ast.SettingDefinition(name, value, location=location)
         return setting
 
     def parse_cmap_format(self):

--- a/Tests/voltLib/parser_test.py
+++ b/Tests/voltLib/parser_test.py
@@ -1193,6 +1193,24 @@ class ParserTest(unittest.TestCase):
              ("CMAP_FORMAT", (3, 1, 4)))
         )
 
+    def test_do_not_touch_cmap(self):
+        [option1, option2, option3, option4] = self.parse(
+            'DO_NOT_TOUCH_CMAP\n'
+            'CMAP_FORMAT 0 3 4\n'
+            'CMAP_FORMAT 1 0 6\n'
+            'CMAP_FORMAT 3 1 4'
+        ).statements
+        self.assertEqual(
+            ((option1.name, option1.value),
+             (option2.name, option2.value),
+             (option3.name, option3.value),
+             (option4.name, option4.value)),
+            (("DO_NOT_TOUCH_CMAP", True),
+             ("CMAP_FORMAT", (0, 3, 4)),
+             ("CMAP_FORMAT", (1, 0, 6)),
+             ("CMAP_FORMAT", (3, 1, 4)))
+        )
+
     def test_stop_at_end(self):
         doc = self.parse_(
             'DEF_GLYPH ".notdef" ID 0 TYPE BASE END_GLYPH END\0\0\0\0'


### PR DESCRIPTION
Corresponds to the “Do not overwrite camp table” option in VOLT.