### PR TITLE
Raise an exception when ClassDefBuilder attempts to add a duplicate glyph.

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2575,7 +2575,7 @@ class ClassDefBuilder(object):
         self.classes_.add(glyphs)
         for glyph in glyphs:
             if glyph in self.glyphs_:
-                raise ValueError(f"Glyph {glyph} is already present in class.")
+                raise OpenTypeLibError(f"Glyph {glyph} is already present in class.", None)
             self.glyphs_[glyph] = glyphs
 
     def classes(self):

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2574,7 +2574,8 @@ class ClassDefBuilder(object):
             return
         self.classes_.add(glyphs)
         for glyph in glyphs:
-            assert glyph not in self.glyphs_
+            if glyph in self.glyphs_:
+                raise TypeError(f"Glyph {glyph} already present in class.")
             self.glyphs_[glyph] = glyphs
 
     def classes(self):

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2575,7 +2575,7 @@ class ClassDefBuilder(object):
         self.classes_.add(glyphs)
         for glyph in glyphs:
             if glyph in self.glyphs_:
-                raise TypeError(f"Glyph {glyph} already present in class.")
+                raise ValueError(f"Glyph {glyph} is already present in class.")
             self.glyphs_[glyph] = glyphs
 
     def classes(self):

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1103,15 +1103,9 @@ class ClassDefBuilderTest(object):
 
     def test_add_exception(self):
         b = builder.ClassDefBuilder(useClass0=True)
-        b.add({"a", "b", "c", "d"})
-        with pytest.raises(TypeError):
-            b.add({"a"})
-        with pytest.raises(TypeError):
-            b.add({"b"})
-        with pytest.raises(TypeError):
-            b.add({"c"})
-        with pytest.raises(TypeError):
-            b.add({"d"})
+        b.add({"a", "b", "c"})
+        with pytest.raises(ValueError):
+            b.add({"a", "d"})
 
 
 buildStatTable_test_data = [

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1101,6 +1101,18 @@ class ClassDefBuilderTest(object):
         assert not b.canAdd({"d", "e", "f"})
         assert not b.canAdd({"f"})
 
+    def test_add_exception(self):
+        b = builder.ClassDefBuilder(useClass0=True)
+        b.add({"a", "b", "c", "d"})
+        with pytest.raises(TypeError):
+            b.add({"a"})
+        with pytest.raises(TypeError):
+            b.add({"b"})
+        with pytest.raises(TypeError):
+            b.add({"c"})
+        with pytest.raises(TypeError):
+            b.add({"d"})
+
 
 buildStatTable_test_data = [
     ([

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -2,7 +2,7 @@ import io
 import struct
 from fontTools.misc.fixedTools import floatToFixed
 from fontTools.misc.testTools import getXML
-from fontTools.otlLib import builder
+from fontTools.otlLib import builder, error
 from fontTools import ttLib
 from fontTools.ttLib.tables import otTables
 import pytest
@@ -1104,7 +1104,7 @@ class ClassDefBuilderTest(object):
     def test_add_exception(self):
         b = builder.ClassDefBuilder(useClass0=True)
         b.add({"a", "b", "c"})
-        with pytest.raises(ValueError):
+        with pytest.raises(error.OpenTypeLibError):
             b.add({"a", "d"})
 
 


### PR DESCRIPTION
There is currently an assertion in ClassDefBuild.add that stops a glyph that is already present in a class from being added again. However, there is no error reported, and thus it can be quite difficult to debug.

This PR changes this assertion into a raised exception, while also adding the related tests.