### PR TITLE
Move builders to otlib

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -5,6 +5,7 @@ from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.parser import Parser
 from fontTools.feaLib.ast import FeatureFile
 from fontTools.otlLib import builder as otl
+from fontTools.otlLib.lookupBuilders import *
 from fontTools.otlLib.maxContextCalc import maxCtxFont
 from fontTools.ttLib import newTable, getTableModule
 from fontTools.ttLib.tables import otBase, otTables
@@ -1046,14 +1047,18 @@ class Builder(object):
     def add_class_pair_pos(self, location, glyphclass1, value1,
                            glyphclass2, value2):
         lookup = self.get_lookup_(location, PairPosBuilder)
-        lookup.addClassPair(location, glyphclass1, value1, glyphclass2, value2)
+        otValue1 = makeOpenTypeValueRecord(value1, pairPosContext=True)
+        otValue2 = makeOpenTypeValueRecord(value2, pairPosContext=True)
+        lookup.addClassPair(location, glyphclass1, otValue1, glyphclass2, otValue2)
 
     def add_subtable_break(self, location):
         self.cur_lookup_.add_subtable_break(location)
 
     def add_specific_pair_pos(self, location, glyph1, value1, glyph2, value2):
         lookup = self.get_lookup_(location, PairPosBuilder)
-        lookup.addGlyphPair(location, glyph1, value1, glyph2, value2)
+        otValue1 = makeOpenTypeValueRecord(value1, pairPosContext = True)
+        otValue2 = makeOpenTypeValueRecord(value2, pairPosContext = True)
+        lookup.addGlyphPair(location, glyph1, otValue1, glyph2, otValue2)
 
     def add_single_pos(self, location, prefix, suffix, pos, forceChain):
         if prefix or suffix or forceChain:
@@ -1061,8 +1066,9 @@ class Builder(object):
         else:
             lookup = self.get_lookup_(location, SinglePosBuilder)
             for glyphs, value in pos:
+                otValue = makeOpenTypeValueRecord(value, pairPosContext = False)
                 for glyph in glyphs:
-                    lookup.add_pos(location, glyph, value)
+                    lookup.add_pos(location, glyph, otValue)
 
     def add_single_pos_chained_(self, location, prefix, suffix, pos):
         # https://github.com/fonttools/fonttools/issues/514
@@ -1075,13 +1081,13 @@ class Builder(object):
             if value is None:
                 subs.append(None)
                 continue
-            otValue, _ = makeOpenTypeValueRecord(value, pairPosContext=False)
+            otValue = makeOpenTypeValueRecord(value, pairPosContext=False)
             sub = chain.find_chainable_single_pos(targets, glyphs, otValue)
             if sub is None:
                 sub = self.get_chained_lookup_(location, SinglePosBuilder)
                 targets.append(sub)
             for glyph in glyphs:
