### PR TITLE
instancer: add --ignore-overlap-errors option

### DIFF
--- a/Lib/fontTools/ttLib/removeOverlaps.py
+++ b/Lib/fontTools/ttLib/removeOverlaps.py
@@ -115,7 +115,8 @@ def _simplify(path: pathops.Path, debugGlyphName: str) -> pathops.Path:
         )
         return path
     except pathops.PathOpsError as e:
-        path.dump()
+        if log.isEnabledFor(logging.DEBUG):
+            path.dump()
         raise RemoveOverlapsError(
             f"Failed to remove overlaps from glyph {debugGlyphName!r}"
         ) from e
@@ -162,6 +163,7 @@ def removeOverlaps(
     font: ttFont.TTFont,
     glyphNames: Optional[Iterable[str]] = None,
     removeHinting: bool = True,
+    ignoreErrors=False,
 ) -> None:
     """Simplify glyphs in TTFont by merging overlapping contours.
 
@@ -179,6 +181,8 @@ def removeOverlaps(
         glyphNames: optional iterable of glyph names (str) to remove overlaps from.
             By default, all glyphs in the font are processed.
         removeHinting (bool): set to False to keep hinting for unmodified glyphs.
+        ignoreErrors (bool): set to True to ignore errors while removing overlaps,
+            thus keeping the tricky glyphs unchanged (fonttools/fonttools#2363).
     """
     try:
         glyfTable = font["glyf"]
@@ -206,10 +210,15 @@ def removeOverlaps(
     )
     modified = set()
     for glyphName in glyphNames:
-        if removeTTGlyphOverlaps(
-            glyphName, glyphSet, glyfTable, hmtxTable, removeHinting
-        ):
-            modified.add(glyphName)
+        try:
+            if removeTTGlyphOverlaps(
+                glyphName, glyphSet, glyfTable, hmtxTable, removeHinting
+            ):
+                modified.add(glyphName)
+        except RemoveOverlapsError:
+            if not ignoreErrors:
+                raise
+            log.error("Failed to remove overlaps for '%s'", glyphName)
 
     log.debug("Removed overlaps for %s glyphs:\n%s", len(modified), " ".join(modified))
 


### PR DESCRIPTION
This is to be able to ignore tricky glyphs that sometimes trip up Skia PathOps.Simplify operation.
We have no idea how to fix this upstream (short of having the glyphs redrawn), and perfect is the enemy of good..

Works around https://github.com/fonttools/fonttools/issues/2363 and https://github.com/google/fonts/issues/3365

/cc @nathan-williams