### PR TITLE
Experiment with hypothesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ Lib/**/*.c
 
 # Ctags
 tags
+
+.hypothesis

--- a/Lib/fontTools/pens/basePen.py
+++ b/Lib/fontTools/pens/basePen.py
@@ -40,8 +40,12 @@ from typing import Any, Tuple
 
 from fontTools.misc.loggingTools import LogMixin
 
-__all__ =  ["AbstractPen", "NullPen", "BasePen",
+__all__ =  ["AbstractPen", "NullPen", "BasePen", "PenError",
 			"decomposeSuperBezierSegment", "decomposeQuadraticSegment"]
+
+
+class PenError(Exception):
+	"""Represents an error during penning."""
 
 
 class AbstractPen:

--- a/Lib/fontTools/pens/pointPen.py
+++ b/Lib/fontTools/pens/pointPen.py
@@ -13,9 +13,9 @@ For instance, whether or not a point is smooth, and its name.
 """
 
 import math
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional, Tuple
 
-from fontTools.pens.basePen import AbstractPen
+from fontTools.pens.basePen import AbstractPen, PenError
 
 __all__ = [
 	"AbstractPointPen",
@@ -74,7 +74,8 @@ class BasePointToSegmentPen(AbstractPointPen):
 		self.currentPath = None
 
 	def beginPath(self, identifier=None, **kwargs):
-		assert self.currentPath is None
+		if self.currentPath is not None:
+			raise PenError("Path already begun.")
 		self.currentPath = []
 
 	def _flushContour(self, segments):
@@ -106,7 +107,8 @@ class BasePointToSegmentPen(AbstractPointPen):
 		raise NotImplementedError
 
 	def endPath(self):
-		assert self.currentPath is not None
+		if self.currentPath is None:
+			raise PenError("Path not begun.")
 		points = self.currentPath
 		self.currentPath = None
 		if not points:
@@ -154,6 +156,8 @@ class BasePointToSegmentPen(AbstractPointPen):
 
 	def addPoint(self, pt, segmentType=None, smooth=False, name=None,
 				 identifier=None, **kwargs):
+		if self.currentPath is None:
+			raise PenError("Path not begun")
 		self.currentPath.append((pt, segmentType, smooth, name, kwargs))
 
 
@@ -161,6 +165,9 @@ class PointToSegmentPen(BasePointToSegmentPen):
 	"""
 	Adapter class that converts the PointPen protocol to the
 	(Segment)Pen protocol.
+
+	NOTE: The segment pen does not support and will drop point names, identifiers
+	and kwargs.
 	"""
 
 	def __init__(self, segmentPen, outputImpliedClosingLine=False):
@@ -169,21 +176,23 @@ class PointToSegmentPen(BasePointToSegmentPen):
 		self.outputImpliedClosingLine = outputImpliedClosingLine
 
 	def _flushContour(self, segments):
-		assert len(segments) >= 1
+		if not segments:
+			raise PenError("Must have at least one segment.")
 		pen = self.pen
 		if segments[0][0] == "move":
 			# It's an open path.
 			closed = False
 			points = segments[0][1]
-			assert len(points) == 1, "illegal move segment point count: %d" % len(points)
-			movePt, smooth, name, kwargs = points[0]
+			if len(points) != 1:
+				raise PenError(f"Illegal move segment point count: {len(points)}")
+			movePt, _, _ , _ = points[0]
 			del segments[0]
 		else:
 			# It's a closed path, do a moveTo to the last
 			# point of the last segment.
 			closed = True
 			segmentType, points = segments[-1]
-			movePt, smooth, name, kwargs = points[-1]
+			movePt, _, _ , _ = points[-1]
 		if movePt is None:
 			# quad special case: a contour with no on-curve points contains
 			# one "qcurve" segment that ends with a point that's None. We
@@ -196,9 +205,10 @@ class PointToSegmentPen(BasePointToSegmentPen):
 		lastPt = movePt
 		for i in range(nSegments):
 			segmentType, points = segments[i]
-			points = [pt for pt, smooth, name, kwargs in points]
+			points = [pt for pt, _, _ , _ in points]
 			if segmentType == "line":
-				assert len(points) == 1, "illegal line segment point count: %d" % len(points)
+				if len(points) != 1:
+					raise PenError(f"Illegal line segment point count: {len(points)}")
 				pt = points[0]
 				# For closed contours, a 'lineTo' is always implied from the last oncurve
 				# point to the starting point, thus we can omit it when the last and
@@ -224,7 +234,7 @@ class PointToSegmentPen(BasePointToSegmentPen):
 				pen.qCurveTo(*points)
 				lastPt = points[-1]
 			else:
-				assert 0, "illegal segmentType: %s" % segmentType
+				raise PenError(f"Illegal segmentType: {segmentType}")
 		if closed:
 			pen.closePath()
 		else:
@@ -232,6 +242,7 @@ class PointToSegmentPen(BasePointToSegmentPen):
 
 	def addComponent(self, glyphName, transform, identifier=None, **kwargs):
 		del identifier  # unused
+		del kwargs  # unused
 		self.pen.addComponent(glyphName, transform)
 
 
@@ -260,27 +271,35 @@ class SegmentToPointPen(AbstractPen):
 		self.contour.append((pt, "move"))
 
 	def lineTo(self, pt):
-		assert self.contour is not None, "contour missing required initial moveTo"
+		if self.contour is None:
+			raise PenError("Contour missing required initial moveTo")
 		self.contour.append((pt, "line"))
 
 	def curveTo(self, *pts):
-		assert self.contour is not None, "contour missing required initial moveTo"
+		if not pts:
+			raise PenError("Must pass in at least one point")
+		if self.contour is None:
+			raise PenError("Contour missing required initial moveTo")
 		for pt in pts[:-1]:
 			self.contour.append((pt, None))
 		self.contour.append((pts[-1], "curve"))
 
 	def qCurveTo(self, *pts):
+		if not pts:
+			raise PenError("Must pass in at least one point")
 		if pts[-1] is None:
 			self.contour = []
 		else:
-			assert self.contour is not None, "contour missing required initial moveTo"
+			if self.contour is None:
+				raise PenError("Contour missing required initial moveTo")
 		for pt in pts[:-1]:
 			self.contour.append((pt, None))
 		if pts[-1] is not None:
 			self.contour.append((pts[-1], "qcurve"))
 
 	def closePath(self):
-		assert self.contour is not None, "contour missing required initial moveTo"
+		if self.contour is None:
+			raise PenError("Contour missing required initial moveTo")
 		if len(self.contour) > 1 and self.contour[0][0] == self.contour[-1][0]:
 			self.contour[0] = self.contour[-1]
 			del self.contour[-1]
@@ -294,12 +313,14 @@ class SegmentToPointPen(AbstractPen):
 		self.contour = None
 
 	def endPath(self):
-		assert self.contour is not None, "contour missing required initial moveTo"
+		if self.contour is None:
+			raise PenError("Contour missing required initial moveTo")
 		self._flushContour()
 		self.contour = None
 
 	def addComponent(self, glyphName, transform):
-		assert self.contour is None
+		if self.contour is not None:
+			raise PenError("Components must be added before or after contours")
 		self.pen.addComponent(glyphName, transform)
 
 
@@ -314,6 +335,8 @@ class GuessSmoothPointPen(AbstractPointPen):
 		self._points = None
 
 	def _flushContour(self):
+		if self._points is None:
+			raise PenError("Path not begun")
 		points = self._points
 		nPoints = len(points)
 		if not nPoints:
@@ -329,7 +352,7 @@ class GuessSmoothPointPen(AbstractPointPen):
 			# closed path containing 1 point (!), ignore.
 			indices = []
 		for i in indices:
-			pt, segmentType, dummy, name, kwargs = points[i]
+			pt, segmentType, _, name, kwargs = points[i]
 			if segmentType is None:
 				continue
 			prev = i - 1
@@ -352,7 +375,8 @@ class GuessSmoothPointPen(AbstractPointPen):
 			self._outPen.addPoint(pt, segmentType, smooth, name, **kwargs)
 
 	def beginPath(self, identifier=None, **kwargs):
-		assert self._points is None
+		if self._points is not None:
+			raise PenError("Path already begun")
 		self._points = []
 		if identifier is not None:
 			kwargs["identifier"] = identifier
@@ -365,12 +389,15 @@ class GuessSmoothPointPen(AbstractPointPen):
 
 	def addPoint(self, pt, segmentType=None, smooth=False, name=None,
 				 identifier=None, **kwargs):
+		if self._points is None:
+			raise PenError("Path not begun")
 		if identifier is not None:
 			kwargs["identifier"] = identifier
 		self._points.append((pt, segmentType, False, name, kwargs))
 
 	def addComponent(self, glyphName, transformation, identifier=None, **kwargs):
-		assert self._points is None
+		if self._points is not None:
+			raise PenError("Components must be added before or after contours")
 		if identifier is not None:
 			kwargs["identifier"] = identifier
 		self._outPen.addComponent(glyphName, transformation, **kwargs)
@@ -440,19 +467,26 @@ class ReverseContourPointPen(AbstractPointPen):
 		pen.endPath()
 
 	def beginPath(self, identifier=None, **kwargs):
-		assert self.currentContour is None
+		if self.currentContour is not None:
+			raise PenError("Path already begun")
 		self.currentContour = []
 		self.currentContourIdentifier = identifier
 		self.onCurve = []
 
 	def endPath(self):
-		assert self.currentContour is not None
+		if self.currentContour is None:
+			raise PenError("Path not begun")
 		self._flushContour()
 		self.currentContour = None
 
-	def addPoint(self, pt, segmentType=None, smooth=False, name=None, **kwargs):
+	def addPoint(self, pt, segmentType=None, smooth=False, name=None, identifier=None, **kwargs):
+		if self.currentContour is None:
+			raise PenError("Path not begun")
+		if identifier is not None:
+			kwargs["identifier"] = identifier
 		self.currentContour.append((pt, segmentType, smooth, name, kwargs))
 
 	def addComponent(self, glyphName, transform, identifier=None, **kwargs):
-		assert self.currentContour is None
+		if self.currentContour is not None:
+			raise PenError("Components must be added before or after contours")
 		self.pen.addComponent(glyphName, transform, identifier=identifier, **kwargs)

--- a/Lib/fontTools/pens/recordingPen.py
+++ b/Lib/fontTools/pens/recordingPen.py
@@ -122,16 +122,22 @@ class RecordingPointPen(AbstractPointPen):
 	def __init__(self):
 		self.value = []
 
-	def beginPath(self, **kwargs):
+	def beginPath(self, identifier=None, **kwargs):
+		if identifier is not None:
+			kwargs["identifier"] = identifier
 		self.value.append(("beginPath", (), kwargs))
 
 	def endPath(self):
 		self.value.append(("endPath", (), {}))
 
-	def addPoint(self, pt, segmentType=None, smooth=False, name=None, **kwargs):
+	def addPoint(self, pt, segmentType=None, smooth=False, name=None, identifier=None, **kwargs):
+		if identifier is not None:
+			kwargs["identifier"] = identifier
 		self.value.append(("addPoint", (pt, segmentType, smooth, name), kwargs))
 
-	def addComponent(self, baseGlyphName, transformation, **kwargs):
+	def addComponent(self, baseGlyphName, transformation, identifier=None, **kwargs):
+		if identifier is not None:
+			kwargs["identifier"] = identifier
 		self.value.append(("addComponent", (baseGlyphName, transformation), kwargs))
 
 	def replay(self, pointPen):

--- a/Tests/pens/test_pen_crashers.py
+++ b/Tests/pens/test_pen_crashers.py
@@ -1,0 +1,211 @@
+from string import ascii_letters, digits, printable
+from typing import Any, Dict, Optional, Tuple
+
+from fontTools.pens.basePen import PenError
+from fontTools.pens.pointPen import (
+    PointToSegmentPen,
+    SegmentToPointPen,
+    ReverseContourPointPen,
+    GuessSmoothPointPen,
+)
+from fontTools.pens.recordingPen import RecordingPen, RecordingPointPen
+from hypothesis import strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, rule
+
+# XXX: generate glyph (Tests/pens/recordingPen_test.py -> _TestGlyph) instead
+#      of command stream and draw that into recordingpens?
+
+st_glyph_name = st.text(ascii_letters + digits + "._")
+st_coordinate = st.floats() | st.integers()
+st_point = st.tuples(st_coordinate, st_coordinate)
+st_segment_type = st.none() | st.sampled_from(["move", "line", "curve", "qcurve"])
+st_identifier = st.none() | st.text(printable)
+st_point_name = st.none() | st.text(printable)
+st_transformation = st.tuples(
+    st_coordinate,
+    st_coordinate,
+    st_coordinate,
+    st_coordinate,
+    st_coordinate,
+    st_coordinate,
+)
+st_kwargs = st.dictionaries(
+    st.text(printable).filter(
+        lambda x: x
+        not in {
+            "pt",
+            "segmentType",
+            "smooth",
+            "name",
+            "identifier",
+            "kwargs",
+            "baseGlyphName",
+            "transformation",
+        }
+    ),
+    st.none() | st.booleans() | st.integers() | st.text(printable),
+)
+
+
+class PointMonkey(RuleBasedStateMachine):
+    """Give point pens a good shake to find unexpected crashes, swallowing expected errors."""
+
+    def __init__(self):
+        super().__init__()
+        self.pen = RecordingPointPen()
+
+    @rule(identifier=st_identifier, kwargs=st_kwargs)
+    def begin_path(self, identifier: Optional[str], kwargs: Dict[str, Any]) -> None:
+        try:
+            self.pen.beginPath(identifier, **kwargs)
+        except PenError:
+            pass
+
+    @rule()
+    def end_path(self) -> None:
+        try:
+            self.pen.endPath()
+        except PenError:
+            pass
+
+    @rule(
+        pt=st_point,
+        segmentType=st_segment_type,
+        smooth=st.booleans(),
+        name=st_point_name,
+        identifier=st_identifier,
+        kwargs=st_kwargs,
+    )
+    def add_point(
+        self,
+        pt: Tuple[float, float],
+        segmentType: Optional[str],
+        smooth: bool,
+        name: Optional[str],
+        identifier: Optional[str],
+        kwargs: Dict[str, Any],
+    ) -> None:
+        try:
+            self.pen.addPoint(pt, segmentType, smooth, name, identifier, **kwargs)
+        except PenError:
+            pass
+
+    @rule(
+        baseGlyphName=st_glyph_name,
+        transformation=st_transformation,
+        identifier=st_identifier,
+        kwargs=st_kwargs,
+    )
+    def add_component(
+        self,
+        baseGlyphName: str,
+        transformation: Tuple[float, float, float, float, float, float],
+        identifier: Optional[str],
+        kwargs: Dict[str, Any],
+    ) -> None:
+        try:
+            self.pen.addComponent(baseGlyphName, transformation, identifier, **kwargs)
+        except PenError:
+            pass
+
+
+class PointSegmentPointMonkey(PointMonkey):
+    # NOTE: Segment pens drop point names,identifiers and kwargs.
+
+    def __init__(self):
+        super().__init__()
+        self.pen = PointToSegmentPen(SegmentToPointPen(RecordingPointPen()))
+
+
+class ReverseContourMonkey(PointMonkey):
+    def __init__(self):
+        super().__init__()
+        self.pen = ReverseContourPointPen(ReverseContourPointPen(RecordingPointPen()))
+
+
+class GuessSmoothPointMonkey(PointMonkey):
+    def __init__(self):
+        super().__init__()
+        self.pen = GuessSmoothPointPen(RecordingPointPen())
+
+
+p2s2ptest = PointSegmentPointMonkey.TestCase
+rctest = ReverseContourMonkey.TestCase
+gsptest = GuessSmoothPointMonkey.TestCase
+
+
+class SegmentMonkey(RuleBasedStateMachine):
+    def __init__(self):
+        super().__init__()
+        self.pen = RecordingPen()
+
+    @rule(pt=st_point)
+    def moveTo(self, pt: Tuple[float, float]) -> None:
+        try:
+            self.pen.moveTo(pt)
+        except PenError:
+            pass
+
+    @rule(pt=st_point)
+    def lineTo(self, pt: Tuple[float, float]) -> None:
+        try:
+            self.pen.lineTo(pt)
+        except PenError:
+            pass
+
+    @rule(points=st.lists(st_point))
+    def curveTo(self, points: Tuple[float, float]) -> None:
+        try:
+            self.pen.curveTo(*points)
+        except PenError:
+            pass
+
+    @rule(points=st.lists(st_point))
+    def qCurveTo(self, points: Tuple[float, float]) -> None:
+        try:
+            self.pen.qCurveTo(*points)
+        except PenError:
+            pass
+
+    @rule()
+    def closePath(self) -> None:
+        try:
+            self.pen.closePath()
+        except PenError:
+            pass
+
+    @rule()
+    def endPath(self) -> None:
+        try:
+            self.pen.endPath()
+        except PenError:
+            pass
+
+    @rule(glyphName=st_glyph_name, transformation=st_transformation)
+    def addComponent(
+        self,
+        glyphName: str,
+        transformation: Tuple[float, float, float, float, float, float],
+    ) -> None:
+        try:
+            self.pen.addComponent(glyphName, transformation)
+        except PenError:
+            pass
+
+
+class SegmentPointSegmentMonkey(SegmentMonkey):
+    def __init__(self):
+        super().__init__()
+        self.pen = SegmentToPointPen(PointToSegmentPen(RecordingPen()))
+
+
+class SegmentPointSegmentNoSmoothGuessMonkey(SegmentMonkey):
+    def __init__(self):
+        super().__init__()
+        self.pen = SegmentToPointPen(
+            PointToSegmentPen(RecordingPen()), guessSmooth=False
+        )
+
+
+s2p2stest = SegmentPointSegmentMonkey.TestCase
+s2p2snsgtest = SegmentPointSegmentNoSmoothGuessMonkey.TestCase

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ tox>=2.5
 bump2version>=0.5.6
 sphinx>=1.5.5
 mypy>=0.782
+hypothesis


### PR DESCRIPTION
Wherein I use [Hypothesis](https://hypothesis.readthedocs.io) to add property based testing to the suite, a.k.a blasting your API with random data and checking if invariants hold. Think of a monkey throwing shit at your API to see what sticks.

As a first step, this PR utilizes stateful testing to give pens a good thrashing to shake out unhandled crashers. I know that there are invariants to consider while using the API, and I sketched out a more intelligent test at https://gist.github.com/madig/08d3d07aad47e45e96ba3d4fac23ded4. I however need something better than a recording pen to compare against, because some pens do some processing like removing empty paths and turning single points into a `move` with `smooth=False` or buffer paths and retire them after endPath, so a dumb recording pen ends up with a different command stream if you addComponent inbetween.

As an initial finding, there's some inconsistency in how pens handle identifier and kwarg args.