### PR TITLE
[feaLib] Format anchors one per line instead of all on the same line

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1146,9 +1146,7 @@ class MarkBasePosStatement(Statement):
     def asFea(self, indent=""):
         res = "pos base {}".format(self.base.asFea())
         for a, m in self.marks:
-            res += ("\n" + indent + SHIFT + "{} mark @{}".format(
-                a.asFea(), m.name)
-            )
+            res += "\n" + indent + SHIFT + "{} mark @{}".format(a.asFea(), m.name)
         res += ";"
         return res
 
@@ -1197,8 +1195,11 @@ class MarkLigPosStatement(Statement):
                 temp = "\n" + indent + SHIFT * 2 + "<anchor NULL>"
             else:
                 for a, m in l:
-                    temp += ("\n" + indent + SHIFT * 2 + "{} mark @{}".format(
-                        a.asFea(), m.name)
+                    temp += (
+                        "\n"
+                        + indent
+                        + SHIFT * 2
+                        + "{} mark @{}".format(a.asFea(), m.name)
                     )
             ligs.append(temp)
         res += ("\n" + indent + SHIFT + "ligComponent").join(ligs)
@@ -1222,9 +1223,7 @@ class MarkMarkPosStatement(Statement):
     def asFea(self, indent=""):
         res = "pos mark {}".format(self.baseMarks.asFea())
         for a, m in self.marks:
-            res += ("\n" + indent + SHIFT + "{} mark @{}".format(
-                a.asFea(), m.name)
-            )
+            res += "\n" + indent + SHIFT + "{} mark @{}".format(a.asFea(), m.name)
         res += ";"
         return res
 
@@ -1267,7 +1266,7 @@ class MultipleSubstStatement(Statement):
                 res += " " + " ".join(map(asFea, self.suffix))
         else:
             res += asFea(self.glyph)
-        replacement = self.replacement or [ NullGlyph() ]
+        replacement = self.replacement or [NullGlyph()]
         res += " by "
         res += " ".join(map(asFea, replacement))
         res += ";"

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1146,7 +1146,9 @@ class MarkBasePosStatement(Statement):
     def asFea(self, indent=""):
         res = "pos base {}".format(self.base.asFea())
         for a, m in self.marks:
-            res += " {} mark @{}".format(a.asFea(), m.name)
+            res += ("\n" + indent + SHIFT + "{} mark @{}".format(
+                a.asFea(), m.name)
+            )
         res += ";"
         return res
 
@@ -1192,10 +1194,12 @@ class MarkLigPosStatement(Statement):
         for l in self.marks:
             temp = ""
             if l is None or not len(l):
-                temp = " <anchor NULL>"
+                temp = "\n" + indent + SHIFT * 2 + "<anchor NULL>"
             else:
                 for a, m in l:
-                    temp += " {} mark @{}".format(a.asFea(), m.name)
+                    temp += ("\n" + indent + SHIFT * 2 + "{} mark @{}".format(
+                        a.asFea(), m.name)
+                    )
             ligs.append(temp)
         res += ("\n" + indent + SHIFT + "ligComponent").join(ligs)
         res += ";"
@@ -1218,7 +1222,9 @@ class MarkMarkPosStatement(Statement):
     def asFea(self, indent=""):
         res = "pos mark {}".format(self.baseMarks.asFea())
         for a, m in self.marks:
-            res += " {} mark @{}".format(a.asFea(), m.name)
+            res += ("\n" + indent + SHIFT + "{} mark @{}".format(
+                a.asFea(), m.name)
+            )
         res += ";"
         return res
 

--- a/Tests/feaLib/data/GPOS_4.fea
+++ b/Tests/feaLib/data/GPOS_4.fea
@@ -6,7 +6,11 @@ markClass [cedilla] <anchor 222 22> @BOTTOM_MARKS;
 markClass [ogonek] <anchor 333 33> @SIDE_MARKS;
 
 feature test {
-    pos base a <anchor 11 1> mark @TOP_MARKS <anchor 12 -1> mark @BOTTOM_MARKS;
-    pos base [b c] <anchor 22 -2> mark @BOTTOM_MARKS;
-    pos base d <anchor 33 3> mark @SIDE_MARKS;
+    pos base a
+        <anchor 11 1> mark @TOP_MARKS
+        <anchor 12 -1> mark @BOTTOM_MARKS;
+    pos base [b c]
+        <anchor 22 -2> mark @BOTTOM_MARKS;
+    pos base d
+        <anchor 33 3> mark @SIDE_MARKS;
 } test;

--- a/Tests/feaLib/data/GPOS_5.fea
+++ b/Tests/feaLib/data/GPOS_5.fea
@@ -5,14 +5,29 @@ markClass [ogonek] <anchor 800 -10> @OGONEK;
 
 feature test {
 
-    pos ligature [c_t s_t] <anchor 500 800> mark @TOP_MARKS <anchor 500 -200> mark @BOTTOM_MARKS
-        ligComponent <anchor 1500 800> mark @TOP_MARKS <anchor 1500 -200> mark @BOTTOM_MARKS <anchor 1550 0> mark @OGONEK;
+    pos ligature [c_t s_t]
+            <anchor 500 800> mark @TOP_MARKS
+            <anchor 500 -200> mark @BOTTOM_MARKS
+        ligComponent
+            <anchor 1500 800> mark @TOP_MARKS
+            <anchor 1500 -200> mark @BOTTOM_MARKS
+            <anchor 1550 0> mark @OGONEK;
 
-    pos ligature f_l <anchor 300 800> mark @TOP_MARKS <anchor 300 -200> mark @BOTTOM_MARKS
-        ligComponent <anchor 600 800> mark @TOP_MARKS <anchor 600 -200> mark @BOTTOM_MARKS;
+    pos ligature f_l
+            <anchor 300 800> mark @TOP_MARKS
+            <anchor 300 -200> mark @BOTTOM_MARKS
+        ligComponent
+            <anchor 600 800> mark @TOP_MARKS
+            <anchor 600 -200> mark @BOTTOM_MARKS;
 
-    pos ligature [f_f_l] <anchor 300 800> mark @TOP_MARKS <anchor 300 -200> mark @BOTTOM_MARKS
-        ligComponent <anchor 600 800> mark @TOP_MARKS <anchor 600 -200> mark @BOTTOM_MARKS
-        ligComponent <anchor 900 800> mark @TOP_MARKS <anchor 900 -200> mark @BOTTOM_MARKS;
+    pos ligature [f_f_l]
+            <anchor 300 800> mark @TOP_MARKS
+            <anchor 300 -200> mark @BOTTOM_MARKS
+        ligComponent
+            <anchor 600 800> mark @TOP_MARKS
+            <anchor 600 -200> mark @BOTTOM_MARKS
+        ligComponent
+            <anchor 900 800> mark @TOP_MARKS
+            <anchor 900 -200> mark @BOTTOM_MARKS;
 
 } test;

--- a/Tests/feaLib/data/GPOS_6.fea
+++ b/Tests/feaLib/data/GPOS_6.fea
@@ -5,6 +5,9 @@ markClass macron <anchor 2 2 contourpoint 22> @TOP_MARKS;
 markClass [cedilla] <anchor 3 3 contourpoint 33> @BOTTOM_MARKS;
 
 feature test {
-    pos mark [acute grave macron ogonek] <anchor 500 200> mark @TOP_MARKS <anchor 500 -80> mark @BOTTOM_MARKS;
-    pos mark [dieresis caron] <anchor 500 200> mark @TOP_MARKS;
+    pos mark [acute grave macron ogonek]
+        <anchor 500 200> mark @TOP_MARKS
+        <anchor 500 -80> mark @BOTTOM_MARKS;
+    pos mark [dieresis caron]
+        <anchor 500 200> mark @TOP_MARKS;
 } test;

--- a/Tests/feaLib/data/bug453.fea
+++ b/Tests/feaLib/data/bug453.fea
@@ -2,10 +2,12 @@
 feature mark {
     lookup mark1 {
         markClass [acute] <anchor 150 -10> @TOP_MARKS;
-        pos base [e] <anchor 250 450> mark @TOP_MARKS;
+        pos base [e]
+            <anchor 250 450> mark @TOP_MARKS;
     } mark1;
     lookup mark2 {
         markClass [acute] <anchor 150 -20> @TOP_MARKS_2;
-        pos base [e] <anchor 250 450> mark @TOP_MARKS_2;
+        pos base [e]
+            <anchor 250 450> mark @TOP_MARKS_2;
     } mark2;
 } mark;

--- a/Tests/feaLib/data/spec6d2.fea
+++ b/Tests/feaLib/data/spec6d2.fea
@@ -9,7 +9,11 @@ markClass [dieresis umlaut] <anchor 300 -10> @TOP_MARKS;
 markClass [cedilla] <anchor 300 600> @BOTTOM_MARKS;
 
 feature test {
-    pos base [e o] <anchor 250 450> mark @TOP_MARKS <anchor 250 -12> mark @BOTTOM_MARKS;
-#test-fea2fea: pos base [a u] <anchor 265 450> mark @TOP_MARKS <anchor 250 -10> mark @BOTTOM_MARKS;
-    position base [a u] <anchor 265 450> mark @TOP_MARKS <anchor 250-10> mark @BOTTOM_MARKS;
+    pos base [e o]
+        <anchor 250 450> mark @TOP_MARKS
+        <anchor 250 -12> mark @BOTTOM_MARKS;
+#test-fea2fea: pos base [a u]
+    position base [a u]
+        <anchor 265 450> mark @TOP_MARKS
+        <anchor 250 -10> mark @BOTTOM_MARKS;
 } test;

--- a/Tests/feaLib/data/spec6e.fea
+++ b/Tests/feaLib/data/spec6e.fea
@@ -4,7 +4,10 @@ markClass sukun <anchor 261 488> @TOP_MARKS;
 markClass kasratan <anchor 346 -98> @BOTTOM_MARKS;
 
 feature test {
-    pos ligature lam_meem_jeem <anchor 625 1800> mark @TOP_MARKS    # mark above lam
-        ligComponent <anchor 376 -368> mark @BOTTOM_MARKS    # mark below meem
-        ligComponent <anchor NULL>;   # jeem has no marks
+    pos ligature lam_meem_jeem
+            <anchor 625 1800> mark @TOP_MARKS    # mark above lam
+        ligComponent
+            <anchor 376 -368> mark @BOTTOM_MARKS    # mark below meem
+        ligComponent
+            <anchor NULL>;   # jeem has no marks
 } test;

--- a/Tests/feaLib/data/spec6f.fea
+++ b/Tests/feaLib/data/spec6f.fea
@@ -2,5 +2,6 @@ languagesystem DFLT dflt;
 
 feature test {
     markClass damma <anchor 189 -103> @MARK_CLASS_1;
-    pos mark hamza <anchor 221 301> mark @MARK_CLASS_1;
+    pos mark hamza
+        <anchor 221 301> mark @MARK_CLASS_1;
 } test;

--- a/Tests/feaLib/data/spec6h_ii.fea
+++ b/Tests/feaLib/data/spec6h_ii.fea
@@ -12,8 +12,10 @@ lookup CNTXT_PAIR_POS {
 } CNTXT_PAIR_POS;
  
 lookup CNTXT_MARK_TO_BASE {
-    pos base o <anchor 250 450> mark @ALL_MARKS;
-    pos base c <anchor 250 450> mark @ALL_MARKS;
+    pos base o
+        <anchor 250 450> mark @ALL_MARKS;
+    pos base c
+        <anchor 250 450> mark @ALL_MARKS;
 } CNTXT_MARK_TO_BASE;
 
 feature test {


### PR DESCRIPTION
This changes the formatting of ast.MarkBasePosStatement, ast.MarkLigPosStatement, ast.MarkMarkPosStatement to indent the anchor statements and make them a bit more legible or diffable.

For example:
```
pos base a <anchor 11 1> mark @TOP_MARKS <anchor 12 -1> mark @BOTTOM_MARKS;
pos ligature [c_t s_t] <anchor 500 800> mark @TOP_MARKS <anchor 500 -200> mark @BOTTOM_MARKS
    ligComponent <anchor 1500 800> mark @TOP_MARKS <anchor 1500 -200> mark @BOTTOM_MARKS <anchor 1550 0> mark @OGONEK;
pos mark [acute grave macron ogonek] <anchor 500 200> mark @TOP_MARKS <anchor 500 -80> mark @BOTTOM_MARKS;
```
would become
```
pos base a
    <anchor 11 1> mark @TOP_MARKS
    <anchor 12 -1> mark @BOTTOM_MARKS;
pos ligature [c_t s_t]
        <anchor 500 800> mark @TOP_MARKS
        <anchor 500 -200> mark @BOTTOM_MARKS
    ligComponent
        <anchor 1500 800> mark @TOP_MARKS
        <anchor 1500 -200> mark @BOTTOM_MARKS
        <anchor 1550 0> mark @OGONEK;
pos mark [acute grave macron ogonek]
    <anchor 500 200> mark @TOP_MARKS
    <anchor 500 -80> mark @BOTTOM_MARKS;
```