### PR TITLE
Subset COLRv1 & prune unused CPAL entries

### DIFF
--- a/Lib/fontTools/colorLib/builder.py
+++ b/Lib/fontTools/colorLib/builder.py
@@ -229,7 +229,7 @@ def buildCOLR(
     self.version = colr.Version = version
 
     if version == 0:
-        self._fromOTTable(colr)
+        self.ColorLayers = self._decompileColorLayersV0(colr)
     else:
         colr.VarStore = varStore
         self.table = colr

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -14,7 +14,7 @@ import sys
 import struct
 import array
 import logging
-from collections import Counter
+from collections import Counter, defaultdict
 from types import MethodType
 
 __usage__ = "pyftsubset font-file [glyph...] [--option=value]..."
@@ -2057,10 +2057,53 @@ def subset_glyphs(self, s):
 	# TODO: also prune ununsed varIndices in COLR.VarStore
 	return bool(layersV0) or bool(self.table.BaseGlyphV1List.BaseGlyphV1Record)
 
-# TODO: prune unused palettes
 @_add_method(ttLib.getTableClass('CPAL'))
 def prune_post_subset(self, font, options):
-	return True
+	colr = font.get("COLR")
+	if not colr:  # drop CPAL if COLR was subsetted to empty
+		return False
+
+	colors_by_index = defaultdict(list)
+
+	def collect_colors_by_index(paint):
+		if hasattr(paint, "Color"):  # either solid colors...
+			colors_by_index[paint.Color.PaletteIndex].append(paint.Color)
+		elif hasattr(paint, "ColorLine"):  # ... or gradient color stops
+			for stop in paint.ColorLine.ColorStop:
+				colors_by_index[stop.Color.PaletteIndex].append(stop.Color)
+
+	if colr.version == 0:
+		for layers in colr.ColorLayers.values():
+			for layer in layers:
+				colors_by_index[layer.colorID].append(layer)
+	else:
+		if colr.table.LayerRecordArray:
+			for layer in colr.table.LayerRecordArray.LayerRecord:
+				colors_by_index[layer.PaletteIndex].append(layer)
+		for record in colr.table.BaseGlyphV1List.BaseGlyphV1Record:
+			record.Paint.traverse(colr.table, collect_colors_by_index)
+
+	retained_palette_indices = set(colors_by_index.keys())
+	for palette in self.palettes:
+		palette[:] = [c for i, c in enumerate(palette) if i in retained_palette_indices]
+		assert len(palette) == len(retained_palette_indices)
+
+	for new_index, old_index in enumerate(sorted(retained_palette_indices)):
+		for record in colors_by_index[old_index]:
+			if hasattr(record, "colorID"):  # v0
+				record.colorID = new_index
+			elif hasattr(record, "PaletteIndex"):  # v1
+				record.PaletteIndex = new_index
+			else:
+				raise AssertionError(record)
+
+	self.numPaletteEntries = len(self.palettes[0])
+
+	if self.version == 1:
+		self.paletteEntryLabels = [
+			label for i, label in self.paletteEntryLabels if i in retained_palette_indices
+		]
+	return bool(self.numPaletteEntries)
 
 @_add_method(otTables.MathGlyphConstruction)
 def closure_glyphs(self, glyphs):

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2044,11 +2044,7 @@ def subset_glyphs(self, s):
 	)
 	del self.ColorLayers
 
