### PR TITLE
Turn on feaLib debugging from the environment

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -2,7 +2,11 @@ from fontTools.misc.py23 import *
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import binary2num, safeEval
 from fontTools.feaLib.error import FeatureLibError
-from fontTools.feaLib.lookupDebugInfo import LookupDebugInfo, LOOKUP_DEBUG_INFO_KEY
+from fontTools.feaLib.lookupDebugInfo import (
+    LookupDebugInfo,
+    LOOKUP_DEBUG_INFO_KEY,
+    LOOKUP_DEBUG_ENV_VAR,
+)
 from fontTools.feaLib.parser import Parser
 from fontTools.feaLib.ast import FeatureFile
 from fontTools.otlLib import builder as otl
@@ -31,6 +35,7 @@ from collections import defaultdict
 import itertools
 import logging
 import warnings
+import os
 
 
 log = logging.getLogger(__name__)
@@ -210,7 +215,7 @@ class Builder(object):
                 self.font["BASE"] = base
             elif "BASE" in self.font:
                 del self.font["BASE"]
-        if debug:
+        if debug or os.environ.get(LOOKUP_DEBUG_ENV_VAR):
             self.buildDebg()
 
     def get_chained_lookup_(self, location, builder_class):

--- a/Lib/fontTools/feaLib/lookupDebugInfo.py
+++ b/Lib/fontTools/feaLib/lookupDebugInfo.py
@@ -1,6 +1,7 @@
 from typing import NamedTuple
 
 LOOKUP_DEBUG_INFO_KEY = "com.github.fonttools.feaLib"
+LOOKUP_DEBUG_ENV_VAR  = "FONTTOOLS_LOOKUP_DEBUGGING"
 
 class LookupDebugInfo(NamedTuple):
     """Information about where a lookup came from, to be embedded in a font"""


### PR DESCRIPTION
This builds on #2052 (Feature file debugging). Currently we can add the `Debg` table to the font but you have to ask for it in Python, in whatever calls `addOpenTypeFeatures`.

With this patch, you can export `FONTTOOLS_LOOKUP_DEBUGGING=1` to get feature file debugging. This makes it really easy to enable source-level debugging without having to modify your existing (fontmake or whatever) toolchain.