### PR TITLE
Test that passing a markFilterSet sets the appropriate lookup flag

### DIFF
--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -514,7 +514,6 @@ class BuilderTest(object):
         s = builder.buildSingleSubstSubtable({"one": "two"})
         flags = (
             builder.LOOKUP_FLAG_RIGHT_TO_LEFT
-            | builder.LOOKUP_FLAG_USE_MARK_FILTERING_SET
         )
         lookup = builder.buildLookup([s], flags, markFilterSet=999)
         assert getXML(lookup.toXML) == [


### PR DESCRIPTION
See discussion in 3b50a5. Don't add the USE_MARK_FILTERING_SET flag explicitly, but still check it is set on export.