### PR TITLE
[otlLib] Refactor chained contextual builders

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -868,7 +868,7 @@ class Builder(object):
     def add_chain_context_subst(self, location,
                                 prefix, glyphs, suffix, lookups):
         lookup = self.get_lookup_(location, ChainContextSubstBuilder)
-        lookup.substitutions.append((prefix, glyphs, suffix,
+        lookup.rules.append((prefix, glyphs, suffix,
                                      self.find_lookup_builders_(lookups)))
 
     def add_alternate_subst(self, location,
@@ -880,7 +880,7 @@ class Builder(object):
         if prefix or suffix:
             chain = self.get_lookup_(location, ChainContextSubstBuilder)
             lookup = self.get_chained_lookup_(location, AlternateSubstBuilder)
-            chain.substitutions.append((prefix, [{glyph}], suffix, [lookup]))
+            chain.rules.append((prefix, [{glyph}], suffix, [lookup]))
         else:
             lookup = self.get_lookup_(location, AlternateSubstBuilder)
         if glyph in lookup.alternates:
@@ -935,7 +935,7 @@ class Builder(object):
         if prefix or suffix or forceChain:
             chain = self.get_lookup_(location, ChainContextSubstBuilder)
             lookup = self.get_chained_lookup_(location, LigatureSubstBuilder)
-            chain.substitutions.append((prefix, glyphs, suffix, [lookup]))
+            chain.rules.append((prefix, glyphs, suffix, [lookup]))
         else:
             lookup = self.get_lookup_(location, LigatureSubstBuilder)
 
@@ -953,7 +953,7 @@ class Builder(object):
             chain = self.get_lookup_(location, ChainContextSubstBuilder)
             sub = self.get_chained_lookup_(location, MultipleSubstBuilder)
             sub.mapping[glyph] = replacements
-            chain.substitutions.append((prefix, [{glyph}], suffix, [sub]))
+            chain.rules.append((prefix, [{glyph}], suffix, [sub]))
             return
         lookup = self.get_lookup_(location, MultipleSubstBuilder)
         if glyph in lookup.mapping:
@@ -973,7 +973,7 @@ class Builder(object):
     def add_reverse_chain_single_subst(self, location, old_prefix,
                                        old_suffix, mapping):
         lookup = self.get_lookup_(location, ReverseChainSingleSubstBuilder)
-        lookup.substitutions.append((old_prefix, old_suffix, mapping))
+        lookup.rules.append((old_prefix, old_suffix, mapping))
 
     def add_single_subst(self, location, prefix, suffix, mapping, forceChain):
         if self.cur_feature_name_ == "aalt":
@@ -1007,7 +1007,7 @@ class Builder(object):
         if sub is None:
             sub = self.get_chained_lookup_(location, SingleSubstBuilder)
         sub.mapping.update(mapping)
-        chain.substitutions.append((prefix, [mapping.keys()], suffix, [sub]))
+        chain.rules.append((prefix, [mapping.keys()], suffix, [sub]))
 
     def add_cursive_pos(self, location, glyphclass, entryAnchor, exitAnchor):
         lookup = self.get_lookup_(location, CursivePosBuilder)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -156,14 +156,16 @@ class AlternateSubstBuilder(LookupBuilder):
         self.alternates[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
 
 
-class ChainContextPosBuilder(LookupBuilder):
-    def __init__(self, font, location):
-        LookupBuilder.__init__(self, font, location, 'GPOS', 8)
-        self.rules = []  # (prefix, input, suffix, lookups)
-
+class ChainContextualBuilder(LookupBuilder):
     def equals(self, other):
         return (LookupBuilder.equals(self, other) and
                 self.rules == other.rules)
+
+
+class ChainContextPosBuilder(ChainContextualBuilder):
+    def __init__(self, font, location):
+        LookupBuilder.__init__(self, font, location, 'GPOS', 8)
+        self.rules = []  # (prefix, input, suffix, lookups)
 
     def build(self):
         subtables = []
@@ -212,14 +214,10 @@ class ChainContextPosBuilder(LookupBuilder):
                            self.SUBTABLE_BREAK_, [self.SUBTABLE_BREAK_]))
 
 
-class ChainContextSubstBuilder(LookupBuilder):
+class ChainContextSubstBuilder(ChainContextualBuilder):
     def __init__(self, font, location):
         LookupBuilder.__init__(self, font, location, 'GSUB', 6)
         self.substitutions = []  # (prefix, input, suffix, lookups)
-
-    def equals(self, other):
-        return (LookupBuilder.equals(self, other) and
-                self.substitutions == other.substitutions)
 
     def build(self):
         subtables = []

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -161,6 +161,10 @@ class ChainContextualBuilder(LookupBuilder):
         return (LookupBuilder.equals(self, other) and
                 self.rules == other.rules)
 
+    def add_subtable_break(self, location):
+        self.rules.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
+                           self.SUBTABLE_BREAK_, [self.SUBTABLE_BREAK_]))
+
 
 class ChainContextPosBuilder(ChainContextualBuilder):
     def __init__(self, font, location):
@@ -208,10 +212,6 @@ class ChainContextPosBuilder(ChainContextualBuilder):
                     all(lookup.can_add(glyph, value) for glyph in glyphs):
                 res = lookup
         return res
-
-    def add_subtable_break(self, location):
-        self.rules.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
-                           self.SUBTABLE_BREAK_, [self.SUBTABLE_BREAK_]))
 
 
 class ChainContextSubstBuilder(ChainContextualBuilder):
