### PR TITLE
Add registry for custom table packer/unpacker classes

### DIFF
--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -830,10 +830,42 @@ def getTableModule(tag):
 		return getattr(tables, pyTag)
 
 
+# Registry for custom table packer/unpacker classes. Keys are table
+# tags, values are (moduleName, className) tuples.
+# See registerCustomTableClass() and getCustomTableClass()
+_customTableRegistry = {}
+
+
+def registerCustomTableClass(tag, moduleName, className=None):
+	"""Register a custom packer/unpacker class for a table.
+	The 'moduleName' must be an importable module. If no 'className'
+	is given, it is derived from the tag, for example it will be
+	table_C_U_S_T_ for a 'CUST' tag.
+	"""
+	if className is None:
+		className = "table_" + tagToIdentifier(tag)
+	_customTableRegistry[tag] = (moduleName, className)
+
+
+def getCustomTableClass(tag):
+	"""Return the custom table class for tag, if one has been registered
+	with 'registerCustomTableClass()'. Else return None.
+	"""
+	if tag not in _customTableRegistry:
+		return None
+	import importlib
+	moduleName, className = _customTableRegistry[tag]
+	module = importlib.import_module(moduleName)
+	return getattr(module, className)
+
+
 def getTableClass(tag):
 	"""Fetch the packer/unpacker class for a table.
 	Return None when no class is found.
 	"""
+	tableClass = getCustomTableClass(tag)
+	if tableClass is not None:
+		return tableClass
 	module = getTableModule(tag)
 	if module is None:
 		from .tables.DefaultTable import DefaultTable

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -860,9 +860,7 @@ def getCustomTableClass(tag):
 
 
 def getTableClass(tag):
-	"""Fetch the packer/unpacker class for a table.
-	Return None when no class is found.
-	"""
+	"""Fetch the packer/unpacker class for a table."""
 	tableClass = getCustomTableClass(tag)
 	if tableClass is not None:
 		return tableClass

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -841,6 +841,9 @@ def registerCustomTableClass(tag, moduleName, className=None):
 	The 'moduleName' must be an importable module. If no 'className'
 	is given, it is derived from the tag, for example it will be
 	table_C_U_S_T_ for a 'CUST' tag.
+
+	The registered table class should be a subclass of
+	fontTools.ttLib.tables.DefaultTable.DefaultTable
 	"""
 	if className is None:
 		className = "table_" + tagToIdentifier(tag)

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -847,6 +847,11 @@ def registerCustomTableClass(tag, moduleName, className=None):
 	_customTableRegistry[tag] = (moduleName, className)
 
 
+def unregisterCustomTableClass(tag):
+	"""Unregister the custom packer/unpacker class for a table."""
+	_customTableRegistry.pop(tag)
+
+
 def getCustomTableClass(tag):
 	"""Return the custom table class for tag, if one has been registered
 	with 'registerCustomTableClass()'. Else return None.

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -849,7 +849,7 @@ def registerCustomTableClass(tag, moduleName, className=None):
 
 def unregisterCustomTableClass(tag):
 	"""Unregister the custom packer/unpacker class for a table."""
-	_customTableRegistry.pop(tag)
+	del _customTableRegistry[tag]
 
 
 def getCustomTableClass(tag):

--- a/Tests/ttLib/ttFont_test.py
+++ b/Tests/ttLib/ttFont_test.py
@@ -1,0 +1,42 @@
+import io
+from fontTools.ttLib import TTFont, newTable, registerCustomTableClass
+from fontTools.ttLib.tables.DefaultTable import DefaultTable
+
+
+class CustomTableClass(DefaultTable):
+
+    def decompile(self, data, ttFont):
+        self.numbers = list(data)
+
+    def compile(self, ttFont):
+        return bytes(self.numbers)
+
+    # not testing XML read/write
+
+
+table_C_U_S_T_ = CustomTableClass  # alias for testing
+
+
+TABLETAG = "CUST"
+
+
+def test_registerCustomTableClass():
+    font = TTFont()
+    font[TABLETAG] = newTable(TABLETAG)
+    font[TABLETAG].data = b"\x00\x01\xff"
+    f = io.BytesIO()
+    font.save(f)
+    f.seek(0)
+    assert font[TABLETAG].data == b"\x00\x01\xff"
+    registerCustomTableClass(TABLETAG, "ttFont_test", "CustomTableClass")
+    font = TTFont(f)
+    assert font[TABLETAG].numbers == [0, 1, 255]
+    assert font[TABLETAG].compile(font) == b"\x00\x01\xff"
+
+
+def test_registerCustomTableClassStandardName():
+    registerCustomTableClass(TABLETAG, "ttFont_test")
+    font = TTFont()
+    font[TABLETAG] = newTable(TABLETAG)
+    font[TABLETAG].numbers = [4, 5, 6]
+    assert font[TABLETAG].compile(font) == b"\x04\x05\x06"

