### PR TITLE
add module to remove overlaps from TTF with skia-pathops

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -27,4 +27,4 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     source .venv/bin/activate
 fi
 
-python -m pip install $ci_requirements
+python -m pip install --upgrade $ci_requirements

--- a/Lib/fontTools/ttLib/removeOverlaps.py
+++ b/Lib/fontTools/ttLib/removeOverlaps.py
@@ -89,13 +89,10 @@ def removeOverlaps(
         else:
             path = skPathFromSimpleGlyph(glyphName, glyphSet)
 
-        # duplicate path
-        path2 = pathops.Path(path)
-
         # remove overlaps
-        path2.simplify()
+        path2 = pathops.simplify(path, clockwise=path.clockwise)
 
-        # replace TTGlyph if simplified copy is different
+        # replace TTGlyph if simplified path is different
         if path2 != path:
             glyfTable[glyphName] = glyph = ttfGlyphFromSkPath(path2)
             # also ensure hmtx LSB == glyph.xMin so glyph origin is at x=0

--- a/Lib/fontTools/ttLib/removeOverlaps.py
+++ b/Lib/fontTools/ttLib/removeOverlaps.py
@@ -71,6 +71,18 @@ def removeOverlaps(
     if glyphNames is None:
         glyphNames = font.getGlyphOrder()
 
+    # process all simple glyphs first, then composites with increasing component depth,
+    # so that we don't unnecessarily decompose components simply because their base
+    # glyph has overlaps
+    glyphNames = sorted(
+        glyphNames,
+        key=lambda name: (
+            glyfTable[name].getCompositeMaxpValues(glyfTable).maxComponentDepth
+            if glyfTable[name].isComposite()
+            else 0,
+            name,
+        ),
+    )
     for glyphName in glyphNames:
         if glyfTable[glyphName].isComposite():
             path = skPathFromCompositeGlyph(glyphName, glyphSet)

--- a/Lib/fontTools/ttLib/removeOverlaps.py
+++ b/Lib/fontTools/ttLib/removeOverlaps.py
@@ -111,7 +111,11 @@ def removeOverlaps(
     for glyphName in glyphNames:
         glyph = glyfTable[glyphName]
         # decompose composite glyphs only if components overlap each other
-        if glyph.isComposite() and not componentsOverlap(glyph, glyphSet):
+        if (
+            glyph.numberOfContours == 0
+            or glyph.isComposite()
+            and not componentsOverlap(glyph, glyphSet)
+        ):
             continue
 
         path = skPathFromGlyph(glyphName, glyphSet)

--- a/Lib/fontTools/ttLib/removeOverlaps.py
+++ b/Lib/fontTools/ttLib/removeOverlaps.py
@@ -95,8 +95,8 @@ def removeTTGlyphOverlaps(
         # remove overlaps
         path2 = pathops.simplify(path, clockwise=path.clockwise)
 
-        # replace TTGlyph if simplified path is different
-        if path2 != path:
+        # replace TTGlyph if simplified path is different (ignoring contour order)
+        if {tuple(c) for c in path.contours} != {tuple(c) for c in path2.contours}:
             glyfTable[glyphName] = glyph = ttfGlyphFromSkPath(path2)
             # simplified glyph is always unhinted
             assert not glyph.program

--- a/Lib/fontTools/ttLib/removeOverlaps.py
+++ b/Lib/fontTools/ttLib/removeOverlaps.py
@@ -97,8 +97,8 @@ def removeOverlaps(
         glyphNames = font.getGlyphOrder()
 
     # process all simple glyphs first, then composites with increasing component depth,
-    # so that we don't unnecessarily decompose components simply because their base
-    # glyph has overlaps
+    # so that by the time we test for component intersections the respective base glyphs
+    # have already been simplified
     glyphNames = sorted(
         glyphNames,
         key=lambda name: (

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -87,6 +87,7 @@ from fontTools.varLib.merger import MutatorMerger
 from contextlib import contextmanager
 import collections
 from copy import deepcopy
+from enum import IntEnum
 import logging
 from itertools import islice
 import os
@@ -119,6 +120,12 @@ class NormalizedAxisRange(AxisRange):
         if self.maximum < 0:
             raise ValueError(f"Expected axis range maximum >= 0; got {self.maximum}")
         return self
+
+
+class OverlapsMode(IntEnum):
+    KEEP_AND_DONT_SET_FLAGS = 0
+    KEEP_AND_SET_FLAGS = 1
+    REMOVE = 2
 
 
 def instantiateTupleVariationStore(
@@ -578,7 +585,7 @@ class _TupleVarStoreAdapter(object):
 
 
 def instantiateItemVariationStore(itemVarStore, fvarAxes, axisLimits):
-    """ Compute deltas at partial location, and update varStore in-place.
+    """Compute deltas at partial location, and update varStore in-place.
 
     Remove regions in which all axes were instanced, or fall outside the new axis
     limits. Scale the deltas of the remaining regions where only some of the axes
@@ -1175,9 +1182,13 @@ def populateAxisDefaults(varfont, axisLimits):
 
 
 def instantiateVariableFont(
-    varfont, axisLimits, inplace=False, optimize=True, overlap=True
+    varfont,
+    axisLimits,
+    inplace=False,
+    optimize=True,
+    overlap=OverlapsMode.KEEP_AND_SET_FLAGS,
 ):
-    """ Instantiate variable font, either fully or partially.
+    """Instantiate variable font, either fully or partially.
 
     Depending on whether the `axisLimits` dictionary references all or some of the
     input varfont's axes, the output font will either be a full instance (static
@@ -1198,13 +1209,20 @@ def instantiateVariableFont(
             remaining 'gvar' table's deltas. Possibly faster, and might work around
             rendering issues in some buggy environments, at the cost of a slightly
             larger file size.
-        overlap (bool): variable fonts usually contain overlapping contours, and some
-            font rendering engines on Apple platforms require that the `OVERLAP_SIMPLE`
-            and `OVERLAP_COMPOUND` flags in the 'glyf' table be set to force rendering
-            using a non-zero fill rule. Thus we always set these flags on all glyphs
-            to maximise cross-compatibility of the generated instance. You can disable
-            this by setting `overalap` to False.
+        overlap (OverlapsMode): variable fonts usually contain overlapping contours, and
+            some font rendering engines on Apple platforms require that the
+            `OVERLAP_SIMPLE` and `OVERLAP_COMPOUND` flags in the 'glyf' table be set to
+            force rendering using a non-zero fill rule. Thus we always set these flags
+            on all glyphs to maximise cross-compatibility of the generated instance.
+            You can disable this by passing OverlapsMode.KEEP_AND_DONT_SET_FLAGS.
+            If you want to remove the overlaps altogether and merge overlapping
+            contours and components, you can pass OverlapsMode.REMOVE. Note that this
+            requires the skia-pathops package (available to pip install).
+            The overlap parameter only has effect when generating full static instances.
     """
+    # 'overlap' used to be bool and is now enum; for backward compat keep accepting bool
+    overlap = OverlapsMode(int(overlap))
+
     sanityCheckVariableTables(varfont)
 
     axisLimits = populateAxisDefaults(varfont, axisLimits)
@@ -1245,8 +1263,14 @@ def instantiateVariableFont(
         instantiateFvar(varfont, axisLimits)
 
     if "fvar" not in varfont:
-        if "glyf" in varfont and overlap:
-            setMacOverlapFlags(varfont["glyf"])
+        if "glyf" in varfont:
+            if overlap == OverlapsMode.KEEP_AND_SET_FLAGS:
+                setMacOverlapFlags(varfont["glyf"])
+            elif overlap == OverlapsMode.REMOVE:
+                from fontTools.ttLib.removeOverlaps import removeOverlaps
+
+                log.info("Removing overlaps from glyf table")
+                removeOverlaps(varfont)
 
     varLib.set_default_weight_width_slant(
         varfont,
@@ -1346,6 +1370,13 @@ def parseArgs(args):
         help="Don't set OVERLAP_SIMPLE/OVERLAP_COMPOUND glyf flags (only applicable "
         "when generating a full instance)",
     )
+    parser.add_argument(
+        "--remove-overlaps",
+        dest="remove_overlaps",
+        action="store_true",
+        help="Merge overlapping contours and components (only applicable "
+        "when generating a full instance). Requires skia-pathops",
+    )
     loggingGroup = parser.add_mutually_exclusive_group(required=False)
     loggingGroup.add_argument(
         "-v", "--verbose", action="store_true", help="Run more verbosely."
@@ -1354,6 +1385,11 @@ def parseArgs(args):
         "-q", "--quiet", action="store_true", help="Turn verbosity off."
     )
     options = parser.parse_args(args)
+
+    if options.remove_overlaps:
+        options.overlap = OverlapsMode.REMOVE
+    else:
+        options.overlap = OverlapsMode(int(options.overlap))
 
     infile = options.input
     if not os.path.isfile(infile):

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -122,7 +122,7 @@ class NormalizedAxisRange(AxisRange):
         return self
 
 
-class OverlapsMode(IntEnum):
+class OverlapMode(IntEnum):
     KEEP_AND_DONT_SET_FLAGS = 0
     KEEP_AND_SET_FLAGS = 1
     REMOVE = 2
@@ -1186,7 +1186,7 @@ def instantiateVariableFont(
     axisLimits,
     inplace=False,
     optimize=True,
-    overlap=OverlapsMode.KEEP_AND_SET_FLAGS,
+    overlap=OverlapMode.KEEP_AND_SET_FLAGS,
 ):
     """Instantiate variable font, either fully or partially.
 
@@ -1209,19 +1209,19 @@ def instantiateVariableFont(
             remaining 'gvar' table's deltas. Possibly faster, and might work around
             rendering issues in some buggy environments, at the cost of a slightly
             larger file size.
-        overlap (OverlapsMode): variable fonts usually contain overlapping contours, and
+        overlap (OverlapMode): variable fonts usually contain overlapping contours, and
             some font rendering engines on Apple platforms require that the
             `OVERLAP_SIMPLE` and `OVERLAP_COMPOUND` flags in the 'glyf' table be set to
             force rendering using a non-zero fill rule. Thus we always set these flags
             on all glyphs to maximise cross-compatibility of the generated instance.
-            You can disable this by passing OverlapsMode.KEEP_AND_DONT_SET_FLAGS.
+            You can disable this by passing OverlapMode.KEEP_AND_DONT_SET_FLAGS.
             If you want to remove the overlaps altogether and merge overlapping
-            contours and components, you can pass OverlapsMode.REMOVE. Note that this
+            contours and components, you can pass OverlapMode.REMOVE. Note that this
             requires the skia-pathops package (available to pip install).
             The overlap parameter only has effect when generating full static instances.
     """
     # 'overlap' used to be bool and is now enum; for backward compat keep accepting bool
-    overlap = OverlapsMode(int(overlap))
+    overlap = OverlapMode(int(overlap))
 
     sanityCheckVariableTables(varfont)
 
@@ -1264,9 +1264,9 @@ def instantiateVariableFont(
 
     if "fvar" not in varfont:
         if "glyf" in varfont:
-            if overlap == OverlapsMode.KEEP_AND_SET_FLAGS:
+            if overlap == OverlapMode.KEEP_AND_SET_FLAGS:
                 setMacOverlapFlags(varfont["glyf"])
-            elif overlap == OverlapsMode.REMOVE:
+            elif overlap == OverlapMode.REMOVE:
                 from fontTools.ttLib.removeOverlaps import removeOverlaps
 
                 log.info("Removing overlaps from glyf table")
@@ -1387,9 +1387,9 @@ def parseArgs(args):
     options = parser.parse_args(args)
 
     if options.remove_overlaps:
-        options.overlap = OverlapsMode.REMOVE
+        options.overlap = OverlapMode.REMOVE
     else:
-        options.overlap = OverlapsMode(int(options.overlap))
+        options.overlap = OverlapMode(int(options.overlap))
 
     infile = options.input
     if not os.path.isfile(infile):

--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,16 @@ are required to unlock the extra features named "ufo", etc.
 
   *Extra:* ``type1``
 
+- ``Lib/fontTools/ttLib/removeOverlaps.py``
+
+  Simplify TrueType glyphs by merging overlapping contours and components.
+
+  * `skia-pathops <https://pypi.python.org/pypy/skia-pathops>`__: Python
+    bindings for the Skia library's PathOps module, performing boolean
+    operations on paths (union, intersection, etc.).
+
+  *Extra:* ``pathops``
+
 - ``Lib/fontTools/pens/cocoaPen.py``
 
   Pen for drawing glyphs with Cocoa ``NSBezierPath``, requires:

--- a/Snippets/remove-overlaps.py
+++ b/Snippets/remove-overlaps.py
@@ -5,7 +5,9 @@
 
 
 import sys
-from fontTools.ttLib import TTFont
+from typing import Iterable, Optional, Mapping
+from fontTools.ttLib import ttFont
+from fontTools.ttLib.tables import _g_l_y_f
 from fontTools.pens.recordingPen import DecomposingRecordingPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 
@@ -17,15 +19,19 @@ except ImportError:
         "`pip install skia-pathops` and then retry."
     )
 
+_TTGlyphMapping = Mapping[str, ttFont._TTGlyph]
 
-def skpath_from_simple_glyph(glyphName, glyphSet):
+
+def skpath_from_simple_glyph(glyphName: str, glyphSet: _TTGlyphMapping) -> pathops.Path:
     path = pathops.Path()
     pathPen = path.getPen()
     glyphSet[glyphName].draw(pathPen)
     return path
 
 
-def skpath_from_composite_glyph(glyphName, glyphSet):
+def skpath_from_composite_glyph(
+    glyphName: str, glyphSet: _TTGlyphMapping
+) -> pathops.Path:
     # record TTGlyph outlines without components
     dcPen = DecomposingRecordingPen(glyphSet)
     glyphSet[glyphName].draw(dcPen)
@@ -36,7 +42,7 @@ def skpath_from_composite_glyph(glyphName, glyphSet):
     return path
 
 
-def simple_glyph_from_skpath(path):
+def simple_glyph_from_skpath(path: pathops.Path) -> _g_l_y_f.Glyph:
     # Skia paths have no 'components', no need for glyphSet
     ttPen = TTGlyphPen(glyphSet=None)
     path.draw(ttPen)
@@ -47,39 +53,48 @@ def simple_glyph_from_skpath(path):
     return glyph
 
 
-def main():
-    if len(sys.argv) != 3:
-        print("usage: remove-overlaps.py fontfile.ttf outfile.ttf")
+def remove_overlaps(
+    font: ttFont.TTFont, glyphNames: Optional[Iterable[str]] = None
+) -> None:
+    if glyphNames is None:
+        glyphNames = font.getGlyphOrder()
+
+    glyfTable = font["glyf"]
+    hmtxTable = font["hmtx"]
+    glyphSet = font.getGlyphSet()
+
+    for glyphName in glyphNames:
+        if glyfTable[glyphName].isComposite():
+            path = skpath_from_composite_glyph(glyphName, glyphSet)
+        else:
+            path = skpath_from_simple_glyph(glyphName, glyphSet)
+
+        # duplicate path
+        path2 = pathops.Path(path)
+
+        # remove overlaps
+        path2.simplify()
+
+        # replace TTGlyph if simplified copy is different
+        if path2 != path:
+            glyfTable[glyphName] = glyph = simple_glyph_from_skpath(path2)
+            # also ensure hmtx LSB == glyph.xMin so glyph origin is at x=0
+            width, lsb = hmtxTable[glyphName]
+            if lsb != glyph.xMin:
+                hmtxTable[glyphName] = (width, glyph.xMin)
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print("usage: remove-overlaps.py fontfile.ttf outfile.ttf [GLYPHNAMES ...]")
         sys.exit(1)
 
     src = sys.argv[1]
     dst = sys.argv[2]
+    glyphNames = sys.argv[3:] or None
 
-    with TTFont(src) as f:
-        glyfTable = f["glyf"]
-        hmtxTable = f["hmtx"]
-        glyphSet = f.getGlyphSet()
-
-        for glyphName in glyphSet.keys():
-            if glyfTable[glyphName].isComposite():
-                path = skpath_from_composite_glyph(glyphName, glyphSet)
-            else:
-                path = skpath_from_simple_glyph(glyphName, glyphSet)
-
-            # duplicate path
-            path2 = pathops.Path(path)
-
-            # remove overlaps
-            path2.simplify()
-
-            # replace TTGlyph if simplified copy is different
-            if path2 != path:
-                glyfTable[glyphName] = glyph = simple_glyph_from_skpath(path2)
-                # also ensure hmtx LSB == glyph.xMin so glyph origin is at x=0
-                width, lsb = hmtxTable[glyphName]
-                if lsb != glyph.xMin:
-                    hmtxTable[glyphName] = (width, glyph.xMin)
-
+    with ttFont.TTFont(src) as f:
+        remove_overlaps(f, glyphNames)
         f.save(dst)
 
 

--- a/Snippets/remove-overlaps.py
+++ b/Snippets/remove-overlaps.py
@@ -1,0 +1,76 @@
+#! /usr/bin/env python3
+
+# Example script to remove overlaps in TTF using skia-pathops
+
+
+import sys
+from fontTools.ttLib import TTFont
+from fontTools.pens.recordingPen import DecomposingRecordingPen
+from fontTools.pens.ttGlyphPen import TTGlyphPen
+
+try:
+    import pathops
+except ImportError:
+    sys.exit(
+        "This script requires the skia-pathops module. "
+        "`pip install skia-pathops` and then retry."
+    )
+
+
+def skpath_from_simple_glyph(glyphName, glyphSet):
+    path = pathops.Path()
+    pathPen = path.getPen()
+    glyphSet[glyphName].draw(pathPen)
+    return path
+
+
+def skpath_from_composite_glyph(glyphName, glyphSet):
+    # record TTGlyph outlines without components
+    dcPen = DecomposingRecordingPen(glyphSet)
+    glyphSet[glyphName].draw(dcPen)
+    # replay recording onto a skia-pathops Path
+    path = pathops.Path()
+    pathPen = path.getPen()
+    dcPen.replay(pathPen)
+    return path
+
+
+def tt_glyph_from_skpath(path):
+    ttPen = TTGlyphPen(None)
+    path.draw(ttPen)
+    return ttPen.glyph()
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: remove-overlaps.py fontfile.ttf outfile.ttf")
+        sys.exit(1)
+
+    src = sys.argv[1]
+    dst = sys.argv[2]
+
+    with TTFont(src) as f:
+        glyfTable = f["glyf"]
+        glyphSet = f.getGlyphSet()
+
+        for glyphName in glyphSet.keys():
+            if glyfTable[glyphName].isComposite():
+                path = skpath_from_composite_glyph(glyphName, glyphSet)
+            else:
+                path = skpath_from_simple_glyph(glyphName, glyphSet)
+
+            # duplicate path
+            path2 = pathops.Path(path)
+
+            # remove overlaps
+            path2.simplify()
+
+            # replace TTGlyph if simplified copy is different
+            if path2 != path:
+                glyfTable[glyphName] = tt_glyph_from_skpath(path2)
+
+        f.save(dst)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/varLib/data/PartialInstancerTest3-VF.ttx
+++ b/Tests/varLib/data/PartialInstancerTest3-VF.ttx
@@ -1,0 +1,439 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.15">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="A"/>
+    <GlyphID id="2" name="B"/>
+    <GlyphID id="3" name="C"/>
+    <GlyphID id="4" name="D"/>
+    <GlyphID id="5" name="E"/>
+    <GlyphID id="6" name="F"/>
+    <GlyphID id="7" name="space"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0xc3d4abe6"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Wed Sep 23 12:54:22 2020"/>
+    <modified value="Tue Sep 29 18:06:03 2020"/>
+    <xMin value="-152"/>
+    <yMin value="-200"/>
+    <xMax value="1059"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="600"/>
+    <minLeftSideBearing value="-152"/>
+    <minRightSideBearing value="-559"/>
+    <xMaxExtent value="1059"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="8"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="12"/>
+    <maxCompositeContours value="3"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="3"/>
+    <maxComponentDepth value="1"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="513"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="70"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="A" width="500" lsb="153"/>
+    <mtx name="B" width="500" lsb="-152"/>
+    <mtx name="C" width="500" lsb="-133"/>
+    <mtx name="D" width="500" lsb="-97"/>
+    <mtx name="E" width="500" lsb="-87"/>
+    <mtx name="F" width="500" lsb="-107"/>
+    <mtx name="space" width="600" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="A" xMin="153" yMin="-66" xMax="350" yMax="646">
+      <contour>
+        <pt x="153" y="646" on="1"/>
+        <pt x="350" y="646" on="1"/>
+        <pt x="350" y="-66" on="1"/>
+        <pt x="153" y="-66" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="B" xMin="-152" yMin="39" xMax="752" yMax="592">
+      <contour>
+        <pt x="-152" y="448" on="1"/>
+        <pt x="752" y="448" on="1"/>
+        <pt x="752" y="215" on="1"/>
+        <pt x="-152" y="215" on="1"/>
+      </contour>
+      <contour>
+        <pt x="129" y="592" on="1"/>
+        <pt x="401" y="592" on="1"/>
+        <pt x="401" y="39" on="1"/>
+        <pt x="129" y="39" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="C" xMin="-133" yMin="-66" xMax="771" yMax="646">
+      <component glyphName="A" x="-250" y="0" flags="0x4"/>
+      <component glyphName="B" x="19" y="-28" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="D" xMin="-97" yMin="-66" xMax="1059" yMax="646">
+      <component glyphName="A" x="-250" y="0" flags="0x4"/>
+      <component glyphName="B" x="307" y="-28" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="E" xMin="-87" yMin="-87" xMax="801" yMax="650">
+      <component glyphName="A" x="450" y="-77" scalex="0.9397" scale01="0.34204" scale10="-0.34204" scaley="0.9397" flags="0x4"/>
+      <component glyphName="A" x="8" y="4" flags="0x4"/>
+      <component glyphName="A" x="-240" y="0" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="-107" yMin="-95" xMax="837" yMax="650">
+      <component glyphName="A" x="501" y="-114" scalex="0.866" scale01="0.5" scale10="-0.5" scaley="0.866" flags="0x4"/>
+      <component glyphName="A" x="-12" y="4" flags="0x4"/>
+      <component glyphName="A" x="-260" y="0" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="space"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Remove Overlaps Test
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.000;NONE;RemoveOverlapsTest-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Remove Overlaps Test Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      RemoveOverlapsTest-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=1 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=8 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+        <Item index="1" value="[]"/>
+        <Item index="2" value="[]"/>
+        <Item index="3" value="[]"/>
+        <Item index="4" value="[]"/>
+        <Item index="5" value="[]"/>
+        <Item index="6" value="[]"/>
+        <Item index="7" value="[]"/>
+      </VarData>
+    </VarStore>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=1 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisOrdering value="0"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=0 -->
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
+
+  <fvar>
+
+    <!-- Weight -->
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>400.0</MinValue>
+      <DefaultValue>400.0</DefaultValue>
+      <MaxValue>700.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+
+    <!-- Regular -->
+    <NamedInstance flags="0x0" subfamilyNameID="257">
+      <coord axis="wght" value="400.0"/>
+    </NamedInstance>
+
+    <!-- Regular -->
+    <NamedInstance flags="0x0" subfamilyNameID="257">
+      <coord axis="wght" value="700.0"/>
+    </NamedInstance>
+  </fvar>
+
+  <gvar>
+    <version value="1"/>
+    <reserved value="0"/>
+    <glyphVariations glyph="A">
+      <tuple>
+        <coord axis="wght" value="1.0"/>
+        <delta pt="0" x="-40" y="0"/>
+        <delta pt="1" x="40" y="0"/>
+        <delta pt="2" x="40" y="0"/>
+        <delta pt="3" x="-40" y="0"/>
+        <delta pt="4" x="0" y="0"/>
+        <delta pt="5" x="0" y="0"/>
+        <delta pt="6" x="0" y="0"/>
+        <delta pt="7" x="0" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="B">
+      <tuple>
+        <coord axis="wght" value="1.0"/>
+        <delta pt="0" x="-40" y="0"/>
+        <delta pt="2" x="40" y="0"/>
+        <delta pt="5" x="40" y="20"/>
+        <delta pt="7" x="-40" y="-20"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="C">
+      <tuple>
+        <coord axis="wght" value="1.0"/>
+        <delta pt="0" x="0" y="0"/>
+        <delta pt="1" x="0" y="0"/>
+        <delta pt="2" x="0" y="0"/>
+        <delta pt="3" x="0" y="0"/>
+        <delta pt="4" x="0" y="0"/>
+        <delta pt="5" x="0" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="D">
+      <tuple>
+        <coord axis="wght" value="1.0"/>
+        <delta pt="0" x="0" y="0"/>
+        <delta pt="1" x="0" y="0"/>
+        <delta pt="2" x="0" y="0"/>
+        <delta pt="3" x="0" y="0"/>
+        <delta pt="4" x="0" y="0"/>
+        <delta pt="5" x="0" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="E">
+      <tuple>
+        <coord axis="wght" value="1.0"/>
+        <delta pt="0" x="0" y="0"/>
+        <delta pt="1" x="0" y="0"/>
+        <delta pt="2" x="0" y="0"/>
+        <delta pt="3" x="0" y="0"/>
+        <delta pt="4" x="0" y="0"/>
+        <delta pt="5" x="0" y="0"/>
+        <delta pt="6" x="0" y="0"/>
+      </tuple>
+    </glyphVariations>
+    <glyphVariations glyph="F">
+      <tuple>
+        <coord axis="wght" value="1.0"/>
+        <delta pt="0" x="0" y="0"/>
+        <delta pt="1" x="0" y="0"/>
+        <delta pt="2" x="0" y="0"/>
+        <delta pt="3" x="0" y="0"/>
+        <delta pt="4" x="0" y="0"/>
+        <delta pt="5" x="0" y="0"/>
+        <delta pt="6" x="0" y="0"/>
+      </tuple>
+    </glyphVariations>
+  </gvar>
+
+</ttFont>

--- a/Tests/varLib/data/test_results/PartialInstancerTest3-VF-instance-400-no-overlap-flags.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest3-VF-instance-400-no-overlap-flags.ttx
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.15">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="A"/>
+    <GlyphID id="2" name="B"/>
+    <GlyphID id="3" name="C"/>
+    <GlyphID id="4" name="D"/>
+    <GlyphID id="5" name="E"/>
+    <GlyphID id="6" name="F"/>
+    <GlyphID id="7" name="space"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0x98c89e17"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Wed Sep 23 12:54:22 2020"/>
+    <modified value="Tue Sep 29 18:06:03 2020"/>
+    <xMin value="-152"/>
+    <yMin value="-200"/>
+    <xMax value="1059"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="600"/>
+    <minLeftSideBearing value="-152"/>
+    <minRightSideBearing value="-559"/>
+    <xMaxExtent value="1059"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="8"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="12"/>
+    <maxCompositeContours value="3"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="3"/>
+    <maxComponentDepth value="1"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="513"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="70"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="A" width="500" lsb="153"/>
+    <mtx name="B" width="500" lsb="-152"/>
+    <mtx name="C" width="500" lsb="-133"/>
+    <mtx name="D" width="500" lsb="-97"/>
+    <mtx name="E" width="500" lsb="-87"/>
+    <mtx name="F" width="500" lsb="-107"/>
+    <mtx name="space" width="600" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="A" xMin="153" yMin="-66" xMax="350" yMax="646">
+      <contour>
+        <pt x="153" y="646" on="1"/>
+        <pt x="350" y="646" on="1"/>
+        <pt x="350" y="-66" on="1"/>
+        <pt x="153" y="-66" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="B" xMin="-152" yMin="39" xMax="752" yMax="592">
+      <contour>
+        <pt x="-152" y="448" on="1"/>
+        <pt x="752" y="448" on="1"/>
+        <pt x="752" y="215" on="1"/>
+        <pt x="-152" y="215" on="1"/>
+      </contour>
+      <contour>
+        <pt x="129" y="592" on="1"/>
+        <pt x="401" y="592" on="1"/>
+        <pt x="401" y="39" on="1"/>
+        <pt x="129" y="39" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="C" xMin="-133" yMin="-66" xMax="771" yMax="646">
+      <component glyphName="A" x="-250" y="0" flags="0x4"/>
+      <component glyphName="B" x="19" y="-28" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="D" xMin="-97" yMin="-66" xMax="1059" yMax="646">
+      <component glyphName="A" x="-250" y="0" flags="0x4"/>
+      <component glyphName="B" x="307" y="-28" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="E" xMin="-87" yMin="-87" xMax="801" yMax="650">
+      <component glyphName="A" x="450" y="-77" scalex="0.9397" scale01="0.34204" scale10="-0.34204" scaley="0.9397" flags="0x4"/>
+      <component glyphName="A" x="8" y="4" flags="0x4"/>
+      <component glyphName="A" x="-240" y="0" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="-107" yMin="-95" xMax="837" yMax="650">
+      <component glyphName="A" x="501" y="-114" scalex="0.866" scale01="0.5" scale10="-0.5" scaley="0.866" flags="0x4"/>
+      <component glyphName="A" x="-12" y="4" flags="0x4"/>
+      <component glyphName="A" x="-260" y="0" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="space"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Remove Overlaps Test
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.000;NONE;RemoveOverlapsTest-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Remove Overlaps Test Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      RemoveOverlapsTest-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=1 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisOrdering value="0"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=0 -->
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
+
+</ttFont>

--- a/Tests/varLib/data/test_results/PartialInstancerTest3-VF-instance-400-no-overlaps.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest3-VF-instance-400-no-overlaps.ttx
@@ -1,0 +1,343 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.15">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="A"/>
+    <GlyphID id="2" name="B"/>
+    <GlyphID id="3" name="C"/>
+    <GlyphID id="4" name="D"/>
+    <GlyphID id="5" name="E"/>
+    <GlyphID id="6" name="F"/>
+    <GlyphID id="7" name="space"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0x1cd9cd87"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Wed Sep 23 12:54:22 2020"/>
+    <modified value="Tue Sep 29 18:06:03 2020"/>
+    <xMin value="-152"/>
+    <yMin value="-200"/>
+    <xMax value="1059"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="600"/>
+    <minLeftSideBearing value="-152"/>
+    <minRightSideBearing value="-559"/>
+    <xMaxExtent value="1059"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="20"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="16"/>
+    <maxCompositeContours value="3"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="3"/>
+    <maxComponentDepth value="1"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="513"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="70"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="A" width="500" lsb="153"/>
+    <mtx name="B" width="500" lsb="-152"/>
+    <mtx name="C" width="500" lsb="-133"/>
+    <mtx name="D" width="500" lsb="-97"/>
+    <mtx name="E" width="500" lsb="-87"/>
+    <mtx name="F" width="500" lsb="-107"/>
+    <mtx name="space" width="600" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="A" xMin="153" yMin="-66" xMax="350" yMax="646">
+      <contour>
+        <pt x="153" y="646" on="1"/>
+        <pt x="350" y="646" on="1"/>
+        <pt x="350" y="-66" on="1"/>
+        <pt x="153" y="-66" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="B" xMin="-152" yMin="39" xMax="752" yMax="592">
+      <contour>
+        <pt x="-152" y="448" on="1"/>
+        <pt x="129" y="448" on="1"/>
+        <pt x="129" y="592" on="1"/>
+        <pt x="401" y="592" on="1"/>
+        <pt x="401" y="448" on="1"/>
+        <pt x="752" y="448" on="1"/>
+        <pt x="752" y="215" on="1"/>
+        <pt x="401" y="215" on="1"/>
+        <pt x="401" y="39" on="1"/>
+        <pt x="129" y="39" on="1"/>
+        <pt x="129" y="215" on="1"/>
+        <pt x="-152" y="215" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="C" xMin="-133" yMin="-66" xMax="771" yMax="646">
+      <contour>
+        <pt x="-97" y="646" on="1"/>
+        <pt x="100" y="646" on="1"/>
+        <pt x="100" y="420" on="1"/>
+        <pt x="148" y="420" on="1"/>
+        <pt x="148" y="564" on="1"/>
+        <pt x="420" y="564" on="1"/>
+        <pt x="420" y="420" on="1"/>
+        <pt x="771" y="420" on="1"/>
+        <pt x="771" y="187" on="1"/>
+        <pt x="420" y="187" on="1"/>
+        <pt x="420" y="11" on="1"/>
+        <pt x="148" y="11" on="1"/>
+        <pt x="148" y="187" on="1"/>
+        <pt x="100" y="187" on="1"/>
+        <pt x="100" y="-66" on="1"/>
+        <pt x="-97" y="-66" on="1"/>
+        <pt x="-97" y="187" on="1"/>
+        <pt x="-133" y="187" on="1"/>
+        <pt x="-133" y="420" on="1"/>
+        <pt x="-97" y="420" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="D" xMin="-97" yMin="-66" xMax="1059" yMax="646">
+      <component glyphName="A" x="-250" y="0" flags="0x4"/>
+      <component glyphName="B" x="307" y="-28" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="E" xMin="-87" yMin="-87" xMax="801" yMax="650">
+      <component glyphName="A" x="450" y="-77" scalex="0.9397" scale01="0.34204" scale10="-0.34204" scaley="0.9397" flags="0x4"/>
+      <component glyphName="A" x="8" y="4" flags="0x4"/>
+      <component glyphName="A" x="-240" y="0" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="-107" yMin="-95" xMax="837" yMax="650">
+      <contour>
+        <pt x="141" y="650" on="1"/>
+        <pt x="338" y="650" on="1"/>
+        <pt x="338" y="538" on="1"/>
+        <pt x="481" y="620" on="1"/>
+        <pt x="837" y="4" on="1"/>
+        <pt x="667" y="-95" on="1"/>
+        <pt x="338" y="474" on="1"/>
+        <pt x="338" y="-62" on="1"/>
+        <pt x="141" y="-62" on="1"/>
+      </contour>
+      <contour>
+        <pt x="-107" y="646" on="1"/>
+        <pt x="90" y="646" on="1"/>
+        <pt x="90" y="-66" on="1"/>
+        <pt x="-107" y="-66" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="space"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Remove Overlaps Test
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.000;NONE;RemoveOverlapsTest-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Remove Overlaps Test Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      RemoveOverlapsTest-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=1 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisOrdering value="0"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=0 -->
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
+
+</ttFont>

--- a/Tests/varLib/data/test_results/PartialInstancerTest3-VF-instance-700-no-overlaps.ttx
+++ b/Tests/varLib/data/test_results/PartialInstancerTest3-VF-instance-700-no-overlaps.ttx
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.15">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="A"/>
+    <GlyphID id="2" name="B"/>
+    <GlyphID id="3" name="C"/>
+    <GlyphID id="4" name="D"/>
+    <GlyphID id="5" name="E"/>
+    <GlyphID id="6" name="F"/>
+    <GlyphID id="7" name="space"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0xc12af6d1"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Wed Sep 23 12:54:22 2020"/>
+    <modified value="Tue Sep 29 18:06:03 2020"/>
+    <xMin value="-192"/>
+    <yMin value="-200"/>
+    <xMax value="1099"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="600"/>
+    <minLeftSideBearing value="-192"/>
+    <minRightSideBearing value="-599"/>
+    <xMaxExtent value="1099"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="8"/>
+    <maxPoints value="16"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="513"/>
+    <usWeightClass value="700"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="70"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="A" width="500" lsb="113"/>
+    <mtx name="B" width="500" lsb="-192"/>
+    <mtx name="C" width="500" lsb="-173"/>
+    <mtx name="D" width="500" lsb="-137"/>
+    <mtx name="E" width="500" lsb="-127"/>
+    <mtx name="F" width="500" lsb="-147"/>
+    <mtx name="space" width="600" lsb="0"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name="space"/><!-- SPACE -->
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x44" name="D"/><!-- LATIN CAPITAL LETTER D -->
+      <map code="0x45" name="E"/><!-- LATIN CAPITAL LETTER E -->
+      <map code="0x46" name="F"/><!-- LATIN CAPITAL LETTER F -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="A" xMin="113" yMin="-66" xMax="390" yMax="646">
+      <contour>
+        <pt x="113" y="646" on="1"/>
+        <pt x="390" y="646" on="1"/>
+        <pt x="390" y="-66" on="1"/>
+        <pt x="113" y="-66" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="B" xMin="-192" yMin="19" xMax="792" yMax="612">
+      <contour>
+        <pt x="-192" y="448" on="1"/>
+        <pt x="89" y="448" on="1"/>
+        <pt x="89" y="612" on="1"/>
+        <pt x="441" y="612" on="1"/>
+        <pt x="441" y="448" on="1"/>
+        <pt x="792" y="448" on="1"/>
+        <pt x="792" y="215" on="1"/>
+        <pt x="441" y="215" on="1"/>
+        <pt x="441" y="19" on="1"/>
+        <pt x="89" y="19" on="1"/>
+        <pt x="89" y="215" on="1"/>
+        <pt x="-192" y="215" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="C" xMin="-173" yMin="-66" xMax="811" yMax="646">
+      <contour>
+        <pt x="-137" y="646" on="1"/>
+        <pt x="140" y="646" on="1"/>
+        <pt x="140" y="584" on="1"/>
+        <pt x="460" y="584" on="1"/>
+        <pt x="460" y="420" on="1"/>
+        <pt x="811" y="420" on="1"/>
+        <pt x="811" y="187" on="1"/>
+        <pt x="460" y="187" on="1"/>
+        <pt x="460" y="-9" on="1"/>
+        <pt x="140" y="-9" on="1"/>
+        <pt x="140" y="-66" on="1"/>
+        <pt x="-137" y="-66" on="1"/>
+        <pt x="-137" y="187" on="1"/>
+        <pt x="-173" y="187" on="1"/>
+        <pt x="-173" y="420" on="1"/>
+        <pt x="-137" y="420" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="D" xMin="-137" yMin="-66" xMax="1099" yMax="646">
+      <contour>
+        <pt x="-137" y="646" on="1"/>
+        <pt x="140" y="646" on="1"/>
+        <pt x="140" y="420" on="1"/>
+        <pt x="396" y="420" on="1"/>
+        <pt x="396" y="584" on="1"/>
+        <pt x="748" y="584" on="1"/>
+        <pt x="748" y="420" on="1"/>
+        <pt x="1099" y="420" on="1"/>
+        <pt x="1099" y="187" on="1"/>
+        <pt x="748" y="187" on="1"/>
+        <pt x="748" y="-9" on="1"/>
+        <pt x="396" y="-9" on="1"/>
+        <pt x="396" y="187" on="1"/>
+        <pt x="140" y="187" on="1"/>
+        <pt x="140" y="-66" on="1"/>
+        <pt x="-137" y="-66" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="E" xMin="-127" yMin="-100" xMax="839" yMax="663">
+      <contour>
+        <pt x="121" y="650" on="1"/>
+        <pt x="398" y="650" on="1"/>
+        <pt x="398" y="592" on="1"/>
+        <pt x="596" y="663" on="1"/>
+        <pt x="839" y="-6" on="1"/>
+        <pt x="579" y="-100" on="1"/>
+        <pt x="398" y="396" on="1"/>
+        <pt x="398" y="-62" on="1"/>
+        <pt x="150" y="-62" on="1"/>
+        <pt x="150" y="-66" on="1"/>
+        <pt x="-127" y="-66" on="1"/>
+        <pt x="-127" y="646" on="1"/>
+        <pt x="121" y="646" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="F" xMin="-147" yMin="-115" xMax="872" yMax="650">
+      <contour>
+        <pt x="101" y="650" on="1"/>
+        <pt x="378" y="650" on="1"/>
+        <pt x="378" y="561" on="1"/>
+        <pt x="516" y="640" on="1"/>
+        <pt x="872" y="24" on="1"/>
+        <pt x="632" y="-115" on="1"/>
+        <pt x="378" y="325" on="1"/>
+        <pt x="378" y="-62" on="1"/>
+        <pt x="130" y="-62" on="1"/>
+        <pt x="130" y="-66" on="1"/>
+        <pt x="-147" y="-66" on="1"/>
+        <pt x="-147" y="646" on="1"/>
+        <pt x="101" y="646" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="space"/><!-- contains no outline data -->
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Weight
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Remove Overlaps Test
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.000;NONE;RemoveOverlapsTest-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Remove Overlaps Test Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      RemoveOverlapsTest-Regular
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+    </extraNames>
+  </post>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=1 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="256"/>  <!-- Weight -->
+        <AxisOrdering value="0"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=0 -->
+    <ElidedFallbackNameID value="2"/>  <!-- Regular -->
+  </STAT>
+
+</ttFont>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ scipy==1.5.2; platform_python_implementation != "PyPy"
 munkres==1.1.2; platform_python_implementation == "PyPy"
 zopfli==0.1.6
 fs==2.4.11
+skia-pathops==0.4.2
 # this is only required to run Tests/cu2qu/{ufo,cli}_test.py
 ufoLib2==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ scipy==1.5.2; platform_python_implementation != "PyPy"
 munkres==1.1.2; platform_python_implementation == "PyPy"
 zopfli==0.1.6
 fs==2.4.11
-skia-pathops==0.4.2; platform_python_implementation != "PyPy"
+skia-pathops==0.5.0; platform_python_implementation != "PyPy"
 # this is only required to run Tests/cu2qu/{ufo,cli}_test.py
 ufoLib2==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ scipy==1.5.2; platform_python_implementation != "PyPy"
 munkres==1.1.2; platform_python_implementation == "PyPy"
 zopfli==0.1.6
 fs==2.4.11
-skia-pathops==0.4.2
+skia-pathops==0.4.2; platform_python_implementation != "PyPy"
 # this is only required to run Tests/cu2qu/{ufo,cli}_test.py
 ufoLib2==0.6.2

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ extras_require = {
 	],
 	# for fontTools.ttLib.removeOverlaps, to remove overlaps in TTF fonts
 	"pathops": [
-		"skia-pathops >= 0.4.2",
+		"skia-pathops >= 0.5.0",
 	],
 }
 # use a special 'all' key as shorthand to includes all the extra dependencies

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ extras_require = {
 	],
 	# for fontTools.ttLib.removeOverlaps, to remove overlaps in TTF fonts
 	"pathops": [
-		"skia-pathops >= 0.4.1",
+		"skia-pathops >= 0.4.2",
 	],
 }
 # use a special 'all' key as shorthand to includes all the extra dependencies

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,10 @@ extras_require = {
 	"type1": [
 		"xattr; sys_platform == 'darwin'",
 	],
+	# for fontTools.ttLib.removeOverlaps, to remove overlaps in TTF fonts
+	"pathops": [
+		"skia-pathops >= 0.4.1",
+	],
 }
 # use a special 'all' key as shorthand to includes all the extra dependencies
 extras_require["all"] = sum(extras_require.values(), [])

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,11 @@ skip_missing_interpreters=true
 [testenv]
 setenv =
     cy: FONTTOOLS_WITH_CYTHON=1
+# use 'download = true' to have tox install the latest pip inside the virtualenv.
+# We need this to be able to install skia-pathops on Linux, which uses a
+# relatively recent 'manylinux2014' platform tag.
+# https://github.com/tox-dev/tox/issues/791#issuecomment-518713438
+download = true
 deps =
     cov: coverage>=4.3
     pytest


### PR DESCRIPTION
this may help for VF generated instances containing overlaps on old macOS (10.11 El Capitan and lower) that seem to ignore the OVERLAP_SIMPLE/OVERLAP_COMPOUND flags,  see https://github.com/google/fonts/issues/2602

Note I haven't tested this, feel free to use and improve on it.

EDIT (30/09/2020):

The PR has changed from a snippet to a full-blown new module called `fontTools.ttLib.removeOverlaps`. This exports a `removeOverlaps` function that takes a TTFont and an optional list of glyphNames to modify (by default it does them all).
Also, the `fonttools varLib.instancer` tool has a new `--remove-overlaps` command-line option that uses the new module to remove overlaps of full VF instances.
Finally, in the `instantiateVariableFont` function in `varLib.instancer` module, the `overlap` option is no longer a `bool` (True/False) value, but is now an enumeration (IntEnum) called `OverlapMode`. The default is the same as before, ie. KEEP_AND_SET_FLAGS. The client can set it to `OverlapMode.REMOVE` to request that overlaps be removed from a full instance (does nothing for partial VFs). The old True/False `overlap` values continue to work as before (they are casted to enum automatically).

Note that the new feature requires the [skia-pathops](https://github.com/fonttools/fonttools) package. I added a new extra requirement called `pathops` (so one can do `pip install fonttools[pathops]`). Alternatively, one can `pip install skia-pathops` separately as usual.