### PR TITLE
Add ttLib.TTFont.getTableTags public method for access to full set of table tags in a TTFont object

### DIFF
--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -656,6 +656,17 @@ class TTFont(object):
 		else:
 			raise KeyError(tag)
 
+	def getTableTags(self):
+		"""Returns a list of available table tags as strings.
+		"""
+		if self.reader:
+			return list(self.reader.keys())
+		else:
+			table_tags = list(self.tables.keys())
+			if "GlyphOrder" in table_tags:
+				table_tags.remove("GlyphOrder")
+			return table_tags
+
 	def getGlyphSet(self, preferCFF=True):
 		"""Return a generic GlyphSet, which is a dict-like object
 		mapping glyph names to glyph objects. The returned glyph objects

--- a/Tests/ttLib/ttFont_test.py
+++ b/Tests/ttLib/ttFont_test.py
@@ -1,4 +1,5 @@
 import io
+from pathlib import Path
 from fontTools.ttLib import TTFont, newTable, registerCustomTableClass, unregisterCustomTableClass
 from fontTools.ttLib.tables.DefaultTable import DefaultTable
 
@@ -46,3 +47,54 @@ def test_registerCustomTableClassStandardName():
         assert font[TABLETAG].compile(font) == b"\x04\x05\x06"
     finally:
         unregisterCustomTableClass(TABLETAG)
+
+
+def test_gettabletags_method(tmp_path):
+    tt_tables = ["head", "hhea", "maxp", "OS/2", "hmtx", "cmap", "fpgm", "prep", "cvt ", "loca", "glyf", "name", "post", "gasp", "DSIG"]
+    cff_tables = ["head", "hhea", "maxp", "OS/2", "name", "cmap", "post", "CFF ", "hmtx", "DSIG"]
+
+    # TT tests
+      # xml import
+    tt_font = TTFont()
+    tt_font.importXML(Path("Tests/ttLib/data/TestTTF-Regular.ttx"))
+
+    res_tt = tt_font.getTableTags()
+    assert len(res_tt) == 15
+    for table in tt_tables:
+        assert table in tt_font
+        assert table in res_tt
+
+      # font binary file path read
+    tt_path = tmp_path / "tt_test.ttf"
+    tt_font.save(tt_path)
+    tt_2_font = TTFont(tt_path)
+
+    res_tt_2 = tt_2_font.getTableTags()
+    assert len(res_tt_2) == 15
+    for table in tt_tables:
+        assert table in tt_2_font
+        assert table in res_tt_2
+
+    # CFF tests
+      # xml import
+    cff_font = TTFont()
+    cff_font.importXML(Path("Tests/ttLib/data/TestOTF-Regular.otx"))
+
+    res_cff = cff_font.getTableTags()
+    assert len(res_cff) == 10
+    for table in cff_tables:
+        assert table in cff_font
+        assert table in res_cff
+
+      # font binary file path read
+    cff_path = tmp_path / "cff_test.otf"
+    cff_font.save(cff_path)
+    cff_2_font = TTFont(cff_path)
+
+    res_cff_2 = cff_2_font.getTableTags()
+    assert len(res_cff_2) == 10
+    for table in cff_tables:
+        assert table in cff_2_font
+        assert table in res_cff_2
+
+


### PR DESCRIPTION
I was trying to do the following:

```python
for table in [GET A LIST OF AVAILABLE TTFont TABLE TAGS]:
    table_data = tt.getTableData(table)
    ...
```

and couldn't find a consistent approach to get a list of available table tags across TTFont obj's that are instantiated from font binary file paths and TTX XML imports.  These data seem to be buried in the `reader.keys()` or `tables.keys()` instance attribute methods based on whether the TTFont is gen'd from a font file path (reader appears to include full data with all table tags, tables appears to include partial table data in my test on NotoSansDevanagari-Regular.ttf) or XML import (reader instance attribute not available, tables has full list but includes an unnecessary "GlyphOrder" item).  

This PR adds a new `ttLib.TTFont.getTableTags` public method that appears to return a consistent table tag list irrespective of the approach used to gen the TTFont obj.