### PR TITLE
py23 transition: Convert `basestring` to `str`

### DIFF
--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -118,7 +118,7 @@ class CFFFontSet(object):
 		"""
 		if hasattr(nameOrIndex, "__index__"):
 			index = nameOrIndex.__index__()
-		elif isinstance(nameOrIndex, basestring):
+		elif isinstance(nameOrIndex, str):
 			name = nameOrIndex
 			try:
 				index = self.fontNames.index(name)
@@ -261,7 +261,7 @@ class CFFFontSet(object):
 				self.topDictIndex = TopDictIndex(None, cff2GetGlyphOrder, None)
 			self.topDictIndex.append(topDict)
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 				name, attrs, content = element
 				topDict.fromXML(name, attrs, content)
@@ -277,7 +277,7 @@ class CFFFontSet(object):
 			if not hasattr(self, "GlobalSubrs"):
 				self.GlobalSubrs = GlobalSubrsIndex()
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 				name, attrs, content = element
 				subr = subrCharStringClass()
@@ -879,7 +879,7 @@ class FDArrayIndex(Index):
 			return
 		fontDict = FontDict()
 		for element in content:
-			if isinstance(element, basestring):
+			if isinstance(element, str):
 				continue
 			name, attrs, content = element
 			fontDict.fromXML(name, attrs, content)
@@ -1106,7 +1106,7 @@ class CharStrings(object):
 
 	def fromXML(self, name, attrs, content):
 		for element in content:
-			if isinstance(element, basestring):
+			if isinstance(element, str):
 				continue
 			name, attrs, content = element
 			if name != "CharString":
@@ -1282,7 +1282,7 @@ def parseNum(s):
 def parseBlendList(s):
 	valueList = []
 	for element in s:
-		if isinstance(element, basestring):
+		if isinstance(element, str):
 			continue
 		name, attrs, content = element
 		blendList = attrs["value"].split()
@@ -1358,7 +1358,7 @@ class TableConverter(SimpleConverter):
 	def xmlRead(self, name, attrs, content, parent):
 		ob = self.getClass()()
 		for element in content:
-			if isinstance(element, basestring):
+			if isinstance(element, str):
 				continue
 			name, attrs, content = element
 			ob.fromXML(name, attrs, content)
@@ -1650,7 +1650,7 @@ def parseCharset(numGlyphs, file, strings, isCID, fmt):
 class EncodingCompiler(object):
 
 	def __init__(self, strings, encoding, parent):
-		assert not isinstance(encoding, basestring)
+		assert not isinstance(encoding, str)
 		data0 = packEncoding0(parent.dictObj.charset, encoding, parent.strings)
 		data1 = packEncoding1(parent.dictObj.charset, encoding, parent.strings)
 		if len(data0) < len(data1):
@@ -1721,7 +1721,7 @@ class EncodingConverter(SimpleConverter):
 			return attrs["name"]
 		encoding = [".notdef"] * 256
 		for element in content:
-			if isinstance(element, basestring):
+			if isinstance(element, str):
 				continue
 			name, attrs, content = element
 			code = safeEval(attrs["code"])
@@ -1833,7 +1833,7 @@ class FDArrayConverter(TableConverter):
 	def xmlRead(self, name, attrs, content, parent):
 		fdArray = FDArrayIndex()
 		for element in content:
-			if isinstance(element, basestring):
+			if isinstance(element, str):
 				continue
 			name, attrs, content = element
 			fdArray.fromXML(name, attrs, content)
@@ -2332,7 +2332,7 @@ class TopDictCompiler(DictCompiler):
 					self.rawDict["charset"] = charsetCode
 			if hasattr(self.dictObj, "Encoding") and self.dictObj.Encoding:
 				encoding = self.dictObj.Encoding
-				if not isinstance(encoding, basestring):
+				if not isinstance(encoding, str):
 					children.append(EncodingCompiler(strings, encoding, self))
 		else:
 			if hasattr(self.dictObj, "VarStore"):

--- a/Lib/fontTools/cffLib/specializer.py
+++ b/Lib/fontTools/cffLib/specializer.py
@@ -18,7 +18,7 @@ from fontTools.cffLib import maxStackLimit
 
 
 def stringToProgram(string):
-	if isinstance(string, basestring):
+	if isinstance(string, str):
 		string = string.split()
 	program = []
 	for token in string:
@@ -70,7 +70,7 @@ def programToCommands(program, getNumRegions=None):
 	it = iter(program)
 
 	for token in it:
-		if not isinstance(token, basestring):
+		if not isinstance(token, str):
 			stack.append(token)
 			continue
 

--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -478,7 +478,7 @@ class FontBuilder(object):
                 nameID = nameName
             else:
                 nameID = _nameIDs[nameName]
-            if isinstance(nameValue, basestring):
+            if isinstance(nameValue, str):
                 nameValue = dict(en=nameValue)
             nameTable.addMultilingualName(
                 nameValue, ttFont=self.font, nameID=nameID, windows=windows, mac=mac

--- a/Lib/fontTools/misc/etree.py
+++ b/Lib/fontTools/misc/etree.py
@@ -11,7 +11,7 @@ or subclasses built-in ElementTree classes to add features that are
 only availble in lxml, like OrderedDict for attributes, pretty_print and
 iterwalk.
 """
