### PR TITLE
Instancer: update name table

### DIFF
--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1131,7 +1131,7 @@ def updateNameTable(varfont, axisLimits):
     # If we're instantiating a partial font, we will populate the unpinned
     # axes with their default axis values.
     fvarDefaults = {a.axisTag: a.defaultValue for a in fvar.axes}
-    axisCoords = axisLimits
+    axisCoords = deepcopy(axisLimits)
     for axisTag, val in fvarDefaults.items():
         if axisTag not in axisCoords or isinstance(axisCoords[axisTag], tuple):
             axisCoords[axisTag] = val

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1121,7 +1121,7 @@ def updateNameTable(varfont, axisLimits):
     """Update an instatiated variable font's name table using the Axis
     Values from the STAT table.
 
-    The updated nametable will conform to the R/I/B/BI naming model.
+    The updated name table will conform to the R/I/B/BI naming model.
     """
     if "STAT" not in varfont:
         raise ValueError("Cannot update name table since there is no STAT table.")
@@ -1546,7 +1546,7 @@ def instantiateVariableFont(
         varfont = deepcopy(varfont)
 
     if updateFontNames:
-        log.info("Updating nametable")
+        log.info("Updating name table")
         updateNameTable(varfont, axisLimits)
 
     if "gvar" in varfont:
@@ -1695,7 +1695,7 @@ def parseArgs(args):
     parser.add_argument(
         "--update-name-table",
         action="store_true",
-        help="Update the instantiated font's nametable. Input font must have "
+        help="Update the instantiated font's `name` table. Input font must have "
         "a STAT table with Axis Value Tables",
     )
     loggingGroup = parser.add_mutually_exclusive_group(required=False)

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1124,7 +1124,9 @@ def updateNameTable(varfont, axisLimits):
     """
     if "STAT" not in varfont:
         raise ValueError("Cannot update name table since there is no STAT table.")
-    stat = varfont["STAT"]
+    stat = varfont["STAT"].table
+    if not stat.AxisValueArray:
+        raise ValueError("Cannot update name table since there are no STAT Axis Values")
     fvar = varfont["fvar"]
 
     # The updated name table must reflect the new 'zero origin' of the font.
@@ -1139,7 +1141,7 @@ def updateNameTable(varfont, axisLimits):
     # To get the required Axis Values for the zero origin, we can simply
     # duplicate the STAT table and instantiate it using the axis coords we
     # created in the previous step.
-    stat_new = deepcopy(stat).table
+    stat_new = deepcopy(stat)
     _instantiateSTAT(stat_new, axisCoords)
     checkMissingAxisValues(stat_new, axisCoords)
 
@@ -1232,7 +1234,7 @@ def _updateNameRecords(varfont, axisValueTables):
             getName(n, *platEncLang).toUnicode() for n in ribbiNameIDs
         )
         typoSubFamilyName = " ".join(
-            getName(n, *platEncLang).toUnicode() for n in axisValueNameIDs
+            getName(n, *platEncLang).toUnicode() for n in axisValueNameIDs if nonRibbiNameIDs
         )
 
         # If neither subFamilyName and typographic SubFamilyName exist,

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1693,7 +1693,7 @@ def parseArgs(args):
         "when generating a full instance). Requires skia-pathops",
     )
     parser.add_argument(
-        "--update-nametable",
+        "--update-name-table",
         action="store_true",
         help="Update the instantiated font's nametable. Input font must have "
         "a STAT table with Axis Value Tables",
@@ -1749,7 +1749,7 @@ def main(args=None):
         inplace=True,
         optimize=options.optimize,
         overlap=options.overlap,
-        updateFontNames=options.update_nametable,
+        updateFontNames=options.update_name_table,
     )
 
     outfile = (

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1298,49 +1298,73 @@ def instantiateVariableFont(
     return varfont
 
 
-def updateNameTable(varfont, axisLimits):
-    nametable = varfont["name"]
-    if "STAT" not in varfont:
-        raise ValueError("Cannot update name table since there is no STAT table.")
-    stat = varfont['STAT']
+def axisValuesFromAxisLimits(stat, axisLimits):
 
     axisRecords = stat.table.DesignAxisRecord.Axis
     axisValues = stat.table.AxisValueArray.AxisValue
 
-    axisOrder = {a.AxisOrdering: a.AxisTag for a in axisRecords}
-    keptAxisValues = []
-    for axisValue in axisValues:
-        # TODO Format 4
-        if axisValue.Format == 4:
-            continue
+    format4 = [a for a in axisValues if a.Format == 4]
+    nonformat4  = [a for a in axisValues if a not in format4]
+    axisValues = format4 + nonformat4
 
-        axisTag = axisOrder[axisValue.AxisIndex]
-        if axisTag in axisLimits:
-            pinnedAxis = isinstance(axisLimits[axisTag], (float, int))
-        else:
-            pinnedAxis = False
+    axisOrder = {a.AxisOrdering: a.AxisTag for a in axisRecords}
+    pinnedAxes = set(k for k, v in axisLimits.items() if isinstance(v, (float, int)))
+
+    results, seen_axes = [], set()
+    for axisValue in axisValues:
 
         # Ignore axisValue if it has ELIDABLE_AXIS_VALUE_NAME flag enabled.
         # Enabling this flag will hide the axisValue in application font menus.
         if axisValue.Flags == 2:
             continue
 
-        if axisValue.Format in (1, 3):
+        if axisValue.Format == 4:
+            axisIndexes = set(r.AxisIndex for r in axisValue.AxisValueRecord)
+            if seen_axes - axisIndexes != seen_axes:
+                continue
+            # TODO fix dup appends 
+            for rec in axisValue.AxisValueRecord:
+                axisTag = axisOrder[rec.AxisIndex]
+                if axisTag not in pinnedAxes:
+                    continue
+                if rec.Value == axisLimits[axisTag]:
+                    seen_axes.add(rec.AxisIndex)
+                    results.append((rec.AxisIndex, axisValue))
+
+        elif axisValue.Format in (1, 3):
+            axisTag = axisOrder[axisValue.AxisIndex]
             # Add axisValue if it's used to link to another variable font
             if axisTag not in axisLimits and axisValue.Value == 1.0:
-                keptAxisValues.append(axisValue)
+                seen_axes.add(rec.AxisIndex)
+                results.append((axisValue.AxisIndex, axisValue))
 
+            if axisTag not in pinnedAxes:
+                continue
             # Add axisValue if its value is in the axisLimits and the user has
             # pinned the axis
-            elif pinnedAxis and axisValue.Value == axisLimits[axisTag]:
-                keptAxisValues.append(axisValue)
+            elif axisValue.Value == axisLimits[axisTag]:
+                seen_axes.add(rec.AxisIndex)
+                results.append((axisValue.AxisIndex,axisValue))
 
-        if axisValue.Format == 2:
-            if pinnedAxis and axisLimits[axisTag] >= axisValue.RangeMinValue \
+        elif axisValue.Format == 2:
+            axisTag = axisOrder[axisValue.AxisIndex]
+            if axisTag not in pinnedAxes:
+                continue
+            if axisLimits[axisTag] >= axisValue.RangeMinValue \
                 and axisLimits[axisTag] <= axisValue.RangeMaxValue:
-                    keptAxisValues.append(axisValue)
+                    seen_axes.add(axisValue.AxisIndex)
+                    results.append((axisValue.AxisIndex, axisValue))
+    return [v for k, v in sorted(results)]
 
-    _updateNameRecords(varfont, nametable, keptAxisValues)
+
+def updateNameTable(varfont, axisLimits):
+    if "STAT" not in varfont:
+        raise ValueError("Cannot update name table since there is no STAT table.")
+    stat = varfont['STAT']
+    nametable = varfont["name"]
+
+    selectedAxisValues = axisValuesFromAxisLimits(stat, axisLimits)
+    _updateNameRecords(varfont, nametable, selectedAxisValues)
 
 
 def _updateNameRecords(varfont, nametable, axisValues):

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1225,14 +1225,19 @@ def _updateNameRecords(varfont, axisValueTables):
         subFamilyName = " ".join(r.toUnicode() for r in subFamilyNameRecords if r)
 
         typoSubFamilyNameRecords = [
-            getName(a.ValueNameID, *platEncLang) for a in nonRibbiAxisValues if a
+            getName(a.ValueNameID, *platEncLang) for a in axisValueTables if a
         ]
         typoSubFamilyName = " ".join(
             r.toUnicode() for r in typoSubFamilyNameRecords if r
         )
 
+        familyNameSuffixRecords = [
+            getName(a.ValueNameID, *platEncLang) for a in nonRibbiAxisValues if a
+        ]
+        familyNameSuffix = " ".join(r.toUnicode() for r in familyNameSuffixRecords if r)
         updateNameTableStyleRecords(
             varfont,
+            familyNameSuffix,
             subFamilyName,
             typoSubFamilyName,
             *platEncLang,
@@ -1260,7 +1265,13 @@ def _ribbiAxisValueTables(nametable, axisValueTables):
 
 
 def updateNameTableStyleRecords(
-    varfont, ribbiName, nonRibbiName, platformID=3, platEncID=1, langID=0x409
+    varfont,
+    familyNameSuffix,
+    subFamilyName,
+    typoSubFamilyName,
+    platformID=3,
+    platEncID=1,
+    langID=0x409,
 ):
     # TODO (Marc F) It may be nice to make this part of a standalone
     # font renamer in the future.
@@ -1285,15 +1296,13 @@ def updateNameTableStyleRecords(
 
     nameIDs = {
         NameID.FAMILY_NAME: currentFamilyName,
-        NameID.SUBFAMILY_NAME: ribbiName
+        NameID.SUBFAMILY_NAME: subFamilyName
         or nametable.getName(NameID.SUBFAMILY_NAME, *platEncLang).toUnicode(),
     }
-    if nonRibbiName:
-        nameIDs[NameID.FAMILY_NAME] = f"{currentFamilyName} {nonRibbiName}".strip()
+    if typoSubFamilyName:
+        nameIDs[NameID.FAMILY_NAME] = f"{currentFamilyName} {familyNameSuffix}".strip()
         nameIDs[NameID.TYPOGRAPHIC_FAMILY_NAME] = currentFamilyName
-        nameIDs[
-            NameID.TYPOGRAPHIC_SUBFAMILY_NAME
-        ] = f"{nonRibbiName} {ribbiName}".strip()
+        nameIDs[NameID.TYPOGRAPHIC_SUBFAMILY_NAME] = f"{typoSubFamilyName}".strip()
 
     newFamilyName = nameIDs.get(NameID.TYPOGRAPHIC_FAMILY_NAME) or nameIDs.get(
         NameID.FAMILY_NAME

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1309,9 +1309,9 @@ def _updateStyleRecords(
 
 
 def _updateUniqueIdNameRecord(varfont, nameIDs, platEncLang):
-    name = varfont["name"]
-    record = name.getName(NameID.UNIQUE_FONT_IDENTIFIER, *platEncLang)
-    if not record:
+    nametable = varfont["name"]
+    currentRecord = nametable.getName(NameID.UNIQUE_FONT_IDENTIFIER, *platEncLang)
+    if not currentRecord:
         return None
 
     def isSubString(string1, string2):
@@ -1319,13 +1319,13 @@ def _updateUniqueIdNameRecord(varfont, nameIDs, platEncLang):
             return True
         return False
 
-    # Check if full name and postscript name are a substring
+    # Check if full name and postscript name are a substring of currentRecord
     for nameID in (4, 6):
-        nameRecord = name.getName(nameID, *platEncLang)
+        nameRecord = nametable.getName(nameID, *platEncLang)
         if not nameRecord:
             continue
-        if isSubString(record.toUnicode(), nameRecord.toUnicode()):
-            return record.toUnicode().replace(
+        if isSubString(currentRecord.toUnicode(), nameRecord.toUnicode()):
+            return currentRecord.toUnicode().replace(
                 nameRecord.toUnicode(), nameIDs[nameRecord.nameID]
             )
     # TODO (M Foley) Construct new uniqueID if full name or postscript names are not subsets

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1156,20 +1156,22 @@ def updateNameTable(varfont, axisLimits):
     # If we're instantiating a partial font, we will populate the unpinned
     # axes with their default axis values.
     fvarDefaults = {a.axisTag: a.defaultValue for a in fvar.axes}
-    axisCoords = deepcopy(axisLimits)
+    defaultAxisCoords = deepcopy(axisLimits)
     for axisTag, val in fvarDefaults.items():
-        if axisTag not in axisCoords or isinstance(axisCoords[axisTag], tuple):
-            axisCoords[axisTag] = val
+        if axisTag not in defaultAxisCoords or isinstance(
+            defaultAxisCoords[axisTag], tuple
+        ):
+            defaultAxisCoords[axisTag] = val
 
     # To get the required Axis Values for the zero origin, we can simply
     # duplicate the STAT table and instantiate it using the axis coords we
     # created in the previous step.
     stat_new = deepcopy(stat)
-    _instantiateSTAT(stat_new, axisCoords)
-    checkMissingAxisValues(stat_new, axisCoords.keys())
+    _instantiateSTAT(stat_new, defaultAxisCoords)
+    checkMissingAxisValues(stat_new, defaultAxisCoords.keys())
 
     axisValueTables = stat_new.AxisValueArray.AxisValue
-    # Remove axis Values which have Elidable_AXIS_VALUE_NAME flag set.
+    # Remove axis Values which have ELIDABLE_AXIS_VALUE_NAME flag set.
     # Axis Values which have this flag enabled won't be visible in
     # application font menus.
     axisValueTables = [

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1329,9 +1329,6 @@ def axisValueIsSelected(axisValue, seeker):
             axisIndex in seeker and seeker[axisIndex] <= axisValue.RangeMaxValue
         ]) else False
 
-    if axisIndex not in seeker:
-        return False
-
     return False
 
 
@@ -1395,7 +1392,14 @@ def updateNameTable(varfont, axisLimits):
     if "STAT" not in varfont:
         raise ValueError("Cannot update name table since there is no STAT table.")
     stat = varfont['STAT']
+    fvar = varfont['fvar']
     nametable = varfont["name"]
+
+    # add default axis values if they are missing from axisLimits
+    fvarDefaults = {a.axisTag: a.defaultValue for a in fvar.axes}
+    for k, v in fvarDefaults.items():
+        if k not in axisLimits:
+            axisLimits[k] = v
 
     selectedAxisValues = axisValuesFromAxisLimits(stat, axisLimits)
     _updateNameRecords(varfont, nametable, selectedAxisValues)

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1312,22 +1312,24 @@ def axisValueIsSelected(axisValue, seeker):
         return True if all(res) else False
 
     axisIndex = axisValue.AxisIndex
-    if axisIndex not in seeker:
-        return False
 
     if axisValue.Format in (1, 3):
-        # Add axisValue if it's used to link to another variable font
-        if axisIndex not in seeker and axisValue.Value == 1.0:
+        # Add axisValue if it's an attribute of a font. Font family
+        if axisIndex not in seeker and axisValue.Value in [0.0, 1.0]:
             return True
 
-        elif axisValue.Value == seeker[axisIndex]:
+        elif axisIndex in seeker and axisValue.Value == seeker[axisIndex]:
             return True
 
     if axisValue.Format == 2:
         return True if all([
-            seeker[axisIndex] >= axisValue.RangeMinValue,
-            seeker[axisIndex] <= axisValue.RangeMaxValue
+            axisIndex in seeker and seeker[axisIndex] >= axisValue.RangeMinValue,
+            axisIndex in seeker and seeker[axisIndex] <= axisValue.RangeMaxValue
         ]) else False
+
+    if axisIndex not in seeker:
+        return False
+
     return False
 
 
@@ -1358,7 +1360,6 @@ def axisValuesFromAxisLimits(stat, axisLimits):
     axisValues = [a for a in axisValues if axisValueIsSelected(a, axisValuesToFind)]
     axisValuesMissing = set(axisValuesToFind) - set(axisValuesIndexes(axisValues))
     if axisValuesMissing:
-        # TODO better error msg
         missing = [f"{axisTag[i]}={axisValuesToFind[i]}" for i in axisValuesMissing]
         raise ValueError(f"Cannot find AxisValue for {', '.join(missing)}")
     # filter out Elidable axisValues

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1315,6 +1315,7 @@ def axisValuesFromAxisLimits(stat, axisLimits):
 
         # Ignore axisValue if it has ELIDABLE_AXIS_VALUE_NAME flag enabled.
         # Enabling this flag will hide the axisValue in application font menus.
+        # TODO this is too greedy! we need to retain wght axisValues
         if axisValue.Flags == 2:
             continue
 
@@ -1407,12 +1408,14 @@ def _updateStyleRecords(
 #    wwsAxes = frozenset(["wght", "wdth", "ital"])
     currentFamilyName = nametable.getName(NameID.TYPOGRAPHIC_FAMILY_NAME, *lang) or \
             nametable.getName(NameID.FAMILY_NAME, *lang)
-    if not currentFamilyName:
-        return
-    currentFamilyName = currentFamilyName.toUnicode()
 
     currentStyleName = nametable.getName(NameID.TYPOGRAPHIC_SUBFAMILY_NAME, *lang) or \
             nametable.getName(NameID.SUBFAMILY_NAME, *lang)
+    # TODO cleanup
+    if not currentFamilyName or not currentStyleName:
+        print(f"Cannot update {lang} since it's missing a familyName nameID 1 or subFamilyName nameID 2 entry")
+        return
+    currentFamilyName = currentFamilyName.toUnicode()
     currentStyleName = currentStyleName.toUnicode()
 
     ribbiName = " ".join([nametable.getName(a.ValueNameID, *lang).toUnicode() for a in ribbiAxisValues])
@@ -1420,7 +1423,7 @@ def _updateStyleRecords(
 
     nameIDs = {
         NameID.FAMILY_NAME: currentFamilyName,
-        NameID.SUBFAMILY_NAME: ribbiName or "Regular"
+        NameID.SUBFAMILY_NAME: ribbiName or nametable.getName(NameID.SUBFAMILY_NAME, *lang).toUnicode()
     }
     if nonRibbiAxisValues:
         nameIDs[NameID.FAMILY_NAME] = f"{currentFamilyName} {nonRibbiName}"

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1331,25 +1331,39 @@ def axisValueIsSelected(axisValue, seeker):
     return False
 
 
+def axisValueIndexes(axisValue):
+    if axisValue.Format == 4:
+        return [r.AxisIndex for r in axisValue.AxisValueRecord]
+    return [axisValue.AxisIndex]
+
+
+def axisValuesIndexes(axisValues):
+    res = []
+    for axisValue in axisValues:
+        res += axisValueIndexes(axisValue)
+    return res
+
+
 def axisValuesFromAxisLimits(stat, axisLimits):
     axisValues = stat.table.AxisValueArray.AxisValue
     axisRecords = stat.table.DesignAxisRecord.Axis
     axisOrder = {a.AxisTag: a.AxisOrdering for a in axisRecords}
+    axisTag = {a.AxisOrdering: a.AxisTag for a in axisRecords}
     # Only check pinnedAxes for matching AxisValues
-    AxisValuesToFind = {
+    axisValuesToFind = {
         axisOrder[k]: v for k, v in axisLimits.items() \
         if isinstance(v, (float, int))
     }
 
-    axisValues = [a for a in axisValues if axisValueIsSelected(a, AxisValuesToFind)]
-    axisValuesMissing = set(AxisValuesToFind) - set(a.AxisIndex for a in axisValues)
+    axisValues = [a for a in axisValues if axisValueIsSelected(a, axisValuesToFind)]
+    axisValuesMissing = set(axisValuesToFind) - set(axisValuesIndexes(axisValues))
     if axisValuesMissing:
         # TODO better error msg
-        missing = [i for i in axisValuesMissing]
-        raise ValueError(f"Cannot find AxisValues for {missing}")
+        missing = [f"{axisTag[i]}={axisValuesToFind[i]}" for i in axisValuesMissing]
+        raise ValueError(f"Cannot find AxisValue for {', '.join(missing)}")
     # filter out Elidable axisValues
     axisValues = [a for a in axisValues if a.Flags != 2]
-    # TODO sort and remove duplicates so format 4 axisValues are dominant 
+    # TODO sort and remove duplicates so format 4 axisValues are dominant
     return axisValues
 
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1336,7 +1336,7 @@ def axisValuesFromAxisLimits(stat, axisLimits):
             axisTag = axisOrder[axisValue.AxisIndex]
             # Add axisValue if it's used to link to another variable font
             if axisTag not in axisLimits and axisValue.Value == 1.0:
-                seen_axes.add(rec.AxisIndex)
+                seen_axes.add(axisValue.AxisIndex)
                 results.append((axisValue.AxisIndex, axisValue))
 
             if axisTag not in pinnedAxes:
@@ -1344,7 +1344,7 @@ def axisValuesFromAxisLimits(stat, axisLimits):
             # Add axisValue if its value is in the axisLimits and the user has
             # pinned the axis
             elif axisValue.Value == axisLimits[axisTag]:
-                seen_axes.add(rec.AxisIndex)
+                seen_axes.add(axisValue.AxisIndex)
                 results.append((axisValue.AxisIndex,axisValue))
 
         elif axisValue.Format == 2:
@@ -1426,7 +1426,7 @@ def _updateStyleRecords(
         NameID.SUBFAMILY_NAME: ribbiName or nametable.getName(NameID.SUBFAMILY_NAME, *lang).toUnicode()
     }
     if nonRibbiAxisValues:
-        nameIDs[NameID.FAMILY_NAME] = f"{currentFamilyName} {nonRibbiName}"
+        nameIDs[NameID.FAMILY_NAME] = f"{currentFamilyName} {nonRibbiName}".strip()
         nameIDs[NameID.TYPOGRAPHIC_FAMILY_NAME] = currentFamilyName
         nameIDs[NameID.TYPOGRAPHIC_SUBFAMILY_NAME] = f"{nonRibbiName} {ribbiName}".strip()
 #    # Include WWS name records if there are nonWwsParticles

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1303,14 +1303,22 @@ def updateNameTable(varfont, axisLimits):
     if "STAT" not in varfont:
         raise ValueError("Cannot update name table since there is no STAT table.")
     stat = varfont['STAT']
+
     axisRecords = stat.table.DesignAxisRecord.Axis
     axisValues = stat.table.AxisValueArray.AxisValue
 
     axisOrder = {a.AxisOrdering: a.AxisTag for a in axisRecords}
     keptAxisValues = []
     for axisValue in axisValues:
+        # TODO Format 4
+        if axisValue.Format == 4:
+            continue
+
         axisTag = axisOrder[axisValue.AxisIndex]
-        pinnedAxis = isinstance(axisLimits[axisTag], float)
+        if axisTag in axisLimits:
+            pinnedAxis = isinstance(axisLimits[axisTag], (float, int))
+        else:
+            pinnedAxis = False
 
         # Ignore axisValue if it has ELIDABLE_AXIS_VALUE_NAME flag enabled.
         # Enabling this flag will hide the axisValue in application font menus.
@@ -1332,10 +1340,6 @@ def updateNameTable(varfont, axisLimits):
                 and axisLimits[axisTag] <= axisValue.RangeMaxValue:
                     keptAxisValues.append(axisValue)
 
-        # TODO Format 4
-        if axisValue.Format == 4:
-            raise NotImplementedError("Cannot update nametable using format 4 axisValues")
-        
     _updateNameRecords(varfont, nametable, keptAxisValues)
 
 
@@ -1397,7 +1401,7 @@ def _updateStyleRecords(
     if nonRibbiAxisValues:
         nameIDs[NameID.FAMILY_NAME] = f"{currentFamilyName} {nonRibbiName}"
         nameIDs[NameID.TYPOGRAPHIC_FAMILY_NAME] = currentFamilyName
-        nameIDs[NameID.TYPOGRAPHIC_SUBFAMILY_NAME] = f"{nonRibbiName} {ribbiName}"
+        nameIDs[NameID.TYPOGRAPHIC_SUBFAMILY_NAME] = f"{nonRibbiName} {ribbiName}".strip()
 #    # Include WWS name records if there are nonWwsParticles
 #    if nonWwsParticles:
 #        nameIDs[21] = f"{currentFamilyName} {' '.join(nonWwsParticles)}"

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -136,6 +136,8 @@ class NameID(IntEnum):
     TYPOGRAPHIC_FAMILY_NAME = 16
     TYPOGRAPHIC_SUBFAMILY_NAME = 17
 
+ELIDABLE_AXIS_VALUE_NAME = 2
+
 
 def instantiateTupleVariationStore(
     variations, axisLimits, origCoords=None, endPts=None
@@ -1363,7 +1365,7 @@ def axisValuesFromAxisLimits(stat, axisLimits):
         missing = [f"{axisTag[i]}={axisValuesToFind[i]}" for i in axisValuesMissing]
         raise ValueError(f"Cannot find AxisValue for {', '.join(missing)}")
     # filter out Elidable axisValues
-    axisValues = [a for a in axisValues if a.Flags != 2]
+    axisValues = [a for a in axisValues if a.Flags & ELIDABLE_AXIS_VALUE_NAME != 2]
     # TODO sort and remove duplicates so format 4 axisValues are dominant
     return axisValues
 

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1166,7 +1166,7 @@ def updateNameTable(varfont, axisLimits):
     # created in the previous step.
     stat_new = deepcopy(stat)
     _instantiateSTAT(stat_new, axisCoords)
-    checkMissingAxisValues(stat_new, axisCoords)
+    checkMissingAxisValues(stat_new, axisCoords.keys())
 
     axisValueTables = stat_new.AxisValueArray.AxisValue
     # Remove axis Values which have Elidable_AXIS_VALUE_NAME flag set.
@@ -1180,7 +1180,7 @@ def updateNameTable(varfont, axisLimits):
     _updateNameRecords(varfont, axisValueTables)
 
 
-def checkMissingAxisValues(stat, axisCoords):
+def checkMissingAxisValues(stat, axisTags):
     seen = set()
     axisValues = stat.AxisValueArray.AxisValue
     designAxes = stat.DesignAxisRecord.Axis
@@ -1193,10 +1193,10 @@ def checkMissingAxisValues(stat, axisCoords):
             axisTag = designAxes[val.AxisIndex].AxisTag
             seen.add(axisTag)
 
-    missingAxes = set(axisCoords) - seen
+    missingAxes = set(axisTags) - seen
     if missingAxes:
-        missing = ", ".join(f"'{i}={axisCoords[i]}'" for i in missingAxes)
-        raise ValueError(f"Cannot find Axis Values [{missing}]")
+        missing = ", ".join(missingAxes)
+        raise ValueError(f"Cannot find Axis Values for axes [{missing}]")
 
 
 def _sortAxisValues(stat):

--- a/Lib/fontTools/varLib/instancer.py
+++ b/Lib/fontTools/varLib/instancer.py
@@ -1154,7 +1154,7 @@ def updateNameTable(varfont, axisLimits):
         v for v in axisValueTables if v.Flags & ELIDABLE_AXIS_VALUE_NAME != 2
     ]
     stat_new.AxisValueArray.AxisValue = axisValueTables
-    axisValueTables = _sortedAxisValues(stat_new, axisCoords)
+    axisValueTables = _sortedAxisValues(stat_new)
     _updateNameRecords(varfont, axisValueTables)
 
 
@@ -1177,7 +1177,7 @@ def checkMissingAxisValues(stat, axisCoords):
         raise ValueError(f"Cannot find Axis Values [{missing}]")
 
 
-def _sortedAxisValues(stat, axisCoords):
+def _sortedAxisValues(stat):
     # Sort and remove duplicates ensuring that format 4 Axis Values
     # are dominant
     axisValues = stat.AxisValueArray.AxisValue

--- a/Tests/varLib/data/PartialInstancerTest-VF.ttx
+++ b/Tests/varLib/data/PartialInstancerTest-VF.ttx
@@ -479,6 +479,9 @@
     <namerecord nameID="296" platformID="3" platEncID="1" langID="0x409">
       TestVariableFont-XCdBd
     </namerecord>
+    <namerecord nameID="297" platformID="3" platEncID="1" langID="0x409">
+      Normal
+    </namerecord>
   </name>
 
   <post>
@@ -763,6 +766,15 @@
         <ValueNameID value="295"/>  <!-- Upright -->
         <Value value="0.0"/>
         <LinkedValue value="1.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="4">
+        <!-- AxisCount=1 -->
+        <Flags value="2"/>
+        <ValueNameID value="297"/>  <!-- Normal -->
+        <AxisValueRecord index="0">
+          <AxisIndex value="1"/>
+          <Value value="100.0"/>
+        </AxisValueRecord>
       </AxisValue>
     </AxisValueArray>
     <ElidedFallbackNameID value="2"/>  <!-- Regular -->

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -2045,7 +2045,7 @@ def test_updateNametable_partial(varfont):
 
 
 def test_updateNameTable_missing_axisValues(varfont):
-    with pytest.raises(ValueError, match="Cannot find Axis Value Tables \['wght=200'\]"):
+    with pytest.raises(ValueError, match="Cannot find Axis Values \['wght=200'\]"):
         instancer.updateNameTable(varfont, {"wght": 200})
 
 

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -2013,7 +2013,7 @@ def test_updateNametable_partial(varfont):
 
 
 def test_updateNameTable_missing_axisValues(varfont):
-    with pytest.raises(ValueError, match="Cannot find AxisValue for wght=200"):
+    with pytest.raises(ValueError, match="Cannot find Axis Value Tables wght=200"):
         instancer.updateNameTable(varfont, {"wght": 200})
 
 

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1962,6 +1962,39 @@ def test_updateNameTable_with_registered_axes(varfont):
     assert names[(17, 3, 1, 0x409)] == "Thin Condensed"
 
 
+def test_updateNameTable_with_multilingual_names(varfont):
+    name = varfont["name"]
+    name.setName("Test Variable Font", 1, 3, 1, 0x405)
+    name.setName("Normal", 2, 3, 1, 0x405)
+    name.setName("Normal", 261, 3, 1, 0x405) # nameID 261=Regular STAT entry
+    name.setName("Negreta",266, 3, 1, 0x405) # nameID 266=Black STAT entry
+    name.setName("Zhuštěné", 279, 3, 1, 0x405) # nameID 279=Condensed STAT entry
+
+    # Regular | Normal
+    instancer.updateNameTable(varfont, {"wdth": 100, "wght": 400})
+    names = _get_name_records(varfont)
+    assert names[(1, 3, 1, 0x405)] == "Test Variable Font"
+    assert names[(2, 3, 1, 0x405)] == "Normal"
+    assert (16, 3, 1, 0x405) not in names
+    assert (17, 3, 1, 0x405) not in names
+
+    # Black | Negreta
+    instancer.updateNameTable(varfont, {"wdth": 100, "wght": 900})
+    names = _get_name_records(varfont)
+    assert names[(1, 3, 1, 0x405)] == "Test Variable Font Negreta"
+    assert names[(2, 3, 1, 0x405)] == "Normal"
+    assert names[(16, 3, 1, 0x405)] == "Test Variable Font"
+    assert names[(17, 3, 1, 0x405)] == "Negreta"
+
+    # Black Condensed | Negreta Zhuštěné
+    instancer.updateNameTable(varfont, {"wdth": 79, "wght": 900})
+    names = _get_name_records(varfont)
+    assert names[(1, 3, 1, 0x405)] == "Test Variable Font Negreta Zhuštěné"
+    assert names[(2, 3, 1, 0x405)] == "Normal"
+    assert names[(16, 3, 1, 0x405)] == "Test Variable Font"
+    assert names[(17, 3, 1, 0x405)] == "Negreta Zhuštěné"
+
+
 def test_sanityCheckVariableTables(varfont):
     font = ttLib.TTFont()
     with pytest.raises(ValueError, match="Missing required table fvar"):

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -2000,6 +2000,7 @@ def test_updatetNameTable_axis_order(varfont):
 
 def test_updateNameTable_with_multilingual_names(varfont):
     name = varfont["name"]
+    # langID 0x405 is the Czech Windows langID
     name.setName("Test Variable Font", 1, 3, 1, 0x405)
     name.setName("Normal", 2, 3, 1, 0x405)
     name.setName("Normal", 261, 3, 1, 0x405) # nameID 261=Regular STAT entry
@@ -2035,17 +2036,16 @@ def test_updateNameTable_with_multilingual_names(varfont):
 
 
 def test_updateNametable_partial(varfont):
-    instancer.updateNameTable(varfont, {"wdth": 79, "wght": (400, 900)})
+    instancer.updateNameTable(varfont, {"wdth": 79, "wght": instancer.AxisRange(400, 900)})
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font Condensed"
     assert names[(2, 3, 1, 0x409)] == "Regular"
-    assert (3, 3, 1, 0x405) not in names
     assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
     assert names[(17, 3, 1, 0x409)] == "Condensed"
 
 
 def test_updateNameTable_missing_axisValues(varfont):
-    with pytest.raises(ValueError, match="Cannot find Axis Values for axes \[wght\]"):
+    with pytest.raises(ValueError, match="Cannot find Axis Values \['wght=200'\]"):
         instancer.updateNameTable(varfont, {"wght": 200})
 
 

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -2045,7 +2045,7 @@ def test_updateNametable_partial(varfont):
 
 
 def test_updateNameTable_missing_axisValues(varfont):
-    with pytest.raises(ValueError, match="Cannot find Axis Values \['wght=200'\]"):
+    with pytest.raises(ValueError, match="Cannot find Axis Values for axes \[wght\]"):
         instancer.updateNameTable(varfont, {"wght": 200})
 
 

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1995,6 +1995,15 @@ def test_updateNameTable_with_multilingual_names(varfont):
     assert names[(17, 3, 1, 0x405)] == "Negreta Zhuštěné"
 
 
+def test_updateNametable_partial(varfont):
+    instancer.updateNameTable(varfont, {"wdth": 79, "wght": (400, 900)})
+    names = _get_name_records(varfont)
+    assert names[(1, 3, 1, 0x409)] == "Test Variable Font Condensed"
+    assert names[(2, 3, 1, 0x409)] == "Regular"
+    assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
+    assert names[(17, 3, 1, 0x409)] == "Condensed" #? maybe Condensed Regular?
+
+
 def test_sanityCheckVariableTables(varfont):
     font = ttLib.TTFont()
     with pytest.raises(ValueError, match="Missing required table fvar"):

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -2106,6 +2106,23 @@ def test_updateNameTable_format4_axisValues(varfont):
     assert names[(17, 3, 1, 0x409)] == "Dominant Value"
 
 
+def test_updateNameTable_elided_axisValues(varfont):
+    stat = varfont["STAT"].table
+    # set ELIDABLE_AXIS_VALUE_NAME flag for all axisValues
+    for axisValue in stat.AxisValueArray.AxisValue:
+        axisValue.Flags |= instancer.ELIDABLE_AXIS_VALUE_NAME
+
+    stat.ElidedFallbackNameID = 266 # Regular --> Black
+    instancer.updateNameTable(varfont, {"wght": 400})
+    names = _get_name_records(varfont)
+    # Since all axis values are elided, the elided fallback name
+    # must be used to construct the style names. Since we
+    # changed it to Black, we need both a typoSubFamilyName and
+    # the subFamilyName set so it conforms to the RIBBI model.
+    assert names[(2, 3, 1, 0x409)] == "Regular"
+    assert names[(17, 3, 1, 0x409)] == "Black"
+
+
 def test_sanityCheckVariableTables(varfont):
     font = ttLib.TTFont()
     with pytest.raises(ValueError, match="Missing required table fvar"):

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1209,8 +1209,8 @@ class InstantiateSTATTest(object):
     @pytest.mark.parametrize(
         "location, expected",
         [
-            ({"wght": 400}, ["Regular", "Condensed", "Upright"]),
-            ({"wdth": 100}, ["Thin", "Regular", "Black", "Upright"]),
+            ({"wght": 400}, ["Regular", "Condensed", "Upright", "Normal"]),
+            ({"wdth": 100}, ["Thin", "Regular", "Black", "Upright", "Normal"]),
         ],
     )
     def test_pin_and_drop_axis(self, varfont, location, expected):
@@ -1344,7 +1344,7 @@ class InstantiateSTATTest(object):
 def test_pruningUnusedNames(varfont):
     varNameIDs = instancer.getVariationNameIDs(varfont)
 
-    assert varNameIDs == set(range(256, 296 + 1))
+    assert varNameIDs == set(range(256, 297 + 1))
 
     fvar = varfont["fvar"]
     stat = varfont["STAT"].table

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1926,7 +1926,7 @@ def _get_name_records(varfont):
 
 def test_updateNameTable_with_registered_axes(varfont):
     # Regular
-    instancer.updateNameTable(varfont, {"wght": 400, "wdth": 100})
+    instancer.updateNameTable(varfont, {"wght": 400})
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font"
     assert names[(2, 3, 1, 0x0409)] == "Regular"
@@ -1935,7 +1935,7 @@ def test_updateNameTable_with_registered_axes(varfont):
     assert (17, 3, 1, 0x409) not in names
 
     # Black
-    instancer.updateNameTable(varfont, {"wght": 900, "wdth": 100})
+    instancer.updateNameTable(varfont, {"wght": 900})
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font Black"
     assert names[(2, 3, 1, 0x409)] == "Regular"
@@ -1944,7 +1944,7 @@ def test_updateNameTable_with_registered_axes(varfont):
     assert names[(17, 3, 1, 0x409)] == "Black"
 
     # Thin
-    instancer.updateNameTable(varfont, {"wght": 100, "wdth": 100})
+    instancer.updateNameTable(varfont, {"wght": 100})
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font Thin"
     assert names[(2, 3, 1, 0x409)] == "Regular"
@@ -1971,7 +1971,7 @@ def test_updateNameTable_with_multilingual_names(varfont):
     name.setName("Zhuštěné", 279, 3, 1, 0x405) # nameID 279=Condensed STAT entry
 
     # Regular | Normal
-    instancer.updateNameTable(varfont, {"wdth": 100, "wght": 400})
+    instancer.updateNameTable(varfont, {"wght": 400})
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x405)] == "Test Variable Font"
     assert names[(2, 3, 1, 0x405)] == "Normal"
@@ -1979,7 +1979,7 @@ def test_updateNameTable_with_multilingual_names(varfont):
     assert (17, 3, 1, 0x405) not in names
 
     # Black | Negreta
-    instancer.updateNameTable(varfont, {"wdth": 100, "wght": 900})
+    instancer.updateNameTable(varfont, {"wght": 900})
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x405)] == "Test Variable Font Negreta"
     assert names[(2, 3, 1, 0x405)] == "Normal"
@@ -2002,6 +2002,11 @@ def test_updateNametable_partial(varfont):
     assert names[(2, 3, 1, 0x409)] == "Regular"
     assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
     assert names[(17, 3, 1, 0x409)] == "Condensed" #? maybe Condensed Regular?
+
+
+def test_updateNameTable_missing_axisValues(varfont):
+    with pytest.raises(ValueError, match="Cannot find AxisValue for wght=200"):
+        instancer.updateNameTable(varfont, {"wght": 200})
 
 
 def test_sanityCheckVariableTables(varfont):

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -7,6 +7,7 @@ from fontTools.ttLib.tables import _f_v_a_r, _g_l_y_f
 from fontTools.ttLib.tables import otTables
 from fontTools.ttLib.tables.TupleVariation import TupleVariation
 from fontTools import varLib
+from fontTools.otlLib.builder import buildStatTable
 from fontTools.varLib import instancer
 from fontTools.varLib.mvar import MVAR_ENTRIES
 from fontTools.varLib import builder
@@ -1967,7 +1968,35 @@ def test_updateNameTable_with_registered_axes(varfont):
 
 
 def test_updatetNameTable_axis_order(varfont):
-    pass
+    axes = [
+        dict(
+            tag="wght",
+            name="Weight",
+            values=[
+                dict(value=400, name='Regular'),
+            ],
+        ),
+        dict(
+            tag="wdth",
+            name="Width",
+            values=[
+                dict(value=75, name="Condensed"),
+            ]
+        )
+    ]
+    buildStatTable(varfont, axes)
+    instancer.updateNameTable(varfont, {"wdth": 75, "wght": 400})
+    names = _get_name_records(varfont)
+    assert names[(17, 3, 1, 0x409)] == "Regular Condensed"
+
+    # Swap the axes so the names get swapped
+    axes[0], axes[1] = axes[1], axes[0]
+
+    buildStatTable(varfont, axes)
+    instancer.updateNameTable(varfont, {"wdth": 75, "wght": 400})
+    names = _get_name_records(varfont)
+    assert names[(17, 3, 1, 0x409)] == "Condensed Regular"
+
 
 def test_updateNameTable_with_multilingual_names(varfont):
     name = varfont["name"]

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1969,7 +1969,6 @@ def test_updateNameTable_with_registered_axes(varfont):
 def test_updatetNameTable_axis_order(varfont):
     pass
 
-
 def test_updateNameTable_with_multilingual_names(varfont):
     name = varfont["name"]
     name.setName("Test Variable Font", 1, 3, 1, 0x405)
@@ -2017,7 +2016,7 @@ def test_updateNametable_partial(varfont):
 
 
 def test_updateNameTable_missing_axisValues(varfont):
-    with pytest.raises(ValueError, match="Cannot find Axis Value Tables wght=200"):
+    with pytest.raises(ValueError, match="Cannot find Axis Value Tables \['wght=200'\]"):
         instancer.updateNameTable(varfont, {"wght": 200})
 
 
@@ -2029,7 +2028,8 @@ def test_updateNameTable_missing_stat(varfont):
 
 def test_updateNameTable_vf_with_italic_attribute(varfont):
     font_link_axisValue = varfont["STAT"].table.AxisValueArray.AxisValue[4]
-    font_link_axisValue.Flags = 0
+    # Unset ELIDABLE_AXIS_VALUE_NAME flag
+    font_link_axisValue.Flags &= ~instancer.ELIDABLE_AXIS_VALUE_NAME
     font_link_axisValue.ValueNameID = 294 # Roman --> Italic
 
     # Italic

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -2032,6 +2032,33 @@ def test_updateNameTable_vf_with_italic_attribute(varfont):
     assert names[(17, 3, 1, 0x409)] == "Black Condensed Italic"
 
 
+def test_updateNameTable_format4_axisValues(varfont):
+    # format 4 axisValues should dominate the other axisValues
+    stat = varfont["STAT"].table
+
+    axisValue = otTables.AxisValue()
+    axisValue.Format = 4
+    axisValue.Flags = 0
+    varfont["name"].setName("Dominant Value", 297, 3, 1, 0x409)
+    axisValue.ValueNameID = 297
+    axisValue.AxisValueRecord = []
+    for tag, value in (("wght", 900), ("wdth", 79)):
+        rec = otTables.AxisValueRecord()
+        rec.AxisIndex = next(
+            i for i, a in enumerate(stat.DesignAxisRecord.Axis) if a.AxisTag == tag
+        )
+        rec.Value = value
+        axisValue.AxisValueRecord.append(rec)
+    stat.AxisValueArray.AxisValue.append(axisValue)
+
+    instancer.updateNameTable(varfont, {"wdth": 79, "wght": 900})
+    names = _get_name_records(varfont)
+    assert names[(1, 3, 1, 0x409)] == "Test Variable Font Dominant Value"
+    assert names[(2, 3, 1, 0x409)] == "Regular"
+    assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
+    assert names[(17, 3, 1, 0x409)] == "Dominant Value"
+
+
 def test_sanityCheckVariableTables(varfont):
     font = ttLib.TTFont()
     with pytest.raises(ValueError, match="Missing required table fvar"):

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1930,6 +1930,7 @@ def test_updateNameTable_with_registered_axes(varfont):
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font"
     assert names[(2, 3, 1, 0x0409)] == "Regular"
+    assert names[(3, 3, 1, 0x0409)] == "2.001;GOOG;TestVariableFont-Regular"
     assert names[(6, 3, 1, 0x409)] == "TestVariableFont-Regular"
     assert (16, 3, 1, 0x409) not in names
     assert (17, 3, 1, 0x409) not in names
@@ -1939,6 +1940,7 @@ def test_updateNameTable_with_registered_axes(varfont):
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font Black"
     assert names[(2, 3, 1, 0x409)] == "Regular"
+    assert names[(3, 3, 1, 0x0409)] == "2.001;GOOG;TestVariableFont-Black"
     assert names[(6, 3, 1, 0x409)] == "TestVariableFont-Black"
     assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
     assert names[(17, 3, 1, 0x409)] == "Black"
@@ -1948,6 +1950,7 @@ def test_updateNameTable_with_registered_axes(varfont):
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font Thin"
     assert names[(2, 3, 1, 0x409)] == "Regular"
+    assert names[(3, 3, 1, 0x0409)] == "2.001;GOOG;TestVariableFont-Thin"
     assert names[(6, 3, 1, 0x409)] == "TestVariableFont-Thin"
     assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
     assert names[(17, 3, 1, 0x409)] == "Thin"
@@ -1957,6 +1960,7 @@ def test_updateNameTable_with_registered_axes(varfont):
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font Thin Condensed"
     assert names[(2, 3, 1, 0x409)] == "Regular"
+    assert names[(3, 3, 1, 0x0409)] == "2.001;GOOG;TestVariableFont-ThinCondensed"
     assert names[(6, 3, 1, 0x409)] == "TestVariableFont-ThinCondensed"
     assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
     assert names[(17, 3, 1, 0x409)] == "Thin Condensed"
@@ -1975,6 +1979,7 @@ def test_updateNameTable_with_multilingual_names(varfont):
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x405)] == "Test Variable Font"
     assert names[(2, 3, 1, 0x405)] == "Normal"
+    assert (3, 3, 1, 0x405) not in names
     assert (16, 3, 1, 0x405) not in names
     assert (17, 3, 1, 0x405) not in names
 
@@ -1983,6 +1988,7 @@ def test_updateNameTable_with_multilingual_names(varfont):
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x405)] == "Test Variable Font Negreta"
     assert names[(2, 3, 1, 0x405)] == "Normal"
+    assert (3, 3, 1, 0x405) not in names
     assert names[(16, 3, 1, 0x405)] == "Test Variable Font"
     assert names[(17, 3, 1, 0x405)] == "Negreta"
 
@@ -1991,6 +1997,7 @@ def test_updateNameTable_with_multilingual_names(varfont):
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x405)] == "Test Variable Font Negreta Zhuštěné"
     assert names[(2, 3, 1, 0x405)] == "Normal"
+    assert (3, 3, 1, 0x405) not in names
     assert names[(16, 3, 1, 0x405)] == "Test Variable Font"
     assert names[(17, 3, 1, 0x405)] == "Negreta Zhuštěné"
 
@@ -2000,6 +2007,7 @@ def test_updateNametable_partial(varfont):
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font Condensed"
     assert names[(2, 3, 1, 0x409)] == "Regular"
+    assert (3, 3, 1, 0x405) not in names
     assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
     assert names[(17, 3, 1, 0x409)] == "Condensed" #? maybe Condensed Regular?
 

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -2041,7 +2041,7 @@ def test_updateNametable_partial(varfont):
     assert names[(2, 3, 1, 0x409)] == "Regular"
     assert (3, 3, 1, 0x405) not in names
     assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
-    assert names[(17, 3, 1, 0x409)] == "Condensed" #? maybe Condensed Regular?
+    assert names[(17, 3, 1, 0x409)] == "Condensed"
 
 
 def test_updateNameTable_missing_axisValues(varfont):

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1966,6 +1966,10 @@ def test_updateNameTable_with_registered_axes(varfont):
     assert names[(17, 3, 1, 0x409)] == "Thin Condensed"
 
 
+def test_updatetNameTable_axis_order(varfont):
+    pass
+
+
 def test_updateNameTable_with_multilingual_names(varfont):
     name = varfont["name"]
     name.setName("Test Variable Font", 1, 3, 1, 0x405)
@@ -2015,6 +2019,12 @@ def test_updateNametable_partial(varfont):
 def test_updateNameTable_missing_axisValues(varfont):
     with pytest.raises(ValueError, match="Cannot find Axis Value Tables wght=200"):
         instancer.updateNameTable(varfont, {"wght": 200})
+
+
+def test_updateNameTable_missing_stat(varfont):
+    del varfont["STAT"]
+    with pytest.raises(ValueError, match="Cannot update name table since there is no STAT table."):
+        instancer.updateNameTable(varfont, {"wght": 400})
 
 
 def test_updateNameTable_vf_with_italic_attribute(varfont):

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1916,6 +1916,43 @@ def test_normalizeAxisLimits_missing_from_fvar(varfont):
         instancer.normalizeAxisLimits(varfont, {"ZZZZ": 1000})
 
 
+def _get_name_records(varfont):
+    nametable = varfont["name"]
+    return {
+        (r.nameID, r.platformID, r.platEncID, r.langID): r.toUnicode()
+        for r in nametable.names
+    }
+
+
+def test_updateNameTable(varfont):
+    instancer.updateNameTable(varfont, {"wght": 400, "wdth": 100})
+    names = _get_name_records(varfont)
+    assert names[(1, 3, 1, 0x409)] == "Test Variable Font"
+    assert names[(2, 3, 1, 0x0409)] == "Regular"
+    assert names[(6, 3, 1, 0x409)] == "TestVariableFont-Regular"
+    assert (16, 3, 1, 0x409) not in names
+    assert (17, 3, 1, 0x409) not in names
+
+    instancer.updateNameTable(varfont, {"wght": 900, "wdth": 100})
+    names = _get_name_records(varfont)
+    assert names[(1, 3, 1, 0x409)] == "Test Variable Font Black"
+    assert names[(2, 3, 1, 0x409)] == "Regular"
+    assert names[(6, 3, 1, 0x409)] == "TestVariableFont-Black"
+    assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
+    assert names[(17, 3, 1, 0x409)] == "Black"
+
+    instancer.updateNameTable(varfont, {"wght": 100, "wdth": 100})
+    names = _get_name_records(varfont)
+    assert names[(1, 3, 1, 0x409)] == "Test Variable Font Thin"
+    assert names[(2, 3, 1, 0x409)] == "Regular"
+    assert names[(6, 3, 1, 0x409)] == "TestVariableFont-Thin"
+    assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
+    assert names[(17, 3, 1, 0x409)] == "Thin"
+
+    # TODO (Marc F) this doesn't work because our test font is using Format 4 for wdth axis
+    instancer.updateNameTable(varfont, {"wdth": 79, "wdth": 400})
+
+
 def test_sanityCheckVariableTables(varfont):
     font = ttLib.TTFont()
     with pytest.raises(ValueError, match="Missing required table fvar"):

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -2009,6 +2009,29 @@ def test_updateNameTable_missing_axisValues(varfont):
         instancer.updateNameTable(varfont, {"wght": 200})
 
 
+def test_updateNameTable_vf_with_italic_attribute(varfont):
+    font_link_axisValue = varfont["STAT"].table.AxisValueArray.AxisValue[4]
+    font_link_axisValue.Flags = 0
+    font_link_axisValue.ValueNameID = 294 # Roman --> Italic
+
+    # Italic
+    instancer.updateNameTable(varfont, {"wght": 400})
+    names = _get_name_records(varfont)
+    assert names[(1, 3, 1, 0x409)] == "Test Variable Font"
+    assert names[(2, 3, 1, 0x409)] == "Italic"
+    assert (16, 3, 1, 0x405) not in names
+    assert (17, 3, 1, 0x405) not in names
+
+    # Black Condensed Italic
+    instancer.updateNameTable(varfont, {"wdth": 79, "wght": 900})
+    names = _get_name_records(varfont)
+    assert names[(1, 3, 1, 0x409)] == "Test Variable Font Black Condensed"
+    assert names[(2, 3, 1, 0x409)] == "Italic"
+    assert names[(6, 3, 1, 0x409)] == "TestVariableFont-BlackCondensedItalic"
+    assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
+    assert names[(17, 3, 1, 0x409)] == "Black Condensed Italic"
+
+
 def test_sanityCheckVariableTables(varfont):
     font = ttLib.TTFont()
     with pytest.raises(ValueError, match="Missing required table fvar"):

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -1924,7 +1924,8 @@ def _get_name_records(varfont):
     }
 
 
-def test_updateNameTable(varfont):
+def test_updateNameTable_with_registered_axes(varfont):
+    # Regular
     instancer.updateNameTable(varfont, {"wght": 400, "wdth": 100})
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font"
@@ -1933,6 +1934,7 @@ def test_updateNameTable(varfont):
     assert (16, 3, 1, 0x409) not in names
     assert (17, 3, 1, 0x409) not in names
 
+    # Black
     instancer.updateNameTable(varfont, {"wght": 900, "wdth": 100})
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font Black"
@@ -1941,6 +1943,7 @@ def test_updateNameTable(varfont):
     assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
     assert names[(17, 3, 1, 0x409)] == "Black"
 
+    # Thin
     instancer.updateNameTable(varfont, {"wght": 100, "wdth": 100})
     names = _get_name_records(varfont)
     assert names[(1, 3, 1, 0x409)] == "Test Variable Font Thin"
@@ -1949,8 +1952,14 @@ def test_updateNameTable(varfont):
     assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
     assert names[(17, 3, 1, 0x409)] == "Thin"
 
-    # TODO (Marc F) this doesn't work because our test font is using Format 4 for wdth axis
-    instancer.updateNameTable(varfont, {"wdth": 79, "wdth": 400})
+    # Thin Condensed
+    instancer.updateNameTable(varfont, {"wdth": 79, "wght": 100})
+    names = _get_name_records(varfont)
+    assert names[(1, 3, 1, 0x409)] == "Test Variable Font Thin Condensed"
+    assert names[(2, 3, 1, 0x409)] == "Regular"
+    assert names[(6, 3, 1, 0x409)] == "TestVariableFont-ThinCondensed"
+    assert names[(16, 3, 1, 0x409)] == "Test Variable Font"
+    assert names[(17, 3, 1, 0x409)] == "Thin Condensed"
 
 
 def test_sanityCheckVariableTables(varfont):


### PR DESCRIPTION
**Warning, still very much a WIP. I need to do further tests and investigate whether we actually need WWS name records etc.**

Currently, `varLib.instancer` will only prune unused name records when instantiating a variable font. This PR will allow users to optionally update the name table by using the STAT table axisValues.

@twardoch I'm wondering whether you'd be interesting in reviewing this PR and its output? your knowledge of application font handling is far superior to mine. I'm currently debating whether I should keep the WWS entries for static instances?

TODO:
 - Write tests and seek out more hardcore edge cases
 - ~~Update uniqueID name records~~
- ~~Ensure multilingual name records actually work. Atm they're simply overwritten.~~
- ~~Support format 4 axisValues~~
- Tidyup/refactor once we're confident the output works across all platforms etc
