### PR TITLE
Fix documentation for MultipleSubstStatement (fixes #2012)

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1119,11 +1119,14 @@ class MarkMarkPosStatement(Statement):
 class MultipleSubstStatement(Statement):
     """A multiple substitution statement.
 
-    ``prefix``, ``glyph``, ``suffix`` and ``replacement`` should be lists of
-    `glyph-containing objects`_.
-
-    If ``forceChain`` is True, this is expressed as a chaining rule
-    (e.g. ``sub f' i' by f_i``) even when no context is given."""
+    Args:
+        prefix: a list of `glyph-containing objects`_.
+        glyph: a single glyph-containing object.
+        suffix: a list of glyph-containing objects.
+        replacement: a list of glyph-containing objects.
+        forceChain: If true, the statement is expressed as a chaining rule
+            (e.g. ``sub f' i' by f_i``) even when no context is given.
+    """
     def __init__(
         self, prefix, glyph, suffix, replacement, forceChain=False, location=None
     ):


### PR DESCRIPTION
This fixes the docstring; yes, it does it using a Google-style docstring, and yes, this is currently inconsistent, but half the docstrings I've written so far are Python and the other half are Google-style so we're inconsistent already, and better docs doesn't hurt. Going through all the docstrings and converting them all to Google-style is on my todo list. Consider this just getting one in early. :-)