### PR TITLE
[feaLib] fixed two instances of 'DeprecationWarning: invalid escape sequence'

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -700,7 +700,7 @@ class AttachStatement(Statement):
 
 
 class ChainContextPosStatement(Statement):
-    """A chained contextual positioning statement.
+    r"""A chained contextual positioning statement.
 
     ``prefix``, ``glyphs``, and ``suffix`` should be lists of
     `glyph-containing objects`_ .
@@ -708,7 +708,7 @@ class ChainContextPosStatement(Statement):
     ``lookups`` should be a list of elements representing what lookups
     to apply at each glyph position. Each element should be a
     :class:`LookupBlock` to apply a single chaining lookup at the given
-    position, a list of :class:`LookupBlock`\\ s to apply multiple
+    position, a list of :class:`LookupBlock`\ s to apply multiple
     lookups, or ``None`` to apply no lookup. The length of the outer
     list should equal the length of ``glyphs``; the inner lists can be
     of variable length."""
@@ -758,7 +758,7 @@ class ChainContextPosStatement(Statement):
 
 
 class ChainContextSubstStatement(Statement):
-    """A chained contextual substitution statement.
+    r"""A chained contextual substitution statement.
 
     ``prefix``, ``glyphs``, and ``suffix`` should be lists of
     `glyph-containing objects`_ .
@@ -766,7 +766,7 @@ class ChainContextSubstStatement(Statement):
     ``lookups`` should be a list of elements representing what lookups
     to apply at each glyph position. Each element should be a
     :class:`LookupBlock` to apply a single chaining lookup at the given
-    position, a list of :class:`LookupBlock`\\ s to apply multiple
+    position, a list of :class:`LookupBlock`\ s to apply multiple
     lookups, or ``None`` to apply no lookup. The length of the outer
     list should equal the length of ``glyphs``; the inner lists can be
     of variable length."""

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -708,7 +708,7 @@ class ChainContextPosStatement(Statement):
     ``lookups`` should be a list of elements representing what lookups
     to apply at each glyph position. Each element should be a
     :class:`LookupBlock` to apply a single chaining lookup at the given
-    position, a list of :class:`LookupBlock`\ s to apply multiple
+    position, a list of :class:`LookupBlock`\\ s to apply multiple
     lookups, or ``None`` to apply no lookup. The length of the outer
     list should equal the length of ``glyphs``; the inner lists can be
     of variable length."""
@@ -766,7 +766,7 @@ class ChainContextSubstStatement(Statement):
     ``lookups`` should be a list of elements representing what lookups
     to apply at each glyph position. Each element should be a
     :class:`LookupBlock` to apply a single chaining lookup at the given
-    position, a list of :class:`LookupBlock`\ s to apply multiple
+    position, a list of :class:`LookupBlock`\\ s to apply multiple
     lookups, or ``None`` to apply no lookup. The length of the outer
     list should equal the length of ``glyphs``; the inner lists can be
     of variable length."""


### PR DESCRIPTION
...although I'm not sure what this backslash-space sequence is supposed to do.