### PR TITLE
Use newer version of GuessSmoothPointPen from fontPens

### DIFF
--- a/Lib/fontTools/pens/pointPen.py
+++ b/Lib/fontTools/pens/pointPen.py
@@ -367,8 +367,8 @@ class GuessSmoothPointPen(AbstractPointPen):
 			if pt != prevPt and pt != nextPt:
 				dx1, dy1 = pt[0] - prevPt[0], pt[1] - prevPt[1]
 				dx2, dy2 = nextPt[0] - pt[0], nextPt[1] - pt[1]
-				a1 = math.atan2(dx1, dy1)
-				a2 = math.atan2(dx2, dy2)
+				a1 = math.atan2(dy1, dx1)
+				a2 = math.atan2(dy2, dx2)
 				if abs(a1 - a2) < self._error:
 					points[i] = pt, segmentType, True, name, kwargs
 

--- a/Lib/fontTools/pens/pointPen.py
+++ b/Lib/fontTools/pens/pointPen.py
@@ -330,8 +330,9 @@ class GuessSmoothPointPen(AbstractPointPen):
 	should be "smooth", ie. that it's a "tangent" point or a "curve" point.
 	"""
 
-	def __init__(self, outPen):
+	def __init__(self, outPen, error=0.05):
 		self._outPen = outPen
+		self._error = error
 		self._points = None
 
 	def _flushContour(self):
@@ -368,7 +369,7 @@ class GuessSmoothPointPen(AbstractPointPen):
 				dx2, dy2 = nextPt[0] - pt[0], nextPt[1] - pt[1]
 				a1 = math.atan2(dx1, dy1)
 				a2 = math.atan2(dx2, dy2)
-				if abs(a1 - a2) < 0.05:
+				if abs(a1 - a2) < self._error:
 					points[i] = pt, segmentType, True, name, kwargs
 
 		for pt, segmentType, smooth, name, kwargs in points:


### PR DESCRIPTION
Allows GuessSmoothPointPen to accept a parameterized tolerance for testing. Note that the code is not exactly identical to the fontPens version to keep the diff minimal. As a bonus, `math.atan2()` call is fixed as well. See also #2343.