### PR TITLE
Distinguish between axis tag and id.

### DIFF
--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -599,8 +599,8 @@ class FontBuilder(object):
 
         assert "fvar" in self.font, "fvar must to be set up first"
         assert "CFF2" in self.font, "CFF2 must to be set up first"
-        axisTags = [a.axisTag for a in self.font["fvar"].axes]
-        varRegionList = buildVarRegionList(regions, axisTags)
+        axisIds = [axis.axisId for axis in self.font["fvar"].axes]
+        varRegionList = buildVarRegionList(regions, axisIds)
         varData = buildVarData(list(range(len(regions))), None, optimize=False)
         varStore = buildVarStore(varRegionList, [varData])
         vstore = VarStoreData(otVarStore=varStore)
@@ -830,10 +830,17 @@ def addFvar(font, axes, instances):
 
     fvar = newTable('fvar')
     nameTable = font['name']
+    axisTagsSeen = {}
 
     for tag, minValue, defaultValue, maxValue, name in axes:
         axis = Axis()
         axis.axisTag = Tag(tag)
+        if axis.axisTag in axisTagsSeen:
+            axisTagsSeen[axis.axisTag] += 1
+            axis.axisId = f"{axis.axisTag}#{axisTagsSeen[axis.axisTag]}"
+        else:
+            axisTagsSeen[axis.axisTag] = 0
+            axis.axisId = axis.axisTag
         axis.minValue, axis.defaultValue, axis.maxValue = minValue, defaultValue, maxValue
         axis.axisNameID = nameTable.addName(tounicode(name))
         fvar.axes.append(axis)

--- a/Lib/fontTools/ttLib/tables/_c_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_c_v_a_r.py
@@ -32,7 +32,7 @@ class table__c_v_a_r(DefaultTable.DefaultTable):
         tupleVariationCount, tuples, data = compileTupleVariationStore(
             variations=[v for v in self.variations if v.hasImpact()],
             pointCount=len(ttFont["cvt "].values),
-            axisTags=[axis.axisTag for axis in ttFont["fvar"].axes],
+            axisIds=[axis.axisId for axis in ttFont["fvar"].axes],
             sharedTupleIndices={},
             useSharedPoints=useSharedPoints)
         header = {
@@ -48,14 +48,14 @@ class table__c_v_a_r(DefaultTable.DefaultTable):
         ])
 
     def decompile(self, data, ttFont):
-        axisTags = [axis.axisTag for axis in ttFont["fvar"].axes]
+        axisIds = [axis.axisId for axis in ttFont["fvar"].axes]
         header = {}
         sstruct.unpack(CVAR_HEADER_FORMAT, data[0:CVAR_HEADER_SIZE], header)
         self.majorVersion = header["majorVersion"]
         self.minorVersion = header["minorVersion"]
         assert self.majorVersion == 1, self.majorVersion
         self.variations = decompileTupleVariationStore(
-            tableTag=self.tableTag, axisTags=axisTags,
+            tableTag=self.tableTag, axisIds=axisIds,
             tupleVariationCount=header["tupleVariationCount"],
             pointCount=len(ttFont["cvt "].values), sharedTuples=None,
             data=data, pos=CVAR_HEADER_SIZE, dataPos=header["offsetToData"])
@@ -74,9 +74,9 @@ class table__c_v_a_r(DefaultTable.DefaultTable):
                     var.fromXML(tupleName, tupleAttrs, tupleContent)
 
     def toXML(self, writer, ttFont):
-        axisTags = [axis.axisTag for axis in ttFont["fvar"].axes]
+        axisIds = [axis.axisId for axis in ttFont["fvar"].axes]
         writer.simpletag("version",
                          major=self.majorVersion, minor=self.minorVersion)
         writer.newline()
         for var in self.variations:
-            var.toXML(writer, axisTags)
+            var.toXML(writer, axisIds)

--- a/Lib/fontTools/varLib/builder.py
+++ b/Lib/fontTools/varLib/builder.py
@@ -8,20 +8,20 @@ def buildVarRegionAxis(axisSupport):
 	self.StartCoord, self.PeakCoord, self.EndCoord = [float(v) for v in axisSupport]
 	return self
 
-def buildVarRegion(support, axisTags):
-	assert all(tag in axisTags for tag in support.keys()), ("Unknown axis tag found.", support, axisTags)
+def buildVarRegion(support, axisIds):
+	assert all(axisId in axisIds for axisId in support.keys()), ("Unknown axis id found.", support, axisIds)
 	self = ot.VarRegion()
 	self.VarRegionAxis = []
-	for tag in axisTags:
-		self.VarRegionAxis.append(buildVarRegionAxis(support.get(tag, (0,0,0))))
+	for axisId in axisIds:
+		self.VarRegionAxis.append(buildVarRegionAxis(support.get(axisId, (0,0,0))))
 	return self
 
-def buildVarRegionList(supports, axisTags):
+def buildVarRegionList(supports, axisIds):
 	self = ot.VarRegionList()
-	self.RegionAxisCount = len(axisTags)
+	self.RegionAxisCount = len(axisIds)
 	self.Region = []
 	for support in supports:
-		self.Region.append(buildVarRegion(support, axisTags))
+		self.Region.append(buildVarRegion(support, axisIds))
 	self.RegionCount = len(self.Region)
 	return self
 

