### PR TITLE
[otlLib] Ensure built ValueRecords are padded with 0s like when decompiled

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2190,8 +2190,8 @@ def buildPairPosGlyphsSubtable(pairs, glyphMap, valueFormat1=None, valueFormat2=
         for glyph2, val1, val2 in sorted(p[glyph], key=lambda x: glyphMap[x[0]]):
             pvr = ot.PairValueRecord()
             pvr.SecondGlyph = glyph2
-            pvr.Value1 = val1 if valueFormat1 else None
-            pvr.Value2 = val2 if valueFormat2 else None
+            pvr.Value1 = ValueRecord(src=val1, valueFormat=valueFormat1) if valueFormat1 else None
+            pvr.Value2 = ValueRecord(src=val2, valueFormat=valueFormat2) if valueFormat2 else None
             ps.PairValueRecord.append(pvr)
         ps.PairValueCount = len(ps.PairValueRecord)
     self.PairSetCount = len(self.PairSet)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2089,9 +2089,9 @@ def buildPairPosClassesSubtable(pairs, glyphMap, valueFormat1=None, valueFormat2
         self.Class1Record.append(rec1)
         for c2 in classes2:
             rec2 = ot.Class2Record()
-            rec2.Value1, rec2.Value2 = pairs.get((c1, c2), (None, None))
-            if valueFormat1 and rec2.Value1 is None: rec2.Value1 = ValueRecord(valueFormat1)
-            if valueFormat2 and rec2.Value2 is None: rec2.Value2 = ValueRecord(valueFormat2)
+            val1, val2 = pairs.get((c1, c2), (None, None))
+            rec2.Value1 = ValueRecord(src=val1, valueFormat=valueFormat1) if valueFormat1 else None
+            rec2.Value2 = ValueRecord(src=val2, valueFormat=valueFormat2) if valueFormat2 else None
             rec1.Class2Record.append(rec2)
     self.Class1Count = len(self.Class1Record)
     self.Class2Count = len(classes2)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -11,6 +11,7 @@ from fontTools.ttLib.tables.otBase import (
 from fontTools.ttLib.tables import otBase
 from fontTools.feaLib.ast import STATNameStatement
 from fontTools.otlLib.error import OpenTypeLibError
+from functools import reduce
 import logging
 import copy
 
@@ -2312,10 +2313,8 @@ def buildSinglePosSubtable(values, glyphMap):
     """
     self = ot.SinglePos()
     self.Coverage = buildCoverage(values.keys(), glyphMap)
-    valueRecords = [values[g] for g in self.Coverage.glyphs]
-    self.ValueFormat = 0
-    for v in valueRecords:
-        self.ValueFormat |= v.getFormat()
+    valueFormat = self.ValueFormat = reduce(int.__or__, [v.getFormat() for v in values.values()], 0)
+    valueRecords = [ValueRecord(src=values[g], valueFormat=valueFormat) for g in self.Coverage.glyphs]
     if all(v == valueRecords[0] for v in valueRecords):
         self.Format = 1
         if self.ValueFormat != 0:

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -922,6 +922,7 @@ class BuilderTest(object):
             },
             self.GLYPHMAP,
         )
+
         assert getXML(subtable.toXML) == [
             '<PairPos Format="1">',
             "  <Coverage>",
@@ -935,11 +936,12 @@ class BuilderTest(object):
             "    <!-- PairValueCount=2 -->",
             '    <PairValueRecord index="0">',
             '      <SecondGlyph value="zero"/>',
-            '      <Value1/>',
+            '      <Value1 XPlacement="0" YPlacement="0"/>',
             '      <Value2 XPlacement="-50"/>',
             "    </PairValueRecord>",
             '    <PairValueRecord index="1">',
             '      <SecondGlyph value="one"/>',
+            '      <Value1 XPlacement="0" YPlacement="0"/>',
             '      <Value2 XPlacement="-20"/>',
             "    </PairValueRecord>",
             "  </PairSet>",

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -861,7 +861,7 @@ class BuilderTest(object):
             '      <Value2 XPlacement="-20"/>',
             "    </Class2Record>",
             '    <Class2Record index="2">',
-            "      <Value1/>",
+            '      <Value1 XPlacement="0" YPlacement="0"/>',
             '      <Value2 XPlacement="-50"/>',
             "    </Class2Record>",
             "  </Class1Record>",

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1042,8 +1042,8 @@ class BuilderTest(object):
             "  </Coverage>",
             '  <ValueFormat value="3"/>',
             "  <!-- ValueCount=2 -->",
-            '  <Value index="0" XPlacement="777"/>',
-            '  <Value index="1" YPlacement="-888"/>',
+            '  <Value index="0" XPlacement="777" YPlacement="0"/>',
+            '  <Value index="1" XPlacement="0" YPlacement="-888"/>',
             "</SinglePos>",
         ]
 


### PR DESCRIPTION
Follow up from https://github.com/fonttools/fonttools/pull/2229

see discussion at https://github.com/fonttools/fonttools/commit/2089d051265d96db9dfdbcf15af10e1e003ccd82#r48578120 