### PR TITLE
[varLib.instancer] update instantiateVariableFont docs to indicate L3 support

### DIFF
--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -1170,7 +1170,8 @@ def instantiateVariableFont(
             If the value is `None`, the default coordinate as per 'fvar' table for
             that axis is used.
             The limit values can also be (min, max) tuples for restricting an
-            axis's variation range, but this is not implemented yet.
+            axis's variation range. The default axis value must be included in
+            the new range.
         inplace (bool): whether to modify input TTFont object in-place instead of
             returning a distinct object.
         optimize (bool): if False, do not perform IUP-delta optimization on the


### PR DESCRIPTION
Updated to indicate that Level 3 axis range sub-spaces are supported

This section will need to be updated if/when https://github.com/fonttools/fonttools/issues/2157 is closed with an implementation for L4