--- a/Lib/fontTools/varLib/cff.py
+++ b/Lib/fontTools/varLib/cff.py
@@ -30,7 +30,7 @@ MergeTypeError = VarLibCFFPointTypeMergeError
 
 def addCFFVarStore(varFont, varModel, varDataList, masterSupports):
 	fvarTable = varFont['fvar']
-	axisKeys = [axis.axisTag for axis in fvarTable.axes]
+	axisKeys = [axis.axisId for axis in fvarTable.axes]
 	varTupleList = varLib.builder.buildVarRegionList(masterSupports, axisKeys)
 	varStoreCFFV = varLib.builder.buildVarStore(varTupleList, varDataList)
 

--- a/Lib/fontTools/varLib/featureVars.py
+++ b/Lib/fontTools/varLib/featureVars.py
@@ -19,7 +19,7 @@ def addFeatureVariations(font, conditionalSubstitutions, featureTag='rvrn'):
     The `conditionalSubstitutions` argument is a list of (Region, Substitutions)
     tuples.
 
-    A Region is a list of Boxes. A Box is a dict mapping axisTags to
+    A Region is a list of Boxes. A Box is a dict mapping axisIds to
     (minValue, maxValue) tuples. Irrelevant axes may be omitted and they are
     interpretted as extending to end of axis in each direction.  A Box represents
     an orthogonal 'rectangular' subset of an N-dimensional design space.
@@ -54,7 +54,7 @@ def overlayFeatureVariations(conditionalSubstitutions):
     The `conditionalSubstitutions` argument is a list of (Region, Substitutions)
     tuples.
 
-    A Region is a list of Boxes. A Box is a dict mapping axisTags to
+    A Region is a list of Boxes. A Box is a dict mapping axisIds to
     (minValue, maxValue) tuples. Irrelevant axes may be omitted and they are
     interpretted as extending to end of axis in each direction.  A Box represents
     an orthogonal 'rectangular' subset of an N-dimensional design space.
@@ -179,14 +179,14 @@ def overlayBox(top, bot):
     intersection = {}
     intersection.update(top)
     intersection.update(bot)
-    for axisTag in set(top) & set(bot):
-        min1, max1 = top[axisTag]
-        min2, max2 = bot[axisTag]
+    for axisId in set(top) & set(bot):
+        min1, max1 = top[axisId]
+        min2, max2 = bot[axisId]
         minimum = max(min1, min2)
         maximum = min(max1, max2)
         if not minimum < maximum:
             return None, bot # Do not intersect
-        intersection[axisTag] = minimum,maximum
+        intersection[axisId] = minimum,maximum
 
     # Remainder
     #
@@ -202,12 +202,12 @@ def overlayBox(top, bot):
     remainder = dict(bot)
     exactlyOne = False
     fullyInside = False
-    for axisTag in bot:
-        if axisTag not in intersection:
+    for axisId in bot:
+        if axisId not in intersection:
             fullyInside = False
             continue # Axis range lies fully within
-        min1, max1 = intersection[axisTag]
-        min2, max2 = bot[axisTag]
+        min1, max1 = intersection[axisId]
+        min2, max2 = bot[axisId]
         if min1 <= min2 and max2 <= max1:
             continue # Axis range lies fully within
 
@@ -235,7 +235,7 @@ def overlayBox(top, bot):
             # Remainder leaks out from both sides.  Can't cut either.
             return intersection, bot
 
-        remainder[axisTag] = minimum,maximum
+        remainder[axisId] = minimum,maximum
 
     if fullyInside:
         # bot is fully within intersection.  Remainder is empty.
@@ -311,17 +311,17 @@ def addFeatureVariationsRaw(font, conditionalSubstitutions, featureTag='rvrn'):
 
     lookupMap = buildSubstitutionLookups(gsub, allSubstitutions)
 
-    axisIndices = {axis.axisTag: axisIndex for axisIndex, axis in enumerate(font["fvar"].axes)}
+    axisIndices = {axis.axisId: axisIndex for axisIndex, axis in enumerate(font["fvar"].axes)}
 
     featureVariationRecords = []
     for conditionSet, substitutions in conditionalSubstitutions:
         conditionTable = []
-        for axisTag, (minValue, maxValue) in sorted(conditionSet.items()):
+        for axisId, (minValue, maxValue) in sorted(conditionSet.items()):
             if minValue > maxValue:
                 raise VarLibValidationError(
                     "A condition set has a minimum value above the maximum value."
                 )
-            ct = buildConditionTable(axisIndices[axisTag], minValue, maxValue)
+            ct = buildConditionTable(axisIndices[axisId], minValue, maxValue)
             conditionTable.append(ct)
 
         lookupIndices = [lookupMap[subst] for subst in substitutions]

--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -1020,9 +1020,9 @@ class VariationMerger(AligningMerger):
 	"""A merger that takes multiple master fonts, and builds a
 	variable font."""
 
-	def __init__(self, model, axisTags, font):
+	def __init__(self, model, axisIds, font):
 		Merger.__init__(self, font)
-		self.store_builder = varStore.OnlineVarStoreBuilder(axisTags)
+		self.store_builder = varStore.OnlineVarStoreBuilder(axisIds)
 		self.setModel(model)
 
 	def setModel(self, model):

--- a/Lib/fontTools/varLib/mutator.py
+++ b/Lib/fontTools/varLib/mutator.py
@@ -170,7 +170,7 @@ def instantiateVariableFont(varfont, location, inplace=False, overlap=True):
 		varfont = TTFont(stream)
 
 	fvar = varfont['fvar']
