### PR TITLE
[py23] Nit: change py23 deprecation warning from "next release" to "future release"

### DIFF
--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -9,7 +9,7 @@ from io import StringIO as UnicodeIO
 from types import SimpleNamespace
 
 warnings.warn(
-    "The py23 module has been deprecated and will be removed in the next release. "
+    "The py23 module has been deprecated and will be removed in a future release. "
     "Please update your code.",
     DeprecationWarning,
 )


### PR DESCRIPTION
This warning doesn't seem to have teeth since it has been around for 2+ yrs :) 