### PR TITLE
[varlib] disambiguate cff merge errors

### DIFF
--- a/Lib/fontTools/varLib/cff.py
+++ b/Lib/fontTools/varLib/cff.py
@@ -20,7 +20,9 @@ from fontTools.varLib.models import allEqual
 from fontTools.misc.psCharStrings import T2CharString, T2OutlineExtractor
 from fontTools.pens.t2CharStringPen import T2CharStringPen, t2c_round
 
-from .errors import VarLibCFFDictMergeError, VarLibCFFPointTypeMergeError, VarLibMergeError
+from .errors import (
+	VarLibCFFDictMergeError, VarLibCFFPointTypeMergeError,
+	VarLibCFFHintTypeMergeError,VarLibMergeError)
 
 
 # Backwards compatibility
@@ -539,7 +541,7 @@ class CFF2CharStringMergePen(T2CharStringPen):
 		else:
 			cmd = self._commands[self.pt_index]
 			if cmd[0] != hint_type:
-				raise VarLibCFFPointTypeMergeError(hint_type, self.pt_index, len(cmd[1]),
+				raise VarLibCFFHintTypeMergeError(hint_type, self.pt_index, len(cmd[1]),
 					cmd[0], self.glyphName)
 			cmd[1].append(args)
 		self.pt_index += 1
@@ -548,14 +550,14 @@ class CFF2CharStringMergePen(T2CharStringPen):
 		# For hintmask, fonttools.cffLib.specializer.py expects
 		# each of these to be represented by two sequential commands:
 		# first holding only the operator name, with an empty arg list,
-		# second with an empty string as the op name, and  the mask arg list.
+		# second with an empty string as the op name, and the mask arg list.
 		if self.m_index == 0:
 			self._commands.append([hint_type, []])
 			self._commands.append(["", [abs_args]])
 		else:
 			cmd = self._commands[self.pt_index]
 			if cmd[0] != hint_type:
-				raise VarLibCFFPointTypeMergeError(hint_type, self.pt_index, len(cmd[1]),
+				raise VarLibCFFHintTypeMergeError(hint_type, self.pt_index, len(cmd[1]),
 					cmd[0], self.glyphName)
 			self.pt_index += 1
 			cmd = self._commands[self.pt_index]

--- a/Lib/fontTools/varLib/errors.py
+++ b/Lib/fontTools/varLib/errors.py
@@ -24,12 +24,24 @@ class VarLibCFFDictMergeError(VarLibMergeError):
 
 
 class VarLibCFFPointTypeMergeError(VarLibMergeError):
-    """Raised when a CFF glyph cannot be merged."""
+    """Raised when a CFF glyph cannot be merged because of point type differences."""
 
     def __init__(self, point_type, pt_index, m_index, default_type, glyph_name):
         error_msg = (
             f"Glyph '{glyph_name}': '{point_type}' at point index {pt_index} in "
             f"master index {m_index} differs from the default font point type "
+            f"'{default_type}'"
+        )
+        self.args = (error_msg,)
+
+
+class VarLibCFFHintTypeMergeError(VarLibMergeError):
+    """Raised when a CFF glyph cannot be merged because of hint type differences."""
+
+    def __init__(self, hint_type, cmd_index, m_index, default_type, glyph_name):
+        error_msg = (
+            f"Glyph '{glyph_name}': '{hint_type}' at index {cmd_index} in "
+            f"master index {m_index} differs from the default font hint type "
             f"'{default_type}'"
         )
         self.args = (error_msg,)


### PR DESCRIPTION
Add VarLibCFFHintTypeMergeError, raised when hint (and hintmask) incompatibilities occur during CFF merging.

Closes #2197 