-	axes = {a.axisTag:(a.minValue,a.defaultValue,a.maxValue) for a in fvar.axes}
+	axes = {a.axisId:(a.minValue,a.defaultValue,a.maxValue) for a in fvar.axes}
 	loc = normalizeLocation(location, axes)
 	if 'avar' in varfont:
 		maps = varfont['avar'].segments
@@ -265,10 +265,10 @@ def instantiateVariableFont(varfont, location, inplace=False, overlap=True):
 			for condition in record.ConditionSet.ConditionTable:
 				if condition.Format == 1:
 					axisIdx = condition.AxisIndex
-					axisTag = fvar.axes[axisIdx].axisTag
+					axisId = fvar.axes[axisIdx].axisId
 					Min = condition.FilterRangeMinValue
 					Max = condition.FilterRangeMaxValue
-					v = loc[axisTag]
+					v = loc[axisId]
 					if not (Min <= v <= Max):
 						applies = False
 				else:
@@ -337,7 +337,7 @@ def instantiateVariableFont(varfont, location, inplace=False, overlap=True):
 		asm.append("IDEF[ ]")
 		args = [str(len(loc))]
 		for a in fvar.axes:
-			args.append(str(floatToFixed(loc[a.axisTag], 14)))
+			args.append(str(floatToFixed(loc[a.axisId], 14)))
 		asm.append("NPUSHW[ ] " + ' '.join(args))
 		asm.append("ENDF[ ]")
 		fpgm.program.fromAssembly(asm)

--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -14,10 +14,10 @@ def _getLocationKey(loc):
 
 class OnlineVarStoreBuilder(object):
 
-	def __init__(self, axisTags):
-		self._axisTags = axisTags
+	def __init__(self, axisIds):
+		self._axisIds = axisIds
 		self._regionMap = {}
-		self._regionList = buildVarRegionList([], axisTags)
+		self._regionList = buildVarRegionList([], axisIds)
 		self._store = buildVarStore(self._regionList, [])
 		self._data = None
 		self._model = None
@@ -56,7 +56,7 @@ class OnlineVarStoreBuilder(object):
 			key = _getLocationKey(region)
 			idx = regionMap.get(key)
 			if idx is None:
-				varRegion = buildVarRegion(region, self._axisTags)
+				varRegion = buildVarRegion(region, self._axisIds)
 				idx = regionMap[key] = len(regionList.Region)
 				regionList.Region.append(varRegion)
 			regionIndices.append(idx)
@@ -132,7 +132,7 @@ ot.VarData.addItem = VarData_addItem
 
 def VarRegion_get_support(self, fvar_axes):
 	return {
-		fvar_axes[i].axisTag: (reg.StartCoord,reg.PeakCoord,reg.EndCoord)
+		fvar_axes[i].axisId: (reg.StartCoord,reg.PeakCoord,reg.EndCoord)
 		for i, reg in enumerate(self.VarRegionAxis)
 		if reg.PeakCoord != 0
 	}

--- a/Snippets/interpolate.py
+++ b/Snippets/interpolate.py
@@ -34,6 +34,7 @@ def AddFontVariations(font):
     fvar = font["fvar"] = table__f_v_a_r()
 
     weight = Axis()
+    weight.axisId = "weight"
     weight.axisTag = "wght"
     weight.nameID = AddName(font, "Weight").nameID
     weight.minValue, weight.defaultValue, weight.maxValue = (100, 400, 900)
@@ -48,7 +49,7 @@ def AddFontVariations(font):
             ("Black", 900)):
         inst = NamedInstance()
         inst.nameID = AddName(font, name).nameID
-        inst.coordinates = {"wght": wght}
+        inst.coordinates = {"weight": wght}
         fvar.instances.append(inst)
 
 

--- a/Tests/ttLib/tables/TupleVariation_test.py
+++ b/Tests/ttLib/tables/TupleVariation_test.py
@@ -229,9 +229,9 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.0, 0.5, 0.5), "wdth": (0.0, 0.8, 0.8)},
 			[(7,4), (8,5), (9,6)])
-		axisTags = ["wght", "wdth"]
-		sharedPeakIndices = { var.compileCoord(axisTags): 0x77 }
-		tup, deltas, _ = var.compile(axisTags, sharedPeakIndices,
+		axisIds = ["wght", "wdth"]
+		sharedPeakIndices = { var.compileCoord(axisIds): 0x77 }
+		tup, deltas, _ = var.compile(axisIds, sharedPeakIndices,
 		                          sharedPoints={0,1,2})
 		# len(deltas)=8; flags=None; tupleIndex=0x77
 		# embeddedPeaks=[]; intermediateCoord=[]
@@ -244,9 +244,9 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.3, 0.5, 0.7), "wdth": (0.1, 0.8, 0.9)},
 			[(7,4), (8,5), (9,6)])
-		axisTags = ["wght", "wdth"]
-		sharedPeakIndices = { var.compileCoord(axisTags): 0x77 }
-		tup, deltas, _ = var.compile(axisTags, sharedPeakIndices,
+		axisIds = ["wght", "wdth"]
+		sharedPeakIndices = { var.compileCoord(axisIds): 0x77 }
+		tup, deltas, _ = var.compile(axisIds, sharedPeakIndices,
 		                          sharedPoints={0,1,2})
 		# len(deltas)=8; flags=INTERMEDIATE_REGION; tupleIndex=0x77
 		# embeddedPeak=[]; intermediateCoord=[(0.3, 0.1), (0.7, 0.9)]
@@ -259,9 +259,9 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.0, 0.5, 0.5), "wdth": (0.0, 0.8, 0.8)},
 			[(7,4), (8,5), (9,6)])
