### PR TITLE
[subset] Allow LangSys tags in --layout-scripts

### DIFF
--- a/Tests/subset/data/expect_layout_scripts.ttx
+++ b/Tests/subset/data/expect_layout_scripts.ttx
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=2 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="arab"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="2"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=1 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="URD "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=2 -->
+              <FeatureIndex index="0" value="1"/>
+              <FeatureIndex index="1" value="2"/>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="2"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=1 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="TRK "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=2 -->
+              <FeatureIndex index="0" value="0"/>
+              <FeatureIndex index="1" value="2"/>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=3 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="locl"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="2"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="locl"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="numr"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=3 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="uni06F4" out="uni06F4.urd"/>
+          <Substitution in="uni06F6" out="uni06F6.urd"/>
+          <Substitution in="uni06F7" out="uni06F7.urd"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="uni06F0" out="uni06F0.numr"/>
+          <Substitution in="uni06F1" out="uni06F1.numr"/>
+          <Substitution in="uni06F2" out="uni06F2.numr"/>
+          <Substitution in="uni06F3" out="uni06F3.numr"/>
+          <Substitution in="uni06F4" out="uni06F4.numr"/>
+          <Substitution in="uni06F4.urd" out="uni06F4.urd.numr"/>
+          <Substitution in="uni06F5" out="uni06F5.numr"/>
+          <Substitution in="uni06F6" out="uni06F6.numr"/>
+          <Substitution in="uni06F6.urd" out="uni06F6.urd.numr"/>
+          <Substitution in="uni06F7" out="uni06F7.numr"/>
+          <Substitution in="uni06F7.urd" out="uni06F7.urd.numr"/>
+          <Substitution in="uni06F8" out="uni06F8.numr"/>
+          <Substitution in="uni06F9" out="uni06F9.numr"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="i" out="i.TRK"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/Tests/subset/data/layout_scripts.ttx
+++ b/Tests/subset/data/layout_scripts.ttx
@@ -1,0 +1,997 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.17">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="i"/>
+    <GlyphID id="2" name="uni06F0"/>
+    <GlyphID id="3" name="uni06F1"/>
+    <GlyphID id="4" name="uni06F2"/>
+    <GlyphID id="5" name="uni06F3"/>
+    <GlyphID id="6" name="uni06F4"/>
+    <GlyphID id="7" name="uni06F5"/>
+    <GlyphID id="8" name="uni06F6"/>
+    <GlyphID id="9" name="uni06F7"/>
+    <GlyphID id="10" name="uni06F8"/>
+    <GlyphID id="11" name="uni06F9"/>
+    <GlyphID id="12" name="uni06F4.urd"/>
+    <GlyphID id="13" name="uni06F6.urd"/>
+    <GlyphID id="14" name="uni06F7.urd"/>
+    <GlyphID id="15" name="uni06F0.numr"/>
+    <GlyphID id="16" name="uni06F1.numr"/>
+    <GlyphID id="17" name="uni06F2.numr"/>
+    <GlyphID id="18" name="uni06F3.numr"/>
+    <GlyphID id="19" name="uni06F4.numr"/>
+    <GlyphID id="20" name="uni06F5.numr"/>
+    <GlyphID id="21" name="uni06F6.numr"/>
+    <GlyphID id="22" name="uni06F7.numr"/>
+    <GlyphID id="23" name="uni06F8.numr"/>
+    <GlyphID id="24" name="uni06F9.numr"/>
+    <GlyphID id="25" name="uni06F4.urd.numr"/>
+    <GlyphID id="26" name="uni06F6.urd.numr"/>
+    <GlyphID id="27" name="uni06F7.urd.numr"/>
+    <GlyphID id="28" name="i.TRK"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="0.114"/>
+    <checkSumAdjustment value="0xe87b6e18"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri May  7 21:08:01 2010"/>
+    <modified value="Thu Jan  1 00:00:00 1970"/>
+    <xMin value="-581"/>
+    <yMin value="-898"/>
+    <xMax value="11462"/>
+    <yMax value="1814"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1124"/>
+    <descent value="-634"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="11435"/>
+    <minLeftSideBearing value="-581"/>
+    <minRightSideBearing value="-970"/>
+    <xMaxExtent value="11462"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="29"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="29"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="456"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="260"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="5"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00100000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="ALIF"/>
+    <fsSelection value="00000000 11000000"/>
+    <usFirstCharIndex value="105"/>
+    <usLastCharIndex value="1785"/>
+    <sTypoAscender value="1124"/>
+    <sTypoDescender value="-634"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1814"/>
+    <usWinDescent value="897"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 11010011"/>
+    <ulCodePageRange2 value="00000000 00001000 00000000 00000000"/>
+    <sxHeight value="433"/>
+    <sCapHeight value="646"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="8"/>
+  </OS_2>
+
+  <name>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright 2010-2020 The Amiri Project Authors (https://github.com/alif-type/amiri).
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Amiri
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      0.114;ALIF;Amiri-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Amiri Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 0.114
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      Amiri-Regular
+    </namerecord>
+  </name>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6f0" name="uni06F0"/><!-- EXTENDED ARABIC-INDIC DIGIT ZERO -->
+      <map code="0x6f1" name="uni06F1"/><!-- EXTENDED ARABIC-INDIC DIGIT ONE -->
+      <map code="0x6f2" name="uni06F2"/><!-- EXTENDED ARABIC-INDIC DIGIT TWO -->
+      <map code="0x6f3" name="uni06F3"/><!-- EXTENDED ARABIC-INDIC DIGIT THREE -->
+      <map code="0x6f4" name="uni06F4"/><!-- EXTENDED ARABIC-INDIC DIGIT FOUR -->
+      <map code="0x6f5" name="uni06F5"/><!-- EXTENDED ARABIC-INDIC DIGIT FIVE -->
+      <map code="0x6f6" name="uni06F6"/><!-- EXTENDED ARABIC-INDIC DIGIT SIX -->
+      <map code="0x6f7" name="uni06F7"/><!-- EXTENDED ARABIC-INDIC DIGIT SEVEN -->
+      <map code="0x6f8" name="uni06F8"/><!-- EXTENDED ARABIC-INDIC DIGIT EIGHT -->
+      <map code="0x6f9" name="uni06F9"/><!-- EXTENDED ARABIC-INDIC DIGIT NINE -->
+    </cmap_format_4>
+    <cmap_format_12 platformID="0" platEncID="4" format="12" reserved="0" length="40" language="0" nGroups="2">
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6f0" name="uni06F0"/><!-- EXTENDED ARABIC-INDIC DIGIT ZERO -->
+      <map code="0x6f1" name="uni06F1"/><!-- EXTENDED ARABIC-INDIC DIGIT ONE -->
+      <map code="0x6f2" name="uni06F2"/><!-- EXTENDED ARABIC-INDIC DIGIT TWO -->
+      <map code="0x6f3" name="uni06F3"/><!-- EXTENDED ARABIC-INDIC DIGIT THREE -->
+      <map code="0x6f4" name="uni06F4"/><!-- EXTENDED ARABIC-INDIC DIGIT FOUR -->
+      <map code="0x6f5" name="uni06F5"/><!-- EXTENDED ARABIC-INDIC DIGIT FIVE -->
+      <map code="0x6f6" name="uni06F6"/><!-- EXTENDED ARABIC-INDIC DIGIT SIX -->
+      <map code="0x6f7" name="uni06F7"/><!-- EXTENDED ARABIC-INDIC DIGIT SEVEN -->
+      <map code="0x6f8" name="uni06F8"/><!-- EXTENDED ARABIC-INDIC DIGIT EIGHT -->
+      <map code="0x6f9" name="uni06F9"/><!-- EXTENDED ARABIC-INDIC DIGIT NINE -->
+    </cmap_format_12>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6f0" name="uni06F0"/><!-- EXTENDED ARABIC-INDIC DIGIT ZERO -->
+      <map code="0x6f1" name="uni06F1"/><!-- EXTENDED ARABIC-INDIC DIGIT ONE -->
+      <map code="0x6f2" name="uni06F2"/><!-- EXTENDED ARABIC-INDIC DIGIT TWO -->
+      <map code="0x6f3" name="uni06F3"/><!-- EXTENDED ARABIC-INDIC DIGIT THREE -->
+      <map code="0x6f4" name="uni06F4"/><!-- EXTENDED ARABIC-INDIC DIGIT FOUR -->
+      <map code="0x6f5" name="uni06F5"/><!-- EXTENDED ARABIC-INDIC DIGIT FIVE -->
+      <map code="0x6f6" name="uni06F6"/><!-- EXTENDED ARABIC-INDIC DIGIT SIX -->
+      <map code="0x6f7" name="uni06F7"/><!-- EXTENDED ARABIC-INDIC DIGIT SEVEN -->
+      <map code="0x6f8" name="uni06F8"/><!-- EXTENDED ARABIC-INDIC DIGIT EIGHT -->
+      <map code="0x6f9" name="uni06F9"/><!-- EXTENDED ARABIC-INDIC DIGIT NINE -->
+    </cmap_format_4>
+    <cmap_format_12 platformID="3" platEncID="10" format="12" reserved="0" length="40" language="0" nGroups="2">
+      <map code="0x69" name="i"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6f0" name="uni06F0"/><!-- EXTENDED ARABIC-INDIC DIGIT ZERO -->
+      <map code="0x6f1" name="uni06F1"/><!-- EXTENDED ARABIC-INDIC DIGIT ONE -->
+      <map code="0x6f2" name="uni06F2"/><!-- EXTENDED ARABIC-INDIC DIGIT TWO -->
+      <map code="0x6f3" name="uni06F3"/><!-- EXTENDED ARABIC-INDIC DIGIT THREE -->
+      <map code="0x6f4" name="uni06F4"/><!-- EXTENDED ARABIC-INDIC DIGIT FOUR -->
+      <map code="0x6f5" name="uni06F5"/><!-- EXTENDED ARABIC-INDIC DIGIT FIVE -->
+      <map code="0x6f6" name="uni06F6"/><!-- EXTENDED ARABIC-INDIC DIGIT SIX -->
+      <map code="0x6f7" name="uni06F7"/><!-- EXTENDED ARABIC-INDIC DIGIT SEVEN -->
+      <map code="0x6f8" name="uni06F8"/><!-- EXTENDED ARABIC-INDIC DIGIT EIGHT -->
+      <map code="0x6f9" name="uni06F9"/><!-- EXTENDED ARABIC-INDIC DIGIT NINE -->
+    </cmap_format_12>
+  </cmap>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-512"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="Amiri-Regular">
+      <version value="0.114"/>
+      <Copyright value="Copyright 2010-2020 The Amiri Project Authors https:github.comalif-typeamiri."/>
+      <FullName value="Amiri"/>
+      <FamilyName value="Amiri"/>
+      <Weight value="Regular"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlinePosition value="-512"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="-581 -898 11462 1814"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="0"/>
+        <nominalWidthX value="253"/>
+        <Subrs>
+          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+          <CharString index="0">
+            3 2 3 1 vhcurveto
+            endchar
+          </CharString>
+          <CharString index="1">
+            177 113 -106 callgsubr
+            return
+          </CharString>
+          <CharString index="2">
+            487 531 rmoveto
+            -5 -82 -21 -36 -38 10 -36 10 -16 18 5 25 5 25 1 18 -2 8 -2 8 -5 5 -8 1 -8 1 -4 -7 -3 -13 -14 -69 -26 -36 -40 -4 -29 -3 -23 4 -19 11 rrcurveto
+            -8 5 -24 31 -39 57 -17 26 -12 0 -6 -23 -25 -101 rcurveline
+            -3 -13 5 -16 14 -20 79 -117 45 -148 11 -178 1 -8 2 -6 4 -3 4 -3 4 0 6 2 6 2 3 4 2 7 20 79 -11 123 -42 169 39 -3 35 16 32 35 rrcurveto
+            14 -11 17 -9 20 -6 63 -20 40 23 18 65 13 49 7 46 2 41 rrcurveto
+            20 1 -6 9 -10 hhcurveto
+            -10 -5 -6 -12 -1 hvcurveto
+            endchar
+          </CharString>
+          <CharString index="3">
+            rmoveto
+            -45 13 -33 20 -23 28 -3 4 0 3 3 3 27 30 33 15 38 -1 rrcurveto
+            28 20 -8 -13 13 hvcurveto
+            5 -5 3 0 4 2 3 1 0 3 -1 6 -6 13 -11 16 -15 16 rrcurveto
+            14 -13 -14 7 -14 hhcurveto
+            -30 -33 -21 -43 -37 hvcurveto
+            -15 -19 -12 -20 -7 -23 -3 -7 1 -9 3 -8 11 -25 31 -23 53 -19 -51 -45 -38 -53 -24 -60 -5 -12 -1 -6 5 -1 6 -3 7 4 7 10 26 40 32 36 34 30 rrcurveto
+            37 33 37 24 37 16 10 4 7 8 4 13 16 50 rcurveline
+            4 10 -5 3 -12 -4 -18 -7 -23 -14 -28 -22 -7 -5 -9 -2 -9 3 rrcurveto
+            endchar
+          </CharString>
+          <CharString index="4">
+            311 -77 rmoveto
+            21 89 26 81 29 73 29 73 39 74 45 76 rrcurveto
+            6 11 2 9 8 vvcurveto
+            -6 97 rlineto
+            9 -1 -2 4 -5 hhcurveto
+            -5 -5 -6 -10 -5 hvcurveto
+            -79 -149 -53 -135 -27 -121 -4 -19 -7 2 -7 21 -55 159 -61 140 -70 124 -11 20 -8 -8 -5 -35 -13 -81 rcurveline
+            -2 -10 1 -8 3 -6 57 -95 46 -93 38 -90 38 -90 20 -68 2 -45 rrcurveto
+            -7 3 -4 4 -3 vhcurveto
+            4 -3 4 0 5 2 5 2 2 5 2 7 rrcurveto
+            endchar
+          </CharString>
+          <CharString index="5">
+            rmoveto
+            19 69 -12 87 -41 106 -10 24 -4 14 2 3 rrcurveto
+            10 10 11 5 12 hhcurveto
+            31 25 -26 -51 20 hvcurveto
+            2 -3 1 -2 3 -1 rrcurveto
+            2 2 1 3 2 hvcurveto
+            12 34 21 34 28 35 2 2 2 4 1 4 14 51 rcurveline
+            3 0 2 -3 1 vhcurveto
+            -3 1 -2 -1 -4 -3 -24 -22 -21 -32 -16 -43 -22 49 -28 24 -36 -2 -32 -1 -21 -19 -12 -38 -12 -39 2 -39 13 -38 29 -80 17 -68 4 -55 rrcurveto
+            -6 3 -2 4 5 -107 callsubr
+          </CharString>
+          <CharString index="6">
+            158 296 -95 callgsubr
+          </CharString>
+          <CharString index="7">
+            136 657 rmoveto
+            -13 -53 -16 -49 -17 -44 -18 -43 -22 -44 -27 -46 rrcurveto
+            -4 -6 -1 -6 -5 vvcurveto
+            3 -58 rlineto
+            -6 2 -2 3 3 3 3 6 3 vhcurveto
+            48 90 31 81 17 72 2 12 4 -1 4 -13 33 -95 37 -84 42 -75 7 -12 4 5 3 21 8 49 rcurveline
+            1 6 0 4 -2 4 -34 57 -28 56 -23 54 -22 54 -12 41 -2 27 rrcurveto
+            4 -1 3 -3 2 vhcurveto
+            -2 1 -3 0 -3 -1 -3 -1 -1 -4 -1 -4 rrcurveto
+            endchar
+          </CharString>
+          <CharString index="8">
+            220 500 rmoveto
+            -67 -86 -32 -66 2 -47 4 -86 75 -35 146 14 5 -82 22 -87 39 -91 15 -35 9 -2 6 33 18 105 rcurveline
+            3 15 -3 16 -10 18 -32 59 -18 73 -3 86 -3 87 -16 66 -32 45 -39 56 -43 0 -46 -56 rrcurveto
+            102 -152 rmoveto
+            6 -19 -1 -13 -6 -6 rrcurveto
+            -2 -3 -3 -2 -5 hhcurveto
+            -50 -3 -36 6 -22 14 -16 10 -5 16 7 21 12 39 24 15 36 -10 30 -9 21 -22 11 -35 rrcurveto
+            endchar
+          </CharString>
+          <CharString index="9">
+            53 654 -94 callgsubr
+          </CharString>
+          <CharString index="10">
+            38 655 -88 callgsubr
+          </CharString>
+          <CharString index="11">
+            hhcurveto
+            54 3 49 -4 45 -12 5 -1 4 0 2 1 54 31 rcurveline
+            10 6 0 4 -10 3 -61 14 -61 3 -60 -9 57 83 42 104 25 126 1 7 0 5 -2 2 -2 2 -3 -1 -4 -4 -40 -41 rcurveline
+            -4 -3 -3 -6 -1 -7 -25 -113 -35 -98 -45 -84 rrcurveto
+            endchar
+          </CharString>
+          <CharString index="12">
+            119 655 -85 callgsubr
+          </CharString>
+          <CharString index="13">
+            4 -4 5 0 6 2 6 2 3 5 1 7 20 return
+          </CharString>
+          <CharString index="14">
+            -3 -13 4 -15 12 -19 return
+          </CharString>
+        </Subrs>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          111 endchar
+        </CharString>
+        <CharString name="i">
+          10 -106 callsubr
+          -94 466 -80 callgsubr
+        </CharString>
+        <CharString name="i.TRK">
+          10 -106 callsubr
+          -94 466 -80 callgsubr
+        </CharString>
+        <CharString name="uni06F0">
+          332 -84 callgsubr
+        </CharString>
+        <CharString name="uni06F0.numr">
+          39 -82 callgsubr
+        </CharString>
+        <CharString name="uni06F1">
+          332 -87 callgsubr
+        </CharString>
+        <CharString name="uni06F1.numr">
+          39 -95 callsubr
+        </CharString>
+        <CharString name="uni06F2">
+          332 -97 callgsubr
+        </CharString>
+        <CharString name="uni06F2.numr">
+          39 -98 callsubr
+        </CharString>
+        <CharString name="uni06F3">
+          332 -105 callsubr
+        </CharString>
+        <CharString name="uni06F3.numr">
+          39 263 662 -107 callgsubr
+        </CharString>
+        <CharString name="uni06F4">
+          332 175 515 rmoveto
+          -12 19 -10 8 -7 -1 -4 -2 -4 -5 -2 -10 -25 -105 rcurveline
+          -93 callsubr
+          83 -128 46 -149 7 -168 rrcurveto
+          -7 3 -5 4 -4 vhcurveto
+          -94 callsubr
+          98 -4 110 -26 122 26 -13 33 -5 38 3 63 5 49 28 34 54 9 14 1 10 -7 7 -6 5 -9 -3 -13 -11 rrcurveto
+          -21 -18 -39 -7 -56 3 -38 2 -39 18 -40 34 20 66 50 34 83 1 rrcurveto
+          26 35 -15 -31 42 hvcurveto
+          10 -7 6 0 5 7 3 5 -2 9 -7 14 -35 66 -40 33 -44 -3 -76 -5 -57 -50 -40 -93 -4 -11 -5 0 -5 11 -11 28 -19 35 -27 42 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="uni06F4.numr">
+          39 76 651 rmoveto
+          -12 19 -8 1 -3 -15 -15 -63 rcurveline
+          -2 -7 2 -9 7 -12 50 -77 28 -89 4 -101 rrcurveto
+          -4 2 -3 2 -2 vhcurveto
+          3 -3 3 0 3 1 rrcurveto
+          4 2 2 3 4 vvcurveto
+          12 59 -2 66 -16 73 16 -8 20 -3 22 2 38 3 30 17 20 32 5 8 1 6 -4 5 -4 3 -5 -2 -8 -7 -13 -11 -23 -4 -34 2 -22 1 -24 11 -24 20 rrcurveto
+          12 40 30 20 50 1 rrcurveto
+          16 21 -9 -19 25 hvcurveto
+          6 -4 3 0 3 4 2 3 -1 6 -4 8 -21 40 -24 20 -27 -2 -45 -3 -34 -30 -24 -56 -3 -7 -3 0 -3 7 -6 17 -12 21 -16 25 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="uni06F4.urd">
+          332 229 -83 rmoveto
+          31 115 -20 145 -69 177 -16 40 -6 23 3 4 rrcurveto
+          18 16 19 8 19 hhcurveto
+          52 -1 42 -43 34 -84 2 -6 3 -3 5 -1 3 -1 3 2 3 5 21 57 34 57 47 57 3 4 3 6 2 7 23 85 rcurveline
+          1 6 -1 3 -5 2 -4 1 -4 -2 -6 -5 -41 -36 -34 -53 -27 -73 -36 82 -48 40 -59 -3 -53 -2 -36 -32 -19 -62 -20 -65 2 -65 22 -64 49 -133 28 -114 6 -92 rrcurveto
+          -9 1 4 -4 8 hhcurveto
+          8 5 3 6 2 hvcurveto
+          endchar
+        </CharString>
+        <CharString name="uni06F4.urd.numr">
+          39 108 303 -102 callsubr
+        </CharString>
+        <CharString name="uni06F5">
+          332 235 526 rmoveto
+          -12 12 -8 -2 -2 -16 -17 -121 rcurveline
+          -2 -15 3 -8 7 -4 8 -4 8 -5 7 -5 -75 -103 -42 -88 -8 -76 -11 -105 29 -55 68 -6 39 -3 34 17 31 36 16 -26 28 -10 40 7 54 9 33 60 13 110 rrcurveto
+          5 39 -17 59 -39 78 -29 58 -63 75 -98 92 rrcurveto
+          16 -184 rmoveto
+          76 -52 58 -68 42 -83 6 -12 2 -10 -4 -10 -10 -27 -17 -15 -23 -3 -17 -2 -14 3 -12 8 -1 7 1 6 3 5 -1 6 -3 4 -4 2 -5 2 -5 -3 -6 -6 rrcurveto
+          -64 -62 -52 -8 -40 45 -20 23 2 44 25 64 15 38 27 48 41 56 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="uni06F5.numr">
+          39 112 656 -99 callgsubr
+        </CharString>
+        <CharString name="uni06F6">
+          332 331 285 rmoveto
+          -74 21 -56 34 -37 47 -5 6 0 5 5 5 45 50 54 25 63 -1 47 -1 34 -12 22 -23 7 -7 6 -1 6 3 5 3 1 5 -3 9 -9 22 -18 26 -26 28 rrcurveto
+          23 -22 -22 11 -24 hhcurveto
+          -50 -55 -35 -72 -61 hvcurveto
+          -26 -31 -20 -33 -12 -38 -4 -13 1 -14 5 -13 18 -43 52 -37 88 -32 -85 -75 -62 -88 -41 -100 -8 -20 -1 -10 8 -3 10 -4 12 7 11 16 44 66 52 60 58 51 rrcurveto
+          61 54 61 41 62 26 17 7 12 14 7 21 26 83 rcurveline
+          6 17 -8 5 -20 -7 -30 -11 -38 -24 -47 -36 -12 -9 -14 -3 -16 5 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="uni06F6.numr">
+          39 170 512 -104 callsubr
+        </CharString>
+        <CharString name="uni06F6.urd">
+          332 -90 callgsubr
+        </CharString>
+        <CharString name="uni06F6.urd.numr">
+          39 -97 callsubr
+        </CharString>
+        <CharString name="uni06F7">
+          332 -103 callsubr
+        </CharString>
+        <CharString name="uni06F7.numr">
+          39 -101 callsubr
+        </CharString>
+        <CharString name="uni06F7.urd">
+          332 104 -50 rmoveto
+          -3 -6 -1 -5 2 -3 2 -3 4 -2 8 1 90 5 83 -7 75 -20 8 -2 6 0 4 2 89 51 rcurveline
+          18 10 0 8 -18 4 -101 23 -101 5 -100 -15 95 139 69 174 42 210 2 11 0 8 -3 3 -4 4 -5 -2 -6 -6 -68 -68 rcurveline
+          -6 -6 -5 -10 -2 -12 -42 -188 -58 -163 -74 -140 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="uni06F7.urd.numr">
+          39 33 312 rmoveto
+          -8 -4 3 -3 9 -96 callsubr
+        </CharString>
+        <CharString name="uni06F8">
+          332 -98 callgsubr
+        </CharString>
+        <CharString name="uni06F8.numr">
+          39 -100 callsubr
+        </CharString>
+        <CharString name="uni06F9">
+          332 -99 callsubr
+        </CharString>
+        <CharString name="uni06F9.numr">
+          39 -93 callgsubr
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+      <CharString index="0">
+        rmoveto
+        -3 -50 -12 -21 -23 6 -22 6 -9 11 3 15 3 15 0 10 -1 5 -1 5 -3 3 -5 1 rrcurveto
+        -5 -2 -4 -8 -2 hvcurveto
+        -8 -41 -16 -22 -24 -2 -17 -2 -14 2 -12 7 -4 3 -15 19 -23 34 -10 15 -8 0 -3 -13 -15 -61 rcurveline
+        -2 -8 3 -9 8 -12 48 -71 27 -88 6 -107 1 -5 1 -4 3 -1 2 -2 2 0 4 1 4 1 1 3 2 4 12 47 -7 74 -25 101 23 -1 21 9 19 21 rrcurveto
+        9 -6 10 -6 12 -3 38 -12 24 13 11 39 7 30 5 27 1 25 rrcurveto
+        12 -3 5 -6 -6 -3 -3 -7 -1 vhcurveto
+        endchar
+      </CharString>
+      <CharString index="1">
+        rmoveto
+        237 vlineto
+        -92 callgsubr
+        return
+      </CharString>
+      <CharString index="2">
+        vlineto
+        -29 0 -27 -5 -16 -102 callgsubr
+        -46 -77 callgsubr
+        vvcurveto
+        return
+      </CharString>
+      <CharString index="3">
+        rmoveto
+        -100 callgsubr
+        return
+      </CharString>
+      <CharString index="4">
+        -81 callgsubr
+        49 0 -17 7 hvcurveto
+        5 -12 0 return
+      </CharString>
+      <CharString index="5">
+        vhcurveto
+        -11 -3 -47 -74 callgsubr
+        26 -79 callgsubr
+        26 -78 callgsubr
+        return
+      </CharString>
+      <CharString index="6">
+        5 5 -1 18 -4 5 rrcurveto
+        -12 return
+      </CharString>
+      <CharString index="7">
+        -27 22 -22 27 27 22 22 27 27 -22 22 -27 -27 -22 -22 -27 vhcurveto
+        return
+      </CharString>
+      <CharString index="8">
+        rmoveto
+        -7 7 -5 -1 -1 -10 -10 -73 rcurveline
+        -2 -9 2 -4 4 -3 5 -2 5 -3 4 -3 -45 -62 -25 -53 -5 -45 -6 -63 17 -33 41 -4 23 -2 21 10 18 22 10 -16 17 -6 24 5 32 5 20 36 8 66 rrcurveto
+        3 23 -11 36 -23 47 -17 34 -38 45 -59 56 rrcurveto
+        10 -111 rmoveto
+        45 -31 35 -41 25 -50 4 -7 1 -6 -2 -6 -6 -16 -11 -9 -13 -2 -11 -1 -8 2 -7 5 -1 4 1 3 2 3 -1 4 -2 2 -2 2 -3 1 -3 -2 -4 -4 rrcurveto
+        -38 -37 -31 -5 -24 27 -12 14 1 27 15 38 9 23 16 29 25 33 rrcurveto
+        endchar
+      </CharString>
+      <CharString index="9">
+        275 527 rmoveto
+        -21 -89 -27 -81 -29 -73 -29 -73 -38 -73 -45 -76 rrcurveto
+        -6 -11 -2 -10 -8 vvcurveto
+        5 -97 rlineto
+        -9 1 3 -3 5 hhcurveto
+        5 5 5 10 5 hvcurveto
+        79 149 53 135 27 121 4 19 7 -2 7 -21 55 -159 61 -140 70 -124 11 -20 8 8 5 35 13 81 rcurveline
+        2 10 -1 8 -3 6 -57 95 -46 93 -38 90 -38 90 -20 68 -2 45 rrcurveto
+        7 -3 5 -4 3 vhcurveto
+        -4 3 -4 0 -5 -2 -5 -2 -2 -6 -2 -7 rrcurveto
+        endchar
+      </CharString>
+      <CharString index="10">
+        137 -96 callgsubr
+      </CharString>
+      <CharString index="11">
+        521 rmoveto
+        -25 -102 -3 -13 4 -15 12 -19 rlinecurve
+        79 -124 46 -149 11 -172 1 -7 2 -5 4 -4 4 -4 5 0 6 2 6 2 3 5 1 7 20 99 -12 128 -42 158 79 -13 57 18 33 49 21 30 13 33 6 37 rrcurveto
+        6 37 3 24 -3 7 rrcurveto
+        7 -3 -6 4 -9 hhcurveto
+        -9 -6 -6 -12 -2 hvcurveto
+        -69 -9 -43 -36 -79 hhcurveto
+        -55 -44 32 62 -33 hvcurveto
+        -11 21 -9 10 -7 -2 -5 -1 -4 -6 -3 -13 rrcurveto
+        endchar
+      </CharString>
+      <CharString index="12">
+        rmoveto
+        12 53 16 49 17 44 18 43 23 45 27 45 rrcurveto
+        4 7 1 5 5 vvcurveto
+        -4 58 rlineto
+        6 -2 2 -3 -3 -3 -3 -6 -3 vhcurveto
+        -47 -90 -32 -81 -16 -72 -2 -12 -5 1 -4 13 -33 95 -36 84 -42 75 -7 12 -5 -5 -3 -21 -8 -49 rcurveline
+        -1 -6 1 -4 2 -4 34 -57 27 -56 23 -54 23 -54 12 -41 1 -27 rrcurveto
+        -4 2 -2 2 -2 vhcurveto
+        3 -2 2 0 3 1 3 2 1 3 2 4 rrcurveto
+        endchar
+      </CharString>
+      <CharString index="13">
+        rmoveto
+        -15 -62 -2 -7 3 -9 7 -12 rlinecurve
+        47 -74 28 -90 7 -103 rrcurveto
+        -4 1 -3 3 -2 vhcurveto
+        2 -3 3 0 4 1 3 2 2 3 1 4 12 59 -7 77 -26 95 48 -8 34 11 20 29 12 18 8 20 4 22 3 22 2 15 -2 4 rrcurveto
+        4 -1 -4 3 -5 hhcurveto
+        -6 -3 -4 -7 -2 hvcurveto
+        -42 -5 -26 -21 -47 hhcurveto
+        -33 -27 19 37 -19 hvcurveto
+        -7 13 -5 6 -5 -1 -3 -1 -2 -4 -2 -7 rrcurveto
+        endchar
+      </CharString>
+      <CharString index="14">
+        103 641 -91 callgsubr
+      </CharString>
+      <CharString index="15">
+        10 6 47 1 7 vhcurveto
+        5 -6 11 -5 vhcurveto
+        -39 -21 -50 -103 callgsubr
+        -26 -13 vvcurveto
+        -182 -105 callgsubr
+        return
+      </CharString>
+      <CharString index="16">
+        rmoveto
+        -40 -52 -19 -39 1 -28 2 -52 45 -21 88 8 3 -49 13 -52 23 -55 9 -21 6 -1 3 20 11 63 rcurveline
+        2 9 -2 10 -6 10 -19 36 -11 44 -2 51 -1 52 -10 40 -19 27 -24 34 -25 0 -28 -34 rrcurveto
+        61 -91 rmoveto
+        -16 5 -2 -9 -10 hhcurveto
+        -30 -2 -22 3 -13 9 -9 6 -3 9 4 13 7 23 14 9 22 -6 18 -5 13 -13 6 -21 rrcurveto
+        endchar
+      </CharString>
+      <CharString index="17">
+        111 -89 callgsubr
+      </CharString>
+      <CharString index="18">
+        522 rmoveto
+        -15 -79 -3 -13 4 -12 9 -10 rlinecurve
+        50 -56 78 -14 105 27 rrcurveto
+        1 1 0 0 hvcurveto
+        3 -1 1 -4 -7 vvcurveto
+        -5 -150 31 -142 70 -132 15 -29 11 3 6 32 17 95 rcurveline
+        3 17 -4 18 -9 17 -71 128 -29 128 13 130 2 16 -8 6 -18 -5 -109 -33 -75 12 -38 57 -19 28 -12 0 -5 -27 rrcurveto
+        endchar
+      </CharString>
+      <CharString index="19">
+        rmoveto
+        -9 -47 -2 -8 2 -7 6 -6 rlinecurve
+        30 -34 46 -8 63 16 rrcurveto
+        3 1 1 -3 -5 vvcurveto
+        -3 -90 19 -85 42 -80 9 -17 6 2 4 19 10 57 rcurveline
+        2 10 -3 11 -5 10 -43 77 -17 77 8 78 1 9 -5 4 -11 -3 -65 -20 -45 7 -23 35 -11 16 -7 0 -3 -16 rrcurveto
+        endchar
+      </CharString>
+      <CharString index="20">
+        246 -86 callgsubr
+      </CharString>
+      <CharString index="21">
+        524 rmoveto
+        -34 -100 -5 -14 3 -17 11 -20 rlinecurve
+        71 -126 35 -148 -2 -171 rrcurveto
+        -12 4 -6 9 -2 vhcurveto
+        9 -2 5 5 4 10 23 69 4 99 -18 129 -13 92 -27 96 -39 100 -17 40 -14 6 -9 -28 rrcurveto
+        endchar
+      </CharString>
+      <CharString index="22">
+        rmoveto
+        -21 -60 -3 -8 2 -10 7 -12 rlinecurve
+        42 -76 21 -89 -1 -102 rrcurveto
+        -7 2 -4 6 -1 vhcurveto
+        5 -1 3 3 3 6 13 41 3 59 -11 78 -8 55 -16 58 -23 60 -11 24 -8 3 -5 -17 rrcurveto
+        endchar
+      </CharString>
+      <CharString index="23">
+        251 -83 callgsubr
+      </CharString>
+      <CharString index="24">
+        312 rmoveto
+        -38 -106 -5 -15 1 -10 8 -5 rlinecurve
+        91 -53 17 -10 11 2 6 17 rlinecurve
+        32 99 5 15 -3 11 -12 8 rlinecurve
+        -83 53 -9 6 -7 2 -5 -3 rlinecurve
+        -4 -1 -3 -4 -2 -6 rrcurveto
+        endchar
+      </CharString>
+      <CharString index="25">
+        122 527 rmoveto
+        -23 -63 -3 -9 0 -6 5 -3 rlinecurve
+        55 -32 10 -6 7 1 3 10 rlinecurve
+        19 60 3 9 -1 6 -8 5 rlinecurve
+        -49 32 -9 6 -6 -1 -3 -9 rlinecurve
+        endchar
+      </CharString>
+      <CharString index="26">
+        -13 -50 -7 -4 -5 2 -19 2 -2 rrcurveto
+        7 return
+      </CharString>
+      <CharString index="27">
+        -104 callgsubr
+        endchar
+      </CharString>
+      <CharString index="28">
+        3 38 hhcurveto
+        38 return
+      </CharString>
+      <CharString index="29">
+        -3 -2 40 hvcurveto
+        -101 callgsubr
+        return
+      </CharString>
+      <CharString index="30">
+        5 11 -3 hvcurveto
+        -5 16 0 27 29 return
+      </CharString>
+      <CharString index="31">
+        5 -5 rrcurveto
+        2 40 return
+      </CharString>
+      <CharString index="32">
+        -5 -12 hhcurveto
+        -4 -5 -1 return
+      </CharString>
+      <CharString index="33">
+        -75 callgsubr
+        -18 -76 callgsubr
+        return
+      </CharString>
+    </GlobalSubrs>
+  </CFF>
+
+  <GDEF>
+    <Version value="0x00010000"/>
+    <GlyphClassDef Format="2">
+      <ClassDef glyph="i" class="1"/>
+      <ClassDef glyph="i.TRK" class="1"/>
+      <ClassDef glyph="uni06F0" class="1"/>
+      <ClassDef glyph="uni06F0.numr" class="1"/>
+      <ClassDef glyph="uni06F1" class="1"/>
+      <ClassDef glyph="uni06F1.numr" class="1"/>
+      <ClassDef glyph="uni06F2" class="1"/>
+      <ClassDef glyph="uni06F2.numr" class="1"/>
+      <ClassDef glyph="uni06F3" class="1"/>
+      <ClassDef glyph="uni06F3.numr" class="1"/>
+      <ClassDef glyph="uni06F4" class="1"/>
+      <ClassDef glyph="uni06F4.numr" class="1"/>
+      <ClassDef glyph="uni06F4.urd" class="1"/>
+      <ClassDef glyph="uni06F4.urd.numr" class="1"/>
+      <ClassDef glyph="uni06F5" class="1"/>
+      <ClassDef glyph="uni06F5.numr" class="1"/>
+      <ClassDef glyph="uni06F6" class="1"/>
+      <ClassDef glyph="uni06F6.numr" class="1"/>
+      <ClassDef glyph="uni06F6.urd" class="1"/>
+      <ClassDef glyph="uni06F6.urd.numr" class="1"/>
+      <ClassDef glyph="uni06F7" class="1"/>
+      <ClassDef glyph="uni06F7.numr" class="1"/>
+      <ClassDef glyph="uni06F7.urd" class="1"/>
+      <ClassDef glyph="uni06F7.urd.numr" class="1"/>
+      <ClassDef glyph="uni06F8" class="1"/>
+      <ClassDef glyph="uni06F8.numr" class="1"/>
+      <ClassDef glyph="uni06F9" class="1"/>
+      <ClassDef glyph="uni06F9.numr" class="1"/>
+    </GlyphClassDef>
+  </GDEF>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=0 -->
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=0 -->
+    </LookupList>
+  </GPOS>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=3 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="4"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="arab"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="4"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=3 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="KSH "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=2 -->
+              <FeatureIndex index="0" value="0"/>
+              <FeatureIndex index="1" value="4"/>
+            </LangSys>
+          </LangSysRecord>
+          <LangSysRecord index="1">
+            <LangSysTag value="SND "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=2 -->
+              <FeatureIndex index="0" value="1"/>
+              <FeatureIndex index="1" value="4"/>
+            </LangSys>
+          </LangSysRecord>
+          <LangSysRecord index="2">
+            <LangSysTag value="URD "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=2 -->
+              <FeatureIndex index="0" value="3"/>
+              <FeatureIndex index="1" value="4"/>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="4"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=1 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="TRK "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=2 -->
+              <FeatureIndex index="0" value="2"/>
+              <FeatureIndex index="1" value="4"/>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=5 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="locl"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="locl"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="2"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="locl"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="4"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="3">
+        <FeatureTag value="locl"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="4">
+        <FeatureTag value="numr"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="3"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=5 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="uni06F4" out="uni06F4.urd"/>
+          <Substitution in="uni06F6" out="uni06F6.urd"/>
+          <Substitution in="uni06F7" out="uni06F7.urd"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="2">
+          <Substitution in="uni06F4" out="uni06F4.urd"/>
+          <Substitution in="uni06F6" out="uni06F6.urd"/>
+          <Substitution in="uni06F7" out="uni06F7.urd"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="uni06F6" out="uni06F6.urd"/>
+          <Substitution in="uni06F7" out="uni06F7.urd"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="uni06F0" out="uni06F0.numr"/>
+          <Substitution in="uni06F1" out="uni06F1.numr"/>
+          <Substitution in="uni06F2" out="uni06F2.numr"/>
+          <Substitution in="uni06F3" out="uni06F3.numr"/>
+          <Substitution in="uni06F4" out="uni06F4.numr"/>
+          <Substitution in="uni06F4.urd" out="uni06F4.urd.numr"/>
+          <Substitution in="uni06F5" out="uni06F5.numr"/>
+          <Substitution in="uni06F6" out="uni06F6.numr"/>
+          <Substitution in="uni06F6.urd" out="uni06F6.urd.numr"/>
+          <Substitution in="uni06F7" out="uni06F7.numr"/>
+          <Substitution in="uni06F7.urd" out="uni06F7.urd.numr"/>
+          <Substitution in="uni06F8" out="uni06F8.numr"/>
+          <Substitution in="uni06F9" out="uni06F9.numr"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="4">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0" Format="1">
+          <Substitution in="i" out="i.TRK"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+  <hmtx>
+    <mtx name=".notdef" width="364" lsb="33"/>
+    <mtx name="i" width="263" lsb="32"/>
+    <mtx name="i.TRK" width="263" lsb="32"/>
+    <mtx name="uni06F0" width="585" lsb="210"/>
+    <mtx name="uni06F0.numr" width="292" lsb="97"/>
+    <mtx name="uni06F1" width="585" lsb="210"/>
+    <mtx name="uni06F1.numr" width="292" lsb="97"/>
+    <mtx name="uni06F2" width="585" lsb="111"/>
+    <mtx name="uni06F2.numr" width="292" lsb="37"/>
+    <mtx name="uni06F3" width="585" lsb="67"/>
+    <mtx name="uni06F3.numr" width="292" lsb="11"/>
+    <mtx name="uni06F4" width="585" lsb="110"/>
+    <mtx name="uni06F4.numr" width="292" lsb="37"/>
+    <mtx name="uni06F4.urd" width="585" lsb="100"/>
+    <mtx name="uni06F4.urd.numr" width="292" lsb="31"/>
+    <mtx name="uni06F5" width="585" lsb="100"/>
+    <mtx name="uni06F5.numr" width="292" lsb="31"/>
+    <mtx name="uni06F6" width="585" lsb="71"/>
+    <mtx name="uni06F6.numr" width="292" lsb="14"/>
+    <mtx name="uni06F6.urd" width="585" lsb="95"/>
+    <mtx name="uni06F6.urd.numr" width="292" lsb="28"/>
+    <mtx name="uni06F7" width="585" lsb="78"/>
+    <mtx name="uni06F7.numr" width="292" lsb="18"/>
+    <mtx name="uni06F7.urd" width="585" lsb="101"/>
+    <mtx name="uni06F7.urd.numr" width="292" lsb="31"/>
+    <mtx name="uni06F8" width="585" lsb="78"/>
+    <mtx name="uni06F8.numr" width="292" lsb="18"/>
+    <mtx name="uni06F9" width="585" lsb="123"/>
+    <mtx name="uni06F9.numr" width="292" lsb="45"/>
+  </hmtx>
+
+</ttFont>

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -78,6 +78,16 @@ class SubsetTest(unittest.TestCase):
 # Tests
 # -----
 
+    def test_layout_scripts(self):
+        _, fontpath = self.compile_font(self.getpath("layout_scripts.ttx"), ".otf")
+        subsetpath = self.temp_path(".otf")
+        subset.main([fontpath, "--glyphs=*", "--layout-features=*",
+                     "--layout-scripts=latn,arab.URD,arab.dflt",
+                     "--output-file=%s" % subsetpath])
+        subsetfont = TTFont(subsetpath)
+        self.expect_ttx(subsetfont, self.getpath("expect_layout_scripts.ttx"),
+                        ["GPOS", "GSUB"])
+
     def test_no_notdef_outline_otf(self):
         _, fontpath = self.compile_font(self.getpath("TestOTF-Regular.ttx"), ".otf")
         subsetpath = self.temp_path(".otf")


### PR DESCRIPTION
Allow specifying which LangSys tags to accept for each script, using `script.lang` form. For example:

    --layout-scripts=arab.dflt,arab.URD,latn

To keep `DefaultLangSys` and `URD` language for `arab` script, and all languages for `latn` script.