### PR TITLE
Expose zopfli and zopfli compression level support in ttLib.TTFont.save method

### DIFF
--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -181,8 +181,14 @@ def compress(data, use_zopfli=False, level=ZLIB_COMPRESSION_LEVEL):
 		from zlib import compress
 		return compress(data, level)
 	else:
-		from zopfli.zlib import compress
-		return compress(data, numiterations=ZOPFLI_LEVELS[level])
+		try:
+			from zopfli.zlib import compress
+			return compress(data, numiterations=ZOPFLI_LEVELS[level])
+		except ImportError:
+			raise ImportError(
+				"zopfli package not found. Please install the zopfli package"
+				"before you use zopfli compression."
+			)
 
 
 class SFNTWriter(object):

--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -157,7 +157,7 @@ ZLIB_COMPRESSION_LEVEL = 6
 # The Python bindings are available at https://pypi.python.org/pypi/zopfli
 # Note: this global variable is deprecated, please use the `use_zopfli`
 # parameter instead
-USE_ZOPFLI = None
+USE_ZOPFLI = False
 
 # mapping between zlib's compression levels and zopfli's 'numiterations'.
 # Use lower values for files over several MB in size or it will be too slow

--- a/Lib/fontTools/ttLib/woff2.py
+++ b/Lib/fontTools/ttLib/woff2.py
@@ -163,7 +163,7 @@ class WOFF2Writer(SFNTWriter):
 	flavor = "woff2"
 
 	def __init__(self, file, numTables, sfntVersion="\000\001\000\000",
-		         flavor=None, flavorData=None):
+		         flavor=None, flavorData=None, use_zopfli=False, compression_level=0):
 		if not haveBrotli:
 			log.error(
 				'The WOFF2 encoder requires the Brotli Python extension, available at: '

--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -275,9 +275,6 @@ def ttDump(input, output, options):
 @Timer(log, 'Done compiling TTX in %(time).3f seconds')
 def ttCompile(input, output, options):
 	log.info('Compiling "%s" to "%s"...' % (input, output))
-	if options.useZopfli:
-		from fontTools.ttLib import sfnt
-		sfnt.USE_ZOPFLI = True
 	ttf = TTFont(options.mergeFile, flavor=options.flavor,
 			recalcBBoxes=options.recalcBBoxes,
 			recalcTimestamp=options.recalcTimestamp,
@@ -289,7 +286,7 @@ def ttCompile(input, output, options):
 		mtime = os.path.getmtime(input)
 		ttf['head'].modified = timestampSinceEpoch(mtime)
 
-	ttf.save(output)
+	ttf.save(output, use_zopfli=options.useZopfli)
 
 
 def guessFileType(fileName):


### PR DESCRIPTION
Closes #2064 

This is an initial stab at addressing Cosimo's comment in https://github.com/fonttools/fonttools/issues/2064#issuecomment-696866956.

The changes here modify the approach to build zopfli compressed woff format files with `ttLib.TTFont` from:

```python
from fontTools.ttLib import sfnt, TTFont

tt = TTFont(filepath)
tt.flavor = "woff"
sfnt.USE_ZOPFLI = True
tt.save(filepath)
```

to:

```python
from fontTools.ttLib import TTFont

tt = TTFont(filepath)
tt.flavor = "woff"
tt.save(filepath, use_zopfli=True)
```

ttx was updated with these changes.