@@ -276,10 +276,6 @@ class ChainContextSubstBuilder(ChainContextualBuilder):
                         not any(g in glyphs for g in sub.mapping.keys())):
                     res = sub
         return res
-
-    def add_subtable_break(self, location):
-        self.rules.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
-                                   self.SUBTABLE_BREAK_, [self.SUBTABLE_BREAK_]))
 
 
 class LigatureSubstBuilder(LookupBuilder):

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -252,8 +252,8 @@ class ChainContextSubstBuilder(ChainContextualBuilder):
 
     def getAlternateGlyphs(self):
         result = {}
-        for (_, _, _, lookuplist) in self.rules:
-            if lookuplist == self.SUBTABLE_BREAK_:
+        for (prefix, _, _, lookuplist) in self.rules:
+            if prefix == self.SUBTABLE_BREAK_:
                 continue
             for lookups in lookuplist:
                 if not isinstance(lookups, list):
@@ -268,8 +268,8 @@ class ChainContextSubstBuilder(ChainContextualBuilder):
     def find_chainable_single_subst(self, glyphs):
         """Helper for add_single_subst_chained_()"""
         res = None
-        for _, _, _, rules in self.rules[::-1]:
-            if rules == self.SUBTABLE_BREAK_:
+        for prefix, _, _, rules in self.rules[::-1]:
+            if prefix == self.SUBTABLE_BREAK_:
                 return res
             for sub in rules:
                 if (isinstance(sub, SingleSubstBuilder) and
@@ -279,7 +279,7 @@ class ChainContextSubstBuilder(ChainContextualBuilder):
 
     def add_subtable_break(self, location):
         self.rules.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
-                                   self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_))
+                                   self.SUBTABLE_BREAK_, [self.SUBTABLE_BREAK_]))
 
 
 class LigatureSubstBuilder(LookupBuilder):

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -217,11 +217,11 @@ class ChainContextPosBuilder(ChainContextualBuilder):
 class ChainContextSubstBuilder(ChainContextualBuilder):
     def __init__(self, font, location):
         LookupBuilder.__init__(self, font, location, 'GSUB', 6)
-        self.substitutions = []  # (prefix, input, suffix, lookups)
+        self.rules = []  # (prefix, input, suffix, lookups)
 
     def build(self):
         subtables = []
-        for (prefix, input, suffix, lookups) in self.substitutions:
+        for (prefix, input, suffix, lookups) in self.rules:
             if prefix == self.SUBTABLE_BREAK_:
                 continue
             st = ot.ChainContextSubst()
@@ -252,7 +252,7 @@ class ChainContextSubstBuilder(ChainContextualBuilder):
 
     def getAlternateGlyphs(self):
         result = {}
-        for (_, _, _, lookuplist) in self.substitutions:
+        for (_, _, _, lookuplist) in self.rules:
             if lookuplist == self.SUBTABLE_BREAK_:
                 continue
             for lookups in lookuplist:
@@ -268,17 +268,17 @@ class ChainContextSubstBuilder(ChainContextualBuilder):
     def find_chainable_single_subst(self, glyphs):
         """Helper for add_single_subst_chained_()"""
         res = None
-        for _, _, _, substitutions in self.substitutions[::-1]:
-            if substitutions == self.SUBTABLE_BREAK_:
+        for _, _, _, rules in self.rules[::-1]:
+            if rules == self.SUBTABLE_BREAK_:
                 return res
-            for sub in substitutions:
+            for sub in rules:
                 if (isinstance(sub, SingleSubstBuilder) and
                         not any(g in glyphs for g in sub.mapping.keys())):
                     res = sub
         return res
 
     def add_subtable_break(self, location):
-        self.substitutions.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
+        self.rules.append((self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_,
                                    self.SUBTABLE_BREAK_, self.SUBTABLE_BREAK_))
 
 
@@ -433,15 +433,15 @@ class MarkMarkPosBuilder(LookupBuilder):
 class ReverseChainSingleSubstBuilder(LookupBuilder):
     def __init__(self, font, location):
         LookupBuilder.__init__(self, font, location, 'GSUB', 8)
-        self.substitutions = []  # (prefix, suffix, mapping)
+        self.rules = []  # (prefix, suffix, mapping)
 
     def equals(self, other):
         return (LookupBuilder.equals(self, other) and
-                self.substitutions == other.substitutions)
+                self.rules == other.rules)
 
     def build(self):
         subtables = []
-        for prefix, suffix, mapping in self.substitutions:
+        for prefix, suffix, mapping in self.rules:
             st = ot.ReverseChainSingleSubst()
             st.Format = 1
             self.setBacktrackCoverage_(prefix, st)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -180,8 +180,12 @@ class ChainContextualBuilder(LookupBuilder):
                         lookupList = [ lookupList ]
                     for l in lookupList:
                         if l.lookup_index is None:
+                            if isinstance(self, ChainContextPosBuilder):
+                                other = "substitution"
+                            else:
+                                other = "positioning"
                             raise OpenTypeLibError('Missing index of the specified '
-                                'lookup, might be a substitution lookup',
+                                f'lookup, might be a {other} lookup',
                                 self.location)
                         rec = self.newLookupRecord_()
                         rec.SequenceIndex = sequenceIndex


### PR DESCRIPTION
This replaces #1991. Mostly this is about refactoring common code to a superclass, but lays a foundation for the optimizer which will come later.