### PR TITLE
Document expected arguments for _TTGlyphSet, _TTGlyph and TTGlyphPen

### DIFF
--- a/Doc/source/ttLib/ttFont.rst
+++ b/Doc/source/ttLib/ttFont.rst
@@ -6,3 +6,4 @@ ttFont
    :inherited-members:
    :members:
    :undoc-members:
+   :private-members:

--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -15,22 +15,34 @@ __all__ = ["TTGlyphPen"]
 class TTGlyphPen(LoggingPen):
     """Pen used for drawing to a TrueType glyph.
 
-    If `handleOverflowingTransforms` is True, the components' transform values
-    are checked that they don't overflow the limits of a F2Dot14 number:
-    -2.0 <= v < +2.0. If any transform value exceeds these, the composite
-    glyph is decomposed.
-    An exception to this rule is done for values that are very close to +2.0
-    (both for consistency with the -2.0 case, and for the relative frequency
-    these occur in real fonts). When almost +2.0 values occur (and all other
-    values are within the range -2.0 <= x <= +2.0), they are clamped to the
-    maximum positive value that can still be encoded as an F2Dot14: i.e.
-    1.99993896484375.
-    If False, no check is done and all components are translated unmodified
-    into the glyf table, followed by an inevitable `struct.error` once an
-    attempt is made to compile them.
+    This pen can be used to construct or modify glyphs in a TrueType format
+    font. After using the pen to draw, use the ``.glyph()`` method to retrieve
+    a :py:class:`~._g_l_y_f.Glyph` object representing the glyph.
     """
 
     def __init__(self, glyphSet, handleOverflowingTransforms=True):
+        """Construct a new pen.
+
+        Args:
+            glyphSet (ttLib._TTGlyphSet): A glyphset object, used to resolve components.
+            handleOverflowingTransforms (bool): See below.
+
+        If ``handleOverflowingTransforms`` is True, the components' transform values
+        are checked that they don't overflow the limits of a F2Dot14 number:
+        -2.0 <= v < +2.0. If any transform value exceeds these, the composite
+        glyph is decomposed.
+
+        An exception to this rule is done for values that are very close to +2.0
+        (both for consistency with the -2.0 case, and for the relative frequency
+        these occur in real fonts). When almost +2.0 values occur (and all other
+        values are within the range -2.0 <= x <= +2.0), they are clamped to the
+        maximum positive value that can still be encoded as an F2Dot14: i.e.
+        1.99993896484375.
+
+        If False, no check is done and all components are translated unmodified
+        into the glyf table, followed by an inevitable ``struct.error`` once an
+        attempt is made to compile them.
+        """
         self.glyphSet = glyphSet
         self.handleOverflowingTransforms = handleOverflowingTransforms
         self.init()
@@ -136,6 +148,7 @@ class TTGlyphPen(LoggingPen):
         return components
 
     def glyph(self, componentFlags=0x4):
+        """Returns a :py:class:`~._g_l_y_f.Glyph` object representing the glyph."""
         assert self._isClosed(), "Didn't close last contour."
 
         components = self._buildComponents(componentFlags)

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -700,6 +700,13 @@ class _TTGlyphSet(object):
 	"""
 
 	def __init__(self, ttFont, glyphs, glyphType):
+		"""Construct a new glyphset.
+
+		Args:
+			font (TTFont): The font object (used to get metrics).
+			glyphs (dict): A dictionary mapping glyph names to ``_TTGlyph`` objects.
+			glyphType (class): Either ``_TTGlyphCFF`` or ``_TTGlyphGlyf``.
+		"""
 		self._glyphs = glyphs
 		self._hmtx = ttFont['hmtx']
 		self._vmtx = ttFont['vmtx'] if 'vmtx' in ttFont else None
@@ -740,6 +747,13 @@ class _TTGlyph(object):
 	"""
 
 	def __init__(self, glyphset, glyph, horizontalMetrics, verticalMetrics=None):
+		"""Construct a new _TTGlyph.
+
+		Args:
+			glyphset (_TTGlyphSet): A glyphset object used to resolve components.
+			glyph (ttLib.tables._g_l_y_f.Glyph): The glyph object.
+			horizontalMetrics (int, int): The glyph's width and left sidebearing.
+		"""
 		self._glyphset = glyphset
 		self._glyph = glyph
 		self.width, self.lsb = horizontalMetrics
@@ -749,7 +763,7 @@ class _TTGlyph(object):
 			self.height, self.tsb = None, None
 
 	def draw(self, pen):
-		"""Draw the glyph onto Pen. See fontTools.pens.basePen for details
+		"""Draw the glyph onto ``pen``. See fontTools.pens.basePen for details
 		how that works.
 		"""
 		self._glyph.draw(pen)


### PR DESCRIPTION
I've been trying to do more complicated stuff (involving components) with the fontBuilder, and it was very painful because it really wasn't clear how to use `TTGlyphPen` to build new glyphs. I will be making some changes to fontBuilder to make it all easier, but this is what I discovered along the way.