--- a/Tests/ttLib/ttFont_test.py
+++ b/Tests/ttLib/ttFont_test.py
@@ -29,16 +29,20 @@ def test_registerCustomTableClass():
     f.seek(0)
     assert font[TABLETAG].data == b"\x00\x01\xff"
     registerCustomTableClass(TABLETAG, "ttFont_test", "CustomTableClass")
-    font = TTFont(f)
-    assert font[TABLETAG].numbers == [0, 1, 255]
-    assert font[TABLETAG].compile(font) == b"\x00\x01\xff"
-    unregisterCustomTableClass(TABLETAG)
+    try:
+        font = TTFont(f)
+        assert font[TABLETAG].numbers == [0, 1, 255]
+        assert font[TABLETAG].compile(font) == b"\x00\x01\xff"
+    finally:
+        unregisterCustomTableClass(TABLETAG)
 
 
 def test_registerCustomTableClassStandardName():
     registerCustomTableClass(TABLETAG, "ttFont_test")
-    font = TTFont()
-    font[TABLETAG] = newTable(TABLETAG)
-    font[TABLETAG].numbers = [4, 5, 6]
-    assert font[TABLETAG].compile(font) == b"\x04\x05\x06"
-    unregisterCustomTableClass(TABLETAG)
+    try:
+        font = TTFont()
+        font[TABLETAG] = newTable(TABLETAG)
+        font[TABLETAG].numbers = [4, 5, 6]
+        assert font[TABLETAG].compile(font) == b"\x04\x05\x06"
+    finally:
+        unregisterCustomTableClass(TABLETAG)

--- a/Tests/ttLib/ttFont_test.py
+++ b/Tests/ttLib/ttFont_test.py
@@ -1,5 +1,5 @@
 import io
-from fontTools.ttLib import TTFont, newTable, registerCustomTableClass
+from fontTools.ttLib import TTFont, newTable, registerCustomTableClass, unregisterCustomTableClass
 from fontTools.ttLib.tables.DefaultTable import DefaultTable
 
 
@@ -32,6 +32,7 @@ def test_registerCustomTableClass():
     font = TTFont(f)
     assert font[TABLETAG].numbers == [0, 1, 255]
     assert font[TABLETAG].compile(font) == b"\x00\x01\xff"
+    unregisterCustomTableClass(TABLETAG)
 
 
 def test_registerCustomTableClassStandardName():
@@ -40,3 +41,4 @@ def test_registerCustomTableClassStandardName():
     font[TABLETAG] = newTable(TABLETAG)
     font[TABLETAG].numbers = [4, 5, 6]
     assert font[TABLETAG].compile(font) == b"\x04\x05\x06"
+    unregisterCustomTableClass(TABLETAG)


### PR DESCRIPTION
Rationale:
- Currently, all sfnt table packer/unpacker classes must live in `fontTools.ttLib.tables`
- Sometimes a project can benefit from private table data, and would like to use the standard TTFont table API, without needing an explicit step to pack/unpack
- Proposals for new OpenType tables would benefit from this, as experimentation can then easily be done without forking fonttools.

Implementation:
```python
def registerCustomTableClass(tag, moduleName, className=None):
    """Register a custom packer/unpacker class for a table.
    The 'moduleName' must be an importable module. If no 'className'
    is given, it is derived from the tag, for example it will be
    table_C_U_S_T_ for a 'CUST' tag.
    """
    ...
```

I considered taking the simpler route by having the register function take a class object, but that would prevent lazy importing.