### PR TITLE
Optionally install PyObjC if on macOS test env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install packages
       run: pip install tox coverage
+    - name: (Optionally install PyObjC package if on macOS platform)
+      if: ${{ runner.os == "macOS" }}
+      run: pip install pyobjc
     - name: Run Tox
       run: tox -e py-cov
     - name: Run Tox without lxml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install packages
       run: pip install tox coverage
-    - name: (Optionally install PyObjC package if on macOS platform)
-      if: ${{ runner.os == "macOS" }}
-      run: pip install pyobjc
     - name: Run Tox
       run: tox -e py-cov
     - name: Run Tox without lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ fs==2.4.11
 skia-pathops==0.5.1.post1; platform_python_implementation != "PyPy"
 # this is only required to run Tests/cu2qu/{ufo,cli}_test.py
 ufoLib2==0.6.2
+pyobjc==6.2.2; sys_platform == "darwin"


### PR DESCRIPTION
Trying my luck with GHA conditional syntax (is there a way to see what a workflow change would do without pushing to github?) in order to fix #2108. The updated workflow should `pip install pyobjc` only on macOS. 