### PR TITLE
removeOverlaps: work around pathops.simplify error

### DIFF
--- a/Lib/fontTools/ttLib/removeOverlaps.py
+++ b/Lib/fontTools/ttLib/removeOverlaps.py
@@ -18,6 +18,10 @@ import pathops
 __all__ = ["removeOverlaps"]
 
 
+class RemoveOverlapsError(Exception):
+    pass
+
+
 log = logging.getLogger("fontTools.ttLib.removeOverlaps")
 
 _TTGlyphMapping = Mapping[str, ttFont._TTGlyph]
@@ -93,7 +97,12 @@ def removeTTGlyphOverlaps(
         path = skPathFromGlyph(glyphName, glyphSet)
 
         # remove overlaps
-        path2 = pathops.simplify(path, clockwise=path.clockwise)
+        try:
+            path2 = pathops.simplify(path, clockwise=path.clockwise)
+        except pathops.PathOpsError as e:
+            raise RemoveOverlapsError(
+                f"Failed to remove overlaps from glyph {glyphName!r}"
+            ) from e
 
         # replace TTGlyph if simplified path is different (ignoring contour order)
         if {tuple(c) for c in path.contours} != {tuple(c) for c in path2.contours}:

--- a/Lib/fontTools/ttLib/removeOverlaps.py
+++ b/Lib/fontTools/ttLib/removeOverlaps.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 from typing import Iterable, Optional, Mapping
 
+from fontTools.misc.roundTools import otRound
 from fontTools.ttLib import ttFont
 from fontTools.ttLib.tables import _g_l_y_f
 from fontTools.ttLib.tables import _h_m_t_x
@@ -99,10 +100,31 @@ def removeTTGlyphOverlaps(
         # remove overlaps
         try:
             path2 = pathops.simplify(path, clockwise=path.clockwise)
-        except pathops.PathOpsError as e:
-            raise RemoveOverlapsError(
-                f"Failed to remove overlaps from glyph {glyphName!r}"
-            ) from e
+        except pathops.PathOpsError:
+            # skia-pathops has a bug where it sometimes fails to simplify paths when
+            # there are float coordinates and control points are very close to one
+            # another. Rounding coordinates to integers works around the bug.
+            # Since we are going to round glyf coordinates later on anyway, here
+            # it is ok(-ish) to also round before simplify. Better than failing the
+            # whole process for the entire font.
+            # https://bugs.chromium.org/p/skia/issues/detail?id=11958
+            # https://github.com/google/fonts/issues/3365
+            path2 = pathops.Path()
+            for verb, points in path:
+                path2.add(verb, *((otRound(p[0]), otRound(p[1])) for p in points))
+            try:
+                path2.simplify(clockwise=path.clockwise)
+            except pathops.PathOpsError as e:
+                path.dump()
+                raise RemoveOverlapsError(
+                    f"Failed to remove overlaps from glyph {glyphName!r}"
+                ) from e
+            else:
+                log.debug(
+                    "skia-pathops failed to simplify '%s' with float coordinates, "
+                    "but succeded using rounded integer coordinates",
+                    glyphName,
+                )
 
         # replace TTGlyph if simplified path is different (ignoring contour order)
         if {tuple(c) for c in path.contours} != {tuple(c) for c in path2.contours}:

--- a/Tests/ttLib/removeOverlaps_test.py
+++ b/Tests/ttLib/removeOverlaps_test.py
@@ -3,7 +3,7 @@ import pytest
 
 pathops = pytest.importorskip("pathops")
 
-from fontTools.ttLib.removeOverlaps import _simplify
+from fontTools.ttLib.removeOverlaps import _simplify, _round_path
 
 
 def test_pathops_simplify_bug_workaround(caplog):
@@ -48,8 +48,4 @@ def test_pathops_simplify_bug_workaround(caplog):
     expected.lineTo(713, 0)
     expected.close()
 
-    rounded_result = pathops.Path()
-    for verb, pts in result:
-        rounded_result.add(verb, *((round(p[0], 3), round(p[1], 3)) for p in pts))
-
-    assert expected == rounded_result
+    assert expected == _round_path(result, round=lambda v: round(v, 3))

--- a/Tests/ttLib/removeOverlaps_test.py
+++ b/Tests/ttLib/removeOverlaps_test.py
@@ -1,0 +1,53 @@
+import logging
+from fontTools.ttLib.removeOverlaps import _simplify
+import pathops
+import pytest
+
+
+def test_pathops_simplify_bug_workaround(caplog):
+    # Paths extracted from Noto Sans Ethiopic instance that fails skia-pathops
+    # https://github.com/google/fonts/issues/3365
+    # https://bugs.chromium.org/p/skia/issues/detail?id=11958
+    path = pathops.Path()
+    path.moveTo(550.461, 0)
+    path.lineTo(550.461, 366.308)
+    path.lineTo(713.229, 366.308)
+    path.lineTo(713.229, 0)
+    path.close()
+    path.moveTo(574.46, 0)
+    path.lineTo(574.46, 276.231)
+    path.lineTo(737.768, 276.231)
+    path.quadTo(820.075, 276.231, 859.806, 242.654)
+    path.quadTo(899.537, 209.077, 899.537, 144.154)
+    path.quadTo(899.537, 79, 853.46, 39.5)
+    path.quadTo(807.383, 0, 712.383, 0)
+    path.close()
+
+    # check that it fails without workaround
+    with pytest.raises(pathops.PathOpsError):
+        pathops.simplify(path)
+
+    # check our workaround works (but with a warning)
+    with caplog.at_level(logging.DEBUG, logger="fontTools.ttLib.removeOverlaps"):
+        result = _simplify(path, debugGlyphName="a")
+
+    assert "skia-pathops failed to simplify 'a' with float coordinates" in caplog.text
+
+    expected = pathops.Path()
+    expected.moveTo(550, 0)
+    expected.lineTo(550, 366)
+    expected.lineTo(713, 366)
+    expected.lineTo(713, 276)
+    expected.lineTo(738, 276)
+    expected.quadTo(820, 276, 860, 243)
+    expected.quadTo(900, 209, 900, 144)
+    expected.quadTo(900, 79, 853, 40)
+    expected.quadTo(807.242, 0.211, 713, 0.001)
+    expected.lineTo(713, 0)
+    expected.close()
+
+    rounded_result = pathops.Path()
+    for verb, pts in result:
+        rounded_result.add(verb, *((round(p[0], 3), round(p[1], 3)) for p in pts))
+
+    assert expected == rounded_result

--- a/Tests/ttLib/removeOverlaps_test.py
+++ b/Tests/ttLib/removeOverlaps_test.py
@@ -1,7 +1,9 @@
 import logging
-from fontTools.ttLib.removeOverlaps import _simplify
-import pathops
 import pytest
+
+pathops = pytest.importorskip("pathops")
+
+from fontTools.ttLib.removeOverlaps import _simplify
 
 
 def test_pathops_simplify_bug_workaround(caplog):


### PR DESCRIPTION
Sometimes skia-pathops simplify may fail (for unknown reasons which I'm still trying to debug).
It's a good idea to know the name of the offending glyph
https://github.com/google/fonts/issues/3365

EDIT: It's actually even better to **not** fail at all. It turns out that if we round the path's coordinates to integers _before_ passing it on to pathops.simplify, then it works -- at least for the two glyphs in the Noto Ethiopic and Telugu fonts which triggered this issue.

The effect of rounding before removing overlaps is minimal, since we are going to round afterwards anyway once we encode the glyf table; besides, we only try rounding when simplify fails with the unrounded float coordinates (the ones that we get from the instancer).

All in all, I believe the workaround is better than blocking those projects while the Skia bug is fixed upstream (https://bugs.chromium.org/p/skia/issues/detail?id=11958), which may take a while since we have no idea what's going on under the hood.