### PR TITLE
TupleVariation: make shared tuples order deterministic

### DIFF
--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -616,9 +616,12 @@ def compileSharedTuples(axisTags, variations,
 	for var in variations:
 		coord = var.compileCoord(axisTags)
 		coordCount[coord] += 1
-	# In python 3.7 and below most_common() ordering is non-deterministic
+	# In python < 3.7, most_common() ordering is non-deterministic
 	# so apply a sort to make sure the ordering is consistent.
-	sharedCoords = sorted(coordCount.most_common(MAX_NUM_SHARED_COORDS))
+	sharedCoords = sorted(
+		coordCount.most_common(MAX_NUM_SHARED_COORDS),
+		key=lambda item: (-item[1], item[0]),
+	)
 	return [c[0] for c in sharedCoords if c[1] > 1]
 
 

--- a/Tests/ttLib/tables/TupleVariation_test.py
+++ b/Tests/ttLib/tables/TupleVariation_test.py
@@ -559,8 +559,12 @@ class TupleVariationTest(unittest.TestCase):
 			self.assertListEqual(deltas, decompile(compile(deltas)))
 
 	def test_compileSharedTuples(self):
-		# Below, the peak coordinate {"wght": 1.0, "wdth": 0.7} appears
-		# three times; {"wght": 1.0, "wdth": 0.8} appears twice.
+		# Below, the peak coordinate {"wght": 1.0, "wdth": 0.8} appears
+		# three times (most frequent sorted first); {"wght": 1.0, "wdth": 0.5}
+		# and {"wght": 1.0, "wdth": 0.7} both appears two times (tie) and
+		# are sorted alphanumerically to ensure determinism.
+		# The peak coordinate {"wght": 1.0, "wdth": 0.9} appears only once
+		# and is thus ignored.
 		# Because the start and end of variation ranges is not encoded
 		# into the shared pool, they should get ignored.
 		deltas = [None] * 4
@@ -579,7 +583,7 @@ class TupleVariationTest(unittest.TestCase):
 			}, deltas),
 			TupleVariation({
 				"wght": (1.0, 1.0, 1.0),
-				"wdth": (0.3, 0.7, 1.0)
+				"wdth": (0.3, 0.5, 1.0)
 			}, deltas),
 			TupleVariation({
 				"wght": (1.0, 1.0, 1.0),
@@ -588,11 +592,19 @@ class TupleVariationTest(unittest.TestCase):
 			TupleVariation({
 				"wght": (1.0, 1.0, 1.0),
 				"wdth": (0.3, 0.9, 1.0)
-            }, deltas)
+			}, deltas),
+			TupleVariation({
+				"wght": (1.0, 1.0, 1.0),
+				"wdth": (0.4, 0.8, 1.0)
+			}, deltas),
+			TupleVariation({
+				"wght": (1.0, 1.0, 1.0),
+				"wdth": (0.5, 0.5, 1.0)
+			}, deltas),
 		]
 		result = compileSharedTuples(["wght", "wdth"], variations)
 		self.assertEqual([hexencode(c) for c in result],
-		                 ["40 00 2C CD", "40 00 33 33"])
+		                 ["40 00 33 33", "40 00 20 00", "40 00 2C CD"])
 
 	def test_decompileSharedTuples_Skia(self):
 		sharedTuples = decompileSharedTuples(


### PR DESCRIPTION
most frequent first (like before https://github.com/fonttools/fonttools/pull/2351), only sort ties alphabetically