-                sub.add_pos(location, glyph, value)
+                sub.add_pos(location, glyph, otValue)
             subs.append(sub)
         assert len(pos) == len(subs), (pos, subs)
         chain.rules.append(
@@ -1132,7 +1138,6 @@ class Builder(object):
 
 
 def makeOpenTypeAnchor(anchor):
-    """ast.Anchor --> otTables.Anchor"""
     if anchor is None:
         return None
     deviceX, deviceY = None, None
@@ -1154,7 +1159,7 @@ _VALUEREC_ATTRS = {
 def makeOpenTypeValueRecord(v, pairPosContext):
     """ast.ValueRecord --> (otBase.ValueRecord, int ValueFormat)"""
     if not v:
-        return None, 0
+        return None
 
     vr = {}
     for astName, (otName, isDevice) in _VALUEREC_ATTRS.items():
@@ -1164,569 +1169,4 @@ def makeOpenTypeValueRecord(v, pairPosContext):
     if pairPosContext and not vr:
         vr = {"YAdvance": 0} if v.vertical else {"XAdvance": 0}
     valRec = otl.buildValue(vr)
-    return valRec, valRec.getFormat()
-
-
-class LookupBuilder(object):
-    SUBTABLE_BREAK_ = "SUBTABLE_BREAK"
-
-    def __init__(self, font, location, table, lookup_type):
-        self.font = font
-        self.glyphMap = font.getReverseGlyphMap()
-        self.location = location
-        self.table, self.lookup_type = table, lookup_type
-        self.lookupflag = 0
-        self.markFilterSet = None
-        self.lookup_index = None  # assigned when making final tables
-        assert table in ('GPOS', 'GSUB')
-
-    def equals(self, other):
-        return (isinstance(other, self.__class__) and
-                self.table == other.table and
-                self.lookupflag == other.lookupflag and
-                self.markFilterSet == other.markFilterSet)
-
-    def inferGlyphClasses(self):
-        """Infers glyph glasses for the GDEF table, such as {"cedilla":3}."""
-        return {}
-
-    def getAlternateGlyphs(self):
-        """Helper for building 'aalt' features."""
-        return {}
-
-    def buildLookup_(self, subtables):
-        return otl.buildLookup(subtables, self.lookupflag, self.markFilterSet)
-
-    def buildMarkClasses_(self, marks):
-        """{"cedilla": ("BOTTOM", ast.Anchor), ...} --> {"BOTTOM":0, "TOP":1}
-
-        Helper for MarkBasePostBuilder, MarkLigPosBuilder, and
-        MarkMarkPosBuilder. Seems to return the same numeric IDs
-        for mark classes as the AFDKO makeotf tool.
-        """
-        ids = {}
-        for mark in sorted(marks.keys(), key=self.font.getGlyphID):
-            markClassName, _markAnchor = marks[mark]
-            if markClassName not in ids:
-                ids[markClassName] = len(ids)
-        return ids
-
-    def setBacktrackCoverage_(self, prefix, subtable):
-        subtable.BacktrackGlyphCount = len(prefix)
-        subtable.BacktrackCoverage = []
-        for p in reversed(prefix):
-            coverage = otl.buildCoverage(p, self.glyphMap)
-            subtable.BacktrackCoverage.append(coverage)
-
-    def setLookAheadCoverage_(self, suffix, subtable):
-        subtable.LookAheadGlyphCount = len(suffix)
-        subtable.LookAheadCoverage = []
-        for s in suffix:
-            coverage = otl.buildCoverage(s, self.glyphMap)
-            subtable.LookAheadCoverage.append(coverage)
-
-    def setInputCoverage_(self, glyphs, subtable):
-        subtable.InputGlyphCount = len(glyphs)
-        subtable.InputCoverage = []
-        for g in glyphs:
-            coverage = otl.buildCoverage(g, self.glyphMap)
-            subtable.InputCoverage.append(coverage)
-
-    def build_subst_subtables(self, mapping, klass):
-        substitutions = [{}]
-        for key in mapping:
-            if key[0] == self.SUBTABLE_BREAK_:
-                substitutions.append({})
-            else:
-                substitutions[-1][key] = mapping[key]
-        subtables = [klass(s) for s in substitutions]
-        return subtables
-
-    def add_subtable_break(self, location):
-        log.warning(FeatureLibError(
-            'unsupported "subtable" statement for lookup type',
-            location
-        ))
-
-
-class AlternateSubstBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GSUB', 3)
-        self.alternates = OrderedDict()
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.alternates == other.alternates)
-
-    def build(self):
-        subtables = self.build_subst_subtables(self.alternates,
-                otl.buildAlternateSubstSubtable)
-        return self.buildLookup_(subtables)
-
-    def getAlternateGlyphs(self):
-        return self.alternates
-
-    def add_subtable_break(self, location):
-        self.alternates[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
-
-
-class ChainContextPosBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GPOS', 8)
-        self.rules = []  # (prefix, input, suffix, lookups)
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.rules == other.rules)
-
-    def build(self):
-        subtables = []
-        for (prefix, glyphs, suffix, lookups) in self.rules:
-            if prefix == self.SUBTABLE_BREAK_:
-                continue
-            st = otTables.ChainContextPos()
-            subtables.append(st)
-            st.Format = 3
-            self.setBacktrackCoverage_(prefix, st)
-            self.setLookAheadCoverage_(suffix, st)
-            self.setInputCoverage_(glyphs, st)
-
-            st.PosCount = 0
-            st.PosLookupRecord = []
-            for sequenceIndex, lookupList in enumerate(lookups):
-                if lookupList is not None:
-                    if not isinstance(lookupList, list):
-                        # Can happen with synthesised lookups
-                        lookupList = [ lookupList ]
-                    for l in lookupList:
-                        st.PosCount += 1
-                        if l.lookup_index is None:
-                            raise FeatureLibError('Missing index of the specified '
-                                'lookup, might be a substitution lookup',
-                                self.location)
-                        rec = otTables.PosLookupRecord()
-                        rec.SequenceIndex = sequenceIndex
-                        rec.LookupListIndex = l.lookup_index
-                        st.PosLookupRecord.append(rec)
-        return self.buildLookup_(subtables)
-
-    def find_chainable_single_pos(self, lookups, glyphs, value):
-        """Helper for add_single_pos_chained_()"""
-        res = None
-        for lookup in lookups[::-1]:
-            if lookup == self.SUBTABLE_BREAK_:
-                return res
-            if isinstance(lookup, SinglePosBuilder) and \
-                    all(lookup.can_add(glyph, value) for glyph in glyphs):
-                res = lookup
-        return res
-
-    def add_subtable_break(self, location):
-        self.rules.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
-                           self.SUBTABLE_BREAK_, [self.SUBTABLE_BREAK_]))
-
-
-class ChainContextSubstBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GSUB', 6)
-        self.substitutions = []  # (prefix, input, suffix, lookups)
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.substitutions == other.substitutions)
-
-    def build(self):
-        subtables = []
-        for (prefix, input, suffix, lookups) in self.substitutions:
-            if prefix == self.SUBTABLE_BREAK_:
-                continue
-            st = otTables.ChainContextSubst()
-            subtables.append(st)
-            st.Format = 3
-            self.setBacktrackCoverage_(prefix, st)
-            self.setLookAheadCoverage_(suffix, st)
-            self.setInputCoverage_(input, st)
-
-            st.SubstCount = 0
-            st.SubstLookupRecord = []
-            for sequenceIndex, lookupList in enumerate(lookups):
-                if lookupList is not None:
-                    if not isinstance(lookupList, list):
-                        # Can happen with synthesised lookups
-                        lookupList = [ lookupList ]
-                    for l in lookupList:
-                        st.SubstCount += 1
-                        if l.lookup_index is None:
-                            raise FeatureLibError('Missing index of the specified '
-                                'lookup, might be a positioning lookup',
-                                self.location)
-                        rec = otTables.SubstLookupRecord()
-                        rec.SequenceIndex = sequenceIndex
-                        rec.LookupListIndex = l.lookup_index
-                        st.SubstLookupRecord.append(rec)
-        return self.buildLookup_(subtables)
-
-    def getAlternateGlyphs(self):
-        result = {}
-        for (_, _, _, lookuplist) in self.substitutions:
-            if lookuplist == self.SUBTABLE_BREAK_:
-                continue
-            for lookups in lookuplist:
-                if not isinstance(lookups, list):
-                    lookups = [lookups]
-                for lookup in lookups:
-                    if lookup is not None:
-                        alts = lookup.getAlternateGlyphs()
-                        for glyph, replacements in alts.items():
-                            result.setdefault(glyph, set()).update(replacements)
-        return result
-
-    def find_chainable_single_subst(self, glyphs):
-        """Helper for add_single_subst_chained_()"""
-        res = None
-        for _, _, _, substitutions in self.substitutions[::-1]:
-            if substitutions == self.SUBTABLE_BREAK_:
-                return res
-            for sub in substitutions:
-                if (isinstance(sub, SingleSubstBuilder) and
-                        not any(g in glyphs for g in sub.mapping.keys())):
-                    res = sub
-        return res
-
-    def add_subtable_break(self, location):
-        self.substitutions.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
-                                   self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_))
-
-
-class LigatureSubstBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GSUB', 4)
-        self.ligatures = OrderedDict()  # {('f','f','i'): 'f_f_i'}
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.ligatures == other.ligatures)
-
-    def build(self):
-        subtables = self.build_subst_subtables(self.ligatures,
-                otl.buildLigatureSubstSubtable)
-        return self.buildLookup_(subtables)
-
-    def add_subtable_break(self, location):
-        self.ligatures[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
-
-
-class MultipleSubstBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GSUB', 2)
-        self.mapping = OrderedDict()
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.mapping == other.mapping)
-
-    def build(self):
-        subtables = self.build_subst_subtables(self.mapping,
-                otl.buildMultipleSubstSubtable)
-        return self.buildLookup_(subtables)
-
-    def add_subtable_break(self, location):
-        self.mapping[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
-
-
-class CursivePosBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GPOS', 3)
-        self.attachments = {}
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.attachments == other.attachments)
-
-    def add_attachment(self, location, glyphs, entryAnchor, exitAnchor):
-        for glyph in glyphs:
-            self.attachments[glyph] = (entryAnchor, exitAnchor)
-
-    def build(self):
-        st = otl.buildCursivePosSubtable(self.attachments, self.glyphMap)
-        return self.buildLookup_([st])
-
-
-class MarkBasePosBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GPOS', 4)
-        self.marks = {}  # glyphName -> (markClassName, anchor)
-        self.bases = {}  # glyphName -> {markClassName: anchor}
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.marks == other.marks and
-                self.bases == other.bases)
-
-    def inferGlyphClasses(self):
-        result = {glyph: 1 for glyph in self.bases}
-        result.update({glyph: 3 for glyph in self.marks})
-        return result
-
-    def build(self):
-        markClasses = self.buildMarkClasses_(self.marks)
-        marks = {mark: (markClasses[mc], anchor)
-                 for mark, (mc, anchor) in self.marks.items()}
-        bases = {}
-        for glyph, anchors in self.bases.items():
-            bases[glyph] = {markClasses[mc]: anchor
-                            for (mc, anchor) in anchors.items()}
-        subtables = otl.buildMarkBasePos(marks, bases, self.glyphMap)
-        return self.buildLookup_(subtables)
-
-
-class MarkLigPosBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GPOS', 5)
-        self.marks = {}  # glyphName -> (markClassName, anchor)
-        self.ligatures = {}  # glyphName -> [{markClassName: anchor}, ...]
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.marks == other.marks and
-                self.ligatures == other.ligatures)
-
-    def inferGlyphClasses(self):
-        result = {glyph: 2 for glyph in self.ligatures}
-        result.update({glyph: 3 for glyph in self.marks})
-        return result
-
-    def build(self):
-        markClasses = self.buildMarkClasses_(self.marks)
-        marks = {mark: (markClasses[mc], anchor)
-                 for mark, (mc, anchor) in self.marks.items()}
-        ligs = {}
-        for lig, components in self.ligatures.items():
-            ligs[lig] = []
-            for c in components:
-                ligs[lig].append({markClasses[mc]: a for mc, a in c.items()})
-        subtables = otl.buildMarkLigPos(marks, ligs, self.glyphMap)
-        return self.buildLookup_(subtables)
-
-
-class MarkMarkPosBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GPOS', 6)
-        self.marks = {}      # glyphName -> (markClassName, anchor)
-        self.baseMarks = {}  # glyphName -> {markClassName: anchor}
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.marks == other.marks and
-                self.baseMarks == other.baseMarks)
-
-    def inferGlyphClasses(self):
-        result = {glyph: 3 for glyph in self.baseMarks}
-        result.update({glyph: 3 for glyph in self.marks})
-        return result
-
-    def build(self):
-        markClasses = self.buildMarkClasses_(self.marks)
-        markClassList = sorted(markClasses.keys(), key=markClasses.get)
-        marks = {mark: (markClasses[mc], anchor)
-                 for mark, (mc, anchor) in self.marks.items()}
-
-        st = otTables.MarkMarkPos()
-        st.Format = 1
-        st.ClassCount = len(markClasses)
-        st.Mark1Coverage = otl.buildCoverage(marks, self.glyphMap)
-        st.Mark2Coverage = otl.buildCoverage(self.baseMarks, self.glyphMap)
-        st.Mark1Array = otl.buildMarkArray(marks, self.glyphMap)
-        st.Mark2Array = otTables.Mark2Array()
-        st.Mark2Array.Mark2Count = len(st.Mark2Coverage.glyphs)
-        st.Mark2Array.Mark2Record = []
-        for base in st.Mark2Coverage.glyphs:
-            anchors = [self.baseMarks[base].get(mc) for mc in markClassList]
-            st.Mark2Array.Mark2Record.append(otl.buildMark2Record(anchors))
-        return self.buildLookup_([st])
-
-
-class ReverseChainSingleSubstBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GSUB', 8)
-        self.substitutions = []  # (prefix, suffix, mapping)
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.substitutions == other.substitutions)
-
-    def build(self):
-        subtables = []
-        for prefix, suffix, mapping in self.substitutions:
-            st = otTables.ReverseChainSingleSubst()
-            st.Format = 1
-            self.setBacktrackCoverage_(prefix, st)
-            self.setLookAheadCoverage_(suffix, st)
-            st.Coverage = otl.buildCoverage(mapping.keys(), self.glyphMap)
-            st.GlyphCount = len(mapping)
-            st.Substitute = [mapping[g] for g in st.Coverage.glyphs]
-            subtables.append(st)
-        return self.buildLookup_(subtables)
-
-    def add_subtable_break(self, location):
-        # Nothing to do here, each substitution is in its own subtable.
-        pass
-
-
-class SingleSubstBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GSUB', 1)
-        self.mapping = OrderedDict()
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.mapping == other.mapping)
-
-    def build(self):
-        subtables = self.build_subst_subtables(self.mapping,
-                otl.buildSingleSubstSubtable)
-        return self.buildLookup_(subtables)
-
-    def getAlternateGlyphs(self):
-        return {glyph: set([repl]) for glyph, repl in self.mapping.items()}
-
-    def add_subtable_break(self, location):
-        self.mapping[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
-
-
-class ClassPairPosSubtableBuilder(object):
-    def __init__(self, builder, valueFormat1, valueFormat2):
-        self.builder_ = builder
-        self.classDef1_, self.classDef2_ = None, None
-        self.values_ = {}  # (glyphclass1, glyphclass2) --> (value1, value2)
-        self.valueFormat1_, self.valueFormat2_ = valueFormat1, valueFormat2
-        self.forceSubtableBreak_ = False
-        self.subtables_ = []
-
-    def addPair(self, gc1, value1, gc2, value2):
-        mergeable = (not self.forceSubtableBreak_ and
-                     self.classDef1_ is not None and
-                     self.classDef1_.canAdd(gc1) and
-                     self.classDef2_ is not None and
-                     self.classDef2_.canAdd(gc2))
-        if not mergeable:
-            self.flush_()
-            self.classDef1_ = otl.ClassDefBuilder(useClass0=True)
-            self.classDef2_ = otl.ClassDefBuilder(useClass0=False)
-            self.values_ = {}
-        self.classDef1_.add(gc1)
-        self.classDef2_.add(gc2)
-        self.values_[(gc1, gc2)] = (value1, value2)
-
-    def addSubtableBreak(self):
-        self.forceSubtableBreak_ = True
-
-    def subtables(self):
-        self.flush_()
-        return self.subtables_
-
-    def flush_(self):
-        if self.classDef1_ is None or self.classDef2_ is None:
-            return
-        st = otl.buildPairPosClassesSubtable(self.values_,
-                                             self.builder_.glyphMap)
-        if st.Coverage is None:
-            return
-        self.subtables_.append(st)
-        self.forceSubtableBreak_ = False
-
-
-class PairPosBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GPOS', 2)
-        self.pairs = []  # [(gc1, value1, gc2, value2)*]
-        self.glyphPairs = {}  # (glyph1, glyph2) --> (value1, value2)
-        self.locations = {}  # (gc1, gc2) --> (filepath, line, column)
-
-    def addClassPair(self, location, glyphclass1, value1, glyphclass2, value2):
-        self.pairs.append((glyphclass1, value1, glyphclass2, value2))
-
-    def addGlyphPair(self, location, glyph1, value1, glyph2, value2):
-        key = (glyph1, glyph2)
-        oldValue = self.glyphPairs.get(key, None)
-        if oldValue is not None:
-            # the Feature File spec explicitly allows specific pairs generated
-            # by an 'enum' rule to be overridden by preceding single pairs
-            otherLoc = self.locations[key]
-            log.debug(
-                'Already defined position for pair %s %s at %s:%d:%d; '
-                'choosing the first value',
-                glyph1, glyph2, otherLoc[0], otherLoc[1], otherLoc[2])
-        else:
-            val1, _ = makeOpenTypeValueRecord(value1, pairPosContext=True)
-            val2, _ = makeOpenTypeValueRecord(value2, pairPosContext=True)
-            self.glyphPairs[key] = (val1, val2)
-            self.locations[key] = location
-
-    def add_subtable_break(self, location):
-        self.pairs.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
-                           self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_))
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.glyphPairs == other.glyphPairs and
-                self.pairs == other.pairs)
-
-    def build(self):
-        builders = {}
-        builder = None
-        for glyphclass1, value1, glyphclass2, value2 in self.pairs:
-            if glyphclass1 is self.SUBTABLE_BREAK_:
-                if builder is not None:
-                    builder.addSubtableBreak()
-                continue
-            val1, valFormat1 = makeOpenTypeValueRecord(
-                value1, pairPosContext=True)
-            val2, valFormat2 = makeOpenTypeValueRecord(
-                value2, pairPosContext=True)
-            builder = builders.get((valFormat1, valFormat2))
-            if builder is None:
-                builder = ClassPairPosSubtableBuilder(
-                    self, valFormat1, valFormat2)
-                builders[(valFormat1, valFormat2)] = builder
-            builder.addPair(glyphclass1, val1, glyphclass2, val2)
-        subtables = []
-        if self.glyphPairs:
-            subtables.extend(
-                otl.buildPairPosGlyphs(self.glyphPairs, self.glyphMap))
-        for key in sorted(builders.keys()):
-            subtables.extend(builders[key].subtables())
-        return self.buildLookup_(subtables)
-
-
-class SinglePosBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GPOS', 1)
-        self.locations = {}  # glyph -> (filename, line, column)
-        self.mapping = {}  # glyph -> otTables.ValueRecord
-
-    def add_pos(self, location, glyph, valueRecord):
-        otValueRecord, _ = makeOpenTypeValueRecord(
-            valueRecord, pairPosContext=False)
-        if not self.can_add(glyph, otValueRecord):
-            otherLoc = self.locations[glyph]
-            raise FeatureLibError(
-                'Already defined different position for glyph "%s" at %s:%d:%d'
-                % (glyph, otherLoc[0], otherLoc[1], otherLoc[2]),
-                location)
-        if otValueRecord:
-            self.mapping[glyph] = otValueRecord
-        self.locations[glyph] = location
-
-    def can_add(self, glyph, value):
-        assert isinstance(value, otl.ValueRecord)
-        curValue = self.mapping.get(glyph)
-        return curValue is None or curValue == value
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.mapping == other.mapping)
-
-    def build(self):
-        subtables = otl.buildSinglePos(self.mapping, self.glyphMap)
-        return self.buildLookup_(subtables)
+    return valRec

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -5,6 +5,7 @@ from fontTools.ttLib.tables import otTables as ot
 from fontTools.ttLib.tables.otBase import ValueRecord, valueRecordFormatDict
 from fontTools.ttLib.tables import otBase, otTables
 from fontTools.otlLib.error import OTLLibError
