### PR TITLE
[ttLib] Fix for #2044: fix maxp.maxComponentDepth calculation

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -650,6 +650,7 @@ class Glyph(object):
 		assert self.isComposite()
 		nContours = 0
 		nPoints = 0
+		initialMaxComponentDepth = maxComponentDepth
 		for compo in self.components:
 			baseGlyph = glyfTable[compo.glyphName]
 			if baseGlyph.numberOfContours == 0:
@@ -657,8 +658,9 @@ class Glyph(object):
 			elif baseGlyph.numberOfContours > 0:
 				nP, nC = baseGlyph.getMaxpValues()
 			else:
-				nP, nC, maxComponentDepth = baseGlyph.getCompositeMaxpValues(
-						glyfTable, maxComponentDepth + 1)
+				nP, nC, componentDepth = baseGlyph.getCompositeMaxpValues(
+						glyfTable, initialMaxComponentDepth + 1)
+				maxComponentDepth = max(maxComponentDepth, componentDepth)
 			nPoints = nPoints + nP
 			nContours = nContours + nC
 		return CompositeMaxpValues(nPoints, nContours, maxComponentDepth)

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -475,13 +475,7 @@ class GlyphTest:
         glyphTable = newTable("glyf")
         glyphTable.glyphs = {}
         glyphTable.glyphOrder = ["zero.numr", "zero.dnom", "percent", "perthousand", "fraction"]
-        pen = TTGlyphPen(glyphTable)
-        pen.moveTo((0, 0))
-        pen.lineTo((100, 0))
-        pen.lineTo((100, 100))
-        pen.lineTo((0, 100))
-        pen.closePath()
-        # simple contour glyph
+        pen = TTGlyphPen(glyphTable)  # empty non-composite glyph
         glyphTable["fraction"] = pen.glyph()
         glyphTable["zero.numr"] = pen.glyph()
         pen = TTGlyphPen(glyphTable)

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -471,6 +471,37 @@ class GlyphTest:
             ]
         )
 
+    def test_getCompositeMaxpValues(self):
+        glyphTable = newTable("glyf")
+        glyphTable.glyphs = {}
+        glyphTable.glyphOrder = ["zero.numr", "zero.dnom", "percent", "perthousand", "fraction"]
+        pen = TTGlyphPen(glyphTable)
+        pen.moveTo((0, 0))
+        pen.lineTo((100, 0))
+        pen.lineTo((100, 100))
+        pen.lineTo((0, 100))
+        pen.closePath()
+        # simple contour glyph
+        glyphTable["fraction"] = pen.glyph()
+        glyphTable["zero.numr"] = pen.glyph()
+        pen = TTGlyphPen(glyphTable)
+        pen.addComponent("zero.numr", (1, 0, 0, 1, 0, 0))
+        glyphTable["zero.dnom"] = pen.glyph()
+        pen = TTGlyphPen(glyphTable)
+        pen.addComponent("zero.numr", (1, 0, 0, 1, 0, 0))
+        pen.addComponent("fraction", (1, 0, 0, 1, 0, 0))
+        pen.addComponent("zero.dnom", (1, 0, 0, 1, 0, 0))
+        glyphTable["percent"] = pen.glyph()
+        pen = TTGlyphPen(glyphTable)
+        pen.addComponent("zero.numr", (1, 0, 0, 1, 0, 0))
+        pen.addComponent("fraction", (1, 0, 0, 1, 0, 0))
+        pen.addComponent("zero.dnom", (1, 0, 0, 1, 0, 0))
+        pen.addComponent("zero.dnom", (1, 0, 0, 1, 0, 0))
+        glyphTable["perthousand"] = pen.glyph()
+        assert glyphTable["zero.dnom"].getCompositeMaxpValues(glyphTable)[2] == 1
+        assert glyphTable["percent"].getCompositeMaxpValues(glyphTable)[2] == 2
+        assert glyphTable["perthousand"].getCompositeMaxpValues(glyphTable)[2] == 2
+
 
 class GlyphComponentTest:
 

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -472,29 +472,27 @@ class GlyphTest:
         )
 
     def test_getCompositeMaxpValues(self):
-        glyphTable = newTable("glyf")
-        glyphTable.glyphs = {}
-        glyphTable.glyphOrder = ["zero.numr", "zero.dnom", "percent", "perthousand", "fraction"]
-        pen = TTGlyphPen(glyphTable)  # empty non-composite glyph
-        glyphTable["fraction"] = pen.glyph()
-        glyphTable["zero.numr"] = pen.glyph()
-        pen = TTGlyphPen(glyphTable)
+        glyphSet = {}
+        pen = TTGlyphPen(glyphSet)  # empty non-composite glyph
+        glyphSet["fraction"] = pen.glyph()
+        glyphSet["zero.numr"] = pen.glyph()
+        pen = TTGlyphPen(glyphSet)
         pen.addComponent("zero.numr", (1, 0, 0, 1, 0, 0))
-        glyphTable["zero.dnom"] = pen.glyph()
-        pen = TTGlyphPen(glyphTable)
+        glyphSet["zero.dnom"] = pen.glyph()
+        pen = TTGlyphPen(glyphSet)
         pen.addComponent("zero.numr", (1, 0, 0, 1, 0, 0))
         pen.addComponent("fraction", (1, 0, 0, 1, 0, 0))
         pen.addComponent("zero.dnom", (1, 0, 0, 1, 0, 0))
-        glyphTable["percent"] = pen.glyph()
-        pen = TTGlyphPen(glyphTable)
+        glyphSet["percent"] = pen.glyph()
+        pen = TTGlyphPen(glyphSet)
         pen.addComponent("zero.numr", (1, 0, 0, 1, 0, 0))
         pen.addComponent("fraction", (1, 0, 0, 1, 0, 0))
         pen.addComponent("zero.dnom", (1, 0, 0, 1, 0, 0))
         pen.addComponent("zero.dnom", (1, 0, 0, 1, 0, 0))
-        glyphTable["perthousand"] = pen.glyph()
-        assert glyphTable["zero.dnom"].getCompositeMaxpValues(glyphTable)[2] == 1
-        assert glyphTable["percent"].getCompositeMaxpValues(glyphTable)[2] == 2
-        assert glyphTable["perthousand"].getCompositeMaxpValues(glyphTable)[2] == 2
+        glyphSet["perthousand"] = pen.glyph()
+        assert glyphSet["zero.dnom"].getCompositeMaxpValues(glyphSet)[2] == 1
+        assert glyphSet["percent"].getCompositeMaxpValues(glyphSet)[2] == 2
+        assert glyphSet["perthousand"].getCompositeMaxpValues(glyphSet)[2] == 2
 
 
 class GlyphComponentTest:

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -472,6 +472,7 @@ class GlyphTest:
         )
 
     def test_getCompositeMaxpValues(self):
+        # https://github.com/fonttools/fonttools/issues/2044
         glyphSet = {}
         pen = TTGlyphPen(glyphSet)  # empty non-composite glyph
         glyphSet["fraction"] = pen.glyph()


### PR DESCRIPTION
The logic in `glyph.getCompositeMaxpValues()` was flawed: it would return a value that is too high when the composite contains more than one nested component. Using a separate variable for the initial value fixes this. This fixes #2044.