### PR TITLE
svgLib: handle arc commands with bool flags not separated by space/comma

### DIFF
--- a/Lib/fontTools/svgLib/path/parser.py
+++ b/Lib/fontTools/svgLib/path/parser.py
@@ -13,18 +13,81 @@ import re
 
 
 COMMANDS = set('MmZzLlHhVvCcSsQqTtAa')
+ARC_COMMANDS = set("Aa")
 UPPERCASE = set('MZLHVCSQTA')
 
 COMMAND_RE = re.compile("([MmZzLlHhVvCcSsQqTtAa])")
-FLOAT_RE = re.compile(r"[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?")
+FLOAT_RE = re.compile(
+    r"[-+]?"  # optional sign
+    r"(?:"
+    r"(?:0|[1-9][0-9]*)(?:\.[0-9]+(?:[eE][-+]?[0-9]+)?)?"  # int/float
+    r"|"
+    r"(?:\.[0-9]+(?:[eE][-+]?[0-9]+)?)"  # float with leading dot (e.g. '.42')
+    r")"
+)
+BOOL_RE = re.compile("^[01]")
+SEPARATOR_RE = re.compile(f"[, \t]")
 
 
 def _tokenize_path(pathdef):
+    arc_cmd = None
     for x in COMMAND_RE.split(pathdef):
         if x in COMMANDS:
+            arc_cmd = x if x in ARC_COMMANDS else None
             yield x
-        for token in FLOAT_RE.findall(x):
-            yield token
+            continue
+
+        if arc_cmd:
+            try:
+                yield from _tokenize_arc_arguments(x)
+            except ValueError as e:
+                raise ValueError(f"Invalid arc command: '{arc_cmd}{x}'") from e
+        else:
+            for token in FLOAT_RE.findall(x):
+                yield token
+
+
+ARC_ARGUMENT_TYPES = (
+    ("rx", FLOAT_RE),
+    ("ry", FLOAT_RE),
+    ("x-axis-rotation", FLOAT_RE),
+    ("large-arc-flag", BOOL_RE),
+    ("sweep-flag", BOOL_RE),
+    ("x", FLOAT_RE),
+    ("y", FLOAT_RE),
+)
+
+
+def _tokenize_arc_arguments(arcdef):
+    raw_args = [s for s in SEPARATOR_RE.split(arcdef) if s]
+    if not raw_args:
+        raise ValueError(f"Not enough arguments: '{arcdef}'")
+    raw_args.reverse()
+
+    i = 0
+    while raw_args:
+        arg = raw_args.pop()
+
+        name, pattern = ARC_ARGUMENT_TYPES[i]
+        match = pattern.search(arg)
+        if not match:
+            raise ValueError(f"Invalid argument for '{name}' parameter: {arg!r}")
+
+        j, k = match.span()
+        yield arg[j:k]
+        arg = arg[k:]
+
+        if arg:
+            raw_args.append(arg)
+
+        # wrap around every 7 consecutive arguments
+        if i == 6:
+            i = 0
+        else:
+            i += 1
+
+    if i != 0:
+        raise ValueError(f"Not enough arguments: '{arcdef}'")
 
 
 def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):


### PR DESCRIPTION
Some SVG authoring tool write arc commands without any space or comma around the boolean 'large-arc' and 'sweep' flags, leading our svg path parser to choke.
E.g. `A1.2 1.2 0 0122 6.2` is currently tokenized as `["A", "1.2", "1.2", "0", "0122", "6.2"]`, whereas it should instead be tokenized as `["A", "1.2", "1.2", "0", "0", "1", "22", "6.2"]`

This PR makes the path parser smarter by special-casing arc command so that we only consume one character ('0' or '1') for these special boolean flags.