+from fontTools.otlLib.classDefBuilder import ClassDefBuilder
 
 
 def buildCoverage(glyphs, glyphMap):
@@ -601,65 +602,6 @@ def buildMarkGlyphSetsDef(markSets, glyphMap):
     self.Coverage = [buildCoverage(m, glyphMap) for m in markSets]
     self.MarkSetCount = len(self.Coverage)
     return self
-
-
-class ClassDefBuilder(object):
-    """Helper for building ClassDef tables."""
-    def __init__(self, useClass0):
-        self.classes_ = set()
-        self.glyphs_ = {}
-        self.useClass0_ = useClass0
-
-    def canAdd(self, glyphs):
-        if isinstance(glyphs, (set, frozenset)):
-            glyphs = sorted(glyphs)
-        glyphs = tuple(glyphs)
-        if glyphs in self.classes_:
-            return True
-        for glyph in glyphs:
-            if glyph in self.glyphs_:
-                return False
-        return True
-
-    def add(self, glyphs):
-        if isinstance(glyphs, (set, frozenset)):
-            glyphs = sorted(glyphs)
-        glyphs = tuple(glyphs)
-        if glyphs in self.classes_:
-            return
-        self.classes_.add(glyphs)
-        for glyph in glyphs:
-            assert glyph not in self.glyphs_
-            self.glyphs_[glyph] = glyphs
-
-    def classes(self):
-        # In ClassDef1 tables, class id #0 does not need to be encoded
-        # because zero is the default. Therefore, we use id #0 for the
-        # glyph class that has the largest number of members. However,
-        # in other tables than ClassDef1, 0 means "every other glyph"
-        # so we should not use that ID for any real glyph classes;
-        # we implement this by inserting an empty set at position 0.
-        #
-        # TODO: Instead of counting the number of glyphs in each class,
-        # we should determine the encoded size. If the glyphs in a large
-        # class form a contiguous range, the encoding is actually quite
-        # compact, whereas a non-contiguous set might need a lot of bytes
-        # in the output file. We don't get this right with the key below.
-        result = sorted(self.classes_, key=lambda s: (len(s), s), reverse=True)
-        if not self.useClass0_:
-            result.insert(0, frozenset())
-        return result
-
-    def build(self):
-        glyphClasses = {}
-        for classID, glyphs in enumerate(self.classes()):
-            if classID == 0:
-                continue
-            for glyph in glyphs:
-                glyphClasses[glyph] = classID
-        classDef = ot.ClassDef()
-        classDef.classDefs = glyphClasses
-        return classDef
 
 
 AXIS_VALUE_NEGATIVE_INFINITY = fixedToFloat(-0x80000000, 16)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -3,6 +3,8 @@ from fontTools.misc.fixedTools import fixedToFloat
 from fontTools import ttLib
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.ttLib.tables.otBase import ValueRecord, valueRecordFormatDict
+from fontTools.ttLib.tables import otBase, otTables
+from fontTools.otlLib.error import OTLLibError
 
 
 def buildCoverage(glyphs, glyphMap):

