### PR TITLE
Test var model error

### DIFF
--- a/Tests/varLib/models_test.py
+++ b/Tests/varLib/models_test.py
@@ -33,41 +33,39 @@ def test_supportScalar():
     assert supportScalar({'wght':.2}, {'wght':(0,2,3)}) == 0.1
     assert supportScalar({'wght':2.5}, {'wght':(0,2,4)}) == 0.75
 
-def test_modeling_error(*, demo=False):
-    # https://github.com/fonttools/fonttools/issues/2213
-    if demo:
-        numLocations=127
-        numSamples=509
-    else:
-        numLocations=31
-        numSamples=251
 
-    locations = [{'axis':float(i)/numLocations} for i in range(numLocations)]
+@pytest.mark.parametrize(
+    "numLocations, numSamples", [
+        (127, 509),
+        (31, 251),
+    ]
+)
+def test_modeling_error(numLocations, numSamples):
+    # https://github.com/fonttools/fonttools/issues/2213
+    locations = [{'axis': float(i)/numLocations} for i in range(numLocations)]
     masterValues = [100. if i else 0. for i in range(numLocations)]
 
     model = VariationModel(locations)
 
     for i in range(numSamples):
-        loc = {'axis':float(i)/numSamples}
+        loc = {'axis': float(i)/numSamples}
         scalars = model.getScalars(loc)
 
         deltas_float = model.getDeltas(masterValues)
-        deltas_round   = model.getDeltas(masterValues, round=round)
+        deltas_round = model.getDeltas(masterValues, round=round)
 
         expected = model.interpolateFromDeltasAndScalars(deltas_float, scalars)
-        actual   = model.interpolateFromDeltasAndScalars(deltas_round, scalars)
+        actual = model.interpolateFromDeltasAndScalars(deltas_round, scalars)
 
         err = abs(actual - expected)
         assert err <= .5, (i, err)
 
-        if demo:
-            deltas_late_round   = [round(d) for d in deltas_float]
-            bad = model.interpolateFromDeltasAndScalars(deltas_late_round, scalars)
-            err_bad = abs(bad  - expected)
-            if err != err_bad:
-                print("{:d}	{:.2}	{:.2}".format(i, err, err_bad))
+        deltas_late_round = [round(d) for d in deltas_float]
+        bad = model.interpolateFromDeltasAndScalars(deltas_late_round, scalars)
+        err_bad = abs(bad - expected)
+        if err != err_bad:
+            print("{:d}	{:.2}	{:.2}".format(i, err, err_bad))
 
-test_modeling_error()
 
 class VariationModelTest(object):
 

--- a/Tests/varLib/models_test.py
+++ b/Tests/varLib/models_test.py
@@ -36,7 +36,7 @@ def test_supportScalar():
 
 @pytest.mark.parametrize(
     "numLocations, numSamples", [
-        (127, 509),
+        pytest.param(127, 509, marks=pytest.mark.slow),
         (31, 251),
     ]
 )

--- a/Tests/varLib/models_test.py
+++ b/Tests/varLib/models_test.py
@@ -60,11 +60,12 @@ def test_modeling_error(numLocations, numSamples):
         err = abs(actual - expected)
         assert err <= .5, (i, err)
 
-        deltas_late_round = [round(d) for d in deltas_float]
-        bad = model.interpolateFromDeltasAndScalars(deltas_late_round, scalars)
-        err_bad = abs(bad - expected)
-        if err != err_bad:
-            print("{:d}	{:.2}	{:.2}".format(i, err, err_bad))
+        # This is how NOT to round deltas.
+        #deltas_late_round = [round(d) for d in deltas_float]
+        #bad = model.interpolateFromDeltasAndScalars(deltas_late_round, scalars)
+        #err_bad = abs(bad - expected)
+        #if err != err_bad:
+        #    print("{:d}	{:.2}	{:.2}".format(i, err, err_bad))
 
 
 class VariationModelTest(object):

--- a/Tests/varLib/models_test.py
+++ b/Tests/varLib/models_test.py
@@ -33,6 +33,41 @@ def test_supportScalar():
     assert supportScalar({'wght':.2}, {'wght':(0,2,3)}) == 0.1
     assert supportScalar({'wght':2.5}, {'wght':(0,2,4)}) == 0.75
 
+def test_modeling_error(*, demo=False):
+    # https://github.com/fonttools/fonttools/issues/2213
+    if demo:
+        numLocations=127
+        numSamples=509
+    else:
+        numLocations=31
+        numSamples=251
+
+    locations = [{'axis':float(i)/numLocations} for i in range(numLocations)]
+    masterValues = [100. if i else 0. for i in range(numLocations)]
+
+    model = VariationModel(locations)
+
+    for i in range(numSamples):
+        loc = {'axis':float(i)/numSamples}
+        scalars = model.getScalars(loc)
+
+        deltas_float = model.getDeltas(masterValues)
+        deltas_round   = model.getDeltas(masterValues, round=round)
+
+        expected = model.interpolateFromDeltasAndScalars(deltas_float, scalars)
+        actual   = model.interpolateFromDeltasAndScalars(deltas_round, scalars)
+
+        err = abs(actual - expected)
+        assert err <= .5, (i, err)
+
+        if demo:
+            deltas_late_round   = [round(d) for d in deltas_float]
+            bad = model.interpolateFromDeltasAndScalars(deltas_late_round, scalars)
+            err_bad = abs(bad  - expected)
+            if err != err_bad:
+                print("{:d}	{:.2}	{:.2}".format(i, err, err_bad))
+
+test_modeling_error()
 
 class VariationModelTest(object):
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,8 @@ filterwarnings =
 	ignore:writePlist:DeprecationWarning:plistlib_test
 	ignore:some_function:DeprecationWarning:fontTools.ufoLib.utils
 	ignore::DeprecationWarning:fontTools.varLib.designspace
+markers = 
+    slow: marks tests as slow (deselect with '-m "not slow"')
 
 [tool:interrogate]
 ignore-semiprivate = true


### PR DESCRIPTION
From the commit message:

    [varLib.models] Add test for modeling rounding error
    
    Tests https://github.com/fonttools/fonttools/pull/2214
    
    If you flip demo to True, it does a slower test and demos the new error as well
    as the error the old code was producing (ie. rounding deltas post-modeling).
    
    Indeed, the new error is always capped by 0.5 as expected, whereas the old one
    was unbounded. Here's the worst-case error of the bad code:
    
    ...
    240     0.42    4.8
    ...
    
    240 is just the line number. 0.42 is new error. 4.8 is old error.
