### PR TITLE
fontBuilder: pass glyphMap to buildCOLR to sort base records by GID 

### DIFF
--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -770,7 +770,7 @@ class FontBuilder(object):
             self.font, conditionalSubstitutions, featureTag=featureTag
         )
 
-    def setupCOLR(self, colorLayers):
+    def setupCOLR(self, colorLayers, version=None, varStore=None):
         """Build new COLR table using color layers dictionary.
 
         Cf. `fontTools.colorLib.builder.buildCOLR`.
@@ -778,7 +778,9 @@ class FontBuilder(object):
         from fontTools.colorLib.builder import buildCOLR
 
         glyphMap = self.font.getReverseGlyphMap()
-        self.font["COLR"] = buildCOLR(colorLayers, glyphMap=glyphMap)
+        self.font["COLR"] = buildCOLR(
+            colorLayers, version=version, glyphMap=glyphMap, varStore=varStore
+        )
 
     def setupCPAL(
         self,

--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -777,7 +777,8 @@ class FontBuilder(object):
         """
         from fontTools.colorLib.builder import buildCOLR
 
-        self.font["COLR"] = buildCOLR(colorLayers)
+        glyphMap = self.font.getReverseGlyphMap()
+        self.font["COLR"] = buildCOLR(colorLayers, glyphMap=glyphMap)
 
     def setupCPAL(
         self,


### PR DESCRIPTION
COLR Base glyph records must be sorted by glyph index. The `colorLib.builder.buildCOLR` function has an optional `glyphMap` parameter that maps from glyph names to glyph indices (as returned from `TTFont.getReverseGlyphMap()`).
FontBuilder knows all that so it should pass it on to colorLib to ensure base records are sorted by GID.