--- a/Lib/fontTools/otlLib/classDefBuilder.py
+++ b/Lib/fontTools/otlLib/classDefBuilder.py
@@ -1,0 +1,60 @@
+from fontTools.ttLib.tables import otTables as ot
+
+
+class ClassDefBuilder(object):
+    """Helper for building ClassDef tables."""
+    def __init__(self, useClass0):
+        self.classes_ = set()
+        self.glyphs_ = {}
+        self.useClass0_ = useClass0
+
+    def canAdd(self, glyphs):
+        if isinstance(glyphs, (set, frozenset)):
+            glyphs = sorted(glyphs)
+        glyphs = tuple(glyphs)
+        if glyphs in self.classes_:
+            return True
+        for glyph in glyphs:
+            if glyph in self.glyphs_:
+                return False
+        return True
+
+    def add(self, glyphs):
+        if isinstance(glyphs, (set, frozenset)):
+            glyphs = sorted(glyphs)
+        glyphs = tuple(glyphs)
+        if glyphs in self.classes_:
+            return
+        self.classes_.add(glyphs)
+        for glyph in glyphs:
+            assert glyph not in self.glyphs_
+            self.glyphs_[glyph] = glyphs
+
+    def classes(self):
+        # In ClassDef1 tables, class id #0 does not need to be encoded
+        # because zero is the default. Therefore, we use id #0 for the
+        # glyph class that has the largest number of members. However,
+        # in other tables than ClassDef1, 0 means "every other glyph"
+        # so we should not use that ID for any real glyph classes;
+        # we implement this by inserting an empty set at position 0.
+        #
+        # TODO: Instead of counting the number of glyphs in each class,
+        # we should determine the encoded size. If the glyphs in a large
+        # class form a contiguous range, the encoding is actually quite
+        # compact, whereas a non-contiguous set might need a lot of bytes
+        # in the output file. We don't get this right with the key below.
+        result = sorted(self.classes_, key=lambda s: (len(s), s), reverse=True)
+        if not self.useClass0_:
+            result.insert(0, frozenset())
+        return result
+
+    def build(self):
+        glyphClasses = {}
+        for classID, glyphs in enumerate(self.classes()):
+            if classID == 0:
+                continue
+            for glyph in glyphs:
+                glyphClasses[glyph] = classID
+        classDef = ot.ClassDef()
+        classDef.classDefs = glyphClasses
+        return classDef

