### PR TITLE
Disable checksum checking by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ dmypy.json
 
 # Cython sources (e.g. cu2qu)
 Lib/**/*.c
+
+# Ctags
+tags

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2711,7 +2711,7 @@ class Subsetter(object):
 def load_font(fontFile,
 	      options,
 	      allowVID=False,
-	      checkChecksums=False,
+	      checkChecksums=0,
 	      dontLoadGlyphNames=False,
 	      lazy=True):
 

--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -43,7 +43,7 @@ class SFNTReader(object):
 		# return default object
 		return object.__new__(cls)
 
-	def __init__(self, file, checkChecksums=1, fontNumber=-1):
+	def __init__(self, file, checkChecksums=0, fontNumber=-1):
 		self.file = file
 		self.checkChecksums = checkChecksums
 

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -18,7 +18,7 @@ class TTFont(object):
 	"""
 
 	def __init__(self, file=None, res_name_or_index=None,
-			sfntVersion="\000\001\000\000", flavor=None, checkChecksums=False,
+			sfntVersion="\000\001\000\000", flavor=None, checkChecksums=0,
 			verbose=None, recalcBBoxes=True, allowVID=False, ignoreDecompileErrors=False,
 			recalcTimestamp=True, fontNumber=-1, lazy=None, quiet=None,
 			_tableCache=None):

--- a/Lib/fontTools/ttLib/woff2.py
+++ b/Lib/fontTools/ttLib/woff2.py
@@ -29,7 +29,7 @@ class WOFF2Reader(SFNTReader):
 
 	flavor = "woff2"
 
-	def __init__(self, file, checkChecksums=1, fontNumber=-1):
+	def __init__(self, file, checkChecksums=0, fontNumber=-1):
 		if not haveBrotli:
 			log.error(
 				'The WOFF2 decoder requires the Brotli Python extension, available at: '


### PR DESCRIPTION
Closes #2057.

Also disabled by default for the WOFF2 reader, largely because that's how the API is documented. I have no idea if this makes sense for WOFF2 the same way it does for SFNT.