### PR TITLE
Remove import of py23 fron subset/__init__.py

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2,7 +2,6 @@
 #
 # Google Author(s): Behdad Esfahbod
 
-from fontTools.misc.py23 import *
 from fontTools.misc.fixedTools import otRound
 from fontTools import ttLib
 from fontTools.ttLib.tables import otTables


### PR DESCRIPTION
This import is causing an unsightly DeprecationWarning.

I checked manually: the only names being used from py23 are
open, range and zip, which are defined to be the same as the
corresponding Python 3 builtins, so this should cause no
visible change except for suppressing the warning.