--- a/Lib/fontTools/otlLib/error.py
+++ b/Lib/fontTools/otlLib/error.py
@@ -1,0 +1,17 @@
+class OTLLibError(Exception):
+    def __init__(self, message, location):
+        Exception.__init__(self, message)
+        self.location = location
+
+    def __str__(self):
+        message = Exception.__str__(self)
+        if self.location:
+            if hasattr(self.location, "__iter__") and not isinstance(
+                self.location, str
+            ):
+                loc = ":".join([str(x) for x in self.location])
+            else:
+                loc = self.location
+            return f"{loc}: {message}"
+        else:
+            return message

--- a/Lib/fontTools/otlLib/lookupBuilders.py
+++ b/Lib/fontTools/otlLib/lookupBuilders.py
@@ -1,0 +1,568 @@
+from collections import defaultdict, OrderedDict
+from fontTools.ttLib.tables import otBase, otTables
+from fontTools.otlLib.error import OTLLibError
+from fontTools.otlLib import builder as otl
+import logging
+
+
+log = logging.getLogger(__name__)
+
+class LookupBuilder(object):
+    SUBTABLE_BREAK_ = "SUBTABLE_BREAK"
+
+    def __init__(self, font, location, table, lookup_type):
+        self.font = font
+        self.glyphMap = font.getReverseGlyphMap()
+        self.location = location
+        self.table, self.lookup_type = table, lookup_type
+        self.lookupflag = 0
+        self.markFilterSet = None
+        self.lookup_index = None  # assigned when making final tables
+        assert table in ('GPOS', 'GSUB')
+
+    def equals(self, other):
+        return (isinstance(other, self.__class__) and
+                self.table == other.table and
+                self.lookupflag == other.lookupflag and
+                self.markFilterSet == other.markFilterSet)
+
+    def inferGlyphClasses(self):
+        """Infers glyph glasses for the GDEF table, such as {"cedilla":3}."""
+        return {}
+
+    def getAlternateGlyphs(self):
+        """Helper for building 'aalt' features."""
+        return {}
+
+    def buildLookup_(self, subtables):
+        return otl.buildLookup(subtables, self.lookupflag, self.markFilterSet)
+
+    def buildMarkClasses_(self, marks):
+        """{"cedilla": ("BOTTOM", ast.Anchor), ...} --> {"BOTTOM":0, "TOP":1}
+
+        Helper for MarkBasePostBuilder, MarkLigPosBuilder, and
+        MarkMarkPosBuilder. Seems to return the same numeric IDs
+        for mark classes as the AFDKO makeotf tool.
+        """
+        ids = {}
+        for mark in sorted(marks.keys(), key=self.font.getGlyphID):
+            markClassName, _markAnchor = marks[mark]
+            if markClassName not in ids:
+                ids[markClassName] = len(ids)
+        return ids
+
+    def setBacktrackCoverage_(self, prefix, subtable):
+        subtable.BacktrackGlyphCount = len(prefix)
+        subtable.BacktrackCoverage = []
+        for p in reversed(prefix):
+            coverage = otl.buildCoverage(p, self.glyphMap)
+            subtable.BacktrackCoverage.append(coverage)
+
+    def setLookAheadCoverage_(self, suffix, subtable):
+        subtable.LookAheadGlyphCount = len(suffix)
+        subtable.LookAheadCoverage = []
+        for s in suffix:
+            coverage = otl.buildCoverage(s, self.glyphMap)
+            subtable.LookAheadCoverage.append(coverage)
+
+    def setInputCoverage_(self, glyphs, subtable):
+        subtable.InputGlyphCount = len(glyphs)
+        subtable.InputCoverage = []
+        for g in glyphs:
+            coverage = otl.buildCoverage(g, self.glyphMap)
+            subtable.InputCoverage.append(coverage)
+
+    def build_subst_subtables(self, mapping, klass):
+        substitutions = [{}]
+        for key in mapping:
+            if key[0] == self.SUBTABLE_BREAK_:
+                substitutions.append({})
+            else:
+                substitutions[-1][key] = mapping[key]
+        subtables = [klass(s) for s in substitutions]
+        return subtables
+
+    def add_subtable_break(self, location):
+        log.warning(OTLLibError(
+            'unsupported "subtable" statement for lookup type',
+            location
+        ))
+
+
+class AlternateSubstBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GSUB', 3)
+        self.alternates = OrderedDict()
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.alternates == other.alternates)
+
+    def build(self):
+        subtables = self.build_subst_subtables(self.alternates,
+                otl.buildAlternateSubstSubtable)
+        return self.buildLookup_(subtables)
+
+    def getAlternateGlyphs(self):
+        return self.alternates
+
+    def add_subtable_break(self, location):
+        self.alternates[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
+
+
+class ChainContextPosBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GPOS', 8)
+        self.rules = []  # (prefix, input, suffix, lookups)
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.rules == other.rules)
+
+    def build(self):
+        subtables = []
+        for (prefix, glyphs, suffix, lookups) in self.rules:
+            if prefix == self.SUBTABLE_BREAK_:
+                continue
+            st = otTables.ChainContextPos()
+            subtables.append(st)
+            st.Format = 3
+            self.setBacktrackCoverage_(prefix, st)
+            self.setLookAheadCoverage_(suffix, st)
+            self.setInputCoverage_(glyphs, st)
+
+            st.PosCount = 0
+            st.PosLookupRecord = []
+            for sequenceIndex, lookupList in enumerate(lookups):
+                if lookupList is not None:
+                    if not isinstance(lookupList, list):
+                        # Can happen with synthesised lookups
+                        lookupList = [ lookupList ]
+                    for l in lookupList:
+                        st.PosCount += 1
+                        if l.lookup_index is None:
+                            raise OTLLibError('Missing index of the specified '
+                                'lookup, might be a substitution lookup',
+                                self.location)
+                        rec = otTables.PosLookupRecord()
+                        rec.SequenceIndex = sequenceIndex
+                        rec.LookupListIndex = l.lookup_index
+                        st.PosLookupRecord.append(rec)
+        return self.buildLookup_(subtables)
+
+    def find_chainable_single_pos(self, lookups, glyphs, value):
+        """Helper for add_single_pos_chained_()"""
+        res = None
+        for lookup in lookups[::-1]:
+            if lookup == self.SUBTABLE_BREAK_:
+                return res
+            if isinstance(lookup, SinglePosBuilder) and \
+                    all(lookup.can_add(glyph, value) for glyph in glyphs):
+                res = lookup
+        return res
+
+    def add_subtable_break(self, location):
+        self.rules.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
+                           self.SUBTABLE_BREAK_, [self.SUBTABLE_BREAK_]))
+
+
+class ChainContextSubstBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GSUB', 6)
+        self.substitutions = []  # (prefix, input, suffix, lookups)
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.substitutions == other.substitutions)
+
+    def build(self):
+        subtables = []
+        for (prefix, input, suffix, lookups) in self.substitutions:
+            if prefix == self.SUBTABLE_BREAK_:
+                continue
+            st = otTables.ChainContextSubst()
+            subtables.append(st)
+            st.Format = 3
+            self.setBacktrackCoverage_(prefix, st)
+            self.setLookAheadCoverage_(suffix, st)
+            self.setInputCoverage_(input, st)
+
+            st.SubstCount = 0
+            st.SubstLookupRecord = []
+            for sequenceIndex, lookupList in enumerate(lookups):
+                if lookupList is not None:
+                    if not isinstance(lookupList, list):
+                        # Can happen with synthesised lookups
+                        lookupList = [ lookupList ]
+                    for l in lookupList:
+                        st.SubstCount += 1
+                        if l.lookup_index is None:
+                            raise OTLLibError('Missing index of the specified '
+                                'lookup, might be a positioning lookup',
+                                self.location)
+                        rec = otTables.SubstLookupRecord()
+                        rec.SequenceIndex = sequenceIndex
+                        rec.LookupListIndex = l.lookup_index
+                        st.SubstLookupRecord.append(rec)
+        return self.buildLookup_(subtables)
+
+    def getAlternateGlyphs(self):
+        result = {}
+        for (_, _, _, lookuplist) in self.substitutions:
+            if lookuplist == self.SUBTABLE_BREAK_:
+                continue
+            for lookups in lookuplist:
+                if not isinstance(lookups, list):
+                    lookups = [lookups]
+                for lookup in lookups:
+                    if lookup is not None:
+                        alts = lookup.getAlternateGlyphs()
+                        for glyph, replacements in alts.items():
+                            result.setdefault(glyph, set()).update(replacements)
+        return result
+
+    def find_chainable_single_subst(self, glyphs):
+        """Helper for add_single_subst_chained_()"""
+        res = None
+        for _, _, _, substitutions in self.substitutions[::-1]:
+            if substitutions == self.SUBTABLE_BREAK_:
+                return res
+            for sub in substitutions:
+                if (isinstance(sub, SingleSubstBuilder) and
+                        not any(g in glyphs for g in sub.mapping.keys())):
+                    res = sub
+        return res
+
+    def add_subtable_break(self, location):
+        self.substitutions.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
+                                   self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_))
+
+
+class LigatureSubstBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GSUB', 4)
+        self.ligatures = OrderedDict()  # {('f','f','i'): 'f_f_i'}
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.ligatures == other.ligatures)
+
+    def build(self):
+        subtables = self.build_subst_subtables(self.ligatures,
+                otl.buildLigatureSubstSubtable)
+        return self.buildLookup_(subtables)
+
+    def add_subtable_break(self, location):
+        self.ligatures[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
+
+
+class MultipleSubstBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GSUB', 2)
+        self.mapping = OrderedDict()
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.mapping == other.mapping)
+
+    def build(self):
+        subtables = self.build_subst_subtables(self.mapping,
+                otl.buildMultipleSubstSubtable)
+        return self.buildLookup_(subtables)
+
+    def add_subtable_break(self, location):
+        self.mapping[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
+
+
+class CursivePosBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GPOS', 3)
+        self.attachments = {}
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.attachments == other.attachments)
+
+    def add_attachment(self, location, glyphs, entryAnchor, exitAnchor):
+        for glyph in glyphs:
+            self.attachments[glyph] = (entryAnchor, exitAnchor)
+
+    def build(self):
+        st = otl.buildCursivePosSubtable(self.attachments, self.glyphMap)
+        return self.buildLookup_([st])
+
+
+class MarkBasePosBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GPOS', 4)
+        self.marks = {}  # glyphName -> (markClassName, anchor)
+        self.bases = {}  # glyphName -> {markClassName: anchor}
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.marks == other.marks and
+                self.bases == other.bases)
+
+    def inferGlyphClasses(self):
+        result = {glyph: 1 for glyph in self.bases}
+        result.update({glyph: 3 for glyph in self.marks})
+        return result
+
+    def build(self):
+        markClasses = self.buildMarkClasses_(self.marks)
+        marks = {mark: (markClasses[mc], anchor)
+                 for mark, (mc, anchor) in self.marks.items()}
+        bases = {}
+        for glyph, anchors in self.bases.items():
+            bases[glyph] = {markClasses[mc]: anchor
+                            for (mc, anchor) in anchors.items()}
+        subtables = otl.buildMarkBasePos(marks, bases, self.glyphMap)
+        return self.buildLookup_(subtables)
+
+
+class MarkLigPosBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GPOS', 5)
+        self.marks = {}  # glyphName -> (markClassName, anchor)
+        self.ligatures = {}  # glyphName -> [{markClassName: anchor}, ...]
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.marks == other.marks and
+                self.ligatures == other.ligatures)
+
+    def inferGlyphClasses(self):
+        result = {glyph: 2 for glyph in self.ligatures}
+        result.update({glyph: 3 for glyph in self.marks})
+        return result
+
+    def build(self):
+        markClasses = self.buildMarkClasses_(self.marks)
+        marks = {mark: (markClasses[mc], anchor)
+                 for mark, (mc, anchor) in self.marks.items()}
+        ligs = {}
+        for lig, components in self.ligatures.items():
+            ligs[lig] = []
+            for c in components:
+                ligs[lig].append({markClasses[mc]: a for mc, a in c.items()})
+        subtables = otl.buildMarkLigPos(marks, ligs, self.glyphMap)
+        return self.buildLookup_(subtables)
+
+
+class MarkMarkPosBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GPOS', 6)
+        self.marks = {}      # glyphName -> (markClassName, anchor)
+        self.baseMarks = {}  # glyphName -> {markClassName: anchor}
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.marks == other.marks and
+                self.baseMarks == other.baseMarks)
+
+    def inferGlyphClasses(self):
+        result = {glyph: 3 for glyph in self.baseMarks}
+        result.update({glyph: 3 for glyph in self.marks})
+        return result
+
+    def build(self):
+        markClasses = self.buildMarkClasses_(self.marks)
+        markClassList = sorted(markClasses.keys(), key=markClasses.get)
+        marks = {mark: (markClasses[mc], anchor)
+                 for mark, (mc, anchor) in self.marks.items()}
+
+        st = otTables.MarkMarkPos()
+        st.Format = 1
+        st.ClassCount = len(markClasses)
+        st.Mark1Coverage = otl.buildCoverage(marks, self.glyphMap)
+        st.Mark2Coverage = otl.buildCoverage(self.baseMarks, self.glyphMap)
+        st.Mark1Array = otl.buildMarkArray(marks, self.glyphMap)
+        st.Mark2Array = otTables.Mark2Array()
+        st.Mark2Array.Mark2Count = len(st.Mark2Coverage.glyphs)
+        st.Mark2Array.Mark2Record = []
+        for base in st.Mark2Coverage.glyphs:
+            anchors = [self.baseMarks[base].get(mc) for mc in markClassList]
+            st.Mark2Array.Mark2Record.append(otl.buildMark2Record(anchors))
+        return self.buildLookup_([st])
+
+
+class ReverseChainSingleSubstBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GSUB', 8)
+        self.substitutions = []  # (prefix, suffix, mapping)
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.substitutions == other.substitutions)
+
+    def build(self):
+        subtables = []
+        for prefix, suffix, mapping in self.substitutions:
+            st = otTables.ReverseChainSingleSubst()
+            st.Format = 1
+            self.setBacktrackCoverage_(prefix, st)
+            self.setLookAheadCoverage_(suffix, st)
+            st.Coverage = otl.buildCoverage(mapping.keys(), self.glyphMap)
+            st.GlyphCount = len(mapping)
+            st.Substitute = [mapping[g] for g in st.Coverage.glyphs]
+            subtables.append(st)
+        return self.buildLookup_(subtables)
+
+    def add_subtable_break(self, location):
+        # Nothing to do here, each substitution is in its own subtable.
+        pass
+
+
+class SingleSubstBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GSUB', 1)
+        self.mapping = OrderedDict()
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.mapping == other.mapping)
+
+    def build(self):
+        subtables = self.build_subst_subtables(self.mapping,
+                otl.buildSingleSubstSubtable)
+        return self.buildLookup_(subtables)
+
+    def getAlternateGlyphs(self):
+        return {glyph: set([repl]) for glyph, repl in self.mapping.items()}
+
+    def add_subtable_break(self, location):
+        self.mapping[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
+
+
+class ClassPairPosSubtableBuilder(object):
+    def __init__(self, builder, valueFormat1, valueFormat2):
+        self.builder_ = builder
+        self.classDef1_, self.classDef2_ = None, None
+        self.values_ = {}  # (glyphclass1, glyphclass2) --> (value1, value2)
+        self.valueFormat1_, self.valueFormat2_ = valueFormat1, valueFormat2
+        self.forceSubtableBreak_ = False
+        self.subtables_ = []
+
+    def addPair(self, gc1, value1, gc2, value2):
+        mergeable = (not self.forceSubtableBreak_ and
+                     self.classDef1_ is not None and
+                     self.classDef1_.canAdd(gc1) and
+                     self.classDef2_ is not None and
+                     self.classDef2_.canAdd(gc2))
+        if not mergeable:
+            self.flush_()
+            self.classDef1_ = otl.ClassDefBuilder(useClass0=True)
+            self.classDef2_ = otl.ClassDefBuilder(useClass0=False)
+            self.values_ = {}
+        self.classDef1_.add(gc1)
+        self.classDef2_.add(gc2)
+        self.values_[(gc1, gc2)] = (value1, value2)
+
+    def addSubtableBreak(self):
+        self.forceSubtableBreak_ = True
+
+    def subtables(self):
+        self.flush_()
+        return self.subtables_
+
+    def flush_(self):
+        if self.classDef1_ is None or self.classDef2_ is None:
+            return
+        st = otl.buildPairPosClassesSubtable(self.values_,
+                                             self.builder_.glyphMap)
+        if st.Coverage is None:
+            return
+        self.subtables_.append(st)
+        self.forceSubtableBreak_ = False
+
+
+class PairPosBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GPOS', 2)
+        self.pairs = []  # [(gc1, value1, gc2, value2)*]
+        self.glyphPairs = {}  # (glyph1, glyph2) --> (value1, value2)
+        self.locations = {}  # (gc1, gc2) --> (filepath, line, column)
+
+    def addClassPair(self, location, glyphclass1, value1, glyphclass2, value2):
+        self.pairs.append((glyphclass1, value1, glyphclass2, value2))
+
+    def addGlyphPair(self, location, glyph1, value1, glyph2, value2):
+        key = (glyph1, glyph2)
+        oldValue = self.glyphPairs.get(key, None)
+        if oldValue is not None:
+            # the Feature File spec explicitly allows specific pairs generated
+            # by an 'enum' rule to be overridden by preceding single pairs
+            otherLoc = self.locations[key]
+            log.debug(
+                'Already defined position for pair %s %s at %s:%d:%d; '
+                'choosing the first value',
+                glyph1, glyph2, otherLoc[0], otherLoc[1], otherLoc[2])
+        else:
+            self.glyphPairs[key] = (value1, value2)
+            self.locations[key] = location
+
+    def add_subtable_break(self, location):
+        self.pairs.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
+                           self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_))
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.glyphPairs == other.glyphPairs and
+                self.pairs == other.pairs)
+
+    def build(self):
+        builders = {}
+        builder = None
+        for glyphclass1, value1, glyphclass2, value2 in self.pairs:
+            if glyphclass1 is self.SUBTABLE_BREAK_:
+                if builder is not None:
+                    builder.addSubtableBreak()
+                continue
+            valFormat1, valFormat2 = 0, 0
+            if value1: valFormat1 = value1.getFormat()
+            if value2: valFormat2 = value2.getFormat()
+            builder = builders.get((valFormat1, valFormat2))
+            if builder is None:
+                builder = ClassPairPosSubtableBuilder(
+                    self, valFormat1, valFormat2)
+                builders[(valFormat1, valFormat2)] = builder
+            builder.addPair(glyphclass1, value1, glyphclass2, value2)
+        subtables = []
+        if self.glyphPairs:
+            subtables.extend(
+                otl.buildPairPosGlyphs(self.glyphPairs, self.glyphMap))
+        for key in sorted(builders.keys()):
+            subtables.extend(builders[key].subtables())
+        return self.buildLookup_(subtables)
+
+
+class SinglePosBuilder(LookupBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GPOS', 1)
+        self.locations = {}  # glyph -> (filename, line, column)
+        self.mapping = {}  # glyph -> otTables.ValueRecord
+
+    def add_pos(self, location, glyph, otValueRecord):
+        if not self.can_add(glyph, otValueRecord):
+            otherLoc = self.locations[glyph]
+            raise OTLLibError(
+                'Already defined different position for glyph "%s" at %s:%d:%d'
+                % (glyph, otherLoc[0], otherLoc[1], otherLoc[2]),
+                location)
+        if otValueRecord:
+            self.mapping[glyph] = otValueRecord
+        self.locations[glyph] = location
+
+    def can_add(self, glyph, value):
+        assert isinstance(value, otl.ValueRecord)
+        curValue = self.mapping.get(glyph)
+        return curValue is None or curValue == value
+
+    def equals(self, other):
+        return (LookupBuilder.equals(self, other) and
+                self.mapping == other.mapping)
+
+    def build(self):
+        subtables = otl.buildSinglePos(self.mapping, self.glyphMap)
+        return self.buildLookup_(subtables)
+

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -3,6 +3,7 @@ from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.feaLib.builder import Builder, addOpenTypeFeatures, \
         addOpenTypeFeaturesFromString
 from fontTools.feaLib.error import FeatureLibError
+from fontTools.otlLib.error import OTLLibError
 from fontTools.ttLib import TTFont
 from fontTools.feaLib.parser import Parser
 from fontTools.feaLib import ast
@@ -225,7 +226,7 @@ class BuilderTest(unittest.TestCase):
 
     def test_pairPos_redefinition_warning(self):
         # https://github.com/fonttools/fonttools/issues/1147
-        logger = logging.getLogger("fontTools.feaLib.builder")
+        logger = logging.getLogger("fontTools.otlLib.lookupBuilders")
         with CapturingLogHandler(logger, "DEBUG") as captor:
             # the pair "yacute semicolon" is redefined in the enum pos
             font = self.build(
@@ -259,7 +260,7 @@ class BuilderTest(unittest.TestCase):
 
     def test_singlePos_redefinition(self):
         self.assertRaisesRegex(
-            FeatureLibError,
+            OTLLibError,
             "Already defined different position for glyph \"A\"",
             self.build, "feature test { pos A 123; pos A 456; } test;")
 
@@ -433,7 +434,7 @@ class BuilderTest(unittest.TestCase):
 
     def test_chain_subst_refrences_GPOS_looup(self):
         self.assertRaisesRegex(
-            FeatureLibError,
+            OTLLibError,
             "Missing index of the specified lookup, might be a positioning lookup",
             self.build,
             "lookup dummy { pos a 50; } dummy;"
@@ -444,7 +445,7 @@ class BuilderTest(unittest.TestCase):
 
     def test_chain_pos_refrences_GSUB_looup(self):
         self.assertRaisesRegex(
-            FeatureLibError,
+            OTLLibError,
             "Missing index of the specified lookup, might be a substitution lookup",
             self.build,
             "lookup dummy { sub a by A; } dummy;"
@@ -571,7 +572,7 @@ class BuilderTest(unittest.TestCase):
         assert "GSUB" in font
 
     def test_unsupported_subtable_break(self):
-        logger = logging.getLogger("fontTools.feaLib.builder")
+        logger = logging.getLogger("fontTools.otlLib.lookupBuilders")
         with CapturingLogHandler(logger, level='WARNING') as captor:
             self.build(
                 "feature test {"


### PR DESCRIPTION
As discussed in #1992, this moves the lookup-builder classes from feaLib to otlLib. It also spins off `ClassDefBuilder` to its own file, and documents otlLib. Note this does not yet contain any of the refactorings from #1991.