### PR TITLE
[otlLib] Build format 1 and format 2 contextual lookups

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -454,7 +454,6 @@ class ChainContextualBuilder(LookupBuilder):
         for _ in inClasses:
             classSet = self.newRuleSet_(format=2, chaining=chaining)
             classSet.populateDefaults()
-            classSets.append(classSet)
 
         coverage = set()
         classRuleAttr = self.ruleAttr_(format=2, chaining=chaining)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -455,7 +455,6 @@ class ChainContextualBuilder(LookupBuilder):
         classSets = []
         for _ in inClasses:
             classSet = self.newRuleSet_(format=2, chaining=chaining)
-            classSet.populateDefaults()
             classSets.append(classSet)
 
         coverage = set()

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -567,20 +567,24 @@ class ChainContextualBuilder(LookupBuilder):
     # The following functions generate the attribute names and subtables according
     # to this naming convention.
     def ruleSetAttr_(self, format=1, chaining=True):
-        if format == 2:
-            formatType = "Class"
-        elif format == 1:
+        if format == 1:
             formatType = "Rule"
+        elif format == 2:
+            formatType = "Class"
+        else:
+            raise AssertionError(formatType)
         subtablename = f"{self.subtable_type[0:3]}{formatType}Set"  # Sub, not Subst.
         if chaining:
             subtablename = "Chain" + subtablename
         return subtablename
 
     def ruleAttr_(self, format=1, chaining=True):
-        if format == 2:
-            formatType = "Class"
-        elif format == 1:
+        if format == 1:
             formatType = ""
+        elif format == 2:
+            formatType = "Class"
+        else:
+            raise AssertionError(formatType)
         subtablename = f"{self.subtable_type[0:3]}{formatType}Rule"  # Sub, not Subst.
         if chaining:
             subtablename = "Chain" + subtablename

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -343,6 +343,8 @@ class ChainContextualBuilder(LookupBuilder):
             w["LookupType"] = CountReference(
                 {"LookupType": st.LookupType}, "LookupType"
             )
+            # We need to make a copy here because compiling
+            # modifies the subtable (finalizing formats etc.)
             copy.deepcopy(st).compile(w, self.font)
             size += len(w.getAllData())
         return size

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -400,6 +400,50 @@ class ChainContextualBuilder(LookupBuilder):
         setattr(st, f"{self.subtable_type}LookupRecord", [])
         return st
 
+    # Format 1 and format 2 GSUB5/GSUB6/GPOS7/GPOS8 rulesets and rules form a family:
+    #
+    #       format 1 ruleset      format 1 rule      format 2 ruleset      format 2 rule
+    # GSUB5 SubRuleSet            SubRule            SubClassSet           SubClassRule
+    # GSUB6 ChainSubRuleSet       ChainSubRule       ChainSubClassSet      ChainSubClassRule
+    # GPOS7 PosRuleSet            PosRule            PosClassSet           PosClassRule
+    # GPOS8 ChainPosRuleSet       ChainPosRule       ChainPosClassSet      ChainPosClassRule
+    #
+    # The following functions generate the attribute names and subtables according
+    # to this naming convention.
+    def ruleSetAttr_(self, format=1, chaining=True):
+        if format == 2:
+            formatType = "Class"
+        elif format == 1:
+            formatType = "Rule"
+        subtablename = f"{self.subtable_type[0:3]}{formatType}Set"  # Sub, not Subst.
+        if chaining:
+            subtablename = "Chain" + subtablename
+        return subtablename
+
+    def ruleAttr_(self, format=1, chaining=True):
+        if format == 2:
+            formatType = "Class"
+        elif format == 1:
+            formatType = ""
+        subtablename = f"{self.subtable_type[0:3]}{formatType}Rule"  # Sub, not Subst.
+        if chaining:
+            subtablename = "Chain" + subtablename
+        return subtablename
+
+    def newRuleSet_(self, format=1, chaining=True):
+        st = getattr(
+            ot, self.ruleSetAttr_(format, chaining)
+        )()  # ot.ChainPosRuleSet()/ot.SubRuleSet()/etc.
+        st.populateDefaults()
+        return st
+
+    def newRule_(self, format=1, chaining=True):
+        st = getattr(
+            ot, self.ruleAttr_(format, chaining)
+        )()  # ot.ChainPosClassRule()/ot.SubClassRule()/etc.
+        st.populateDefaults()
+        return st
+
     def attachSubtableWithCount_(
         self, st, subtable_name, count_name, existing=None, index=None, chaining=False
     ):

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -414,7 +414,7 @@ class ChainContextualBuilder(LookupBuilder):
             self.buildLookupList(rule, ruleAsSubtable)
 
             firstGlyph = list(rule.glyphs[0])[0]
-            if not firstGlyph in rulesetsByFirstGlyph:
+            if firstGlyph not in rulesetsByFirstGlyph:
                 coverage.add(firstGlyph)
                 rulesetsByFirstGlyph[firstGlyph] = []
             rulesetsByFirstGlyph[firstGlyph].append(ruleAsSubtable)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -357,7 +357,10 @@ class ChainContextualBuilder(LookupBuilder):
             self.setInputCoverage_(rule.glyphs, st)
         else:
             self.setCoverage_(rule.glyphs, st)
+        self.buildLookupList(rule, st)
+        return st
 
+    def buildLookupList(self, rule, st):
         for sequenceIndex, lookupList in enumerate(rule.lookups):
             if lookupList is not None:
                 if not isinstance(lookupList, list):
@@ -377,7 +380,6 @@ class ChainContextualBuilder(LookupBuilder):
                     rec = self.newLookupRecord_(st)
                     rec.SequenceIndex = sequenceIndex
                     rec.LookupListIndex = l.lookup_index
