### PR TITLE
Validate required attributes and their types

### DIFF
--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -919,7 +919,7 @@ class BaseDocReader(LogMixin):
                 self.log.warning("Location with undefined axis: \"%s\".", dimName)
                 continue
             xValue = yValue = None
-            self.validateAttributes(dimensionElement, { "xvalue": float })
+            self.validateAttributes(dimensionElement, {"xvalue": float})
             xValue = float(dimensionElement.attrib.get('xvalue'))
             try:
                 yValue = dimensionElement.attrib.get('yvalue')


### PR DESCRIPTION
I generated a (bad) designspace file in an app I've been working on, and was greeted by this from fontmake:

```
fontmake: Error: In 'foo.designspace': Reading Designspace failed: float() argument must be a string or a number, not 'NoneType'
```

Well, thanks. This patch validates the attributes of designspace file elements and provides a more helpful error message.

(Note that I use %-formats instead of f-strings to match existing code style.)