### PR TITLE
Contextual pos/sub format optimizer

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1389,11 +1389,12 @@ class ChainContextSubstBuilder(ChainContextualBuilder):
             st.ChainSubRuleSet.append(ruleset)
         return ruleset
 
-    def newChainRule_(self, ruleset):
+    def newChainRule_(self, ruleset, rule = None):
         if not hasattr(ruleset, "ChainSubRuleCount"):
             ruleset.ChainSubRuleCount = 0
             ruleset.ChainSubRule = []
-        rule = otTables.ChainSubRule()
+        if not rule:
+            rule = otTables.ChainSubRule()
         ruleset.ChainSubRuleCount += 1
         ruleset.ChainSubRule.append(rule)
         return rule

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1294,7 +1294,7 @@ class ChainContextualBuilder(LookupBuilder):
                     for l in lookupList:
                         if l.lookup_index is None:
                             raise FeatureLibError('Missing index of the specified '
-                                'lookup, might be a %s lookup' % self.other,
+                                f'lookup, might be a {self.other} lookup',
                                 self.location)
                         self.addLookupRecord_(st, sequenceIndex, l.lookup_index)
         return self.buildLookup_(subtables)

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1275,6 +1275,10 @@ class ChainContextualBuilder(LookupBuilder):
         return (LookupBuilder.equals(self, other) and
                 self.rules == other.rules)
 
+    def buildLookup_(self, subtables):
+        return otl.buildLookup(subtables, self.lookupflag, self.markFilterSet,
+            optimize="chaining_format", builder=self)
+
     def build(self):
         subtables = []
         for (prefix, glyphs, suffix, lookups) in self.rules:

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1315,7 +1315,32 @@ class ChainContextPosBuilder(ChainContextualBuilder):
         st.PosLookupRecord = []
         return st
 
+    def newChainRuleSet_(self, st, index=None):
+        if not hasattr(st, "ChainPosRuleSetCount"):
+            st.ChainPosRuleSetCount = 0
+            st.ChainPosRuleSet = []
+        ruleset = otTables.ChainPosRuleSet()
+        st.ChainPosRuleSetCount += 1
+        if index:
+            st.ChainPosRuleSet.insert(index, ruleset)
+        else:
+            st.ChainPosRuleSet.append(ruleset)
+        return ruleset
+
+    def newChainRule_(self, ruleset, rule = None):
+        if not hasattr(ruleset, "ChainPosRuleCount"):
+            ruleset.ChainPosRuleCount = 0
+            ruleset.ChainPosRule = []
+        if not rule:
+            rule = otTables.ChainPosRule()
+        ruleset.ChainPosRuleCount += 1
+        ruleset.ChainPosRule.append(rule)
+        return rule
+
     def addLookupRecord_(self, st, sequenceIndex, lookupIndex):
+        if not hasattr(st, "PosCount"):
+            st.PosCount = 0
+            st.PosLookupRecord = []
         rec = otTables.PosLookupRecord()
         rec.SequenceIndex = sequenceIndex
         rec.LookupListIndex = lookupIndex
@@ -1348,7 +1373,31 @@ class ChainContextSubstBuilder(ChainContextualBuilder):
         st.SubstLookupRecord = []
         return st
 
+    def newChainRuleSet_(self, st, index=None):
+        if not hasattr(st, "ChainSubRuleSetCount"):
+            st.ChainSubRuleSetCount = 0
+            st.ChainSubRuleSet = []
+        ruleset = otTables.ChainSubRuleSet()
+        st.ChainSubRuleSetCount += 1
+        if index:
+            st.ChainSubRuleSet.insert(index, ruleset)
+        else:
+            st.ChainSubRuleSet.append(ruleset)
+        return ruleset
+
+    def newChainRule_(self, ruleset):
+        if not hasattr(ruleset, "ChainSubRuleCount"):
+            ruleset.ChainSubRuleCount = 0
+            ruleset.ChainSubRule = []
+        rule = otTables.ChainSubRule()
+        ruleset.ChainSubRuleCount += 1
+        ruleset.ChainSubRule.append(rule)
+        return rule
+
     def addLookupRecord_(self, st, sequenceIndex, lookupIndex):
+        if not hasattr(st, "SubstCount"):
+            st.SubstCount = 0
+            st.SubstLookupRecord = []
         rec = otTables.SubstLookupRecord()
         rec.SequenceIndex = sequenceIndex
         rec.LookupListIndex = lookupIndex

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -20,7 +20,7 @@ LOOKUP_FLAG_IGNORE_MARKS = 0x0008
 LOOKUP_FLAG_USE_MARK_FILTERING_SET = 0x0010
 
 
