### PR TITLE
subset: fix pruning unused CPAL palettes when 0xFFFF is present

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2087,7 +2087,9 @@ def prune_post_subset(self, font, options):
 		for record in colr.table.BaseGlyphV1List.BaseGlyphV1Record:
 			record.Paint.traverse(colr.table, collect_colors_by_index)
 
-	retained_palette_indices = set(colors_by_index.keys())
+	# don't remap palette entry index 0xFFFF, this is always the foreground color
+	# https://github.com/fonttools/fonttools/issues/2257
+	retained_palette_indices = set(colors_by_index.keys()) - {0xFFFF}
 	for palette in self.palettes:
 		palette[:] = [c for i, c in enumerate(palette) if i in retained_palette_indices]
 		assert len(palette) == len(retained_palette_indices)

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -1076,7 +1076,8 @@ def colrv1_path(tmp_path):
             },
             "uniE004": [
                 ("glyph00016", 1),
-                ("glyph00017", 2),
+                ("glyph00017", 0xFFFF),  # special palette index for foreground text
+                ("glyph00018", 2),
             ],
         },
     )
@@ -1130,6 +1131,7 @@ def test_subset_COLRv1_and_CPAL(colrv1_path):
     assert "uniE004" in glyph_set
     assert "glyph00016" in glyph_set
     assert "glyph00017" in glyph_set
+    assert "glyph00018" in glyph_set
 
     assert "COLR" in subset_font
     colr = subset_font["COLR"].table
@@ -1151,10 +1153,11 @@ def test_subset_COLRv1_and_CPAL(colrv1_path):
     baseRecV0 = colr.BaseGlyphRecordArray.BaseGlyphRecord[0]
     assert baseRecV0.BaseGlyph == "uniE004"
     layersV0 = colr.LayerRecordArray.LayerRecord
-    assert len(layersV0) == 2
-    # check v0 palette indices were remapped
+    assert len(layersV0) == 3
+    # check v0 palette indices were remapped (except for 0xFFFF)
     assert layersV0[0].PaletteIndex == 0
-    assert layersV0[1].PaletteIndex == 1
+    assert layersV0[1].PaletteIndex == 0xFFFF
+    assert layersV0[2].PaletteIndex == 1
 
     assert "CPAL" in subset_font
     cpal = subset_font["CPAL"]
@@ -1208,6 +1211,7 @@ def test_subset_COLRv1_downgrade_version(colrv1_path):
         "uniE004",
         "glyph00016",
         "glyph00017",
+        "glyph00018",
     }
 
     assert "COLR" in subset_font


### PR DESCRIPTION
FIxes https://github.com/fonttools/fonttools/issues/2257