### PR TITLE
[instancer] FeatureVariations table is optional in GSUB 1.1 and can be None

### DIFF
--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -683,8 +683,8 @@ def instantiateOTL(varfont, axisLimits):
 
 def instantiateFeatureVariations(varfont, axisLimits):
     for tableTag in ("GPOS", "GSUB"):
-        if tableTag not in varfont or not hasattr(
-            varfont[tableTag].table, "FeatureVariations"
+        if tableTag not in varfont or not getattr(
+            varfont[tableTag].table, "FeatureVariations", None
         ):
             continue
         log.info("Instantiating FeatureVariations of %s table", tableTag)

--- a/Lib/fontTools/varLib/mutator.py
+++ b/Lib/fontTools/varLib/mutator.py
@@ -257,7 +257,7 @@ def instantiateVariableFont(varfont, location, inplace=False, overlap=True):
 		if not tableTag in varfont:
 			continue
 		table = varfont[tableTag].table
-		if not hasattr(table, 'FeatureVariations'):
+		if not getattr(table, 'FeatureVariations', None):
 			continue
 		variations = table.FeatureVariations
 		for record in variations.FeatureVariationRecord:

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1666,6 +1666,19 @@ class InstantiateFeatureVariationsTest(object):
         assert len(rec1.ConditionSet.ConditionTable) == 2
         assert rec1.ConditionSet.ConditionTable[0].Format == 2
 
+    def test_GSUB_FeatureVariations_is_None(self, varfont2):
+        varfont2["GSUB"].table.Version = 0x00010001
+        varfont2["GSUB"].table.FeatureVariations = None
+        tmp = BytesIO()
+        varfont2.save(tmp)
+        varfont = ttLib.TTFont(tmp)
+
+        # DO NOT raise an exception when the optional 'FeatureVariations' attribute is
+        # present but is set to None (e.g. with GSUB 1.1); skip and do nothing.
+        assert varfont["GSUB"].table.FeatureVariations is None
+        instancer.instantiateFeatureVariations(varfont, {"wght": 400, "wdth": 100})
+        assert varfont["GSUB"].table.FeatureVariations is None
+
 
 class LimitTupleVariationAxisRangesTest:
     def check_limit_single_var_axis_range(self, var, axisTag, axisRange, expected):


### PR DESCRIPTION
it is valid to have a font with GSUB v1.1 where FeatureVariations is unused; on loading the GSUB table, the attribute is present and is set to `None`. 
The instancer was simply checking if `hasattr(table, "FeatureVariations")` and assuming that if present, it ought to be not None. But that's not always True.