### PR TITLE
COLRv1: avoid abrupt change after rounding c0 when too near c1's perimeter

### DIFF
--- a/Lib/fontTools/colorLib/builder.py
+++ b/Lib/fontTools/colorLib/builder.py
@@ -34,7 +34,7 @@ from fontTools.ttLib.tables.otTables import (
     VariableInt,
 )
 from .errors import ColorLibError
-from .geometry import nudge_start_circle_almost_inside
+from .geometry import round_start_circle_stable_containment
 
 
 # TODO move type aliases to colorLib.types?
@@ -534,7 +534,7 @@ class LayerV1ListBuilder:
         r1 = _to_variable_value(r1)
 
         # avoid abrupt change after rounding when c0 is near c1's perimeter
-        c = nudge_start_circle_almost_inside(
+        c = round_start_circle_stable_containment(
             (x0.value, y0.value), r0.value, (x1.value, y1.value), r1.value
         )
         x0, y0 = x0._replace(value=c.centre[0]), y0._replace(value=c.centre[1])

--- a/Lib/fontTools/colorLib/builder.py
+++ b/Lib/fontTools/colorLib/builder.py
@@ -534,10 +534,11 @@ class LayerV1ListBuilder:
         r1 = _to_variable_value(r1)
 
         # avoid abrupt change after rounding when c0 is near c1's perimeter
-        c0x, c0y = nudge_start_circle_almost_inside(
+        c = nudge_start_circle_almost_inside(
             (x0.value, y0.value), r0.value, (x1.value, y1.value), r1.value
         )
-        x0, y0 = x0._replace(value=c0x), y0._replace(value=c0y)
+        x0, y0 = x0._replace(value=c.centre[0]), y0._replace(value=c.centre[1])
+        r0 = r0._replace(value=c.radius)
 
         for i, (x, y, r) in enumerate(((x0, y0, r0), (x1, y1, r1))):
             # rounding happens here as floats are converted to integers

--- a/Lib/fontTools/colorLib/geometry.py
+++ b/Lib/fontTools/colorLib/geometry.py
@@ -4,12 +4,8 @@ from math import copysign, cos, hypot, pi
 from fontTools.misc.fixedTools import otRound
 
 
-def _vector_between_points(a, b):
-    return (b[0] - a[0], b[1] - a[1])
-
-
-def _distance_between_points(a, b):
-    return hypot(*_vector_between_points(a, b))
+def _vector_between(origin, target):
+    return (target[0] - origin[0], target[1] - origin[1])
 
 
 def _round_point(pt):
@@ -33,7 +29,7 @@ _NEARLY_ZERO = 1 / (1 << 12)  # 0.000244140625
 
 
 def _is_circle_inside_circle(c0, r0, c1, r1):
-    dist = r0 + _distance_between_points(c0, c1)
+    dist = r0 + hypot(*_vector_between(c0, c1))
     return abs(r1 - dist) <= _NEARLY_ZERO or r1 > dist
 
 
@@ -89,9 +85,9 @@ def nudge_start_circle_almost_inside(c0, r0, c1, r1):
             if rc0 == rc1:  # nowhere to nudge along a zero vector, bail out
                 break
             if inside_after_round:
-                direction = _vector_between_points(rc1, rc0)
+                direction = _vector_between(rc1, rc0)
             else:
-                direction = _vector_between_points(rc0, rc1)
+                direction = _vector_between(rc0, rc1)
             rc0 = _nudge_point(rc0, direction)
             inside_after_round = _is_circle_inside_circle(rc0, rr0, rc1, rr1)
             if inside_before_round == inside_after_round:

--- a/Lib/fontTools/colorLib/geometry.py
+++ b/Lib/fontTools/colorLib/geometry.py
@@ -28,9 +28,9 @@ def _unit_vector(vec):
 _NEARLY_ZERO = 1 / (1 << 12)  # 0.000244140625
 
 
-def _is_circle_inside_circle(c0, r0, c1, r1):
-    dist = r0 + hypot(*_vector_between(c0, c1))
-    return abs(r1 - dist) <= _NEARLY_ZERO or r1 > dist
+def _is_circle_inside_circle(inner_centre, inner_radius, outer_centre, outer_radius):
+    dist = inner_radius + hypot(*_vector_between(inner_centre, outer_centre))
+    return abs(outer_radius - dist) <= _NEARLY_ZERO or outer_radius > dist
 
 
 # The unit vector's X and Y components are respectively

--- a/Lib/fontTools/colorLib/geometry.py
+++ b/Lib/fontTools/colorLib/geometry.py
@@ -1,6 +1,6 @@
 """Helpers for manipulating 2D points and vectors in COLR table."""
 
-from math import copysign, cos, sqrt, pi
+from math import copysign, cos, hypot, pi
 from fontTools.misc.fixedTools import otRound
 
 
@@ -8,12 +8,8 @@ def _vector_between_points(a, b):
     return (b[0] - a[0], b[1] - a[1])
 
 
-def _vector_length(vec):
-    return sqrt(vec[0] * vec[0] + vec[1] * vec[1])
-
-
 def _distance_between_points(a, b):
-    return _vector_length(_vector_between_points(a, b))
+    return hypot(*_vector_between_points(a, b))
 
 
 def _round_point(pt):
@@ -25,7 +21,7 @@ def _round_circle(centre, radius):
 
 
 def _unit_vector(vec):
-    length = _vector_length(vec)
+    length = hypot(*vec)
     if length == 0:
         return None
     return (vec[0] / length, vec[1] / length)

--- a/Lib/fontTools/colorLib/geometry.py
+++ b/Lib/fontTools/colorLib/geometry.py
@@ -78,8 +78,8 @@ class Circle:
         self.centre = _nudge_point(self.centre, direction)
 
 
-def nudge_start_circle_almost_inside(c0, r0, c1, r1):
-    """Nudge c0 so it continues to be inside/outside c1 after rounding.
+def round_start_circle_stable_containment(c0, r0, c1, r1):
+    """Round start circle so that it stays inside/outside end circle after rounding.
 
     The rounding of circle coordinates to integers may cause an abrupt change
     if the start circle c0 is so close to the end circle c1's perimiter that

--- a/Lib/fontTools/colorLib/geometry.py
+++ b/Lib/fontTools/colorLib/geometry.py
@@ -1,0 +1,110 @@
+"""Helpers for manipulating 2D points and vectors in COLR table."""
+
+from math import copysign, cos, sqrt, pi
+from fontTools.misc.fixedTools import otRound
+
+
+def _vector_between_points(a, b):
+    return (b[0] - a[0], b[1] - a[1])
+
+
+def _vector_length(vec):
+    return sqrt(vec[0] * vec[0] + vec[1] * vec[1])
+
+
+def _distance_between_points(a, b):
+    return _vector_length(_vector_between_points(a, b))
+
+
+def _round_point(pt):
+    return (otRound(pt[0]), otRound(pt[1]))
+
+
+def _round_circle(centre, radius):
+    return _round_point(centre), otRound(radius)
+
+
+def _unit_vector(vec):
+    length = _vector_length(vec)
+    if length == 0:
+        return None
+    return (vec[0] / length, vec[1] / length)
+
+
+# This is the same tolerance used by Skia's SkTwoPointConicalGradient.cpp to detect
+# when a radial gradient's focal point lies on the end circle.
+_NEARLY_ZERO = 1 / (1 << 12)  # 0.000244140625
+
+
+def _is_circle_inside_circle(c0, r0, c1, r1):
+    dist = r0 + _distance_between_points(c0, c1)
+    return abs(r1 - dist) <= _NEARLY_ZERO or r1 > dist
+
+
+# The unit vector's X and Y components are respectively
+#   U = (cos(α), sin(α))
+# where α is the angle between the unit vector and the positive x axis.
+_UNIT_VECTOR_THRESHOLD = cos(3 / 8 * pi)  # == sin(1/8 * pi) == 0.38268343236508984
+
+
+def _nudge_point(pt, direction):
+    # Nudge point coordinates -/+ 1.0 approximately based on the direction vector.
+    # We divide the unit circle in 8 equal slices oriented towards the cardinal
+    # (N, E, S, W) and intermediate (NE, SE, SW, NW) directions. To each slice we
+    # map one of the possible cases: -1, 0, +1 for either X and Y coordinate.
+    # E.g. Return (x + 1.0, y - 1.0) if unit vector is oriented towards SE, or
+    # (x - 1.0, y) if it's pointing West, etc.
+    uv = _unit_vector(direction)
+    if not uv:
+        return pt
+
+    result = []
+    for coord, uv_component in zip(pt, uv):
+        if -_UNIT_VECTOR_THRESHOLD <= uv_component < _UNIT_VECTOR_THRESHOLD:
+            # unit vector component near 0: direction almost orthogonal to the
+            # direction of the current axis, thus keep coordinate unchanged
+            result.append(coord)
+        else:
+            # nudge coord by +/- 1.0 in direction of unit vector
+            result.append(coord + copysign(1.0, uv_component))
+    return tuple(result)
+
+
+def nudge_start_circle_almost_inside(c0, r0, c1, r1):
+    """ Nudge c0 so it continues to be inside/outside c1 after rounding.
+
+    The rounding of circle coordinates to integers may cause an abrupt change
+    if the start circle c0 is so close to the end circle c1's perimiter that
+    it ends up falling outside (or inside) as a result of the rounding.
+    To keep the gradient unchanged, we nudge it in the right direction.
+
+    See:
+    https://github.com/googlefonts/colr-gradients-spec/issues/204
+    https://github.com/googlefonts/picosvg/issues/158
+    """
+    inside_before_round = _is_circle_inside_circle(c0, r0, c1, r1)
+    rc0, rr0 = _round_circle(c0, r0)
+    rc1, rr1 = _round_circle(c1, r1)
+    inside_after_round = _is_circle_inside_circle(rc0, rr0, rc1, rr1)
+
+    if inside_before_round != inside_after_round:
+        # at most 2 iterations ought to be enough to converge
+        for _ in range(2):
+            if rc0 == rc1:  # nowhere to nudge along a zero vector, bail out
+                break
+            if inside_after_round:
+                direction = _vector_between_points(rc1, rc0)
+            else:
+                direction = _vector_between_points(rc0, rc1)
+            rc0 = _nudge_point(rc0, direction)
+            inside_after_round = _is_circle_inside_circle(rc0, rr0, rc1, rr1)
+            if inside_before_round == inside_after_round:
+                break
+        else:  # ... or it's a bug
+            raise AssertionError(
+                f"Nudging circle <c0={c0}, r0={r0}> "
+                f"{'inside' if inside_before_round else 'outside'} "
+                f"<c1={c1}, r1={r1}> failed after two attempts!"
+            )
+
+    return rc0

--- a/Lib/fontTools/colorLib/geometry.py
+++ b/Lib/fontTools/colorLib/geometry.py
@@ -90,12 +90,12 @@ def round_start_circle_stable_containment(c0, r0, c1, r1):
     https://github.com/googlefonts/colr-gradients-spec/issues/204
     https://github.com/googlefonts/picosvg/issues/158
     """
-    start_circle, end_circle = Circle(c0, r0), Circle(c1, r1)
+    start, end = Circle(c0, r0), Circle(c1, r1)
 
-    inside_before_round = start_circle.inside(end_circle)
+    inside_before_round = start.inside(end)
 
-    round_start = start_circle.round()
-    round_end = end_circle.round()
+    round_start = start.round()
+    round_end = end.round()
 
     # At most 3 iterations ought to be enough to converge. In the first, we
     # check if the start circle keeps containment after normal rounding; then
@@ -131,9 +131,9 @@ def round_start_circle_stable_containment(c0, r0, c1, r1):
             round_start.nudge_towards(direction)
     else:  # likely a bug
         raise AssertionError(
-            f"Rounding circle {start_circle} "
+            f"Rounding circle {start} "
             f"{'inside' if inside_before_round else 'outside'} "
-            f"{end_circle} failed after {max_attempts} attempts!"
+            f"{end} failed after {max_attempts} attempts!"
         )
 
     return round_start

--- a/Tests/colorLib/builder_test.py
+++ b/Tests/colorLib/builder_test.py
@@ -1,11 +1,7 @@
 from fontTools.ttLib import newTable
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.colorLib import builder
-from fontTools.colorLib.geometry import (
-    nudge_start_circle_almost_inside,
-    _is_circle_inside_circle,
-    _round_circle,
-)
+from fontTools.colorLib.geometry import nudge_start_circle_almost_inside, Circle
 from fontTools.colorLib.builder import LayerV1ListBuilder
 from fontTools.colorLib.errors import ColorLibError
 import pytest
@@ -1066,18 +1062,19 @@ class TrickyRadialGradientTest:
     @staticmethod
     def circle_inside_circle(c0, r0, c1, r1, rounded=False):
         if rounded:
-            return _is_circle_inside_circle(
-                *_round_circle(c0, r0), *_round_circle(c1, r1)
-            )
+            return Circle(c0, r0).round().inside(Circle(c1, r1).round())
         else:
-            return _is_circle_inside_circle(c0, r0, c1, r1)
+            return Circle(c0, r0).inside(Circle(c1, r1))
 
     def nudge_start_circle_position(self, c0, r0, c1, r1, inside=True):
         assert self.circle_inside_circle(c0, r0, c1, r1) is inside
         assert self.circle_inside_circle(c0, r0, c1, r1, rounded=True) is not inside
-        c0 = nudge_start_circle_almost_inside(c0, r0, c1, r1)
-        assert self.circle_inside_circle(c0, r0, c1, r1, rounded=True) is inside
-        return c0
+        r = nudge_start_circle_almost_inside(c0, r0, c1, r1)
+        assert (
+            self.circle_inside_circle(r.centre, r.radius, c1, r1, rounded=True)
+            is inside
+        )
+        return r.centre, r.radius
 
     def test_noto_emoji_mosquito_u1f99f(self):
         # https://github.com/googlefonts/picosvg/issues/158
@@ -1085,22 +1082,26 @@ class TrickyRadialGradientTest:
         r0 = 0
         c1 = (642.99108, 104.70327999999995)
         r1 = 260.0072
-        rc0 = self.nudge_start_circle_position(c0, r0, c1, r1, inside=True)
-        assert rc0 == (386, 71)
+        result = self.nudge_start_circle_position(c0, r0, c1, r1, inside=True)
+        assert result == ((386, 71), 0)
 
     @pytest.mark.parametrize(
         "c0, r0, c1, r1, inside, expected",
         [
             # inside before round, outside after round
-            ((1.4, 0), 0, (2.6, 0), 1.3, True, (2, 0)),
-            ((1, 0), 0.6, (2.8, 0), 2.45, True, (2, 0)),
-            ((6.49, 6.49), 0, (0.49, 0.49), 8.49, True, (5, 5)),
+            ((1.4, 0), 0, (2.6, 0), 1.3, True, ((2, 0), 0)),
+            ((1, 0), 0.6, (2.8, 0), 2.45, True, ((2, 0), 1)),
+            ((6.49, 6.49), 0, (0.49, 0.49), 8.49, True, ((5, 5), 0)),
             # outside before round, inside after round
-            ((0, 0), 0, (2, 0), 1.5, False, (-1, 0)),
-            ((0, -0.5), 0, (0, -2.5), 1.5, False, (0, 1)),
+            ((0, 0), 0, (2, 0), 1.5, False, ((-1, 0), 0)),
+            ((0, -0.5), 0, (0, -2.5), 1.5, False, ((0, 1), 0)),
             # the following ones require two nudges to round correctly
-            ((0.5, 0), 0, (9.4, 0), 8.8, False, (-1, 0)),
-            ((1.5, 1.5), 0, (0.49, 0.49), 1.49, True, (0, 0)),
+            ((0.5, 0), 0, (9.4, 0), 8.8, False, ((-1, 0), 0)),
+            ((1.5, 1.5), 0, (0.49, 0.49), 1.49, True, ((0, 0), 0)),
+            # limit case when circle almost exactly overlap
+            ((0.5000001, 0), 0.5000001, (0.499999, 0), 0.4999999, True, ((0, 0), 0)),
+            # concentrical circles, r0 > r1
+            ((0, 0), 1.49, (0, 0), 1, False, ((0, 0), 2)),
         ],
     )
     def test_nudge_start_circle_position(self, c0, r0, c1, r1, inside, expected):

--- a/Tests/colorLib/builder_test.py
+++ b/Tests/colorLib/builder_test.py
@@ -1,7 +1,7 @@
 from fontTools.ttLib import newTable
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.colorLib import builder
-from fontTools.colorLib.geometry import nudge_start_circle_almost_inside, Circle
+from fontTools.colorLib.geometry import round_start_circle_stable_containment, Circle
 from fontTools.colorLib.builder import LayerV1ListBuilder
 from fontTools.colorLib.errors import ColorLibError
 import pytest
@@ -1066,10 +1066,10 @@ class TrickyRadialGradientTest:
         else:
             return Circle(c0, r0).inside(Circle(c1, r1))
 
-    def nudge_start_circle_position(self, c0, r0, c1, r1, inside=True):
+    def round_start_circle(self, c0, r0, c1, r1, inside=True):
         assert self.circle_inside_circle(c0, r0, c1, r1) is inside
         assert self.circle_inside_circle(c0, r0, c1, r1, rounded=True) is not inside
-        r = nudge_start_circle_almost_inside(c0, r0, c1, r1)
+        r = round_start_circle_stable_containment(c0, r0, c1, r1)
         assert (
             self.circle_inside_circle(r.centre, r.radius, c1, r1, rounded=True)
             is inside
@@ -1082,8 +1082,7 @@ class TrickyRadialGradientTest:
         r0 = 0
         c1 = (642.99108, 104.70327999999995)
         r1 = 260.0072
-        result = self.nudge_start_circle_position(c0, r0, c1, r1, inside=True)
-        assert result == ((386, 71), 0)
+        assert self.round_start_circle(c0, r0, c1, r1, inside=True) == ((386, 71), 0)
 
     @pytest.mark.parametrize(
         "c0, r0, c1, r1, inside, expected",
@@ -1105,4 +1104,4 @@ class TrickyRadialGradientTest:
         ],
     )
     def test_nudge_start_circle_position(self, c0, r0, c1, r1, inside, expected):
-        assert self.nudge_start_circle_position(c0, r0, c1, r1, inside) == expected
+        assert self.round_start_circle(c0, r0, c1, r1, inside) == expected


### PR DESCRIPTION
Fixes encoding a tricky radial gradient in Noto Emoji's 🦟 (U+1F99F) https://github.com/googlefonts/picosvg/issues/158
For more info also see discussion at https://github.com/googlefonts/colr-gradients-spec/issues/204