-        return st
 
     def add_subtable_break(self, location):
         self.rules.append(

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -463,6 +463,9 @@ class ChainContextualBuilder(LookupBuilder):
             if chaining:
                 rule_table.BacktrackGlyphCount = len(rule.prefix)
                 rule_table.LookAheadGlyphCount = len(rule.suffix)
+                # The glyphs in the rule may be list, tuple, odict_keys...
+                # Order is not important anyway because they are guaranteed
+                # to be members of the same class.
                 rule_table.Backtrack = [
                     st.BacktrackClassDef.classDefs[list(x)[0]]
                     for x in reversed(rule.prefix)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -456,6 +456,7 @@ class ChainContextualBuilder(LookupBuilder):
         for _ in inClasses:
             classSet = self.newRuleSet_(format=2, chaining=chaining)
             classSet.populateDefaults()
+            classSets.append(classSet)
 
         coverage = set()
         classRuleAttr = self.ruleAttr_(format=2, chaining=chaining)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -393,38 +393,38 @@ class ChainContextualBuilder(LookupBuilder):
         st.Format = 1
         st.populateDefaults()
         coverage = set()
-        rulesets_by_first_glyph = {}
+        rulesetsByFirstGlyph = {}
         ruleAttr = self.ruleAttr_(format=1, chaining=chaining)
 
         for rule in ruleset.rules:
-            rule_table = self.newRule_(format=1, chaining=chaining)
+            ruleAsSubtable = self.newRule_(format=1, chaining=chaining)
 
             if chaining:
-                rule_table.BacktrackGlyphCount = len(rule.prefix)
-                rule_table.LookAheadGlyphCount = len(rule.suffix)
-                rule_table.Backtrack = [list(x)[0] for x in reversed(rule.prefix)]
-                rule_table.LookAhead = [list(x)[0] for x in rule.suffix]
+                ruleAsSubtable.BacktrackGlyphCount = len(rule.prefix)
+                ruleAsSubtable.LookAheadGlyphCount = len(rule.suffix)
+                ruleAsSubtable.Backtrack = [list(x)[0] for x in reversed(rule.prefix)]
+                ruleAsSubtable.LookAhead = [list(x)[0] for x in rule.suffix]
 
-                rule_table.InputGlyphCount = len(rule.glyphs)
+                ruleAsSubtable.InputGlyphCount = len(rule.glyphs)
             else:
-                rule_table.GlyphCount = len(rule.glyphs)
+                ruleAsSubtable.GlyphCount = len(rule.glyphs)
 
-            rule_table.Input = [list(x)[0] for x in rule.glyphs[1:]]
+            ruleAsSubtable.Input = [list(x)[0] for x in rule.glyphs[1:]]
 
-            self.buildLookupList(rule, rule_table)
+            self.buildLookupList(rule, ruleAsSubtable)
 
             firstGlyph = list(rule.glyphs[0])[0]
-            if not firstGlyph in rulesets_by_first_glyph:
+            if not firstGlyph in rulesetsByFirstGlyph:
                 coverage.add(firstGlyph)
-                rulesets_by_first_glyph[firstGlyph] = []
-            rulesets_by_first_glyph[firstGlyph].append(rule_table)
+                rulesetsByFirstGlyph[firstGlyph] = []
+            rulesetsByFirstGlyph[firstGlyph].append(ruleAsSubtable)
 
         st.Coverage = buildCoverage(coverage, self.glyphMap)
         ruleSets = []
         for g in st.Coverage.glyphs:
             ruleSet = self.newRuleSet_(format=1, chaining=chaining)
-            setattr(ruleSet, ruleAttr, rulesets_by_first_glyph[g])
-            setattr(ruleSet, f"{ruleAttr}Count", len(rulesets_by_first_glyph[g]))
+            setattr(ruleSet, ruleAttr, rulesetsByFirstGlyph[g])
+            setattr(ruleSet, f"{ruleAttr}Count", len(rulesetsByFirstGlyph[g]))
             ruleSets.append(ruleSet)
 
         setattr(st, self.ruleSetAttr_(format=1, chaining=chaining), ruleSets)
@@ -459,41 +459,41 @@ class ChainContextualBuilder(LookupBuilder):
         classRuleAttr = self.ruleAttr_(format=2, chaining=chaining)
 
         for rule in ruleset.rules:
-            rule_table = self.newRule_(format=2, chaining=chaining)
+            ruleAsSubtable = self.newRule_(format=2, chaining=chaining)
             if chaining:
-                rule_table.BacktrackGlyphCount = len(rule.prefix)
-                rule_table.LookAheadGlyphCount = len(rule.suffix)
+                ruleAsSubtable.BacktrackGlyphCount = len(rule.prefix)
+                ruleAsSubtable.LookAheadGlyphCount = len(rule.suffix)
                 # The glyphs in the rule may be list, tuple, odict_keys...
                 # Order is not important anyway because they are guaranteed
                 # to be members of the same class.
-                rule_table.Backtrack = [
+                ruleAsSubtable.Backtrack = [
                     st.BacktrackClassDef.classDefs[list(x)[0]]
                     for x in reversed(rule.prefix)
                 ]
-                rule_table.LookAhead = [
+                ruleAsSubtable.LookAhead = [
                     st.LookAheadClassDef.classDefs[list(x)[0]] for x in rule.suffix
                 ]
 
-                rule_table.InputGlyphCount = len(rule.glyphs)
-                rule_table.Input = [
+                ruleAsSubtable.InputGlyphCount = len(rule.glyphs)
+                ruleAsSubtable.Input = [
                     st.InputClassDef.classDefs[list(x)[0]] for x in rule.glyphs[1:]
                 ]
                 setForThisRule = classSets[
                     st.InputClassDef.classDefs[list(rule.glyphs[0])[0]]
                 ]
             else:
-                rule_table.GlyphCount = len(rule.glyphs)
-                rule_table.Class = [  # The spec calls this InputSequence
+                ruleAsSubtable.GlyphCount = len(rule.glyphs)
+                ruleAsSubtable.Class = [  # The spec calls this InputSequence
                     st.ClassDef.classDefs[list(x)[0]] for x in rule.glyphs[1:]
                 ]
                 setForThisRule = classSets[
                     st.ClassDef.classDefs[list(rule.glyphs[0])[0]]
                 ]
 
-            self.buildLookupList(rule, rule_table)
+            self.buildLookupList(rule, ruleAsSubtable)
             coverage |= set(rule.glyphs[0])
 
-            getattr(setForThisRule, classRuleAttr).append(rule_table)
+            getattr(setForThisRule, classRuleAttr).append(ruleAsSubtable)
             setattr(
                 setForThisRule,
                 f"{classRuleAttr}Count",

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -72,7 +72,8 @@ class BuilderTest(unittest.TestCase):
         PairPosSubtable ChainSubstSubtable SubstSubtable ChainPosSubtable 
         LigatureSubtable AlternateSubtable MultipleSubstSubtable 
         SingleSubstSubtable aalt_chain_contextual_subst AlternateChained 
-        MultipleLookupsPerGlyph MultipleLookupsPerGlyph2
+        MultipleLookupsPerGlyph MultipleLookupsPerGlyph2 GSUB_6_formats
+        GSUB_5_formats
     """.split()
 
     def __init__(self, methodName):

--- a/Tests/feaLib/data/ChainPosSubtable.ttx
+++ b/Tests/feaLib/data/ChainPosSubtable.ttx
@@ -67,24 +67,26 @@
             <LookupListIndex value="1"/>
           </PosLookupRecord>
         </ChainContextPos>
-        <ChainContextPos index="1" Format="3">
-          <!-- BacktrackGlyphCount=1 -->
-          <BacktrackCoverage index="0">
-            <Glyph value="X"/>
-          </BacktrackCoverage>
-          <!-- InputGlyphCount=1 -->
-          <InputCoverage index="0">
+        <ChainContextPos index="1" Format="1">
+          <Coverage>
             <Glyph value="A"/>
-          </InputCoverage>
-          <!-- LookAheadGlyphCount=1 -->
-          <LookAheadCoverage index="0">
-            <Glyph value="Y"/>
-          </LookAheadCoverage>
-          <!-- PosCount=1 -->
-          <PosLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="2"/>
-          </PosLookupRecord>
+          </Coverage>
+          <!-- ChainPosRuleSetCount=1 -->
+          <ChainPosRuleSet index="0">
+            <!-- ChainPosRuleCount=1 -->
+            <ChainPosRule index="0">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="X"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="Y"/>
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="2"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+          </ChainPosRuleSet>
         </ChainContextPos>
         <ChainContextPos index="2" Format="3">
           <!-- BacktrackGlyphCount=1 -->

--- a/Tests/feaLib/data/GPOS_8.ttx
+++ b/Tests/feaLib/data/GPOS_8.ttx
@@ -34,42 +34,40 @@
         <LookupType value="8"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
-        <ChainContextPos index="0" Format="3">
-          <!-- BacktrackGlyphCount=1 -->
-          <BacktrackCoverage index="0">
-            <Glyph value="A"/>
-          </BacktrackCoverage>
-          <!-- InputGlyphCount=4 -->
-          <InputCoverage index="0">
+        <ChainContextPos index="0" Format="1">
+          <Coverage>
             <Glyph value="one"/>
-          </InputCoverage>
-          <InputCoverage index="1">
-            <Glyph value="two"/>
-          </InputCoverage>
-          <InputCoverage index="2">
-            <Glyph value="one"/>
-          </InputCoverage>
-          <InputCoverage index="3">
-            <Glyph value="two"/>
-          </InputCoverage>
-          <!-- LookAheadGlyphCount=0 -->
-          <!-- PosCount=4 -->
-          <PosLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="1"/>
-          </PosLookupRecord>
-          <PosLookupRecord index="1">
-            <SequenceIndex value="1"/>
-            <LookupListIndex value="1"/>
-          </PosLookupRecord>
-          <PosLookupRecord index="2">
-            <SequenceIndex value="2"/>
-            <LookupListIndex value="2"/>
-          </PosLookupRecord>
-          <PosLookupRecord index="3">
-            <SequenceIndex value="3"/>
-            <LookupListIndex value="2"/>
-          </PosLookupRecord>
+          </Coverage>
+          <!-- ChainPosRuleSetCount=1 -->
+          <ChainPosRuleSet index="0">
+            <!-- ChainPosRuleCount=1 -->
+            <ChainPosRule index="0">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="A"/>
+              <!-- InputGlyphCount=4 -->
+              <Input index="0" value="two"/>
+              <Input index="1" value="one"/>
+              <Input index="2" value="two"/>
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- PosCount=4 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+              <PosLookupRecord index="1">
+                <SequenceIndex value="1"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+              <PosLookupRecord index="2">
+                <SequenceIndex value="2"/>
+                <LookupListIndex value="2"/>
+              </PosLookupRecord>
+              <PosLookupRecord index="3">
+                <SequenceIndex value="3"/>
+                <LookupListIndex value="2"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+          </ChainPosRuleSet>
         </ChainContextPos>
       </Lookup>
       <Lookup index="1">

--- a/Tests/feaLib/data/GSUB_5_formats.fea
+++ b/Tests/feaLib/data/GSUB_5_formats.fea
@@ -1,0 +1,20 @@
+lookup GSUB5f1 {
+    ignore sub three four;
+    ignore sub four five;
+} GSUB5f1;
+
+lookup GSUB5f2 {
+    ignore sub [a - z] [A - H] [I - Z];
+    ignore sub [a - z] [A - H] [I - Z];
+    ignore sub [a - z] [I - Z] [A - H];
+} GSUB5f2;
+
+lookup GSUB5f3 {
+    ignore sub e;
+} GSUB5f3;
+
+feature test {
+    lookup GSUB5f1;
+    lookup GSUB5f2;
+    lookup GSUB5f3;
+} test;

--- a/Tests/feaLib/data/GSUB_5_formats.ttx
+++ b/Tests/feaLib/data/GSUB_5_formats.ttx
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=3 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+          <LookupListIndex index="2" value="2"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=3 -->
+      <Lookup index="0">
+        <LookupType value="5"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ContextSubst index="0" Format="1">
+          <Coverage>
+            <Glyph value="three"/>
+            <Glyph value="four"/>
+          </Coverage>
+          <!-- SubRuleSetCount=2 -->
+          <SubRuleSet index="0">
+            <!-- SubRuleCount=1 -->
+            <SubRule index="0">
+              <!-- GlyphCount=2 -->
+              <!-- SubstCount=0 -->
+              <Input index="0" value="four"/>
+            </SubRule>
+          </SubRuleSet>
+          <SubRuleSet index="1">
+            <!-- SubRuleCount=1 -->
+            <SubRule index="0">
+              <!-- GlyphCount=2 -->
+              <!-- SubstCount=0 -->
+              <Input index="0" value="five"/>
+            </SubRule>
+          </SubRuleSet>
+        </ContextSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="5"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ContextSubst index="0" Format="2">
+          <Coverage>
+            <Glyph value="a"/>
+            <Glyph value="b"/>
+            <Glyph value="c"/>
+            <Glyph value="d"/>
+            <Glyph value="e"/>
+            <Glyph value="f"/>
+            <Glyph value="g"/>
+            <Glyph value="h"/>
+            <Glyph value="i"/>
+            <Glyph value="j"/>
+            <Glyph value="k"/>
+            <Glyph value="l"/>
+            <Glyph value="m"/>
+            <Glyph value="n"/>
+            <Glyph value="o"/>
+            <Glyph value="p"/>
+            <Glyph value="q"/>
+            <Glyph value="r"/>
+            <Glyph value="s"/>
+            <Glyph value="t"/>
+            <Glyph value="u"/>
+            <Glyph value="v"/>
+            <Glyph value="w"/>
+            <Glyph value="x"/>
+            <Glyph value="y"/>
+            <Glyph value="z"/>
+          </Coverage>
+          <ClassDef>
+            <ClassDef glyph="A" class="3"/>
+            <ClassDef glyph="B" class="3"/>
+            <ClassDef glyph="C" class="3"/>
+            <ClassDef glyph="D" class="3"/>
+            <ClassDef glyph="E" class="3"/>
+            <ClassDef glyph="F" class="3"/>
+            <ClassDef glyph="G" class="3"/>
+            <ClassDef glyph="H" class="3"/>
+            <ClassDef glyph="I" class="2"/>
+            <ClassDef glyph="J" class="2"/>
+            <ClassDef glyph="K" class="2"/>
+            <ClassDef glyph="L" class="2"/>
+            <ClassDef glyph="M" class="2"/>
+            <ClassDef glyph="N" class="2"/>
+            <ClassDef glyph="O" class="2"/>
+            <ClassDef glyph="P" class="2"/>
+            <ClassDef glyph="Q" class="2"/>
+            <ClassDef glyph="R" class="2"/>
+            <ClassDef glyph="S" class="2"/>
+            <ClassDef glyph="T" class="2"/>
+            <ClassDef glyph="U" class="2"/>
+            <ClassDef glyph="V" class="2"/>
+            <ClassDef glyph="W" class="2"/>
+            <ClassDef glyph="X" class="2"/>
+            <ClassDef glyph="Y" class="2"/>
+            <ClassDef glyph="Z" class="2"/>
+            <ClassDef glyph="a" class="1"/>
+            <ClassDef glyph="b" class="1"/>
+            <ClassDef glyph="c" class="1"/>
+            <ClassDef glyph="d" class="1"/>
+            <ClassDef glyph="e" class="1"/>
+            <ClassDef glyph="f" class="1"/>
+            <ClassDef glyph="g" class="1"/>
+            <ClassDef glyph="h" class="1"/>
+            <ClassDef glyph="i" class="1"/>
+            <ClassDef glyph="j" class="1"/>
+            <ClassDef glyph="k" class="1"/>
+            <ClassDef glyph="l" class="1"/>
+            <ClassDef glyph="m" class="1"/>
+            <ClassDef glyph="n" class="1"/>
+            <ClassDef glyph="o" class="1"/>
+            <ClassDef glyph="p" class="1"/>
+            <ClassDef glyph="q" class="1"/>
+            <ClassDef glyph="r" class="1"/>
+            <ClassDef glyph="s" class="1"/>
+            <ClassDef glyph="t" class="1"/>
+            <ClassDef glyph="u" class="1"/>
+            <ClassDef glyph="v" class="1"/>
+            <ClassDef glyph="w" class="1"/>
+            <ClassDef glyph="x" class="1"/>
+            <ClassDef glyph="y" class="1"/>
+            <ClassDef glyph="z" class="1"/>
+          </ClassDef>
+          <!-- SubClassSetCount=4 -->
+          <SubClassSet index="0">
+            <!-- SubClassRuleCount=0 -->
+          </SubClassSet>
+          <SubClassSet index="1">
+            <!-- SubClassRuleCount=3 -->
+            <SubClassRule index="0">
+              <!-- GlyphCount=3 -->
+              <!-- SubstCount=0 -->
+              <Class index="0" value="3"/>
+              <Class index="1" value="2"/>
+            </SubClassRule>
+            <SubClassRule index="1">
+              <!-- GlyphCount=3 -->
+              <!-- SubstCount=0 -->
+              <Class index="0" value="3"/>
+              <Class index="1" value="2"/>
+            </SubClassRule>
+            <SubClassRule index="2">
+              <!-- GlyphCount=3 -->
+              <!-- SubstCount=0 -->
+              <Class index="0" value="2"/>
+              <Class index="1" value="3"/>
+            </SubClassRule>
+          </SubClassSet>
+          <SubClassSet index="2">
+            <!-- SubClassRuleCount=0 -->
+          </SubClassSet>
+          <SubClassSet index="3">
+            <!-- SubClassRuleCount=0 -->
+          </SubClassSet>
+        </ContextSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="5"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ContextSubst index="0" Format="3">
+          <!-- GlyphCount=1 -->
+          <!-- SubstCount=0 -->
+          <Coverage index="0">
+            <Glyph value="e"/>
+          </Coverage>
+        </ContextSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/Tests/feaLib/data/GSUB_6.ttx
+++ b/Tests/feaLib/data/GSUB_6.ttx
@@ -229,36 +229,30 @@
         <LookupType value="6"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
-        <ChainContextSubst index="0" Format="3">
-          <!-- BacktrackGlyphCount=3 -->
-          <BacktrackCoverage index="0">
-            <Glyph value="E"/>
-          </BacktrackCoverage>
-          <BacktrackCoverage index="1">
-            <Glyph value="D"/>
-          </BacktrackCoverage>
-          <BacktrackCoverage index="2">
-            <Glyph value="A"/>
-          </BacktrackCoverage>
-          <!-- InputGlyphCount=1 -->
-          <InputCoverage index="0">
+        <ChainContextSubst index="0" Format="1">
+          <Coverage>
             <Glyph value="c_t"/>
-          </InputCoverage>
-          <!-- LookAheadGlyphCount=3 -->
-          <LookAheadCoverage index="0">
-            <Glyph value="V"/>
-          </LookAheadCoverage>
-          <LookAheadCoverage index="1">
-            <Glyph value="W"/>
-          </LookAheadCoverage>
-          <LookAheadCoverage index="2">
-            <Glyph value="X"/>
-          </LookAheadCoverage>
-          <!-- SubstCount=1 -->
-          <SubstLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="2"/>
-          </SubstLookupRecord>
+          </Coverage>
+          <!-- ChainSubRuleSetCount=1 -->
+          <ChainSubRuleSet index="0">
+            <!-- ChainSubRuleCount=1 -->
+            <ChainSubRule index="0">
+              <!-- BacktrackGlyphCount=3 -->
+              <Backtrack index="0" value="E"/>
+              <Backtrack index="1" value="D"/>
+              <Backtrack index="2" value="A"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=3 -->
+              <LookAhead index="0" value="V"/>
+              <LookAhead index="1" value="W"/>
+              <LookAhead index="2" value="X"/>
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="2"/>
+              </SubstLookupRecord>
+            </ChainSubRule>
+          </ChainSubRuleSet>
         </ChainContextSubst>
       </Lookup>
     </LookupList>

--- a/Tests/feaLib/data/GSUB_6_formats.fea
+++ b/Tests/feaLib/data/GSUB_6_formats.fea
@@ -1,0 +1,20 @@
+lookup GSUB6f1 {
+    ignore sub one two three' four' five six seven;
+    ignore sub two one three' four' six five seven;
+} GSUB6f1;
+
+lookup GSUB6f2 {
+    ignore sub [A - H] [I - Z] [a - z]' [A - H]' [I - Z]';
+    ignore sub [I - Z] [A - H] [a - z]' [A - H]' [I - Z]';
+    ignore sub [A - H] [I - Z] [a - z]' [I - Z]' [A - H]';
+} GSUB6f2;
+
+lookup GSUB6f3 {
+    ignore sub [space comma semicolon] e';
+} GSUB6f3;
+
+feature test {
+    lookup GSUB6f1;
+    lookup GSUB6f2;
+    lookup GSUB6f3;
+} test;

--- a/Tests/feaLib/data/GSUB_6_formats.ttx
+++ b/Tests/feaLib/data/GSUB_6_formats.ttx
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=3 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+          <LookupListIndex index="2" value="2"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=3 -->
+      <Lookup index="0">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="1">
+          <Coverage>
+            <Glyph value="three"/>
+          </Coverage>
+          <!-- ChainSubRuleSetCount=1 -->
+          <ChainSubRuleSet index="0">
+            <!-- ChainSubRuleCount=2 -->
+            <ChainSubRule index="0">
+              <!-- BacktrackGlyphCount=2 -->
+              <Backtrack index="0" value="two"/>
+              <Backtrack index="1" value="one"/>
+              <!-- InputGlyphCount=2 -->
+              <Input index="0" value="four"/>
+              <!-- LookAheadGlyphCount=3 -->
+              <LookAhead index="0" value="five"/>
+              <LookAhead index="1" value="six"/>
+              <LookAhead index="2" value="seven"/>
+              <!-- SubstCount=0 -->
+            </ChainSubRule>
+            <ChainSubRule index="1">
+              <!-- BacktrackGlyphCount=2 -->
+              <Backtrack index="0" value="one"/>
+              <Backtrack index="1" value="two"/>
+              <!-- InputGlyphCount=2 -->
+              <Input index="0" value="four"/>
+              <!-- LookAheadGlyphCount=3 -->
+              <LookAhead index="0" value="six"/>
+              <LookAhead index="1" value="five"/>
+              <LookAhead index="2" value="seven"/>
+              <!-- SubstCount=0 -->
+            </ChainSubRule>
+          </ChainSubRuleSet>
+        </ChainContextSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="2">
+          <Coverage>
+            <Glyph value="a"/>
+            <Glyph value="b"/>
+            <Glyph value="c"/>
+            <Glyph value="d"/>
+            <Glyph value="e"/>
+            <Glyph value="f"/>
+            <Glyph value="g"/>
+            <Glyph value="h"/>
+            <Glyph value="i"/>
+            <Glyph value="j"/>
+            <Glyph value="k"/>
+            <Glyph value="l"/>
+            <Glyph value="m"/>
+            <Glyph value="n"/>
+            <Glyph value="o"/>
+            <Glyph value="p"/>
+            <Glyph value="q"/>
+            <Glyph value="r"/>
+            <Glyph value="s"/>
+            <Glyph value="t"/>
+            <Glyph value="u"/>
+            <Glyph value="v"/>
+            <Glyph value="w"/>
+            <Glyph value="x"/>
+            <Glyph value="y"/>
+            <Glyph value="z"/>
+          </Coverage>
+          <BacktrackClassDef>
+            <ClassDef glyph="A" class="2"/>
+            <ClassDef glyph="B" class="2"/>
+            <ClassDef glyph="C" class="2"/>
+            <ClassDef glyph="D" class="2"/>
+            <ClassDef glyph="E" class="2"/>
+            <ClassDef glyph="F" class="2"/>
+            <ClassDef glyph="G" class="2"/>
+            <ClassDef glyph="H" class="2"/>
+            <ClassDef glyph="I" class="1"/>
+            <ClassDef glyph="J" class="1"/>
+            <ClassDef glyph="K" class="1"/>
+            <ClassDef glyph="L" class="1"/>
+            <ClassDef glyph="M" class="1"/>
+            <ClassDef glyph="N" class="1"/>
+            <ClassDef glyph="O" class="1"/>
+            <ClassDef glyph="P" class="1"/>
+            <ClassDef glyph="Q" class="1"/>
+            <ClassDef glyph="R" class="1"/>
+            <ClassDef glyph="S" class="1"/>
+            <ClassDef glyph="T" class="1"/>
+            <ClassDef glyph="U" class="1"/>
+            <ClassDef glyph="V" class="1"/>
+            <ClassDef glyph="W" class="1"/>
+            <ClassDef glyph="X" class="1"/>
+            <ClassDef glyph="Y" class="1"/>
+            <ClassDef glyph="Z" class="1"/>
+          </BacktrackClassDef>
+          <InputClassDef>
+            <ClassDef glyph="A" class="3"/>
+            <ClassDef glyph="B" class="3"/>
+            <ClassDef glyph="C" class="3"/>
+            <ClassDef glyph="D" class="3"/>
+            <ClassDef glyph="E" class="3"/>
+            <ClassDef glyph="F" class="3"/>
+            <ClassDef glyph="G" class="3"/>
+            <ClassDef glyph="H" class="3"/>
+            <ClassDef glyph="I" class="2"/>
+            <ClassDef glyph="J" class="2"/>
+            <ClassDef glyph="K" class="2"/>
+            <ClassDef glyph="L" class="2"/>
+            <ClassDef glyph="M" class="2"/>
+            <ClassDef glyph="N" class="2"/>
+            <ClassDef glyph="O" class="2"/>
+            <ClassDef glyph="P" class="2"/>
+            <ClassDef glyph="Q" class="2"/>
+            <ClassDef glyph="R" class="2"/>
+            <ClassDef glyph="S" class="2"/>
+            <ClassDef glyph="T" class="2"/>
+            <ClassDef glyph="U" class="2"/>
+            <ClassDef glyph="V" class="2"/>
+            <ClassDef glyph="W" class="2"/>
+            <ClassDef glyph="X" class="2"/>
+            <ClassDef glyph="Y" class="2"/>
+            <ClassDef glyph="Z" class="2"/>
+            <ClassDef glyph="a" class="1"/>
+            <ClassDef glyph="b" class="1"/>
+            <ClassDef glyph="c" class="1"/>
+            <ClassDef glyph="d" class="1"/>
+            <ClassDef glyph="e" class="1"/>
+            <ClassDef glyph="f" class="1"/>
+            <ClassDef glyph="g" class="1"/>
+            <ClassDef glyph="h" class="1"/>
+            <ClassDef glyph="i" class="1"/>
+            <ClassDef glyph="j" class="1"/>
+            <ClassDef glyph="k" class="1"/>
+            <ClassDef glyph="l" class="1"/>
+            <ClassDef glyph="m" class="1"/>
+            <ClassDef glyph="n" class="1"/>
+            <ClassDef glyph="o" class="1"/>
+            <ClassDef glyph="p" class="1"/>
+            <ClassDef glyph="q" class="1"/>
+            <ClassDef glyph="r" class="1"/>
+            <ClassDef glyph="s" class="1"/>
+            <ClassDef glyph="t" class="1"/>
+            <ClassDef glyph="u" class="1"/>
+            <ClassDef glyph="v" class="1"/>
+            <ClassDef glyph="w" class="1"/>
+            <ClassDef glyph="x" class="1"/>
+            <ClassDef glyph="y" class="1"/>
+            <ClassDef glyph="z" class="1"/>
+          </InputClassDef>
+          <LookAheadClassDef>
+          </LookAheadClassDef>
+          <!-- ChainSubClassSetCount=4 -->
+          <ChainSubClassSet index="0">
+            <!-- ChainSubClassRuleCount=0 -->
+          </ChainSubClassSet>
+          <ChainSubClassSet index="1">
+            <!-- ChainSubClassRuleCount=3 -->
+            <ChainSubClassRule index="0">
+              <!-- BacktrackGlyphCount=2 -->
+              <Backtrack index="0" value="1"/>
+              <Backtrack index="1" value="2"/>
+              <!-- InputGlyphCount=3 -->
+              <Input index="0" value="3"/>
+              <Input index="1" value="2"/>
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=0 -->
+            </ChainSubClassRule>
+            <ChainSubClassRule index="1">
+              <!-- BacktrackGlyphCount=2 -->
+              <Backtrack index="0" value="2"/>
+              <Backtrack index="1" value="1"/>
+              <!-- InputGlyphCount=3 -->
+              <Input index="0" value="3"/>
+              <Input index="1" value="2"/>
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=0 -->
+            </ChainSubClassRule>
+            <ChainSubClassRule index="2">
+              <!-- BacktrackGlyphCount=2 -->
+              <Backtrack index="0" value="1"/>
+              <Backtrack index="1" value="2"/>
+              <!-- InputGlyphCount=3 -->
+              <Input index="0" value="2"/>
+              <Input index="1" value="3"/>
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=0 -->
+            </ChainSubClassRule>
+          </ChainSubClassSet>
+          <ChainSubClassSet index="2">
+            <!-- ChainSubClassRuleCount=0 -->
+          </ChainSubClassSet>
+          <ChainSubClassSet index="3">
+            <!-- ChainSubClassRuleCount=0 -->
+          </ChainSubClassSet>
+        </ChainContextSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="3">
+          <!-- BacktrackGlyphCount=1 -->
+          <BacktrackCoverage index="0">
+            <Glyph value="space"/>
+            <Glyph value="semicolon"/>
+            <Glyph value="comma"/>
+          </BacktrackCoverage>
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0">
+            <Glyph value="e"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- SubstCount=0 -->
+        </ChainContextSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/Tests/feaLib/data/ZeroValue_ChainSinglePos_horizontal.ttx
+++ b/Tests/feaLib/data/ZeroValue_ChainSinglePos_horizontal.ttx
@@ -32,44 +32,39 @@
       <Lookup index="0">
         <LookupType value="8"/>
         <LookupFlag value="0"/>
-        <!-- SubTableCount=2 -->
-        <ChainContextPos index="0" Format="3">
-          <!-- BacktrackGlyphCount=1 -->
-          <BacktrackCoverage index="0">
-            <Glyph value="A"/>
-          </BacktrackCoverage>
-          <!-- InputGlyphCount=1 -->
-          <InputCoverage index="0">
+        <!-- SubTableCount=1 -->
+        <ChainContextPos index="0" Format="1">
+          <Coverage>
             <Glyph value="G"/>
-          </InputCoverage>
-          <!-- LookAheadGlyphCount=1 -->
-          <LookAheadCoverage index="0">
-            <Glyph value="A"/>
-          </LookAheadCoverage>
-          <!-- PosCount=1 -->
-          <PosLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="1"/>
-          </PosLookupRecord>
-        </ChainContextPos>
-        <ChainContextPos index="1" Format="3">
-          <!-- BacktrackGlyphCount=1 -->
-          <BacktrackCoverage index="0">
-            <Glyph value="B"/>
-          </BacktrackCoverage>
-          <!-- InputGlyphCount=1 -->
-          <InputCoverage index="0">
-            <Glyph value="G"/>
-          </InputCoverage>
-          <!-- LookAheadGlyphCount=1 -->
-          <LookAheadCoverage index="0">
-            <Glyph value="B"/>
-          </LookAheadCoverage>
-          <!-- PosCount=1 -->
-          <PosLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="1"/>
-          </PosLookupRecord>
+          </Coverage>
+          <!-- ChainPosRuleSetCount=1 -->
+          <ChainPosRuleSet index="0">
+            <!-- ChainPosRuleCount=2 -->
+            <ChainPosRule index="0">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="A"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="A"/>
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+            <ChainPosRule index="1">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="B"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="B"/>
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+          </ChainPosRuleSet>
         </ChainContextPos>
       </Lookup>
       <Lookup index="1">

--- a/Tests/feaLib/data/ZeroValue_ChainSinglePos_vertical.ttx
+++ b/Tests/feaLib/data/ZeroValue_ChainSinglePos_vertical.ttx
@@ -32,44 +32,39 @@
       <Lookup index="0">
         <LookupType value="8"/>
         <LookupFlag value="0"/>
-        <!-- SubTableCount=2 -->
-        <ChainContextPos index="0" Format="3">
-          <!-- BacktrackGlyphCount=1 -->
-          <BacktrackCoverage index="0">
-            <Glyph value="A"/>
-          </BacktrackCoverage>
-          <!-- InputGlyphCount=1 -->
-          <InputCoverage index="0">
+        <!-- SubTableCount=1 -->
+        <ChainContextPos index="0" Format="1">
+          <Coverage>
             <Glyph value="G"/>
-          </InputCoverage>
-          <!-- LookAheadGlyphCount=1 -->
-          <LookAheadCoverage index="0">
-            <Glyph value="A"/>
-          </LookAheadCoverage>
-          <!-- PosCount=1 -->
-          <PosLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="1"/>
-          </PosLookupRecord>
-        </ChainContextPos>
-        <ChainContextPos index="1" Format="3">
-          <!-- BacktrackGlyphCount=1 -->
-          <BacktrackCoverage index="0">
-            <Glyph value="B"/>
-          </BacktrackCoverage>
-          <!-- InputGlyphCount=1 -->
-          <InputCoverage index="0">
-            <Glyph value="G"/>
-          </InputCoverage>
-          <!-- LookAheadGlyphCount=1 -->
-          <LookAheadCoverage index="0">
-            <Glyph value="B"/>
-          </LookAheadCoverage>
-          <!-- PosCount=1 -->
-          <PosLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="1"/>
-          </PosLookupRecord>
+          </Coverage>
+          <!-- ChainPosRuleSetCount=1 -->
+          <ChainPosRuleSet index="0">
+            <!-- ChainPosRuleCount=2 -->
+            <ChainPosRule index="0">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="A"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="A"/>
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+            <ChainPosRule index="1">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="B"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="B"/>
+              <!-- PosCount=1 -->
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+            </ChainPosRule>
+          </ChainPosRuleSet>
         </ChainContextPos>
       </Lookup>
       <Lookup index="1">

--- a/Tests/feaLib/data/bug512.ttx
+++ b/Tests/feaLib/data/bug512.ttx
@@ -32,50 +32,51 @@
       <Lookup index="0">
         <LookupType value="5"/>
         <LookupFlag value="0"/>
-        <!-- SubTableCount=4 -->
-        <ContextSubst index="0" Format="3">
-          <!-- GlyphCount=1 -->
-          <!-- SubstCount=1 -->
-          <Coverage index="0">
+        <!-- SubTableCount=1 -->
+        <ContextSubst index="0" Format="1">
+          <Coverage>
             <Glyph value="G"/>
-          </Coverage>
-          <SubstLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="1"/>
-          </SubstLookupRecord>
-        </ContextSubst>
-        <ContextSubst index="1" Format="3">
-          <!-- GlyphCount=1 -->
-          <!-- SubstCount=1 -->
-          <Coverage index="0">
             <Glyph value="H"/>
           </Coverage>
-          <SubstLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="1"/>
-          </SubstLookupRecord>
-        </ContextSubst>
-        <ContextSubst index="2" Format="3">
-          <!-- GlyphCount=1 -->
-          <!-- SubstCount=1 -->
-          <Coverage index="0">
-            <Glyph value="G"/>
-          </Coverage>
-          <SubstLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="2"/>
-          </SubstLookupRecord>
-        </ContextSubst>
-        <ContextSubst index="3" Format="3">
-          <!-- GlyphCount=1 -->
-          <!-- SubstCount=1 -->
-          <Coverage index="0">
-            <Glyph value="H"/>
-          </Coverage>
-          <SubstLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="2"/>
-          </SubstLookupRecord>
+          <!-- SubRuleSetCount=2 -->
+          <SubRuleSet index="0">
+            <!-- SubRuleCount=2 -->
+            <SubRule index="0">
+              <!-- GlyphCount=1 -->
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </SubRule>
+            <SubRule index="1">
+              <!-- GlyphCount=1 -->
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="2"/>
+              </SubstLookupRecord>
+            </SubRule>
+          </SubRuleSet>
+          <SubRuleSet index="1">
+            <!-- SubRuleCount=2 -->
+            <SubRule index="0">
+              <!-- GlyphCount=1 -->
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </SubRule>
+            <SubRule index="1">
+              <!-- GlyphCount=1 -->
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="2"/>
+              </SubstLookupRecord>
+            </SubRule>
+          </SubRuleSet>
         </ContextSubst>
       </Lookup>
       <Lookup index="1">

--- a/Tests/feaLib/data/spec5f_ii_3.ttx
+++ b/Tests/feaLib/data/spec5f_ii_3.ttx
@@ -32,111 +32,115 @@
       <Lookup index="0">
         <LookupType value="6"/>
         <LookupFlag value="0"/>
-        <!-- SubTableCount=3 -->
-        <ChainContextSubst index="0" Format="3">
-          <!-- BacktrackGlyphCount=1 -->
-          <BacktrackCoverage index="0">
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="2">
+          <Coverage>
             <Glyph value="a"/>
-            <Glyph value="b"/>
-            <Glyph value="c"/>
-            <Glyph value="d"/>
-            <Glyph value="e"/>
-            <Glyph value="f"/>
-            <Glyph value="g"/>
-            <Glyph value="h"/>
-            <Glyph value="i"/>
-            <Glyph value="j"/>
-            <Glyph value="k"/>
-            <Glyph value="l"/>
-            <Glyph value="m"/>
-            <Glyph value="n"/>
-            <Glyph value="o"/>
-            <Glyph value="p"/>
-            <Glyph value="q"/>
-            <Glyph value="r"/>
-            <Glyph value="s"/>
-            <Glyph value="t"/>
-            <Glyph value="u"/>
-            <Glyph value="v"/>
-            <Glyph value="w"/>
-            <Glyph value="x"/>
-            <Glyph value="y"/>
-            <Glyph value="z"/>
-          </BacktrackCoverage>
-          <!-- InputGlyphCount=3 -->
-          <InputCoverage index="0">
-            <Glyph value="a"/>
-          </InputCoverage>
-          <InputCoverage index="1">
-            <Glyph value="n"/>
-          </InputCoverage>
-          <InputCoverage index="2">
-            <Glyph value="d"/>
-          </InputCoverage>
-          <!-- LookAheadGlyphCount=0 -->
-          <!-- SubstCount=0 -->
-        </ChainContextSubst>
-        <ChainContextSubst index="1" Format="3">
-          <!-- BacktrackGlyphCount=0 -->
-          <!-- InputGlyphCount=3 -->
-          <InputCoverage index="0">
-            <Glyph value="a"/>
-          </InputCoverage>
-          <InputCoverage index="1">
-            <Glyph value="n"/>
-          </InputCoverage>
-          <InputCoverage index="2">
-            <Glyph value="d"/>
-          </InputCoverage>
-          <!-- LookAheadGlyphCount=1 -->
-          <LookAheadCoverage index="0">
-            <Glyph value="a"/>
-            <Glyph value="b"/>
-            <Glyph value="c"/>
-            <Glyph value="d"/>
-            <Glyph value="e"/>
-            <Glyph value="f"/>
-            <Glyph value="g"/>
-            <Glyph value="h"/>
-            <Glyph value="i"/>
-            <Glyph value="j"/>
-            <Glyph value="k"/>
-            <Glyph value="l"/>
-            <Glyph value="m"/>
-            <Glyph value="n"/>
-            <Glyph value="o"/>
-            <Glyph value="p"/>
-            <Glyph value="q"/>
-            <Glyph value="r"/>
-            <Glyph value="s"/>
-            <Glyph value="t"/>
-            <Glyph value="u"/>
-            <Glyph value="v"/>
-            <Glyph value="w"/>
-            <Glyph value="x"/>
-            <Glyph value="y"/>
-            <Glyph value="z"/>
-          </LookAheadCoverage>
-          <!-- SubstCount=0 -->
-        </ChainContextSubst>
-        <ChainContextSubst index="2" Format="3">
-          <!-- BacktrackGlyphCount=0 -->
-          <!-- InputGlyphCount=3 -->
-          <InputCoverage index="0">
-            <Glyph value="a"/>
-          </InputCoverage>
-          <InputCoverage index="1">
-            <Glyph value="n"/>
-          </InputCoverage>
-          <InputCoverage index="2">
-            <Glyph value="d"/>
-          </InputCoverage>
-          <!-- LookAheadGlyphCount=0 -->
-          <!-- SubstCount=1 -->
-          <SubstLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="1"/>
-          </SubstLookupRecord>
+          </Coverage>
+          <BacktrackClassDef>
+            <ClassDef glyph="a" class="1"/>
+            <ClassDef glyph="b" class="1"/>
+            <ClassDef glyph="c" class="1"/>
+            <ClassDef glyph="d" class="1"/>
+            <ClassDef glyph="e" class="1"/>
+            <ClassDef glyph="f" class="1"/>
+            <ClassDef glyph="g" class="1"/>
+            <ClassDef glyph="h" class="1"/>
+            <ClassDef glyph="i" class="1"/>
+            <ClassDef glyph="j" class="1"/>
+            <ClassDef glyph="k" class="1"/>
+            <ClassDef glyph="l" class="1"/>
+            <ClassDef glyph="m" class="1"/>
+            <ClassDef glyph="n" class="1"/>
+            <ClassDef glyph="o" class="1"/>
+            <ClassDef glyph="p" class="1"/>
+            <ClassDef glyph="q" class="1"/>
+            <ClassDef glyph="r" class="1"/>
+            <ClassDef glyph="s" class="1"/>
+            <ClassDef glyph="t" class="1"/>
+            <ClassDef glyph="u" class="1"/>
+            <ClassDef glyph="v" class="1"/>
+            <ClassDef glyph="w" class="1"/>
+            <ClassDef glyph="x" class="1"/>
+            <ClassDef glyph="y" class="1"/>
+            <ClassDef glyph="z" class="1"/>
+          </BacktrackClassDef>
+          <InputClassDef>
+            <ClassDef glyph="a" class="3"/>
+            <ClassDef glyph="d" class="2"/>
+            <ClassDef glyph="n" class="1"/>
+          </InputClassDef>
+          <LookAheadClassDef>
+            <ClassDef glyph="a" class="1"/>
+            <ClassDef glyph="b" class="1"/>
+            <ClassDef glyph="c" class="1"/>
+            <ClassDef glyph="d" class="1"/>
+            <ClassDef glyph="e" class="1"/>
+            <ClassDef glyph="f" class="1"/>
+            <ClassDef glyph="g" class="1"/>
+            <ClassDef glyph="h" class="1"/>
+            <ClassDef glyph="i" class="1"/>
+            <ClassDef glyph="j" class="1"/>
+            <ClassDef glyph="k" class="1"/>
+            <ClassDef glyph="l" class="1"/>
+            <ClassDef glyph="m" class="1"/>
+            <ClassDef glyph="n" class="1"/>
+            <ClassDef glyph="o" class="1"/>
+            <ClassDef glyph="p" class="1"/>
+            <ClassDef glyph="q" class="1"/>
+            <ClassDef glyph="r" class="1"/>
+            <ClassDef glyph="s" class="1"/>
+            <ClassDef glyph="t" class="1"/>
+            <ClassDef glyph="u" class="1"/>
+            <ClassDef glyph="v" class="1"/>
+            <ClassDef glyph="w" class="1"/>
+            <ClassDef glyph="x" class="1"/>
+            <ClassDef glyph="y" class="1"/>
+            <ClassDef glyph="z" class="1"/>
+          </LookAheadClassDef>
+          <!-- ChainSubClassSetCount=4 -->
+          <ChainSubClassSet index="0">
+            <!-- ChainSubClassRuleCount=0 -->
+          </ChainSubClassSet>
+          <ChainSubClassSet index="1">
+            <!-- ChainSubClassRuleCount=0 -->
+          </ChainSubClassSet>
+          <ChainSubClassSet index="2">
+            <!-- ChainSubClassRuleCount=0 -->
+          </ChainSubClassSet>
+          <ChainSubClassSet index="3">
+            <!-- ChainSubClassRuleCount=3 -->
+            <ChainSubClassRule index="0">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="1"/>
+              <!-- InputGlyphCount=3 -->
+              <Input index="0" value="1"/>
+              <Input index="1" value="2"/>
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=0 -->
+            </ChainSubClassRule>
+            <ChainSubClassRule index="1">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=3 -->
+              <Input index="0" value="1"/>
+              <Input index="1" value="2"/>
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="1"/>
+              <!-- SubstCount=0 -->
+            </ChainSubClassRule>
+            <ChainSubClassRule index="2">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=3 -->
+              <Input index="0" value="1"/>
+              <Input index="1" value="2"/>
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </ChainSubClassRule>
+          </ChainSubClassSet>
         </ChainContextSubst>
       </Lookup>
       <Lookup index="1">

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_7_diff.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_7_diff.ttx
@@ -86,26 +86,28 @@
         <LookupType value="7"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
-        <ContextPos index="0" Format="3">
-          <!-- GlyphCount=3 -->
-          <!-- PosCount=2 -->
-          <Coverage index="0" Format="1">
+        <ContextPos index="0" Format="1">
+          <Coverage Format="1">
             <Glyph value="A"/>
           </Coverage>
-          <Coverage index="1" Format="1">
-            <Glyph value="a"/>
-          </Coverage>
-          <Coverage index="2" Format="1">
-            <Glyph value="uni0303"/>
-          </Coverage>
-          <PosLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="0"/>
-          </PosLookupRecord>
-          <PosLookupRecord index="1">
-            <SequenceIndex value="2"/>
-            <LookupListIndex value="1"/>
-          </PosLookupRecord>
+          <!-- PosRuleSetCount=1 -->
+          <PosRuleSet index="0">
+            <!-- PosRuleCount=1 -->
+            <PosRule index="0">
+              <!-- GlyphCount=3 -->
+              <!-- PosCount=2 -->
+              <Input index="0" value="a"/>
+              <Input index="1" value="uni0303"/>
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="0"/>
+              </PosLookupRecord>
+              <PosLookupRecord index="1">
+                <SequenceIndex value="2"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+            </PosRule>
+          </PosRuleSet>
         </ContextPos>
       </Lookup>
     </LookupList>

--- a/Tests/varLib/data/test_results/InterpolateLayoutGPOS_7_same.ttx
+++ b/Tests/varLib/data/test_results/InterpolateLayoutGPOS_7_same.ttx
@@ -86,26 +86,28 @@
         <LookupType value="7"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
-        <ContextPos index="0" Format="3">
-          <!-- GlyphCount=3 -->
-          <!-- PosCount=2 -->
-          <Coverage index="0" Format="1">
+        <ContextPos index="0" Format="1">
+          <Coverage Format="1">
             <Glyph value="A"/>
           </Coverage>
-          <Coverage index="1" Format="1">
-            <Glyph value="a"/>
-          </Coverage>
-          <Coverage index="2" Format="1">
-            <Glyph value="uni0303"/>
-          </Coverage>
-          <PosLookupRecord index="0">
-            <SequenceIndex value="0"/>
-            <LookupListIndex value="0"/>
-          </PosLookupRecord>
-          <PosLookupRecord index="1">
-            <SequenceIndex value="2"/>
-            <LookupListIndex value="1"/>
-          </PosLookupRecord>
+          <!-- PosRuleSetCount=1 -->
+          <PosRuleSet index="0">
+            <!-- PosRuleCount=1 -->
+            <PosRule index="0">
+              <!-- GlyphCount=3 -->
+              <!-- PosCount=2 -->
+              <Input index="0" value="a"/>
+              <Input index="1" value="uni0303"/>
+              <PosLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="0"/>
+              </PosLookupRecord>
+              <PosLookupRecord index="1">
+                <SequenceIndex value="2"/>
+                <LookupListIndex value="1"/>
+              </PosLookupRecord>
+            </PosRule>
+          </PosRuleSet>
         </ContextPos>
       </Lookup>
     </LookupList>


### PR DESCRIPTION
This builds on existing work in the otlLib builder module. Currently we build all contextual/chained contextual lookups as format 3 subtables. However, there are often more efficient representations. Format 1 (simple glyph contexts) and format 2 (class based contexts) may save disk space.

In this PR, we build all the possible representations and compare their byte size, adding the most compact representation to the font. I've tried to break it down into manageable pieces.

Fun fact: I'm working on a font with lots of contextual rules; this patch took the final font size from 236Kb to 144Kb.