### PR TITLE
Use namedtuple to represent contextual rules

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -257,6 +257,14 @@ class AlternateSubstBuilder(LookupBuilder):
         self.alternates[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
 
 
+class ChainContextualRule(
+    namedtuple("ChainContextualRule", ["prefix", "glyphs", "suffix", "lookups"])
+):
+    @property
+    def is_subtable_break(self):
+        return self.prefix == LookupBuilder.SUBTABLE_BREAK_
+
+
 class ChainContextualRuleset:
     def __init__(self):
         self.rules = []

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1398,28 +1398,28 @@ class ChainContextualRulesetTest(object):
         font.setGlyphOrder(["a","b","c","d","A","B","C","D","E"])
         sb = builder.ChainContextSubstBuilder(font, None)
         prefix, input_, suffix, lookups = [["a"], ["b"]], [["c"]], [], [None]
-        sb.rules.append((prefix, input_, suffix, lookups))
+        sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
 
         prefix, input_, suffix, lookups = [["a"], ["d"]], [["c"]], [], [None]
-        sb.rules.append((prefix, input_, suffix, lookups))
+        sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
 
         sb.add_subtable_break(None)
 
         # Second subtable has some glyph classes
         prefix, input_, suffix, lookups = [["A"]], [["E"]], [], [None]
-        sb.rules.append((prefix, input_, suffix, lookups))
+        sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
         prefix, input_, suffix, lookups = [["A"]], [["C","D"]], [], [None]
-        sb.rules.append((prefix, input_, suffix, lookups))
+        sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
         prefix, input_, suffix, lookups = [["A", "B"]], [["E"]], [], [None]
-        sb.rules.append((prefix, input_, suffix, lookups))
+        sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
 
         sb.add_subtable_break(None)
 
         # Third subtable has no pre/post context
         prefix, input_, suffix, lookups = [], [["E"]], [], [None]
-        sb.rules.append((prefix, input_, suffix, lookups))
+        sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
         prefix, input_, suffix, lookups = [], [["C","D"]], [], [None]
-        sb.rules.append((prefix, input_, suffix, lookups))
+        sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
 
         rulesets = sb.rulesets()
         assert len(rulesets) == 3

--- a/Tests/otlLib/mock_builder_test.py
+++ b/Tests/otlLib/mock_builder_test.py
@@ -13,6 +13,7 @@ from fontTools.otlLib.builder import (
     ClassPairPosSubtableBuilder,
     PairPosBuilder,
     SinglePosBuilder,
+    ChainContextualRule
 )
 from fontTools.otlLib.error import OpenTypeLibError
 from fontTools.ttLib import TTFont
@@ -79,7 +80,7 @@ def test_chain_pos_references_GSUB_lookup(ttfont):
     location = MockBuilderLocation((0, "alpha"))
     builder = ChainContextPosBuilder(ttfont, location)
     builder2 = SingleSubstBuilder(ttfont, location)
-    builder.rules.append(([], [], [], [[builder2]]))
+    builder.rules.append(ChainContextualRule([], [], [], [[builder2]]))
 
     with pytest.raises(OpenTypeLibError, match="0:alpha: Missing index of the specified lookup, might be a substitution lookup"):
         builder.build()


### PR DESCRIPTION
As mentioned in #2020:

> Besides, these rules ideally could be turned into a named tuple and their items accessed with attribute lookup (e.g. rule.prefix) instead of unpacking the tuple to get to its items by position.

(Note: This sits on top of #2025. Merge that one first, and this will magically become readable.)