### PR TITLE
Add typing info to plistlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
   include:
     - python: 3.6
       env:
+        - TOXENV=mypy
+    - python: 3.6
+      env:
         - TOXENV=py36-cov,package_readme
         - BUILD_DIST=true
     - python: 3.7

--- a/Lib/fontTools/misc/plistlib.py
+++ b/Lib/fontTools/misc/plistlib.py
@@ -116,7 +116,7 @@ class Data:
 
 
 def _encode_base64(
-    data: bytes, maxlinelength: int = 76, indent_level: int = 1
+    data: bytes, maxlinelength: Optional[int] = 76, indent_level: int = 1
 ) -> bytes:
     data = b64encode(data)
     if data and maxlinelength:
@@ -354,9 +354,7 @@ def _date_element(date: datetime, ctx: SimpleNamespace) -> etree.Element:
     return el
 
 
-def _data_element(
-    data: Union[bytes, Data], ctx: SimpleNamespace
-) -> etree.Element:
+def _data_element(data: bytes, ctx: SimpleNamespace) -> etree.Element:
     el = etree.Element("data")
     el.text = _encode_base64(
         data,
@@ -366,9 +364,7 @@ def _data_element(
     return el
 
 
-def _string_or_data_element(
-    raw_bytes: Union[bytes, bytearray, Data], ctx: SimpleNamespace
-) -> etree.Element:
+def _string_or_data_element(raw_bytes: bytes, ctx: SimpleNamespace) -> etree.Element:
     if ctx.use_builtin_types:
         return _data_element(raw_bytes, ctx)
     else:

--- a/Lib/fontTools/misc/plistlib.py
+++ b/Lib/fontTools/misc/plistlib.py
@@ -378,42 +378,39 @@ def _string_or_data_element(raw_bytes: bytes, ctx: SimpleNamespace) -> etree.Ele
         return _string_element(string, ctx)
 
 
-@singledispatch
-def _make_element(value: Any, ctx: SimpleNamespace) -> NoReturn:
-    raise TypeError("unsupported type: %s" % type(value))
-
-
-PlistEncodable = Union[
-    str,
-    bool,
-    Integral,
-    float,
-    Mapping[str, Any],
-    List[Any],
-    Tuple[Any, ...],
-    datetime,
-    bytes,
-    Data,
-]
-
-_make_element.register(str)(_string_element)  # type: ignore
-_make_element.register(bool)(_bool_element)  # type: ignore
-_make_element.register(Integral)(_integer_element)  # type: ignore
-_make_element.register(float)(_real_element)  # type: ignore
-_make_element.register(collections.abc.Mapping)(_dict_element)  # type: ignore
-_make_element.register(list)(_array_element)  # type: ignore
-_make_element.register(tuple)(_array_element)  # type: ignore
-_make_element.register(datetime)(_date_element)  # type: ignore
-_make_element.register(bytes)(_string_or_data_element)  # type: ignore
-_make_element.register(bytearray)(_data_element)  # type: ignore
-_make_element.register(Data)(lambda v, ctx: _data_element(v.data, ctx))  # type: ignore
-
 # The following is to pacify type checkers. At the time of this writing, neither
 # mypy nor Pyright can deal with singledispatch properly. Mypy additionally
 # complains about a single overload when there should be more (?) so silence it.
-@overload  # type: ignore
+PlistEncodable = Union[
+    bool,
+    bytes,
+    Data,
+    datetime,
+    float,
+    Integral,
+    List[Any],
+    Mapping[str, Any],
+    str,
+    Tuple[Any, ...],
+]
+
+
+@singledispatch
 def _make_element(value: PlistEncodable, ctx: SimpleNamespace) -> etree.Element:
-    ...
+    raise TypeError("unsupported type: %s" % type(value))
+
+
+_make_element.register(str)(_string_element)
+_make_element.register(bool)(_bool_element)
+_make_element.register(Integral)(_integer_element)
+_make_element.register(float)(_real_element)
+_make_element.register(collections.abc.Mapping)(_dict_element)
+_make_element.register(list)(_array_element)
+_make_element.register(tuple)(_array_element)
+_make_element.register(datetime)(_date_element)
+_make_element.register(bytes)(_string_or_data_element)
+_make_element.register(bytearray)(_data_element)
+_make_element.register(Data)(lambda v, ctx: _data_element(v.data, ctx))
 
 
 # Public functions to create element tree from plist-compatible python

--- a/Lib/fontTools/misc/plistlib.py
+++ b/Lib/fontTools/misc/plistlib.py
@@ -5,16 +5,13 @@ from typing import (
     Any,
     Callable,
     Dict,
-    List,
     Mapping,
     MutableMapping,
     Optional,
     Sequence,
-    Tuple,
     Type,
     TypeVar,
     Union,
-    overload,
     IO,
 )
 import warnings

--- a/Lib/fontTools/misc/plistlib.py
+++ b/Lib/fontTools/misc/plistlib.py
@@ -1,14 +1,14 @@
+import collections.abc
 import sys
 import re
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Sequence, Tuple, Union, overload
+from typing import Any, Callable, Dict, List, Mapping, NoReturn, Optional, Sequence, Tuple, Type, TypeVar, Union, overload, IO
 import warnings
 from io import BytesIO
 from datetime import datetime
 from base64 import b64encode, b64decode
 from numbers import Integral
-
 from types import SimpleNamespace
-from collections.abc import Mapping
 from functools import singledispatch
 
 from fontTools.misc import etree
@@ -393,7 +393,6 @@ PlistEncodable = Union[
     Tuple[Any, ...],
     datetime,
     bytes,
-    bytearray,
     Data,
 ]
 
@@ -401,7 +400,7 @@ _make_element.register(str)(_string_element)  # type: ignore
 _make_element.register(bool)(_bool_element)  # type: ignore
 _make_element.register(Integral)(_integer_element)  # type: ignore
 _make_element.register(float)(_real_element)  # type: ignore
-_make_element.register(Mapping)(_dict_element)  # type: ignore
+_make_element.register(collections.abc.Mapping)(_dict_element)  # type: ignore
 _make_element.register(list)(_array_element)  # type: ignore
 _make_element.register(tuple)(_array_element)  # type: ignore
 _make_element.register(datetime)(_date_element)  # type: ignore

--- a/Lib/fontTools/misc/plistlib.py
+++ b/Lib/fontTools/misc/plistlib.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    List,
     Mapping,
     MutableMapping,
     Optional,
@@ -187,7 +188,7 @@ class PlistTarget:
         use_builtin_types: Optional[bool] = None,
         dict_type: Type[MutableMapping[str, Any]] = dict,
     ) -> None:
-        self.stack = []
+        self.stack: List[PlistEncodable] = []
         self.current_key = None
         self.root: Optional[PlistEncodable] = None
         if use_builtin_types is None:
@@ -203,7 +204,7 @@ class PlistTarget:
         self._dict_type = dict_type
 
     def start(self, tag: str, attrib: Mapping[str, str]) -> None:
-        self._data = []
+        self._data: List[str] = []
         handler = _TARGET_START_HANDLERS.get(tag)
         if handler is not None:
             handler(self)
@@ -412,9 +413,11 @@ def _string_or_data_element(raw_bytes: bytes, ctx: SimpleNamespace) -> etree.Ele
         return _string_element(string, ctx)
 
 
-# The following is to pacify type checkers. At the time of this writing, neither
-# mypy nor Pyright can deal with singledispatch properly. Mypy additionally
-# complains about a single overload when there should be more (?) so silence it.
+# The following is probably not entirely correct. The signature should take `Any`
+# and return `NoReturn`. At the time of this writing, neither mypy nor Pyright
+# can deal with singledispatch properly and will apply the signature of the base
+# function to all others. Being slightly dishonest makes it type-check and return
+# usable typing information for the optimistic case.
 @singledispatch
 def _make_element(value: PlistEncodable, ctx: SimpleNamespace) -> etree.Element:
     raise TypeError("unsupported type: %s" % type(value))

--- a/Lib/fontTools/misc/plistlib.py
+++ b/Lib/fontTools/misc/plistlib.py
@@ -51,11 +51,6 @@ PLIST_DOCTYPE = (
 )
 
 
-# Copied from the typeshed module.
-mm = MutableMapping[str, Any]
-_D = TypeVar("_D", bound=mm)
-
-
 # Date should conform to a subset of ISO 8601:
 # YYYY '-' MM '-' DD 'T' HH ':' MM ':' SS 'Z'
 _date_parser = re.compile(
@@ -190,7 +185,7 @@ class PlistTarget:
     def __init__(
         self,
         use_builtin_types: Optional[bool] = None,
-        dict_type: Type[_D] = dict,  # type: ignore
+        dict_type: Type[MutableMapping[str, Any]] = dict,  # type: ignore
     ) -> None:
         self.stack = []
         self.current_key = None
@@ -492,7 +487,7 @@ def totree(
 def fromtree(
     tree: etree.Element,
     use_builtin_types: Optional[bool] = None,
-    dict_type: Type[_D] = dict,  # type: ignore
+    dict_type: Type[MutableMapping[str, Any]] = dict,
 ) -> Any:
     """Convert an XML tree to a plist structure.
 
@@ -524,7 +519,7 @@ def fromtree(
 def load(
     fp: IO[bytes],
     use_builtin_types: Optional[bool] = None,
-    dict_type: Type[_D] = dict,  # type: ignore
+    dict_type: Type[MutableMapping[str, Any]] = dict,
 ) -> Any:
     """Load a plist file into an object.
 
@@ -560,7 +555,7 @@ def load(
 def loads(
     value: bytes,
     use_builtin_types: Optional[bool] = None,
-    dict_type: Type[_D] = dict,  # type: ignore
+    dict_type: Type[MutableMapping[str, Any]] = dict,
 ) -> Any:
     """Load a plist file from a string into an object.
 

--- a/Lib/fontTools/misc/plistlib.py
+++ b/Lib/fontTools/misc/plistlib.py
@@ -185,7 +185,7 @@ class PlistTarget:
     def __init__(
         self,
         use_builtin_types: Optional[bool] = None,
-        dict_type: Type[MutableMapping[str, Any]] = dict,  # type: ignore
+        dict_type: Type[MutableMapping[str, Any]] = dict,
     ) -> None:
         self.stack = []
         self.current_key = None

--- a/Lib/fontTools/misc/plistlib/__init__.py
+++ b/Lib/fontTools/misc/plistlib/__init__.py
@@ -374,7 +374,7 @@ def _dict_element(d: Mapping[str, PlistEncodable], ctx: SimpleNamespace) -> etre
     return el
 
 
-def _array_element(array: Sequence[Any], ctx: SimpleNamespace) -> etree.Element:
+def _array_element(array: Sequence[PlistEncodable], ctx: SimpleNamespace) -> etree.Element:
     el = etree.Element("array")
     if len(array) == 0:
         return el

--- a/Lib/fontTools/misc/plistlib/__init__.py
+++ b/Lib/fontTools/misc/plistlib/__init__.py
@@ -30,7 +30,7 @@ from fontTools.misc.py23 import (
     tobytes,
 )
 
-# By default, we 
+# By default, we
 #  - deserialize <data> elements as bytes and
 #  - serialize bytes as <data> elements.
 # Before, on Python 2, we
@@ -62,7 +62,7 @@ _date_parser = re.compile(
     r"(?::(?P<minute>\d\d)"
     r"(?::(?P<second>\d\d))"
     r"?)?)?)?)?Z",
-    re.ASCII
+    re.ASCII,
 )
 
 
@@ -162,7 +162,7 @@ PlistEncodable = Union[
 
 
 class PlistTarget:
-    """ Event handler using the ElementTree Target API that can be
+    """Event handler using the ElementTree Target API that can be
     passed to a XMLParser to produce property list objects from XML.
     It is based on the CPython plistlib module's _PlistParser class,
     but does not use the expat parser.
@@ -407,8 +407,7 @@ def _string_or_data_element(raw_bytes: bytes, ctx: SimpleNamespace) -> etree.Ele
             string = raw_bytes.decode(encoding="ascii", errors="strict")
         except UnicodeDecodeError:
             raise ValueError(
-                "invalid non-ASCII bytes; use unicode string instead: %r"
-                % raw_bytes
+                "invalid non-ASCII bytes; use unicode string instead: %r" % raw_bytes
             )
         return _string_element(string, ctx)
 
@@ -539,12 +538,8 @@ def load(
     """
 
     if not hasattr(fp, "read"):
-        raise AttributeError(
-            "'%s' object has no attribute 'read'" % type(fp).__name__
-        )
-    target = PlistTarget(
-        use_builtin_types=use_builtin_types, dict_type=dict_type
-    )
+        raise AttributeError("'%s' object has no attribute 'read'" % type(fp).__name__)
+    target = PlistTarget(use_builtin_types=use_builtin_types, dict_type=dict_type)
     parser = etree.XMLParser(target=target)
     result = etree.parse(fp, parser=parser)
     # lxml returns the target object directly, while ElementTree wraps
@@ -608,12 +603,10 @@ def dump(
         ``ValueError``
             if non-representable binary data is present
             and `use_builtin_types` is false.
-   """
+    """
 
     if not hasattr(fp, "write"):
-        raise AttributeError(
-            "'%s' object has no attribute 'write'" % type(fp).__name__
-        )
+        raise AttributeError("'%s' object has no attribute 'write'" % type(fp).__name__)
     root = etree.Element("plist", version="1.0")
     el = totree(
         value,
@@ -632,9 +625,7 @@ def dump(
     else:
         header = XML_DECLARATION + PLIST_DOCTYPE
     fp.write(header)
-    tree.write(
-        fp, encoding="utf-8", pretty_print=pretty_print, xml_declaration=False
-    )
+    tree.write(fp, encoding="utf-8", pretty_print=pretty_print, xml_declaration=False)
 
 
 def dumps(

--- a/Lib/fontTools/misc/plistlib/__init__.py
+++ b/Lib/fontTools/misc/plistlib/__init__.py
@@ -356,7 +356,7 @@ def _real_element(value: float, ctx: SimpleNamespace) -> etree.Element:
     return el
 
 
-def _dict_element(d: Mapping[str, Any], ctx: SimpleNamespace) -> etree.Element:
+def _dict_element(d: Mapping[str, PlistEncodable], ctx: SimpleNamespace) -> etree.Element:
     el = etree.Element("dict")
     items = d.items()
     if ctx.sort_keys:

--- a/Lib/fontTools/misc/plistlib/__init__.py
+++ b/Lib/fontTools/misc/plistlib/__init__.py
@@ -11,7 +11,6 @@ from typing import (
     Optional,
     Sequence,
     Type,
-    TypeVar,
     Union,
     IO,
 )
@@ -78,7 +77,8 @@ def _date_from_string(s: str) -> datetime:
         if val is None:
             break
         lst.append(int(val))
-    return datetime(lst[0], lst[1], lst[2], lst[3], lst[4], lst[5])
+    # NOTE: mypy doesn't know that lst is 6 elements long.
+    return datetime(*lst)  # type:ignore
 
 
 def _date_to_string(d: datetime) -> str:
@@ -393,6 +393,7 @@ def _date_element(date: datetime, ctx: SimpleNamespace) -> etree.Element:
 
 def _data_element(data: bytes, ctx: SimpleNamespace) -> etree.Element:
     el = etree.Element("data")
+    # NOTE: mypy is confused about whether el.text should be str or bytes.
     el.text = _encode_base64(  # type: ignore
         data,
         maxlinelength=(76 if ctx.pretty_print else None),
@@ -577,7 +578,7 @@ def loads(
 
 def dump(
     value: PlistEncodable,
-    fp: IO[Any],
+    fp: IO[bytes],
     sort_keys: bool = True,
     skipkeys: bool = False,
     use_builtin_types: Optional[bool] = None,

--- a/Lib/fontTools/misc/plistlib/__init__.py
+++ b/Lib/fontTools/misc/plistlib/__init__.py
@@ -78,7 +78,7 @@ def _date_from_string(s: str) -> datetime:
         if val is None:
             break
         lst.append(int(val))
-    return datetime(*lst)  # type: ignore
+    return datetime(lst[0], lst[1], lst[2], lst[3], lst[4], lst[5])
 
 
 def _date_to_string(d: datetime) -> str:

--- a/Lib/fontTools/misc/plistlib/__init__.py
+++ b/Lib/fontTools/misc/plistlib/__init__.py
@@ -234,9 +234,10 @@ class PlistTarget:
             # this is the root object
             self.root = value
         else:
-            if not isinstance(self.stack[-1], type([])):
-                raise ValueError("unexpected element: %r" % self.stack[-1])
-            self.stack[-1].append(value)
+            stack_top = self.stack[-1]
+            if not isinstance(stack_top, list):
+                raise ValueError("unexpected element: %r" % stack_top)
+            stack_top.append(value)
 
     def get_data(self) -> str:
         data = "".join(self._data)

--- a/Lib/fontTools/misc/plistlib/__init__.py
+++ b/Lib/fontTools/misc/plistlib/__init__.py
@@ -627,10 +627,10 @@ def dump(
     else:
         header = XML_DECLARATION + PLIST_DOCTYPE
     fp.write(header)
-    tree.write(
+    tree.write(  # type: ignore
         fp,
         encoding="utf-8",
-        pretty_print=pretty_print,  # type: ignore
+        pretty_print=pretty_print,
         xml_declaration=False,
     )
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,8 @@ include *requirements.txt
 include tox.ini
 include run-tests.sh
 
+recursive-include Lib/fontTools py.typed
+
 include .appveyor.yml
 include .codecov.yml
 include .coveragerc

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ pytest>=3.0
 tox>=2.5
 bump2version>=0.5.6
 sphinx>=1.5.5
+mypy

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,4 +2,4 @@ pytest>=3.0
 tox>=2.5
 bump2version>=0.5.6
 sphinx>=1.5.5
-mypy
+mypy>=0.782

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,21 @@
+[mypy]
+python_version = 3.6
+files = Lib/fontTools/misc/plistlib
+follow_imports = silent
+ignore_missing_imports = True
+warn_redundant_casts = True
+warn_unused_configs = True
+warn_unused_ignores = True
+
+[mypy-fontTools.misc.plistlib]
+check_untyped_defs = True
+disallow_any_generics = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_decorators = True
+disallow_untyped_calls = False
+disallow_untyped_defs = True
+no_implicit_optional = True
+no_implicit_reexport = True
+strict_equality = True
+warn_return_any = True

--- a/setup.py
+++ b/setup.py
@@ -452,7 +452,6 @@ setup_params = dict(
 	packages=find_packages("Lib"),
 	include_package_data=True,
 	data_files=find_data_files(),
-	zip_safe=False,  # So mypy can find typing information.
 	ext_modules=ext_modules,
 	setup_requires=setup_requires,
 	extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -452,6 +452,7 @@ setup_params = dict(
 	packages=find_packages("Lib"),
 	include_package_data=True,
 	data_files=find_data_files(),
+	zip_safe=False,  # So mypy can find typing information.
 	ext_modules=ext_modules,
 	setup_requires=setup_requires,
 	extras_require=extras_require,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.0
-envlist = py3{6,7,8}-cov, htmlcov
+envlist = mypy, py3{6,7,8}-cov, htmlcov
 skip_missing_interpreters=true
 
 [testenv]
@@ -32,6 +32,13 @@ skip_install = true
 commands =
     coverage combine
     coverage html
+
+[testenv:mypy]
+deps =
+    -r dev-requirements.txt
+skip_install = true
+commands =
+    mypy
 
 [testenv:codecov]
 passenv = *


### PR DESCRIPTION
Wherein I spend my life adding typing information to the plistlib module and use Pylance in strict checking mode. Maybe I'll get somewhere.

First boss: https://github.com/microsoft/pyright/issues/988

I wish I could just kill `Data`.

The module is half red because the `etree` module could do with some typing information, too.

@chrissimpkins hi there