### PR TITLE
sort shared tuples produced by Counter.most_common()

### DIFF
--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -616,7 +616,9 @@ def compileSharedTuples(axisTags, variations,
 	for var in variations:
 		coord = var.compileCoord(axisTags)
 		coordCount[coord] += 1
-	sharedCoords = coordCount.most_common(MAX_NUM_SHARED_COORDS)
+	# In python 3.7 and below most_common() ordering is non-deterministic
+	# so apply a sort to make sure the ordering is consistent.
+	sharedCoords = sorted(coordCount.most_common(MAX_NUM_SHARED_COORDS))
 	return [c[0] for c in sharedCoords if c[1] > 1]
 
 


### PR DESCRIPTION
In python 3.7 and earlier most_common() sorts first by the item count and then arbitrarily in the event of ties. This can result in two identical instancing operations producing different binary results.