### PR TITLE
[varLib] Test for interpolatability of paths

### DIFF
--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -104,6 +104,7 @@ def test(glyphsets, glyphs=None, names=None):
 
 		try:
 			allVectors = []
+			allNodeTypes = []
 			for glyphset,name in zip(glyphsets, names):
 				#print('.', end='')
 				glyph = glyphset[glyph_name]
@@ -114,8 +115,11 @@ def test(glyphsets, glyphs=None, names=None):
 				del perContourPen
 
 				contourVectors = []
+				nodeTypes = []
+				allNodeTypes.append(nodeTypes)
 				allVectors.append(contourVectors)
 				for contour in contourPens:
+					nodeTypes.append(tuple([ instruction[0] for instruction in contour.value ]))
 					stats = StatisticsPen(glyphset=glyphset)
 					contour.replay(stats)
 					size = abs(stats.area) ** .5 * .5
@@ -131,6 +135,23 @@ def test(glyphsets, glyphs=None, names=None):
 					#print(vector)
 
 			# Check each master against the next one in the list.
+			for i,(m0,m1) in enumerate(zip(allNodeTypes[:-1],allNodeTypes[1:])):
+				if len(m0) != len(m1):
+					print('%s: %s+%s: Glyphs not compatible (wrong number of paths %i+%i)!!!!!' % (glyph_name, names[i], names[i+1], len(m0), len(m1)))
+				if m0 == m1:
+					continue
+				for pathIx, (nodes1, nodes2) in enumerate(zip(m0,m1)):
+					if nodes1 == nodes2:
+						continue
+					print('%s: %s+%s: Glyphs not compatible at path %i!!!!!' % (glyph_name, names[i], names[i+1], pathIx))
+					if len(nodes1) != len(nodes2):
+						print("%s has %i nodes, %s has %i nodes" % (names[i], len(nodes1), names[i+1], len(nodes2)))
+						continue
+					for nodeIx, (n1, n2) in enumerate(zip(nodes1, nodes2)):
+						if n1 != n2:
+							print("At node %i, %s has %s, %s has %s" % (nodeIx, names[i], n1, names[i+1], n2))
+							continue
+
 			for i,(m0,m1) in enumerate(zip(allVectors[:-1],allVectors[1:])):
 				if len(m0) != len(m1):
 					print('%s: %s+%s: Glyphs not compatible!!!!!' % (glyph_name, names[i], names[i+1]))

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -119,7 +119,7 @@ def test(glyphsets, glyphs=None, names=None):
 				allNodeTypes.append(nodeTypes)
 				allVectors.append(contourVectors)
 				for contour in contourPens:
-					nodeTypes.append(tuple([ instruction[0] for instruction in contour.value ]))
+					nodeTypes.append(tuple(instruction[0] for instruction in contour.value))
 					stats = StatisticsPen(glyphset=glyphset)
 					contour.replay(stats)
 					size = abs(stats.area) ** .5 * .5
@@ -135,12 +135,12 @@ def test(glyphsets, glyphs=None, names=None):
 					#print(vector)
 
 			# Check each master against the next one in the list.
-			for i,(m0,m1) in enumerate(zip(allNodeTypes[:-1],allNodeTypes[1:])):
+			for i, (m0, m1) in enumerate(zip(allNodeTypes[:-1], allNodeTypes[1:])):
 				if len(m0) != len(m1):
 					print('%s: %s+%s: Glyphs not compatible (wrong number of paths %i+%i)!!!!!' % (glyph_name, names[i], names[i+1], len(m0), len(m1)))
 				if m0 == m1:
 					continue
-				for pathIx, (nodes1, nodes2) in enumerate(zip(m0,m1)):
+				for pathIx, (nodes1, nodes2) in enumerate(zip(m0, m1)):
 					if nodes1 == nodes2:
 						continue
 					print('%s: %s+%s: Glyphs not compatible at path %i!!!!!' % (glyph_name, names[i], names[i+1], pathIx))


### PR DESCRIPTION
Today I was surprised to run `fontTools varLib.interpolatable` on a font, get a pass, and then find that `fontTools varLib` could not in fact interpolate the font. Here are some more checks in `interpolatable`.

* Checks node count of each path
* Checks operation type of each path node