-		axisTags = ["wght", "wdth"]
-		sharedPeakIndices = { var.compileCoord(axisTags): 0x77 }
-		tup, deltas, _ = var.compile(axisTags, sharedPeakIndices,
+		axisIds = ["wght", "wdth"]
+		sharedPeakIndices = { var.compileCoord(axisIds): 0x77 }
+		tup, deltas, _ = var.compile(axisIds, sharedPeakIndices,
 		                          sharedPoints=None)
 		# len(deltas)=9; flags=PRIVATE_POINT_NUMBERS; tupleIndex=0x77
 		# embeddedPeak=[]; intermediateCoord=[]
@@ -275,9 +275,9 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.0, 0.5, 1.0), "wdth": (0.0, 0.8, 1.0)},
 			[(7,4), (8,5), (9,6)])
-		axisTags = ["wght", "wdth"]
-		sharedPeakIndices = { var.compileCoord(axisTags): 0x77 }
-		tuple, deltas, _ = var.compile(axisTags,
+		axisIds = ["wght", "wdth"]
+		sharedPeakIndices = { var.compileCoord(axisIds): 0x77 }
+		tuple, deltas, _ = var.compile(axisIds,
 		                            sharedPeakIndices, sharedPoints=None)
 		# len(deltas)=9; flags=PRIVATE_POINT_NUMBERS; tupleIndex=0x77
 		# embeddedPeak=[]; intermediateCoord=[(0.0, 0.0), (1.0, 1.0)]
@@ -292,7 +292,7 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.0, 0.5, 0.5), "wdth": (0.0, 0.8, 0.8)},
 			[(7,4), (8,5), (9,6)])
-		tup, deltas, _ = var.compile(axisTags=["wght", "wdth"],
+		tup, deltas, _ = var.compile(axisIds=["wght", "wdth"],
 		                          sharedCoordIndices={}, sharedPoints={0, 1, 2})
 		# len(deltas)=8; flags=EMBEDDED_PEAK_TUPLE
 		# embeddedPeak=[(0.5, 0.8)]; intermediateCoord=[]
@@ -305,7 +305,7 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.0, 0.5, 0.5), "wdth": (0.0, 0.8, 0.8)},
 			[3, 1, 4])
-		tup, deltas, _ = var.compile(axisTags=["wght", "wdth"],
+		tup, deltas, _ = var.compile(axisIds=["wght", "wdth"],
 		                          sharedCoordIndices={}, sharedPoints={0, 1, 2})
 		# len(deltas)=4; flags=EMBEDDED_PEAK_TUPLE
 		# embeddedPeak=[(0.5, 0.8)]; intermediateCoord=[]
@@ -317,7 +317,7 @@ class TupleVariationTest(unittest.TestCase):
 		var = TupleVariation(
 			{"wght": (0.0, 0.5, 1.0), "wdth": (0.0, 0.8, 0.8)},
 			[(7,4), (8,5), (9,6)])
-		tup, deltas, _ = var.compile(axisTags=["wght", "wdth"],
+		tup, deltas, _ = var.compile(axisIds=["wght", "wdth"],
 		                          sharedCoordIndices={},
 		                          sharedPoints={0, 1, 2})
 		# len(deltas)=8; flags=EMBEDDED_PEAK_TUPLE
@@ -333,7 +333,7 @@ class TupleVariationTest(unittest.TestCase):
 			{"wght": (0.0, 0.5, 0.5), "wdth": (0.0, 0.8, 0.8)},
 			[(7,4), (8,5), (9,6)])
 		tup, deltas, _ = var.compile(
-			axisTags=["wght", "wdth"], sharedCoordIndices={}, sharedPoints=None)
+			axisIds=["wght", "wdth"], sharedCoordIndices={}, sharedPoints=None)
 		# len(deltas)=9; flags=PRIVATE_POINT_NUMBERS|EMBEDDED_PEAK_TUPLE
 		# embeddedPeak=[(0.5, 0.8)]; intermediateCoord=[]
 		self.assertEqual("00 09 A0 00 20 00 33 33", hexencode(tup))
@@ -347,7 +347,7 @@ class TupleVariationTest(unittest.TestCase):
 			{"wght": (0.0, 0.5, 0.5), "wdth": (0.0, 0.8, 0.8)},
 			[7, 8, 9])
 		tup, deltas, _ = var.compile(
-			axisTags=["wght", "wdth"], sharedCoordIndices={}, sharedPoints=None)
+			axisIds=["wght", "wdth"], sharedCoordIndices={}, sharedPoints=None)
 		# len(deltas)=5; flags=PRIVATE_POINT_NUMBERS|EMBEDDED_PEAK_TUPLE
 		# embeddedPeak=[(0.5, 0.8)]; intermediateCoord=[]
 		self.assertEqual("00 05 A0 00 20 00 33 33", hexencode(tup))
@@ -360,7 +360,7 @@ class TupleVariationTest(unittest.TestCase):
 			{"wght": (0.4, 0.5, 0.6), "wdth": (0.7, 0.8, 0.9)},
 			[(7,4), (8,5), (9,6)])
 		tup, deltas, _ = var.compile(
-			axisTags = ["wght", "wdth"],
+			axisIds = ["wght", "wdth"],
 			sharedCoordIndices={}, sharedPoints=None)
 		# len(deltas)=9;
 		# flags=PRIVATE_POINT_NUMBERS|INTERMEDIATE_REGION|EMBEDDED_PEAK_TUPLE
