### PR TITLE
[ttLib] when importing XML, only set sfntVersion if the font has no reader and is empty

### DIFF
--- a/Lib/fontTools/misc/xmlReader.py
+++ b/Lib/fontTools/misc/xmlReader.py
@@ -93,11 +93,12 @@ class XMLReader(object):
 		if not stackSize:
 			if name != "ttFont":
 				raise TTXParseError("illegal root tag: %s" % name)
-			sfntVersion = attrs.get("sfntVersion")
-			if sfntVersion is not None:
-				if len(sfntVersion) != 4:
-					sfntVersion = safeEval('"' + sfntVersion + '"')
-				self.ttFont.sfntVersion = sfntVersion
+			if self.ttFont.reader is None and not self.ttFont.tables:
+				sfntVersion = attrs.get("sfntVersion")
+				if sfntVersion is not None:
+					if len(sfntVersion) != 4:
+						sfntVersion = safeEval('"' + sfntVersion + '"')
+					self.ttFont.sfntVersion = sfntVersion
 			self.contentStack.append([])
 		elif stackSize == 1:
 			if subFile is not None:

--- a/Tests/ttLib/ttFont_test.py
+++ b/Tests/ttLib/ttFont_test.py
@@ -46,3 +46,35 @@ def test_registerCustomTableClassStandardName():
         assert font[TABLETAG].compile(font) == b"\x04\x05\x06"
     finally:
         unregisterCustomTableClass(TABLETAG)
+
+
+ttxTTF = r"""<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.9.0">
+  <hmtx>
+    <mtx name=".notdef" width="300" lsb="0"/>
+  </hmtx>
+</ttFont>
+"""
+
+
+ttxOTF = """<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.9.0">
+  <hmtx>
+    <mtx name=".notdef" width="300" lsb="0"/>
+  </hmtx>
+</ttFont>
+"""
+
+
+def test_sfntVersionFromTTX():
+    # https://github.com/fonttools/fonttools/issues/2370
+    font = TTFont()
+    assert font.sfntVersion == "\x00\x01\x00\x00"
+    ttx = io.StringIO(ttxOTF)
+    font.importXML(ttx)
+    # Font is "empty", TTX file sets sfntVersion
+    assert font.sfntVersion == "OTTO"
+    ttx = io.StringIO(ttxTTF)
+    font.importXML(ttx)
+    # Font is not empty, TTX file does not set sfntVersion
+    assert font.sfntVersion == "OTTO"

--- a/Tests/ttLib/ttFont_test.py
+++ b/Tests/ttLib/ttFont_test.py
@@ -71,10 +71,10 @@ def test_sfntVersionFromTTX():
     font = TTFont()
     assert font.sfntVersion == "\x00\x01\x00\x00"
     ttx = io.StringIO(ttxOTF)
+    # Font is "empty", TTX file will determine sfntVersion
     font.importXML(ttx)
-    # Font is "empty", TTX file sets sfntVersion
     assert font.sfntVersion == "OTTO"
     ttx = io.StringIO(ttxTTF)
+    # Font is not "empty", sfntVersion in TTX file will be ignored
     font.importXML(ttx)
-    # Font is not empty, TTX file does not set sfntVersion
     assert font.sfntVersion == "OTTO"


### PR DESCRIPTION
This fixes #2370