-	colorGlyphsV1 = unbuildColrV1(
-		self.table.LayerV1List,
-		self.table.BaseGlyphV1List,
-		ignoreVarIdx=not self.table.VarStore,
-	)
+	colorGlyphsV1 = unbuildColrV1(self.table.LayerV1List, self.table.BaseGlyphV1List)
 	self.table.LayerV1List, self.table.BaseGlyphV1List = buildColrV1(
 		{g: colorGlyphsV1[g] for g in colorGlyphsV1 if g in s.glyphs}
 	)

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -959,87 +959,89 @@ def colrv1_path(tmp_path):
 
     fb.setupCOLR(
         {
-            "uniE000": [
-                {
-                    "format": int(ot.PaintFormat.PaintGlyph),
-                    "glyph": "glyph00010",
-                    "paint": {
-                        "format": int(ot.PaintFormat.PaintSolid),
-                        "paletteIndex": 0,
+            "uniE000": (
+                ot.PaintFormat.PaintColrLayers,
+                [
+                    {
+                        "Format": ot.PaintFormat.PaintGlyph,
+                        "Paint": (ot.PaintFormat.PaintSolid, 0),
+                        "Glyph": "glyph00010",
                     },
-                },
-                {
-                    "format": int(ot.PaintFormat.PaintGlyph),
-                    "glyph": "glyph00011",
-                    "paint": {
-                        "format": int(ot.PaintFormat.PaintSolid),
-                        "paletteIndex": 2,
-                        "alpha": 0.3,
+                    {
+                        "Format": ot.PaintFormat.PaintGlyph,
+                        "Paint": (ot.PaintFormat.PaintSolid, (2, 0.3)),
+                        "Glyph": "glyph00011",
                     },
-                },
-            ],
-            "uniE001": [
-                {
-                    "format": int(ot.PaintFormat.PaintTransform),
-                    "transform": (0.7071, 0.7071, -0.7071, 0.7071, 0, 0),
-                    "paint": {
-                        "format": int(ot.PaintFormat.PaintGlyph),
-                        "glyph": "glyph00012",
-                        "paint": {
-                            "format": int(ot.PaintFormat.PaintRadialGradient),
-                            "c0": (250, 250),
-                            "r0": 250,
-                            "c1": (200, 200),
-                            "r1": 0,
-                            "colorLine": {
-                                "stops": [(0.0, 1), (1.0, 2)], "extend": "repeat"
+                ],
+            ),
+            "uniE001": (
+                ot.PaintFormat.PaintColrLayers,
+                [
+                    {
+                        "Format": ot.PaintFormat.PaintTransform,
+                        "Paint": {
+                            "Format": ot.PaintFormat.PaintGlyph,
+                            "Paint": {
+                                "Format": ot.PaintFormat.PaintRadialGradient,
+                                "x0": 250,
+                                "y0": 250,
+                                "r0": 250,
+                                "x1": 200,
+                                "y1": 200,
+                                "r1": 0,
+                                "ColorLine": {
+                                    "ColorStop": [(0.0, 1), (1.0, 2)],
+                                    "Extend": "repeat",
+                                },
                             },
+                            "Glyph": "glyph00012",
                         },
+                        "Transform": (0.7071, 0.7071, -0.7071, 0.7071, 0, 0),
                     },
-                },
-                {
-                    "format": int(ot.PaintFormat.PaintGlyph),
-                    "glyph": "glyph00013",
-                    "paint": {
-                        "format": int(ot.PaintFormat.PaintSolid),
-                        "paletteIndex": 1,
-                        "alpha": 0.5,
+                    {
+                        "Format": ot.PaintFormat.PaintGlyph,
+                        "Paint": (ot.PaintFormat.PaintSolid, (1, 0.5)),
+                        "Glyph": "glyph00013",
                     },
-                },
-            ],
-            "uniE002": [
-                {
-                    "format": int(ot.PaintFormat.PaintGlyph),
-                    "glyph": "glyph00014",
-                    "paint": {
-                        "format": int(ot.PaintFormat.PaintLinearGradient),
-                        "p0": (0, 0),
-                        "p1": (500, 500),
-                        "colorLine": {"stops": [(0.0, 1), (1.0, 2)]},
-                    },
-                },
-                {
-                    "format": int(ot.PaintFormat.PaintTransform),
-                    "transform": (1, 0, 0, 1, 400, 400),
-                    "paint": {
-                        "format": int(ot.PaintFormat.PaintGlyph),
-                        "glyph": "glyph00015",
-                        "paint": {
-                            "format": int(ot.PaintFormat.PaintSolid),
-                            "paletteIndex": 1,
+                ],
+            ),
+            "uniE002": (
+                ot.PaintFormat.PaintColrLayers,
+                [
+                    {
+                        "Format": ot.PaintFormat.PaintGlyph,
+                        "Paint": {
+                            "Format": ot.PaintFormat.PaintLinearGradient,
+                            "x0": 0,
+                            "y0": 0,
+                            "x1": 500,
+                            "y1": 500,
+                            "x2": -500,
+                            "y2": 500,
+                            "ColorLine": {"ColorStop": [(0.0, 1), (1.0, 2)]},
                         },
+                        "Glyph": "glyph00014",
                     },
-                },
-            ],
+                    {
+                        "Format": ot.PaintFormat.PaintTransform,
+                        "Paint": {
+                            "Format": ot.PaintFormat.PaintGlyph,
+                            "Paint": (ot.PaintFormat.PaintSolid, 1),
+                            "Glyph": "glyph00015",
+                        },
+                        "Transform": (1, 0, 0, 1, 400, 400),
+                    },
+                ],
+            ),
             "uniE003": {
-                "format": int(ot.PaintFormat.PaintRotate),
+                "Format": ot.PaintFormat.PaintRotate,
+                "Paint": {
+                    "Format": ot.PaintFormat.PaintColrGlyph,
+                    "Glyph": "uniE001",
+                },
                 "angle": 45,
                 "centerX": 250,
                 "centerY": 250,
-                "paint": {
-                    "format": int(ot.PaintFormat.PaintColrGlyph),
-                    "glyph": "uniE001",
-                },
             },
         },
     )


### PR DESCRIPTION
This adds support for subsetting COLRv1 base glyphs (#2127)
Does not yet implement ~~pruning unused CPAL palettes (#2174) or~~ unused varIndices in CORL.VarStore.

EDIT: It now also implements pruning unused CPAL palette entries.