-from fontTools.misc.py23 import basestring, unicode, tounicode, open
+from fontTools.misc.py23 import unicode, tounicode, open
 
 
 XML_DECLARATION = """<?xml version='1.0' encoding='%s'?>"""
@@ -356,7 +356,7 @@ except ImportError:
             if isinstance(tag, QName):
                 if tag.text not in qnames:
                     add_qname(tag.text)
-            elif isinstance(tag, basestring):
+            elif isinstance(tag, str):
                 if tag not in qnames:
                     add_qname(tag)
             elif tag is not None and tag is not Comment and tag is not PI:

--- a/Lib/fontTools/misc/filenames.py
+++ b/Lib/fontTools/misc/filenames.py
@@ -16,7 +16,7 @@ by Tal Leming and is copyright (c) 2005-2016, The RoboFab Developers:
 -	Tal Leming
 -	Just van Rossum
 """
-from fontTools.misc.py23 import basestring, unicode
+from fontTools.misc.py23 import unicode
 
 illegalCharacters = r"\" * + / : < > ? [ \ ] | \0".split(" ")
 illegalCharacters += [chr(i) for i in range(1, 32)]

--- a/Lib/fontTools/misc/loggingTools.py
+++ b/Lib/fontTools/misc/loggingTools.py
@@ -60,7 +60,7 @@ class LevelFormatter(logging.Formatter):
 				"only '%' percent style is supported in both python 2 and 3")
 		if fmt is None:
 			fmt = DEFAULT_FORMATS
-		if isinstance(fmt, basestring):
+		if isinstance(fmt, str):
 			default_format = fmt
 			custom_formats = {}
 		elif isinstance(fmt, Mapping):
@@ -151,7 +151,7 @@ def configLogger(**kwargs):
 		handlers = [h]
 	# By default, the top-level library logger is configured.
 	logger = kwargs.pop("logger", "fontTools")
-	if not logger or isinstance(logger, basestring):
+	if not logger or isinstance(logger, str):
 		# empty "" or None means the 'root' logger
 		logger = logging.getLogger(logger)
 	# before (re)configuring, reset named logger and its children (if exist)
@@ -436,7 +436,7 @@ class CapturingLogHandler(logging.Handler):
 	def __init__(self, logger, level):
 		super(CapturingLogHandler, self).__init__(level=level)
 		self.records = []
-		if isinstance(logger, basestring):
+		if isinstance(logger, str):
 			self.logger = logging.getLogger(logger)
 		else:
 			self.logger = logger

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -997,7 +997,7 @@ class T2CharString(object):
 			# If present, remove return and endchar operators.
 			if program and program[-1] in ("return", "endchar"):
 				program = program[:-1]
-		elif program and not isinstance(program[-1], basestring):
+		elif program and not isinstance(program[-1], str):
 			raise CharStringCompileError(
 				"T2CharString or Subr has items on the stack after last operator."
 			)
@@ -1010,7 +1010,7 @@ class T2CharString(object):
 		while i < end:
 			token = program[i]
 			i = i + 1
-			if isinstance(token, basestring):
+			if isinstance(token, str):
 				try:
 					bytecode.extend(bytechr(b) for b in opcodes[token])
 				except KeyError:
@@ -1043,8 +1043,7 @@ class T2CharString(object):
 		self.program = None
 
 	def getToken(self, index,
-			len=len, byteord=byteord, basestring=basestring,
-			isinstance=isinstance):
+			len=len, byteord=byteord, isinstance=isinstance):
 		if self.bytecode is not None:
 			if index >= len(self.bytecode):
 				return None, 0, 0
@@ -1057,7 +1056,7 @@ class T2CharString(object):
 				return None, 0, 0
 			token = self.program[index]
 			index = index + 1
-		isOperator = isinstance(token, basestring)
+		isOperator = isinstance(token, str)
 		return token, isOperator, index
 
 	def getBytes(self, index, nBytes):

--- a/Lib/fontTools/misc/sstruct.py
+++ b/Lib/fontTools/misc/sstruct.py
@@ -68,7 +68,7 @@ def pack(fmt, obj):
 		if name in fixes:
 			# fixed point conversion
 			value = fl2fi(value, fixes[name])
-		elif isinstance(value, basestring):
+		elif isinstance(value, str):
 			value = tobytes(value)
 		elements.append(value)
 	data = struct.pack(*(formatstring,) + tuple(elements))

--- a/Lib/fontTools/misc/textTools.py
+++ b/Lib/fontTools/misc/textTools.py
@@ -12,7 +12,7 @@ safeEval = ast.literal_eval
 
 def readHex(content):
 	"""Convert a list of hex strings to binary data."""
-	return deHexStr(strjoin(chunk for chunk in content if isinstance(chunk, basestring)))
+	return deHexStr(strjoin(chunk for chunk in content if isinstance(chunk, str)))
 
 
 def deHexStr(hexdata):

--- a/Lib/fontTools/ttLib/macUtils.py
+++ b/Lib/fontTools/ttLib/macUtils.py
@@ -40,7 +40,7 @@ class SFNTResourceReader(BytesIO):
 	def __init__(self, path, res_name_or_index):
 		from fontTools import ttLib
 		reader = ResourceReader(path)
-		if isinstance(res_name_or_index, basestring):
+		if isinstance(res_name_or_index, str):
 			rsrc = reader.getNamedResource('sfnt', res_name_or_index)
 		else:
 			rsrc = reader.getIndResource('sfnt', res_name_or_index)

--- a/Lib/fontTools/ttLib/tables/C_O_L_R_.py
+++ b/Lib/fontTools/ttLib/tables/C_O_L_R_.py
@@ -105,11 +105,11 @@ class table_C_O_L_R_(DefaultTable.DefaultTable):
 				self.ColorLayers = {}
 			glyphName = attrs["name"]
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 			layers = []
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 				layer = LayerRecord()
 				layer.fromXML(element[0], element[1], element[2], ttFont)

--- a/Lib/fontTools/ttLib/tables/C_P_A_L_.py
+++ b/Lib/fontTools/ttLib/tables/C_P_A_L_.py
@@ -208,7 +208,7 @@ class table_C_P_A_L_(DefaultTable.DefaultTable):
 			self.paletteTypes.append(int(attrs.get("type", self.DEFAULT_PALETTE_TYPE)))
 			palette = []
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 				attrs = element[1]
 				color = Color.fromHex(attrs["value"])
@@ -217,7 +217,7 @@ class table_C_P_A_L_(DefaultTable.DefaultTable):
 		elif name == "paletteEntryLabels":
 			colorLabels = {}
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 				elementName, elementAttr, _ = element
 				if elementName == "label":

--- a/Lib/fontTools/ttLib/tables/G_M_A_P_.py
+++ b/Lib/fontTools/ttLib/tables/G_M_A_P_.py
@@ -115,7 +115,7 @@ class table_G_M_A_P_(DefaultTable.DefaultTable):
 			gmapRecord = GMAPRecord()
 			self.gmapRecords.append(gmapRecord)
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 				name, attrs, content = element
 				gmapRecord.fromXML(name, attrs, content, ttFont)

--- a/Lib/fontTools/ttLib/tables/G_P_K_G_.py
+++ b/Lib/fontTools/ttLib/tables/G_P_K_G_.py
@@ -106,7 +106,7 @@ class table_G_P_K_G_(DefaultTable.DefaultTable):
 			if not hasattr(self, "GMAPs"):
 				self.GMAPs = []
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 				itemName, itemAttrs, itemContent = element
 				if itemName == "hexdata":
@@ -115,7 +115,7 @@ class table_G_P_K_G_(DefaultTable.DefaultTable):
 			if not hasattr(self, "glyphlets"):
 				self.glyphlets = []
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 				itemName, itemAttrs, itemContent = element
 				if itemName == "hexdata":

--- a/Lib/fontTools/ttLib/tables/M_E_T_A_.py
+++ b/Lib/fontTools/ttLib/tables/M_E_T_A_.py
@@ -173,7 +173,7 @@ class table_M_E_T_A_(DefaultTable.DefaultTable):
 			glyphRec = GlyphRecord()
 			self.glyphRecords.append(glyphRec)
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 				name, attrs, content = element
 				glyphRec.fromXML(name, attrs, content, ttFont)
@@ -207,7 +207,7 @@ class GlyphRecord(object):
 			stringRec = StringRecord()
 			self.stringRecs.append(stringRec)
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 				stringRec.fromXML(name, attrs, content, ttFont)
 			stringRec.stringLen = len(stringRec.string)
@@ -281,7 +281,7 @@ class StringRecord(object):
 
 	def fromXML(self, name, attrs, content, ttFont):
 		for element in content:
-			if isinstance(element, basestring):
+			if isinstance(element, str):
 				continue
 			name, attrs, content = element
 			value = attrs["value"]

--- a/Lib/fontTools/ttLib/tables/V_O_R_G_.py
+++ b/Lib/fontTools/ttLib/tables/V_O_R_G_.py
@@ -84,7 +84,7 @@ class table_V_O_R_G_(DefaultTable.DefaultTable):
 		if name == "VOriginRecord":
 			vOriginRec = VOriginRecord()
 			for element in content:
-				if isinstance(element, basestring):
+				if isinstance(element, str):
 					continue
 				name, attrs, content = element
 				vOriginRec.fromXML(name, attrs, content, ttFont)

--- a/Lib/fontTools/unicode.py
+++ b/Lib/fontTools/unicode.py
@@ -16,7 +16,7 @@ def _makeunicodes(f):
 class _UnicodeCustom(object):
 
 	def __init__(self, f):
-		if isinstance(f, basestring):
+		if isinstance(f, str):
 			with open(f) as fd:
 				codes = _makeunicodes(fd)
 		else:

--- a/Tests/misc/timeTools_test.py
+++ b/Tests/misc/timeTools_test.py
@@ -7,7 +7,7 @@ import pytest
 
 
 def test_asctime():
-    assert isinstance(asctime(), basestring)
+    assert isinstance(asctime(), str)
     assert asctime(time.gmtime(0)) == 'Thu Jan  1 00:00:00 1970'
 
 


### PR DESCRIPTION
Tracking in https://github.com/fonttools/fonttools/issues/2232

This PR replaces `basestring` with `str` across all library and test modules *except* misc.py23.  I tested this locally in cPy3.9 with the py23 module basestring definition removed and the test suite passes

