### PR TITLE
[ttLib.tables._n_a_m_e] Fix #1997: Only attempt to recovered malformed data from bytes

### DIFF
--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -441,7 +441,7 @@ class NameRecord(object):
 		encoding = self.getEncoding()
 		string = self.string
 
-		if encoding == 'utf_16_be' and len(string) % 2 == 1:
+		if isinstance(string, bytes) and encoding == 'utf_16_be' and len(string) % 2 == 1:
 			# Recover badly encoded UTF-16 strings that have an odd number of bytes:
 			# - If the last byte is zero, drop it.  Otherwise,
 			# - If all the odd bytes are zero and all the even bytes are ASCII,

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -305,6 +305,13 @@ class NameTableTest(unittest.TestCase):
 		self.assertGreaterEqual(nameID, 256)
 		self.assertEqual(nameID, table.findMultilingualName(names, minNameID=256))
 
+	def test_addMultilingualName_singleChar(self):
+		# https://github.com/fonttools/fonttools/issues/1997
+		table = table__n_a_m_e()
+		nameID = table.addMultilingualName({"en": "A"})
+		rec = table.getName(nameID, 3, 1)
+		self.assertEqual(rec.toUnicode(), "A")
+
 	def test_decompile_badOffset(self):
                 # https://github.com/fonttools/fonttools/issues/525
 		table = table__n_a_m_e()

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -305,13 +305,6 @@ class NameTableTest(unittest.TestCase):
 		self.assertGreaterEqual(nameID, 256)
 		self.assertEqual(nameID, table.findMultilingualName(names, minNameID=256))
 
-	def test_addMultilingualName_singleChar(self):
-		# https://github.com/fonttools/fonttools/issues/1997
-		table = table__n_a_m_e()
-		nameID = table.addMultilingualName({"en": "A"})
-		rec = table.getName(nameID, 3, 1)
-		self.assertEqual(rec.toUnicode(), "A")
-
 	def test_decompile_badOffset(self):
                 # https://github.com/fonttools/fonttools/issues/525
 		table = table__n_a_m_e()
@@ -351,6 +344,11 @@ class NameRecordTest(unittest.TestCase):
 		name = makeName(b"\1", 111, 0, 2, 7)
 		self.assertEqual("utf_16_be", name.getEncoding())
 		self.assertRaises(UnicodeDecodeError, name.toUnicode)
+
+	def test_toUnicode_singleChar(self):
+		# https://github.com/fonttools/fonttools/issues/1997
+		name = makeName("A", 256, 3, 1, 0x409)
+		self.assertEqual(name.toUnicode(), "A")
 
 	def toXML(self, name):
 		writer = XMLWriter(BytesIO())


### PR DESCRIPTION
Don't attempt to recover malformed data from str, only from bytes. Fixes #1997.