### PR TITLE
[glifLib] Hard-require x and y coordinates

### DIFF
--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -1416,10 +1416,10 @@ def _validateAndMassagePointStructures(contour, pointAttributes, openContourOffC
 				raise GlifLibError("Unknown child elements in point element.")
 		# x and y are required
 		for attr in ("x", "y"):
-			value = element.get(attr)
-			if validate and value is None:
-				raise GlifLibError("Required %s attribute is missing in point element." % attr)
-			point[attr] = _number(value)
+			try:
+				point[attr] = _number(point[attr])
+			except KeyError as e:
+				raise GlifLibError(f"Required {attr} attribute is missing in point element.") from e
 		# segment type
 		pointType = point.pop("type", "offcurve")
 		if validate and pointType not in pointTypeOptions:

--- a/Tests/ufoLib/glifLib_test.py
+++ b/Tests/ufoLib/glifLib_test.py
@@ -10,6 +10,7 @@ from fontTools.ufoLib.glifLib import (
 )
 from fontTools.ufoLib.errors import GlifLibError, UnsupportedGLIFFormat, UnsupportedUFOFormat
 from fontTools.misc.etree import XML_DECLARATION
+from fontTools.pens.recordingPen import RecordingPointPen
 import pytest
 
 GLYPHSETDIR = getDemoFontGlyphSetPath()
@@ -250,6 +251,27 @@ class ReadWriteFuncTest:
 		with pytest.raises(GlifLibError, match="Forbidden GLIF format version"):
 			readGlyphFromString(s, _Glyph(), formatVersions=[1])
 
+	def test_read_ensure_x_y(self):
+		"""Ensure that a proper GlifLibError is raised when point coordinates are
+		missing, regardless of validation setting."""
+
+		s = """<?xml version='1.0' encoding='utf-8'?>
+		<glyph name="A" format="2">
+			<outline>
+				<contour>
+					<point x="545" y="0" type="line"/>
+					<point x="638" type="line"/>
+				</contour>
+			</outline>
+		</glyph>
+		"""
+		pen = RecordingPointPen() 
+
+		with pytest.raises(GlifLibError, match="Required y attribute"):
+			readGlyphFromString(s, _Glyph(), pen)
+
+		with pytest.raises(GlifLibError, match="Required y attribute"):
+			readGlyphFromString(s, _Glyph(), pen, validate=False)
 
 def test_GlyphSet_unsupported_ufoFormatVersion(tmp_path, caplog):
 	with pytest.raises(UnsupportedUFOFormat):


### PR DESCRIPTION
The current code hard-requires `x` and `y` either way but is being coy about it. If you're missing `y` and have validation turned off, you'll just get a `TypeError` about how `None` cannot be converted to a number instead of a proper descriptive `GlifLibError`.

As a tiny side-benefit, my profiler says that this makes `_validateAndMassagePointStructures` go a tiny fraction of a second faster :)