### PR TITLE
[subset] Fix hint-dropping

### DIFF
--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -970,6 +970,13 @@ class ValueRecord(object):
 			format = format | valueRecordFormatDict[name][0]
 		return format
 
+	def getEffectiveFormat(self):
+		format = 0
+		for name,value in self.__dict__.items():
+			if value:
+				format = format | valueRecordFormatDict[name][0]
+		return format
+
 	def toXML(self, xmlWriter, font, valueName, attrs=None):
 		if attrs is None:
 			simpleItems = []

--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -289,7 +289,7 @@ def merge(merger, self, lst):
 	# Merge everything else; though, there shouldn't be anything else. :)
 	merger.mergeObjects(self, lst,
 			    exclude=('Format', 'Coverage', 'Value', 'ValueCount'))
-	self.ValueFormat = reduce(int.__or__, [v.getFormat() for v in self.Value], 0)
+	self.ValueFormat = reduce(int.__or__, [v.getEffectiveFormat() for v in self.Value], 0)
 
 @AligningMerger.merger(ot.PairSet)
 def merge(merger, self, lst):


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/2272

The 4 failing tests are adjacent and because of the second commit.  2 of them just need expectations updated. The other two, that are producing empty lookup:
```
+      <Lookup index="0" empty="1"/>
```
need a fix in `feaLib` (I suppose) to prune empty lookups. I couldn't understand why that's not happening.