@@ -377,7 +377,7 @@ class TupleVariationTest(unittest.TestCase):
 			{"wght": (0.4, 0.5, 0.6), "wdth": (0.7, 0.8, 0.9)},
 			[7, 8, 9])
 		tup, deltas, _ = var.compile(
-			axisTags = ["wght", "wdth"],
+			axisIds = ["wght", "wdth"],
 			sharedCoordIndices={}, sharedPoints=None)
 		# len(deltas)=5;
 		# flags=PRIVATE_POINT_NUMBERS|INTERMEDIATE_REGION|EMBEDDED_PEAK_TUPLE
@@ -616,7 +616,7 @@ class TupleVariationTest(unittest.TestCase):
 
 	def test_decompileSharedTuples_Skia(self):
 		sharedTuples = decompileSharedTuples(
-			axisTags=["wght", "wdth"], sharedTupleCount=8,
+			axisIds=["wght", "wdth"], sharedTupleCount=8,
 			data=SKIA_GVAR_SHARED_TUPLES_DATA, offset=0)
 		self.assertEqual(sharedTuples, SKIA_GVAR_SHARED_TUPLES)
 
@@ -632,14 +632,14 @@ class TupleVariationTest(unittest.TestCase):
 		]
 		self.assertEqual(
 			compileTupleVariationStore(variations, pointCount=8,
-			                           axisTags=["wght", "opsz"],
+			                           axisIds=["wght", "opsz"],
 			                           sharedTupleIndices={}),
             (0, b"", b""))
 
 	def test_compileTupleVariationStore_noVariations(self):
 		self.assertEqual(
 			compileTupleVariationStore(variations=[], pointCount=8,
-			                           axisTags=["wght", "opsz"],
+			                           axisIds=["wght", "opsz"],
 			                           sharedTupleIndices={}),
             (0, b"", b""))
 
