### PR TITLE
Pen error maintenance

### DIFF
--- a/Lib/fontTools/pens/basePen.py
+++ b/Lib/fontTools/pens/basePen.py
@@ -40,8 +40,12 @@ from typing import Tuple
 
 from fontTools.misc.loggingTools import LogMixin
 
-__all__ =  ["AbstractPen", "NullPen", "BasePen",
+__all__ =  ["AbstractPen", "NullPen", "BasePen", "PenError",
 			"decomposeSuperBezierSegment", "decomposeQuadraticSegment"]
+
+
+class PenError(Exception):
+	"""Represents an error during penning."""
 
 
 class AbstractPen:

--- a/Lib/fontTools/pens/pointPen.py
+++ b/Lib/fontTools/pens/pointPen.py
@@ -15,7 +15,7 @@ For instance, whether or not a point is smooth, and its name.
 import math
 from typing import Any, Optional, Tuple
 
-from fontTools.pens.basePen import AbstractPen
+from fontTools.pens.basePen import AbstractPen, PenError
 
 __all__ = [
 	"AbstractPointPen",
@@ -74,7 +74,8 @@ class BasePointToSegmentPen(AbstractPointPen):
 		self.currentPath = None
 
 	def beginPath(self, identifier=None, **kwargs):
-		assert self.currentPath is None
+		if self.currentPath is not None:
+			raise PenError("Path already begun.")
 		self.currentPath = []
 
 	def _flushContour(self, segments):
@@ -106,7 +107,8 @@ class BasePointToSegmentPen(AbstractPointPen):
 		raise NotImplementedError
 
 	def endPath(self):
-		assert self.currentPath is not None
+		if self.currentPath is None:
+			raise PenError("Path not begun.")
 		points = self.currentPath
 		self.currentPath = None
 		if not points:
@@ -154,6 +156,8 @@ class BasePointToSegmentPen(AbstractPointPen):
 
 	def addPoint(self, pt, segmentType=None, smooth=False, name=None,
 				 identifier=None, **kwargs):
+		if self.currentPath is None:
+			raise PenError("Path not begun")
 		self.currentPath.append((pt, segmentType, smooth, name, kwargs))
 
 
@@ -161,6 +165,9 @@ class PointToSegmentPen(BasePointToSegmentPen):
 	"""
 	Adapter class that converts the PointPen protocol to the
 	(Segment)Pen protocol.
+
+	NOTE: The segment pen does not support and will drop point names, identifiers
+	and kwargs.
 	"""
 
 	def __init__(self, segmentPen, outputImpliedClosingLine=False):
@@ -169,21 +176,23 @@ class PointToSegmentPen(BasePointToSegmentPen):
 		self.outputImpliedClosingLine = outputImpliedClosingLine
 
 	def _flushContour(self, segments):
-		assert len(segments) >= 1
+		if not segments:
+			raise PenError("Must have at least one segment.")
 		pen = self.pen
 		if segments[0][0] == "move":
 			# It's an open path.
 			closed = False
 			points = segments[0][1]
-			assert len(points) == 1, "illegal move segment point count: %d" % len(points)
-			movePt, smooth, name, kwargs = points[0]
+			if len(points) != 1:
+				raise PenError(f"Illegal move segment point count: {len(points)}")
+			movePt, _, _ , _ = points[0]
 			del segments[0]
 		else:
 			# It's a closed path, do a moveTo to the last
 			# point of the last segment.
 			closed = True
 			segmentType, points = segments[-1]
-			movePt, smooth, name, kwargs = points[-1]
+			movePt, _, _ , _ = points[-1]
 		if movePt is None:
 			# quad special case: a contour with no on-curve points contains
 			# one "qcurve" segment that ends with a point that's None. We
@@ -196,9 +205,10 @@ class PointToSegmentPen(BasePointToSegmentPen):
 		lastPt = movePt
 		for i in range(nSegments):
 			segmentType, points = segments[i]
-			points = [pt for pt, smooth, name, kwargs in points]
+			points = [pt for pt, _, _ , _ in points]
 			if segmentType == "line":
-				assert len(points) == 1, "illegal line segment point count: %d" % len(points)
+				if len(points) != 1:
+					raise PenError(f"Illegal line segment point count: {len(points)}")
 				pt = points[0]
 				# For closed contours, a 'lineTo' is always implied from the last oncurve
 				# point to the starting point, thus we can omit it when the last and
@@ -224,7 +234,7 @@ class PointToSegmentPen(BasePointToSegmentPen):
 				pen.qCurveTo(*points)
 				lastPt = points[-1]
 			else:
-				assert 0, "illegal segmentType: %s" % segmentType
+				raise PenError(f"Illegal segmentType: {segmentType}")
 		if closed:
 			pen.closePath()
 		else:
@@ -232,6 +242,7 @@ class PointToSegmentPen(BasePointToSegmentPen):
 
 	def addComponent(self, glyphName, transform, identifier=None, **kwargs):
 		del identifier  # unused
+		del kwargs  # unused
 		self.pen.addComponent(glyphName, transform)
 
 
@@ -260,27 +271,35 @@ class SegmentToPointPen(AbstractPen):
 		self.contour.append((pt, "move"))
 
 	def lineTo(self, pt):
-		assert self.contour is not None, "contour missing required initial moveTo"
+		if self.contour is None:
+			raise PenError("Contour missing required initial moveTo")
 		self.contour.append((pt, "line"))
 
 	def curveTo(self, *pts):
-		assert self.contour is not None, "contour missing required initial moveTo"
+		if not pts:
+			raise PenError("Must pass in at least one point")
+		if self.contour is None:
+			raise PenError("Contour missing required initial moveTo")
 		for pt in pts[:-1]:
 			self.contour.append((pt, None))
 		self.contour.append((pts[-1], "curve"))
 
 	def qCurveTo(self, *pts):
+		if not pts:
+			raise PenError("Must pass in at least one point")
 		if pts[-1] is None:
 			self.contour = []
 		else:
-			assert self.contour is not None, "contour missing required initial moveTo"
+			if self.contour is None:
+				raise PenError("Contour missing required initial moveTo")
 		for pt in pts[:-1]:
 			self.contour.append((pt, None))
 		if pts[-1] is not None:
 			self.contour.append((pts[-1], "qcurve"))
 
 	def closePath(self):
-		assert self.contour is not None, "contour missing required initial moveTo"
+		if self.contour is None:
+			raise PenError("Contour missing required initial moveTo")
 		if len(self.contour) > 1 and self.contour[0][0] == self.contour[-1][0]:
 			self.contour[0] = self.contour[-1]
 			del self.contour[-1]
@@ -294,12 +313,14 @@ class SegmentToPointPen(AbstractPen):
 		self.contour = None
 
 	def endPath(self):
-		assert self.contour is not None, "contour missing required initial moveTo"
+		if self.contour is None:
+			raise PenError("Contour missing required initial moveTo")
 		self._flushContour()
 		self.contour = None
 
 	def addComponent(self, glyphName, transform):
-		assert self.contour is None
+		if self.contour is not None:
+			raise PenError("Components must be added before or after contours")
 		self.pen.addComponent(glyphName, transform)
 
 
@@ -314,6 +335,8 @@ class GuessSmoothPointPen(AbstractPointPen):
 		self._points = None
 
 	def _flushContour(self):
+		if self._points is None:
+			raise PenError("Path not begun")
 		points = self._points
 		nPoints = len(points)
 		if not nPoints:
@@ -329,7 +352,7 @@ class GuessSmoothPointPen(AbstractPointPen):
 			# closed path containing 1 point (!), ignore.
 			indices = []
 		for i in indices:
-			pt, segmentType, dummy, name, kwargs = points[i]
+			pt, segmentType, _, name, kwargs = points[i]
 			if segmentType is None:
 				continue
 			prev = i - 1
@@ -352,7 +375,8 @@ class GuessSmoothPointPen(AbstractPointPen):
 			self._outPen.addPoint(pt, segmentType, smooth, name, **kwargs)
 
 	def beginPath(self, identifier=None, **kwargs):
-		assert self._points is None
+		if self._points is not None:
+			raise PenError("Path already begun")
 		self._points = []
 		if identifier is not None:
 			kwargs["identifier"] = identifier
@@ -365,12 +389,15 @@ class GuessSmoothPointPen(AbstractPointPen):
 
 	def addPoint(self, pt, segmentType=None, smooth=False, name=None,
 				 identifier=None, **kwargs):
+		if self._points is None:
+			raise PenError("Path not begun")
 		if identifier is not None:
 			kwargs["identifier"] = identifier
 		self._points.append((pt, segmentType, False, name, kwargs))
 
 	def addComponent(self, glyphName, transformation, identifier=None, **kwargs):
-		assert self._points is None
+		if self._points is not None:
+			raise PenError("Components must be added before or after contours")
 		if identifier is not None:
 			kwargs["identifier"] = identifier
 		self._outPen.addComponent(glyphName, transformation, **kwargs)
@@ -440,19 +467,26 @@ class ReverseContourPointPen(AbstractPointPen):
 		pen.endPath()
 
 	def beginPath(self, identifier=None, **kwargs):
-		assert self.currentContour is None
+		if self.currentContour is not None:
+			raise PenError("Path already begun")
 		self.currentContour = []
 		self.currentContourIdentifier = identifier
 		self.onCurve = []
 
 	def endPath(self):
-		assert self.currentContour is not None
+		if self.currentContour is None:
+			raise PenError("Path not begun")
 		self._flushContour()
 		self.currentContour = None
 
-	def addPoint(self, pt, segmentType=None, smooth=False, name=None, **kwargs):
+	def addPoint(self, pt, segmentType=None, smooth=False, name=None, identifier=None, **kwargs):
+		if self.currentContour is None:
+			raise PenError("Path not begun")
+		if identifier is not None:
+			kwargs["identifier"] = identifier
 		self.currentContour.append((pt, segmentType, smooth, name, kwargs))
 
 	def addComponent(self, glyphName, transform, identifier=None, **kwargs):
-		assert self.currentContour is None
+		if self.currentContour is not None:
+			raise PenError("Components must be added before or after contours")
 		self.pen.addComponent(glyphName, transform, identifier=identifier, **kwargs)

--- a/Lib/fontTools/pens/pointPen.py
+++ b/Lib/fontTools/pens/pointPen.py
@@ -277,7 +277,7 @@ class SegmentToPointPen(AbstractPen):
 
 	def curveTo(self, *pts):
 		if not pts:
-			raise PenError("Must pass in at least one point")
+			raise TypeError("Must pass in at least one point")
 		if self.contour is None:
 			raise PenError("Contour missing required initial moveTo")
 		for pt in pts[:-1]:
@@ -286,7 +286,7 @@ class SegmentToPointPen(AbstractPen):
 
 	def qCurveTo(self, *pts):
 		if not pts:
-			raise PenError("Must pass in at least one point")
+			raise TypeError("Must pass in at least one point")
 		if pts[-1] is None:
 			self.contour = []
 		else:

--- a/Lib/fontTools/pens/recordingPen.py
+++ b/Lib/fontTools/pens/recordingPen.py
@@ -122,16 +122,22 @@ class RecordingPointPen(AbstractPointPen):
 	def __init__(self):
 		self.value = []
 
-	def beginPath(self, **kwargs):
+	def beginPath(self, identifier=None, **kwargs):
+		if identifier is not None:
+			kwargs["identifier"] = identifier
 		self.value.append(("beginPath", (), kwargs))
 
 	def endPath(self):
 		self.value.append(("endPath", (), {}))
 
-	def addPoint(self, pt, segmentType=None, smooth=False, name=None, **kwargs):
+	def addPoint(self, pt, segmentType=None, smooth=False, name=None, identifier=None, **kwargs):
+		if identifier is not None:
+			kwargs["identifier"] = identifier
 		self.value.append(("addPoint", (pt, segmentType, smooth, name), kwargs))
 
-	def addComponent(self, baseGlyphName, transformation, **kwargs):
+	def addComponent(self, baseGlyphName, transformation, identifier=None, **kwargs):
+		if identifier is not None:
+			kwargs["identifier"] = identifier
 		self.value.append(("addComponent", (baseGlyphName, transformation), kwargs))
 
 	def replay(self, pointPen):


### PR DESCRIPTION
Extracted from https://github.com/fonttools/fonttools/pull/2202 to not let my commits rot too long.

1. Make RecordingPointPen actually pass on identifiers
2. Introduce PenError to eventually replace all the asserts in pen code, as assert should be used for debugging only.