### PR TITLE
[feaLib] Allow substituting a glyph class with NULL

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1258,9 +1258,15 @@ class MultipleSubstStatement(Statement):
         """Calls the builder object's ``add_multiple_subst`` callback."""
         prefix = [p.glyphSet() for p in self.prefix]
         suffix = [s.glyphSet() for s in self.suffix]
-        builder.add_multiple_subst(
-            self.location, prefix, self.glyph, suffix, self.replacement, self.forceChain
-        )
+        if not self.replacement and hasattr(self.glyph, "glyphSet"):
+            for glyph in self.glyph.glyphSet():
+                builder.add_multiple_subst(
+                    self.location, prefix, glyph, suffix, self.replacement, self.forceChain
+                )
+        else:
+            builder.add_multiple_subst(
+                self.location, prefix, self.glyph, suffix, self.replacement, self.forceChain
+            )
 
     def asFea(self, indent=""):
         res = "sub "

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -892,16 +892,26 @@ class Parser(object):
                 old, new, old_prefix, old_suffix, forceChain=hasMarks, location=location
             )
 
+        # Glyph deletion, built as GSUB lookup type 2: Multiple substitution
+        # with empty replacement.
+        if is_deletion and len(old) == 1 and num_lookups == 0:
+            return self.ast.MultipleSubstStatement(
+                old_prefix,
+                old[0],
+                old_suffix,
+                (),
+                forceChain=hasMarks,
+                location=location,
+            )
+
         # GSUB lookup type 2: Multiple substitution.
         # Format: "substitute f_f_i by f f i;"
         if (
             not reverse
             and len(old) == 1
             and len(old[0].glyphSet()) == 1
-            and (
-                (len(new) > 1 and max([len(n.glyphSet()) for n in new]) == 1)
-                or len(new) == 0
-            )
+            and len(new) > 1
+            and max([len(n.glyphSet()) for n in new]) == 1
             and num_lookups == 0
         ):
             return self.ast.MultipleSubstStatement(

--- a/Tests/feaLib/data/delete_glyph.fea
+++ b/Tests/feaLib/data/delete_glyph.fea
@@ -1,3 +1,7 @@
 feature test {
 	sub a by NULL;
 } test;
+
+feature test {
+	sub [a b c] by NULL;
+} test;

--- a/Tests/feaLib/data/delete_glyph.ttx
+++ b/Tests/feaLib/data/delete_glyph.ttx
@@ -22,19 +22,30 @@
       <FeatureRecord index="0">
         <FeatureTag value="test"/>
         <Feature>
-          <!-- LookupCount=1 -->
+          <!-- LookupCount=2 -->
           <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
         </Feature>
       </FeatureRecord>
     </FeatureList>
     <LookupList>
-      <!-- LookupCount=1 -->
+      <!-- LookupCount=2 -->
       <Lookup index="0">
         <LookupType value="2"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <MultipleSubst index="0">
           <Substitution in="a" out=""/>
+        </MultipleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <MultipleSubst index="0">
+          <Substitution in="a" out=""/>
+          <Substitution in="b" out=""/>
+          <Substitution in="c" out=""/>
         </MultipleSubst>
       </Lookup>
     </LookupList>


### PR DESCRIPTION
`sub [a b c] by NULL;` was producing errors, now it builds as multiple statements.