### PR TITLE
[varLib] featureVars.addFeatureVariationsRaw: Raise legible error message when script is missing a dflt langsys

### DIFF
--- a/Lib/fontTools/varLib/featureVars.py
+++ b/Lib/fontTools/varLib/featureVars.py
@@ -10,7 +10,7 @@ from fontTools.ttLib.tables import otTables as ot
 from fontTools.otlLib.builder import buildLookup, buildSingleSubstSubtable
 from collections import OrderedDict
 
-from .errors import VarLibValidationError
+from .errors import VarLibError, VarLibValidationError
 
 
 def addFeatureVariations(font, conditionalSubstitutions, featureTag='rvrn'):
@@ -298,6 +298,11 @@ def addFeatureVariationsRaw(font, conditionalSubstitutions, featureTag='rvrn'):
         varFeatureIndex = gsub.FeatureList.FeatureRecord.index(varFeature)
 
         for scriptRecord in gsub.ScriptList.ScriptRecord:
+            if scriptRecord.Script.DefaultLangSys is None:
+                raise VarLibError(
+                    "Feature variations require that the script "
+                    f"'{scriptRecord.ScriptTag}' defines a default language system."
+                )
             langSystems = [lsr.LangSys for lsr in scriptRecord.Script.LangSysRecord]
             for langSys in [scriptRecord.Script.DefaultLangSys] + langSystems:
                 langSys.FeatureIndex.append(varFeatureIndex)


### PR DESCRIPTION
I.e. when you forgot to add `languagesystem grek dflt;` to your feature file.

Before: 

> fontmake: Error: In 'MyFont.designspace': Generating fonts from Designspace failed: 'NoneType' object has no attribute 'FeatureIndex'

After:

> fontmake: Error: In 'MyFont.designspace': Generating fonts from Designspace failed: Feature variations require that the script 'grek' defines a default language system.
