### PR TITLE
[feaLib] Refactor chained contextual builders

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1294,7 +1294,7 @@ class ChainContextualBuilder(LookupBuilder):
                     for l in lookupList:
                         if l.lookup_index is None:
                             raise FeatureLibError('Missing index of the specified '
-                                'lookup, might be a %s lookup' % self.other,
+                                f'lookup, might be a {self.other} lookup',
                                 self.location)
                         self.addLookupRecord_(st, sequenceIndex, l.lookup_index)
         return self.buildLookup_(subtables)


### PR DESCRIPTION
This is just a simple refactoring which eliminates common code from the chained contextual sub/pos builders. The purpose is to lay the groundwork for generating other formats (format 1 and 2 lookups) on a subtable basis.