### PR TITLE
[varLib] Add optional 'simple' supports/region builder

### DIFF
--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -314,14 +314,14 @@ class VariationModel(object):
 				points = axisPoints[axis]
 				peakIndex = points.index(peak)
 				if peakIndex == 0:
-					minimum = peak
+					lower = peak
 				else:
-					minimum = points[peakIndex - 1]
+					lower = points[peakIndex - 1]
 				if peakIndex == len(points) - 1:
-					maximum = peak
+					upper = peak
 				else:
-					maximum = points[peakIndex + 1]
-				region[axis] = (minimum, peak, maximum)
+					upper = points[peakIndex + 1]
+				region[axis] = (lower, peak, upper)
 			supports.append(region)
 		self.supports = supports
 

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -313,14 +313,8 @@ class VariationModel(object):
 				assert peak != 0
 				points = axisPoints[axis]
 				peakIndex = points.index(peak)
-				if peakIndex == 0:
-					lower = peak
-				else:
-					lower = points[peakIndex - 1]
-				if peakIndex == len(points) - 1:
-					upper = peak
-				else:
-					upper = points[peakIndex + 1]
+				lower = peak if peakIndex == 0 else points[peakIndex - 1]
+				upper = peak if peakIndex == len(points) - 1 else points[peakIndex + 1]
 				region[axis] = (lower, peak, upper)
 			supports.append(region)
 		self.supports = supports


### PR DESCRIPTION
Add an optional 'simple' supports/region builder for 'simple' master configurations, addressing some comments in #2207.

With 'simple' I mean:
- There are masters at all corners of the designspace
- Intermediates on an axis must be present at all other axis master locations, too. For example, in a `wght`/`wdth` system, if there is a `wdth` intermediate for narrow, the same intermediate must exist for wide.

The resulting model is equivalent with the one build by the "generic" solver, but it will behave better with respect to rounding at the peak positions: intermediate masters always get matched exactly, instead of being (maximally) 0.5 unit off. (This is especially important if 100% metrics compatibility is desired at the master locations: this is currently not possible with the general solver.)

There will be fewer deltas participating at any one point in the designspace, so this will be more efficient at runtime.

However, as Behdad pointed out, the deltas to be stored will likely be larger, so may be stored less efficiently.