@@ -652,7 +652,7 @@ class TupleVariationTest(unittest.TestCase):
 			               deltas)
 		]
 		tupleVariationCount, tuples, data = compileTupleVariationStore(
-			variations, pointCount=4, axisTags=["wght", "wdth"],
+			variations, pointCount=4, axisIds=["wght", "wdth"],
 			sharedTupleIndices={})
 		self.assertEqual(
 			decompileTupleVariationStore("cvar", ["wght", "wdth"],
@@ -670,7 +670,7 @@ class TupleVariationTest(unittest.TestCase):
 			               deltas)
 		]
 		tupleVariationCount, tuples, data = compileTupleVariationStore(
-			variations, pointCount=4, axisTags=["wght", "wdth"],
+			variations, pointCount=4, axisIds=["wght", "wdth"],
 			sharedTupleIndices={})
 		self.assertEqual(
 			decompileTupleVariationStore("gvar", ["wght", "wdth"],
@@ -681,7 +681,7 @@ class TupleVariationTest(unittest.TestCase):
 
 	def test_decompileTupleVariationStore_Skia_I(self):
 		tvar = decompileTupleVariationStore(
-			tableTag="gvar", axisTags=["wght", "wdth"],
+			tableTag="gvar", axisIds=["wght", "wdth"],
 			tupleVariationCount=8, pointCount=18,
 			sharedTuples=SKIA_GVAR_SHARED_TUPLES,
 			data=SKIA_GVAR_I_DATA, pos=4, dataPos=36)
@@ -694,7 +694,7 @@ class TupleVariationTest(unittest.TestCase):
 
 	def test_decompileTupleVariationStore_empty(self):
 		self.assertEqual(
-			decompileTupleVariationStore(tableTag="gvar", axisTags=[],
+			decompileTupleVariationStore(tableTag="gvar", axisIds=[],
 			                             tupleVariationCount=0, pointCount=5,
 			                             sharedTuples=[],
 			                             data=b"", pos=4, dataPos=4),

--- a/Tests/ttLib/tables/_a_v_a_r_test.py
+++ b/Tests/ttLib/tables/_a_v_a_r_test.py
@@ -30,16 +30,16 @@ class AxisVariationTableTest(unittest.TestCase):
 
     def test_compile(self):
         avar = table__a_v_a_r()
-        avar.segments["wdth"] = {-1.0: -1.0, 0.0: 0.0, 0.3: 0.8, 1.0: 1.0}
-        avar.segments["wght"] = {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}
+        avar.segments["wdth#0"] = {-1.0: -1.0, 0.0: 0.0, 0.3: 0.8, 1.0: 1.0}
+        avar.segments["wght#1"] = {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}
         self.assertEqual(TEST_DATA, avar.compile(self.makeFont(["wdth", "wght"])))
 
     def test_decompile(self):
         avar = table__a_v_a_r()
         avar.decompile(TEST_DATA, self.makeFont(["wdth", "wght"]))
         self.assertAvarAlmostEqual({
-            "wdth": {-1.0: -1.0, 0.0: 0.0, 0.2999878: 0.7999878, 1.0: 1.0},
-            "wght": {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}
+            "wdth#0": {-1.0: -1.0, 0.0: 0.0, 0.2999878: 0.7999878, 1.0: 1.0},
+            "wght#1": {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}
         }, avar.segments)
 
     def test_decompile_unsupportedVersion(self):
@@ -49,11 +49,11 @@ class AxisVariationTableTest(unittest.TestCase):
 
     def test_toXML(self):
         avar = table__a_v_a_r()
-        avar.segments["opsz"] = {-1.0: -1.0, 0.0: 0.0, 0.2999878: 0.7999878, 1.0: 1.0}
+        avar.segments["opsz#0"] = {-1.0: -1.0, 0.0: 0.0, 0.2999878: 0.7999878, 1.0: 1.0}
         writer = XMLWriter(BytesIO())
         avar.toXML(writer, self.makeFont(["opsz"]))
         self.assertEqual([
-            '<segment axis="opsz">',
+            '<segment axis="opsz#0">',
                 '<mapping from="-1.0" to="-1.0"/>',
                 '<mapping from="0.0" to="0.0"/>',
                 '<mapping from="0.3" to="0.8"/>',
@@ -80,9 +80,10 @@ class AxisVariationTableTest(unittest.TestCase):
     def makeFont(axisTags):
         """['opsz', 'wdth'] --> ttFont"""
         fvar = table__f_v_a_r()
-        for tag in axisTags:
+        for i, tag in enumerate(axisTags):
             axis = Axis()
             axis.axisTag = tag
+            axis.axisId = f"{tag}#{i}"
             fvar.axes.append(axis)
         return {"fvar": fvar}
 

--- a/Tests/ttLib/tables/_c_v_a_r_test.py
+++ b/Tests/ttLib/tables/_c_v_a_r_test.py
@@ -35,14 +35,14 @@ CVAR_PRIVATE_POINT_DATA = deHexStr(
 CVAR_XML = [
     '<version major="1" minor="0"/>',
     '<tuple>',
-    '  <coord axis="wght" value="1.0"/>',
+    '  <coord axis="weight" value="1.0"/>',
     '  <delta cvt="2" value="3"/>',
     '  <delta cvt="3" value="1"/>',
     '  <delta cvt="4" value="4"/>',
     '</tuple>',
     '<tuple>',
-    '  <coord axis="wght" value="-1.0"/>',
-    '  <coord axis="wdth" value="0.8"/>',
+    '  <coord axis="weight" value="-1.0"/>',
+    '  <coord axis="width" value="0.8"/>',
     '  <delta cvt="2" value="9"/>',
     '  <delta cvt="3" value="7"/>',
     '  <delta cvt="4" value="8"/>',
@@ -50,8 +50,8 @@ CVAR_XML = [
 ]
 
 CVAR_VARIATIONS = [
-    TupleVariation({"wght": (0.0, 1.0, 1.0)}, [None, None, 3, 1, 4]),
-    TupleVariation({"wght": (-1, -1.0, 0.0), "wdth": (0.0, 0.7999878, 0.7999878)},
+    TupleVariation({"weight": (0.0, 1.0, 1.0)}, [None, None, 3, 1, 4]),
+    TupleVariation({"weight": (-1, -1.0, 0.0), "width": (0.0, 0.7999878, 0.7999878)},
                    [None, None, 9, 7, 8]),
 ]
 
@@ -75,6 +75,7 @@ class CVARTableTest(unittest.TestCase):
         Axis = getTableModule("fvar").Axis
         fvar.axes = [Axis(), Axis()]
         fvar.axes[0].axisTag, fvar.axes[1].axisTag = "wght", "wdth"
+        fvar.axes[0].axisId, fvar.axes[1].axisId = "weight", "width"
         return font, cvar
 
     def test_compile(self):

--- a/Tests/ttLib/tables/_g_v_a_r_test.py
+++ b/Tests/ttLib/tables/_g_v_a_r_test.py
@@ -64,15 +64,15 @@ GVAR_VARIATIONS = {
     ],
     "space": [
         TupleVariation(
-            {"wdth": (0.0, 0.7000122, 0.7000122)},
+            {"width": (0.0, 0.7000122, 0.7000122)},
             [(1, 11), (2, 22), (3, 33), (4, 44)]),
     ],
     "I": [
         TupleVariation(
-            {"wght": (0.0, 0.5, 1.0)},
+            {"weight": (0.0, 0.5, 1.0)},
             [(3,3), (1,1), (4,4), (1,1), (5,5), (9,9), (2,2), (6,6)]),
         TupleVariation(
-            {"wght": (-1.0, -1.0, 0.0), "wdth": (0.0, 0.7999878, 0.7999878)},
+            {"weight": (-1.0, -1.0, 0.0), "width": (0.0, 0.7999878, 0.7999878)},
             [(-8,-88), (7,77), None, None, (-4,44), (3,33), (-2,-22), (1,11)]),
     ],
 }
@@ -83,7 +83,7 @@ GVAR_XML = [
     '<reserved value="0"/>',
     '<glyphVariations glyph="I">',
     '  <tuple>',
-    '    <coord axis="wght" min="0.0" value="0.5" max="1.0"/>',
+    '    <coord axis="weight" min="0.0" value="0.5" max="1.0"/>',
     '    <delta pt="0" x="3" y="3"/>',
     '    <delta pt="1" x="1" y="1"/>',
     '    <delta pt="2" x="4" y="4"/>',
@@ -94,8 +94,8 @@ GVAR_XML = [
     '    <delta pt="7" x="6" y="6"/>',
     '  </tuple>',
     '  <tuple>',
-    '    <coord axis="wght" value="-1.0"/>',
-    '    <coord axis="wdth" value="0.8"/>',
+    '    <coord axis="weight" value="-1.0"/>',
+    '    <coord axis="width" value="0.8"/>',
     '    <delta pt="0" x="-8" y="-88"/>',
     '    <delta pt="1" x="7" y="77"/>',
     '    <delta pt="4" x="-4" y="44"/>',
@@ -106,7 +106,7 @@ GVAR_XML = [
     '</glyphVariations>',
     '<glyphVariations glyph="space">',
     '  <tuple>',
-    '    <coord axis="wdth" value="0.7"/>',
+    '    <coord axis="width" value="0.7"/>',
     '    <delta pt="0" x="1" y="11"/>',
     '    <delta pt="1" x="2" y="22"/>',
     '    <delta pt="2" x="3" y="33"/>',
@@ -157,6 +157,7 @@ class GVARTableTest(unittest.TestCase):
 		glyf.glyphs["I"].coordinates = [(10, 10), (10, 20), (20, 20), (20, 10)]
 		fvar.axes = [Axis(), Axis()]
 		fvar.axes[0].axisTag, fvar.axes[1].axisTag = "wght", "wdth"
+		fvar.axes[0].axisId, fvar.axes[1].axisId = "weight", "width"
 		gvar.variations = variations
 		return font, gvar
 

--- a/Tests/varLib/instancer_test.py
+++ b/Tests/varLib/instancer_test.py
@@ -38,11 +38,13 @@ def optimize(request):
 @pytest.fixture
 def fvarAxes():
     wght = _f_v_a_r.Axis()
+    wght.axisId = "weight"
     wght.axisTag = Tag("wght")
     wght.minValue = 100
     wght.defaultValue = 400
     wght.maxValue = 900
     wdth = _f_v_a_r.Axis()
+    wdth.axisId = "width"
     wdth.axisTag = Tag("wdth")
     wdth.minValue = 70
     wdth.defaultValue = 100
@@ -389,6 +391,7 @@ class InstantiateHVARTest(object):
         # to signal there are variations to the glyph's advance widths.
         fvar = varfont["fvar"]
         axis = _f_v_a_r.Axis()
+        axis.axisId = "test"
         axis.axisTag = "TEST"
         fvar.axes.append(axis)
 
@@ -412,7 +415,7 @@ class InstantiateItemVariationStoreTest(object):
         assert len(region.VarRegionAxis) == 3
         assert region.VarRegionAxis[2].PeakCoord == 0
 
-        fvarAxes = [SimpleNamespace(axisTag=axisTag) for axisTag in axisOrder]
+        fvarAxes = [SimpleNamespace(axisId=axisId) for axisId in axisOrder]
 
         assert region.get_support(fvarAxes) == regionAxes
 
@@ -421,15 +424,15 @@ class InstantiateItemVariationStoreTest(object):
         return builder.buildVarStore(
             builder.buildVarRegionList(
                 [
-                    {"wght": (-1.0, -1.0, 0)},
-                    {"wght": (0, 0.5, 1.0)},
-                    {"wght": (0.5, 1.0, 1.0)},
-                    {"wdth": (-1.0, -1.0, 0)},
-                    {"wght": (-1.0, -1.0, 0), "wdth": (-1.0, -1.0, 0)},
-                    {"wght": (0, 0.5, 1.0), "wdth": (-1.0, -1.0, 0)},
-                    {"wght": (0.5, 1.0, 1.0), "wdth": (-1.0, -1.0, 0)},
+                    {"weight": (-1.0, -1.0, 0)},
+                    {"weight": (0, 0.5, 1.0)},
+                    {"weight": (0.5, 1.0, 1.0)},
+                    {"width": (-1.0, -1.0, 0)},
+                    {"weight": (-1.0, -1.0, 0), "width": (-1.0, -1.0, 0)},
+                    {"weight": (0, 0.5, 1.0), "width": (-1.0, -1.0, 0)},
+                    {"weight": (0.5, 1.0, 1.0), "width": (-1.0, -1.0, 0)},
                 ],
-                ["wght", "wdth"],
+                ["weight", "width"],
             ),
             [
                 builder.buildVarData([0, 1, 2], [[100, 100, 100], [100, 100, 100]]),
@@ -442,13 +445,13 @@ class InstantiateItemVariationStoreTest(object):
     @pytest.mark.parametrize(
         "location, expected_deltas, num_regions",
         [
-            ({"wght": 0}, [[0, 0], [0, 0]], 1),
-            ({"wght": 0.25}, [[50, 50], [0, 0]], 1),
-            ({"wdth": 0}, [[0, 0], [0, 0]], 3),
-            ({"wdth": -0.75}, [[0, 0], [75, 75]], 3),
-            ({"wght": 0, "wdth": 0}, [[0, 0], [0, 0]], 0),
-            ({"wght": 0.25, "wdth": 0}, [[50, 50], [0, 0]], 0),
-            ({"wght": 0, "wdth": -0.75}, [[0, 0], [75, 75]], 0),
+            ({"weight": 0}, [[0, 0], [0, 0]], 1),
+            ({"weight": 0.25}, [[50, 50], [0, 0]], 1),
+            ({"width": 0}, [[0, 0], [0, 0]], 3),
+            ({"width": -0.75}, [[0, 0], [75, 75]], 3),
+            ({"weight": 0, "width": 0}, [[0, 0], [0, 0]], 0),
+            ({"weight": 0.25, "width": 0}, [[50, 50], [0, 0]], 0),
+            ({"weight": 0, "width": -0.75}, [[0, 0], [75, 75]], 0),
         ],
     )
     def test_instantiate_default_deltas(
@@ -550,15 +553,15 @@ class TupleVarStoreAdapterTest(object):
 
     def test_roundtrip(self, fvarAxes):
         regions = [
-            {"wght": (-1.0, -1.0, 0)},
-            {"wght": (0, 0.5, 1.0)},
-            {"wght": (0.5, 1.0, 1.0)},
-            {"wdth": (-1.0, -1.0, 0)},
-            {"wght": (-1.0, -1.0, 0), "wdth": (-1.0, -1.0, 0)},
-            {"wght": (0, 0.5, 1.0), "wdth": (-1.0, -1.0, 0)},
-            {"wght": (0.5, 1.0, 1.0), "wdth": (-1.0, -1.0, 0)},
+            {"weight": (-1.0, -1.0, 0)},
+            {"weight": (0, 0.5, 1.0)},
+            {"weight": (0.5, 1.0, 1.0)},
+            {"width": (-1.0, -1.0, 0)},
+            {"weight": (-1.0, -1.0, 0), "width": (-1.0, -1.0, 0)},
+            {"weight": (0, 0.5, 1.0), "width": (-1.0, -1.0, 0)},
+            {"weight": (0.5, 1.0, 1.0), "width": (-1.0, -1.0, 0)},
         ]
-        axisOrder = [axis.axisTag for axis in fvarAxes]
+        axisOrder = [axis.axisId for axis in fvarAxes]
 
         itemVarStore = builder.buildVarStore(
             builder.buildVarRegionList(regions, axisOrder),
@@ -579,29 +582,29 @@ class TupleVarStoreAdapterTest(object):
 
         assert adapter.tupleVarData == [
             [
-                TupleVariation({"wght": (-1.0, -1.0, 0)}, [10, 70]),
-                TupleVariation({"wght": (0, 0.5, 1.0)}, [-20, -80]),
-                TupleVariation({"wght": (0.5, 1.0, 1.0)}, [30, 90]),
+                TupleVariation({"weight": (-1.0, -1.0, 0)}, [10, 70]),
+                TupleVariation({"weight": (0, 0.5, 1.0)}, [-20, -80]),
+                TupleVariation({"weight": (0.5, 1.0, 1.0)}, [30, 90]),
                 TupleVariation(
-                    {"wght": (-1.0, -1.0, 0), "wdth": (-1.0, -1.0, 0)}, [-40, -100]
+                    {"weight": (-1.0, -1.0, 0), "width": (-1.0, -1.0, 0)}, [-40, -100]
                 ),
                 TupleVariation(
-                    {"wght": (0, 0.5, 1.0), "wdth": (-1.0, -1.0, 0)}, [50, 110]
+                    {"weight": (0, 0.5, 1.0), "width": (-1.0, -1.0, 0)}, [50, 110]
                 ),
                 TupleVariation(
-                    {"wght": (0.5, 1.0, 1.0), "wdth": (-1.0, -1.0, 0)}, [-60, -120]
+                    {"weight": (0.5, 1.0, 1.0), "width": (-1.0, -1.0, 0)}, [-60, -120]
                 ),
             ],
             [
-                TupleVariation({"wdth": (-1.0, -1.0, 0)}, [5, 45]),
+                TupleVariation({"width": (-1.0, -1.0, 0)}, [5, 45]),
                 TupleVariation(
-                    {"wght": (-1.0, -1.0, 0), "wdth": (-1.0, -1.0, 0)}, [-15, -55]
+                    {"weight": (-1.0, -1.0, 0), "width": (-1.0, -1.0, 0)}, [-15, -55]
                 ),
                 TupleVariation(
-                    {"wght": (0, 0.5, 1.0), "wdth": (-1.0, -1.0, 0)}, [25, 65]
+                    {"weight": (0, 0.5, 1.0), "width": (-1.0, -1.0, 0)}, [25, 65]
                 ),
                 TupleVariation(
-                    {"wght": (0.5, 1.0, 1.0), "wdth": (-1.0, -1.0, 0)}, [-35, -75]
+                    {"weight": (0.5, 1.0, 1.0), "width": (-1.0, -1.0, 0)}, [-35, -75]
                 ),
             ],
         ]
@@ -1499,11 +1502,11 @@ def _getSubstitutions(gsub, lookupIndices):
 
 
 def makeFeatureVarsFont(conditionalSubstitutions):
-    axes = set()
+    axisIds = set()
     glyphs = set()
     for region, substitutions in conditionalSubstitutions:
         for box in region:
-            axes.update(box.keys())
+            axisIds.update(box.keys())
         glyphs.update(*substitutions.items())
 
     varfont = ttLib.TTFont()
@@ -1511,9 +1514,10 @@ def makeFeatureVarsFont(conditionalSubstitutions):
 
     fvar = varfont["fvar"] = ttLib.newTable("fvar")
     fvar.axes = []
-    for axisTag in sorted(axes):
+    for axisId in sorted(axisIds):
         axis = _f_v_a_r.Axis()
-        axis.axisTag = Tag(axisTag)
+        axis.axisId = axisId
+        axis.axisTag = axisId
         fvar.axes.append(axis)
 
     featureVars.addFeatureVariations(varfont, conditionalSubstitutions)


### PR DESCRIPTION
Inside an OpenType font an axis is referred to by its index. In ttx
the axis tag was used as an id but the axis tag is not required to be
unique. Explicitly create and use an axis id which is separate from the
axis tag. This allows for proper handling of fonts with multiple axes
which specify the same tag.

Note that this explicitly does not touch the non-fvar axis tags in the
STAT table, which are a separate set of tags.

Implements #1581. 