-def buildLookup(subtables, flags=0, markFilterSet=None):
+def buildLookup(subtables, flags=0, markFilterSet=None, optimize=None, builder=None):
     if subtables is None:
         return None
     subtables = [st for st in subtables if st is not None]

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -72,7 +72,7 @@ class BuilderTest(unittest.TestCase):
         PairPosSubtable ChainSubstSubtable ChainPosSubtable LigatureSubtable
         AlternateSubtable MultipleSubstSubtable SingleSubstSubtable
         aalt_chain_contextual_subst AlternateChained MultipleLookupsPerGlyph
-        MultipleLookupsPerGlyph2
+        MultipleLookupsPerGlyph2 MergeFormat1Contextual
     """.split()
 
     def __init__(self, methodName):

--- a/Tests/feaLib/data/MergeFormat1Contextual.fea
+++ b/Tests/feaLib/data/MergeFormat1Contextual.fea
@@ -1,0 +1,14 @@
+languagesystem DFLT dflt;
+feature test {
+pos A B' 50;
+pos C B' 20;
+pos D B' 20;
+pos E B' 10;
+pos B' 50 A;
+pos B' 20 C;
+pos B' 20 D;
+pos B' 10 E;
+pos C' F G;
+pos C' X Y Z;
+pos J K L C' X Y Z;
+} test;

--- a/Tests/feaLib/data/MergeFormat1Contextual.ttx
+++ b/Tests/feaLib/data/MergeFormat1Contextual.ttx
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=4 -->
+      <Lookup index="0">
+        <LookupType value="8"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextPos index="0" Format="1">
+          <Coverage>
+            <Glyph value="B"/>
+            <Glyph value="C"/>
+          </Coverage>
+          <!-- ChainPosRuleSetCount=2 -->
+          <ChainPosRuleSet index="0">
+            <!-- ChainPosRuleCount=8 -->
+            <ChainPosRule index="0">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="A"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+            <ChainPosRule index="1">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="C"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="2"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+            <ChainPosRule index="2">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="D"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="2"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+            <ChainPosRule index="3">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="E"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="3"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+            <ChainPosRule index="4">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="A"/>
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+            <ChainPosRule index="5">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="C"/>
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="2"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+            <ChainPosRule index="6">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="D"/>
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="2"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+            <ChainPosRule index="7">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="E"/>
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="3"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+          </ChainPosRuleSet>
+          <ChainPosRuleSet index="1">
+            <!-- ChainPosRuleCount=2 -->
+            <ChainPosRule index="0">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=3 -->
+              <LookAhead index="0" value="X"/>
+              <LookAhead index="1" value="Y"/>
+              <LookAhead index="2" value="Z"/>
+            </ChainPosRule>
+            <ChainPosRule index="1">
+              <!-- BacktrackGlyphCount=3 -->
+              <Backtrack index="0" value="L"/>
+              <Backtrack index="1" value="K"/>
+              <Backtrack index="2" value="J"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=3 -->
+              <LookAhead index="0" value="X"/>
+              <LookAhead index="1" value="Y"/>
+              <LookAhead index="2" value="Z"/>
+            </ChainPosRule>
+          </ChainPosRuleSet>
+        </ChainContextPos>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="B"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="50"/>
+        </SinglePos>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="B"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="20"/>
+        </SinglePos>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="B"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="10"/>
+        </SinglePos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>


### PR DESCRIPTION
(First four commits are from #1991.)

This is a WIP but I would appreciate a couple of people to look over what I have so far, to check if the approach makes sense.

Chaining contextual lookups (GPOS6/GSUB8) can be expressed in three different ways:
* Format 1: Simple glyph contexts
* Format 2: Class-based contexts
* Format 3: Coverage-based contexts

Format 3 is the most flexible and we use it for everything. But formats 1 and 2 can be significantly more compact. Sometimes format 1 is just more compact than a corresponding format 3 lookup, but both format 1 and format 2 can also express *multiple rules* within a single lookup. For example, this code:

```
feature test {
pos A B' 50;
pos C B' 20;
pos D B' 20;
pos E B' 10;
pos B' 50 A;
pos B' 20 C;
pos B' 20 D;
pos B' 10 E;
pos C' F G;
pos C' X Y Z;
pos J K L C' X Y Z;
} test;
```

takes 382 bytes when expressed as 11 Format 3 lookups; but all the rules can be merged into a single Format 1 lookup, taking 188 bytes.

This branch runs over the subtables of a contextual sub/pos lookup and attempts to convert them to the other formats. (It only does format 1 for now, but I have code for creating format 2 rules in #1960.) It then tries to merge consecutive format 1 / format 2 lookups, and determines the most compact representation for the subtable list.

If the approach looks good (and I have a couple of questions, like how to handle `binary_len`), then I'll tidy this up, fix the failing tests, and add format 2 support.