### PR TITLE
docs: fix simple typo, ovverride -> override

### DIFF
--- a/Tests/ttLib/woff2_test.py
+++ b/Tests/ttLib/woff2_test.py
@@ -203,7 +203,7 @@ def normalise_font(font, padding=4):
 	# drop DSIG but keep a copy
 	DSIG_copy = copy.deepcopy(font['DSIG'])
 	del font['DSIG']
-	# ovverride TTFont attributes
+	# override TTFont attributes
 	origFlavor = font.flavor
 	origRecalcBBoxes = font.recalcBBoxes
 	origRecalcTimestamp = font.recalcTimestamp


### PR DESCRIPTION
There is a small typo in Tests/ttLib/woff2_test.py.

Should read `override` rather than `ovverride`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md