### PR TITLE
[varLib.mutator] Prune nameIDs from STAT table

### DIFF
--- a/Lib/fontTools/varLib/mutator.py
+++ b/Lib/fontTools/varLib/mutator.py
@@ -360,6 +360,12 @@ def instantiateVariableFont(varfont, location, inplace=False, overlap=True):
 		for i in fvar.instances:
 			exclude.add(i.subfamilyNameID)
 			exclude.add(i.postscriptNameID)
+		if 'STAT' in varfont:
+			stat = varfont['STAT'].table
+			if stat.DesignAxisRecord:
+				exclude.update(a.AxisNameID for a in stat.DesignAxisRecord.Axis)
+			if stat.AxisValueArray:
+				exclude.update(v.ValueNameID for v in stat.AxisValueArray.AxisValue)
 		if 'ltag' in varfont:
 			# Drop the whole 'ltag' table if all its language tags are referenced by
 			# name records to be pruned.


### PR DESCRIPTION
`STAT` table might contain names not in `fvar` table (e.g. `ital` axis in variable font with no italic variations).