### PR TITLE
[otlLib] Use ValueRecord.getEffectiveFormat() to produce smaller lookups

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -1394,10 +1394,10 @@ class PairPosBuilder(LookupBuilder):
                     builder.addSubtableBreak()
                 continue
             valFormat1, valFormat2 = 0, 0
-            if value1:
-                valFormat1 = value1.getFormat()
-            if value2:
-                valFormat2 = value2.getFormat()
+            valFormat1 = value1.getEffectiveFormat() if value1 is not None else 0
+            valFormat2 = value1.getEffectiveFormat() if value2 is not None else 0
+            if not (valFormat1 | valFormat2):
+                continue
             builder = builders.get((valFormat1, valFormat2))
             if builder is None:
                 builder = ClassPairPosSubtableBuilder(self)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -1395,7 +1395,7 @@ class PairPosBuilder(LookupBuilder):
                 continue
             valFormat1, valFormat2 = 0, 0
             valFormat1 = value1.getEffectiveFormat() if value1 is not None else 0
-            valFormat2 = value1.getEffectiveFormat() if value2 is not None else 0
+            valFormat2 = value2.getEffectiveFormat() if value2 is not None else 0
             if not (valFormat1 | valFormat2):
                 continue
             builder = builders.get((valFormat1, valFormat2))
@@ -2073,7 +2073,7 @@ def _getValueFormat(f, values, i):
     mask = 0
     for value in values:
         if value is not None and value[i] is not None:
-            mask |= value[i].getFormat()
+            mask |= value[i].getEffectiveFormat()
     return mask
 
 
@@ -2190,8 +2190,10 @@ def buildPairPosGlyphs(pairs, glyphMap):
 
     p = {}  # (formatA, formatB) --> {(glyphA, glyphB): (valA, valB)}
     for (glyphA, glyphB), (valA, valB) in pairs.items():
-        formatA = valA.getFormat() if valA is not None else 0
-        formatB = valB.getFormat() if valB is not None else 0
+        formatA = valA.getEffectiveFormat() if valA is not None else 0
+        formatB = valB.getEffectiveFormat() if valB is not None else 0
+        if not (formatA | formatB):
+            continue
         pos = p.setdefault((formatA, formatB), {})
         pos[(glyphA, glyphB)] = (valA, valB)
     return [
@@ -2379,7 +2381,7 @@ def buildSinglePosSubtable(values, glyphMap):
     self = ot.SinglePos()
     self.Coverage = buildCoverage(values.keys(), glyphMap)
     valueFormat = self.ValueFormat = reduce(
-        int.__or__, [v.getFormat() for v in values.values()], 0
+        int.__or__, [v.getEffectiveFormat() for v in values.values()], 0
     )
     valueRecords = [
         ValueRecord(src=values[g], valueFormat=valueFormat)

--- a/Tests/feaLib/data/bug633.ttx
+++ b/Tests/feaLib/data/bug633.ttx
@@ -43,21 +43,16 @@
           <ClassDef1>
           </ClassDef1>
           <ClassDef2>
-            <ClassDef glyph="C" class="2"/>
-            <ClassDef glyph="O" class="2"/>
-            <ClassDef glyph="V" class="1"/>
-            <ClassDef glyph="W" class="1"/>
+            <ClassDef glyph="C" class="1"/>
+            <ClassDef glyph="O" class="1"/>
           </ClassDef2>
           <!-- Class1Count=1 -->
-          <!-- Class2Count=3 -->
+          <!-- Class2Count=2 -->
           <Class1Record index="0">
             <Class2Record index="0">
               <Value1 XAdvance="0"/>
             </Class2Record>
             <Class2Record index="1">
-              <Value1 XAdvance="0"/>
-            </Class2Record>
-            <Class2Record index="2">
               <Value1 XAdvance="-20"/>
             </Class2Record>
           </Class1Record>

--- a/Tests/varLib/data/test_results/test_vpal.ttx
+++ b/Tests/varLib/data/test_results/test_vpal.ttx
@@ -38,17 +38,17 @@
             <Glyph value="uniFF1A"/>
             <Glyph value="uni3074"/>
           </Coverage>
-          <ValueFormat value="7"/>
+          <ValueFormat value="5"/>
           <!-- ValueCount=2 -->
-          <Value index="0" XPlacement="-250" YPlacement="0" XAdvance="-500"/>
-          <Value index="1" XPlacement="0" YPlacement="0" XAdvance="-30"/>
+          <Value index="0" XPlacement="-250" XAdvance="-500"/>
+          <Value index="1" XPlacement="0" XAdvance="-30"/>
         </SinglePos>
         <SinglePos index="1" Format="1">
           <Coverage>
             <Glyph value="uni3001"/>
           </Coverage>
-          <ValueFormat value="23"/>
-          <Value XPlacement="-9" YPlacement="0" XAdvance="-500">
+          <ValueFormat value="21"/>
+          <Value XPlacement="-9" XAdvance="-500">
             <XPlaDevice>
               <StartSize value="0"/>
               <EndSize value="4"/>
@@ -73,8 +73,8 @@
           <Coverage>
             <Glyph value="uniFF2D"/>
           </Coverage>
-          <ValueFormat value="87"/>
-          <Value XPlacement="12" YPlacement="0" XAdvance="23">
+          <ValueFormat value="85"/>
+          <Value XPlacement="12" XAdvance="23">
             <XPlaDevice>
               <StartSize value="0"/>
               <EndSize value="1"/>
@@ -91,8 +91,8 @@
           <Coverage>
             <Glyph value="uni3073"/>
           </Coverage>
-          <ValueFormat value="71"/>
-          <Value XPlacement="0" YPlacement="0" XAdvance="-36">
+          <ValueFormat value="68"/>
+          <Value XAdvance="-36">
             <XAdvDevice>
               <StartSize value="0"/>
               <EndSize value="3"/>
@@ -104,8 +104,8 @@
           <Coverage>
             <Glyph value="uni307B"/>
           </Coverage>
-          <ValueFormat value="23"/>
-          <Value XPlacement="11" YPlacement="0" XAdvance="0">
+          <ValueFormat value="17"/>
+          <Value XPlacement="11">
             <XPlaDevice>
               <StartSize value="0"/>
               <EndSize value="2"/>


### PR DESCRIPTION
Continuing from https://github.com/fonttools/fonttools/pull/2275