### PR TITLE
Switch from brotlipy to brotlicffi for PyPy support

### DIFF
--- a/Lib/fontTools/ttLib/woff2.py
+++ b/Lib/fontTools/ttLib/woff2.py
@@ -19,7 +19,10 @@ log = logging.getLogger("fontTools.ttLib.woff2")
 
 haveBrotli = False
 try:
-	import brotli
+	try:
+		import brotlicffi as brotli
+	except ImportError:
+		import brotli
 	haveBrotli = True
 except ImportError:
 	pass

--- a/Tests/ttLib/woff2_test.py
+++ b/Tests/ttLib/woff2_test.py
@@ -21,7 +21,10 @@ import pytest
 
 haveBrotli = False
 try:
-	import brotli
+	try:
+		import brotlicffi as brotli
+	except ImportError:
+		import brotli
 	haveBrotli = True
 except ImportError:
 	pass

--- a/Tests/ttx/ttx_test.py
+++ b/Tests/ttx/ttx_test.py
@@ -18,7 +18,10 @@ try:
 except ImportError:
     zopfli = None
 try:
-    import brotli
+    try:
+        import brotlicffi as brotli
+    except ImportError:
+        import brotli
 except ImportError:
     brotli = None
 

--- a/setup.py
+++ b/setup.py
@@ -82,8 +82,8 @@ extras_require = {
 	# for fontTools.sfnt and fontTools.woff2: to compress/uncompress
 	# WOFF 1.0 and WOFF 2.0 webfonts.
 	"woff": [
-		"brotli >= 1.0.1; platform_python_implementation != 'PyPy'",
-		"brotlipy >= 0.7.0; platform_python_implementation == 'PyPy'",
+		"brotli >= 1.0.1; platform_python_implementation == 'CPython'",
+		"brotlicffi >= 0.8.0; platform_python_implementation != 'CPython'",
 		"zopfli >= 0.1.4",
 	],
 	# for fontTools.unicode and fontTools.unicodedata: to use the latest version


### PR DESCRIPTION
brotlipy has been renamed to brotlicffi to no longer conflict with the import namespace `brotli` and now guarantees the same API as Google's C bindings.

This example project shows how to use the `brotlicffi` library: https://github.com/python-hyper/brotlicffi/tree/master/example