### PR TITLE
MNT: do not warn on import

### DIFF
--- a/Lib/fontTools/agl.py
+++ b/Lib/fontTools/agl.py
@@ -26,7 +26,7 @@ This is used by fontTools when it has to construct glyph names for a font which
 doesn't include any (e.g. format 3.0 post tables).
 """
 
-from fontTools.misc.py23 import tostr
+from fontTools.misc._py23 import tostr
 import re
 
 

--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -11,7 +11,7 @@ the demands of variable fonts. This module parses both original CFF and CFF2.
 
 """
 
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, tobytes, tostr
+from fontTools.misc._py23 import bytechr, byteord, bytesjoin, tobytes, tostr
 from fontTools.misc import sstruct
 from fontTools.misc import psCharStrings
 from fontTools.misc.arrayTools import unionRect, intRect

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from fontTools.misc.py23 import tobytes, tostr
+from fontTools.misc._py23 import tobytes, tostr
 from fontTools.misc.loggingTools import LogMixin
 import collections
 from io import BytesIO, StringIO

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import byteord, tobytes
+from fontTools.misc._py23 import byteord, tobytes
 from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.location import FeatureLibLocation
 from fontTools.misc.encodingTools import getEncoding

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import Tag, tostr
+from fontTools.misc._py23 import Tag, tostr
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import binary2num, safeEval
 from fontTools.feaLib.error import FeatureLibError

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1,7 +1,7 @@
 from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.lexer import Lexer, IncludingLexer, NonIncludingLexer
 from fontTools.misc.encodingTools import getEncoding
-from fontTools.misc.py23 import bytechr, tobytes, tostr
+from fontTools.misc._py23 import bytechr, tobytes, tostr
 import fontTools.feaLib.ast as ast
 import logging
 import os

--- a/Lib/fontTools/misc/_py23.py
+++ b/Lib/fontTools/misc/_py23.py
@@ -1,0 +1,140 @@
+"""Python 2/3 compat layer leftovers."""
+
+import decimal as _decimal
+import math as _math
+from io import BytesIO
+from io import StringIO as UnicodeIO
+from types import SimpleNamespace
+
+__all__ = [
+    "basestring",
+    "bytechr",
+    "byteord",
+    "BytesIO",
+    "bytesjoin",
+    "open",
+    "Py23Error",
+    "range",
+    "RecursionError",
+    "round",
+    "SimpleNamespace",
+    "StringIO",
+    "strjoin",
+    "Tag",
+    "tobytes",
+    "tostr",
+    "tounicode",
+    "unichr",
+    "unicode",
+    "UnicodeIO",
+    "xrange",
+    "zip",
+]
+
+
+class Py23Error(NotImplementedError):
+    pass
+
+
+RecursionError = RecursionError
+StringIO = UnicodeIO
+
+basestring = str
+isclose = _math.isclose
+isfinite = _math.isfinite
+open = open
+range = range
+round = round3 = round
+unichr = chr
+unicode = str
+zip = zip
+
+
+def bytechr(n):
+    return bytes([n])
+
+
+def byteord(c):
+    return c if isinstance(c, int) else ord(c)
+
+
+def strjoin(iterable, joiner=""):
+    return tostr(joiner).join(iterable)
+
+
+def tobytes(s, encoding="ascii", errors="strict"):
+    if isinstance(s, str):
+        return s.encode(encoding, errors)
+    else:
+        return bytes(s)
+
+
+def tounicode(s, encoding="ascii", errors="strict"):
+    if not isinstance(s, unicode):
+        return s.decode(encoding, errors)
+    else:
+        return s
+
+
+tostr = tounicode
+
+
+class Tag(str):
+    @staticmethod
+    def transcode(blob):
+        if isinstance(blob, bytes):
+            blob = blob.decode("latin-1")
+        return blob
+
+    def __new__(self, content):
+        return str.__new__(self, self.transcode(content))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __eq__(self, other):
+        return str.__eq__(self, self.transcode(other))
+
+    def __hash__(self):
+        return str.__hash__(self)
+
+    def tobytes(self):
+        return self.encode("latin-1")
+
+
+def bytesjoin(iterable, joiner=b""):
+    return tobytes(joiner).join(tobytes(item) for item in iterable)
+
+
+def xrange(*args, **kwargs):
+    raise Py23Error("'xrange' is not defined. Use 'range' instead.")
+
+
+def round2(number, ndigits=None):
+    """
+    Implementation of Python 2 built-in round() function.
+    Rounds a number to a given precision in decimal digits (default
+    0 digits). The result is a floating point number. Values are rounded
+    to the closest multiple of 10 to the power minus ndigits; if two
+    multiples are equally close, rounding is done away from 0.
+    ndigits may be negative.
+    See Python 2 documentation:
+    https://docs.python.org/2/library/functions.html?highlight=round#round
+    """
+    if ndigits is None:
+        ndigits = 0
+
+    if ndigits < 0:
+        exponent = 10 ** (-ndigits)
+        quotient, remainder = divmod(number, exponent)
+        if remainder >= exponent // 2 and number >= 0:
+            quotient += 1
+        return float(quotient * exponent)
+    else:
+        exponent = _decimal.Decimal("10") ** (-ndigits)
+
+        d = _decimal.Decimal.from_float(number).quantize(
+            exponent, rounding=_decimal.ROUND_HALF_UP
+        )
+
+        return float(d)

--- a/Lib/fontTools/misc/eexec.py
+++ b/Lib/fontTools/misc/eexec.py
@@ -12,7 +12,7 @@ the new key at the end of the operation.
 
 """
 
-from fontTools.misc.py23 import bytechr, bytesjoin, byteord
+from fontTools.misc._py23 import bytechr, bytesjoin, byteord
 
 
 def _decryptChar(cipher, R):

--- a/Lib/fontTools/misc/etree.py
+++ b/Lib/fontTools/misc/etree.py
@@ -11,7 +11,7 @@ or subclasses built-in ElementTree classes to add features that are
 only availble in lxml, like OrderedDict for attributes, pretty_print and
 iterwalk.
 """
-from fontTools.misc.py23 import unicode, tostr
+from fontTools.misc._py23 import unicode, tostr
 
 
 XML_DECLARATION = """<?xml version='1.0' encoding='%s'?>"""

--- a/Lib/fontTools/misc/macCreatorType.py
+++ b/Lib/fontTools/misc/macCreatorType.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import Tag, bytesjoin, strjoin
+from fontTools.misc._py23 import Tag, bytesjoin, strjoin
 try:
 	import xattr
 except ImportError:

--- a/Lib/fontTools/misc/macRes.py
+++ b/Lib/fontTools/misc/macRes.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin, tostr
+from fontTools.misc._py23 import bytesjoin, tostr
 from io import BytesIO
 import struct
 from fontTools.misc import sstruct

--- a/Lib/fontTools/misc/plistlib/__init__.py
+++ b/Lib/fontTools/misc/plistlib/__init__.py
@@ -23,7 +23,7 @@ from functools import singledispatch
 
 from fontTools.misc import etree
 
-from fontTools.misc.py23 import tostr
+from fontTools.misc._py23 import tostr
 
 
 # By default, we

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -2,7 +2,7 @@
 CFF dictionary data and Type1/Type2 CharStrings.
 """
 
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, strjoin
+from fontTools.misc._py23 import bytechr, byteord, bytesjoin, strjoin
 from fontTools.misc.fixedTools import (
 	fixedToFloat, floatToFixed, floatToFixedToStr, strToFixedToFloat,
 )

--- a/Lib/fontTools/misc/psLib.py
+++ b/Lib/fontTools/misc/psLib.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, tobytes, tostr
+from fontTools.misc._py23 import bytechr, byteord, bytesjoin, tobytes, tostr
 from fontTools.misc import eexec
 from .psOperators import (
 	PSOperators,

--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -1,17 +1,37 @@
 """Python 2/3 compat layer leftovers."""
 
-import decimal as _decimal
-import math as _math
 import warnings
-from contextlib import redirect_stderr, redirect_stdout
-from io import BytesIO
-from io import StringIO as UnicodeIO
-from types import SimpleNamespace
+
+from ._py23 import (
+    basestring,
+    bytechr,
+    byteord,
+    BytesIO,
+    bytesjoin,
+    open,
+    Py23Error,
+    range,
+    RecursionError,
+    round,
+    SimpleNamespace,
+    StringIO,
+    strjoin,
+    Tag,
+    tobytes,
+    tostr,
+    tounicode,
+    unichr,
+    unicode,
+    UnicodeIO,
+    xrange,
+    zip,
+)
 
 warnings.warn(
     "The py23 module has been deprecated and will be removed in a future release. "
     "Please update your code.",
     DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = [
@@ -38,111 +58,3 @@ __all__ = [
     "xrange",
     "zip",
 ]
-
-
-class Py23Error(NotImplementedError):
-    pass
-
-
-RecursionError = RecursionError
-StringIO = UnicodeIO
-
-basestring = str
-isclose = _math.isclose
-isfinite = _math.isfinite
-open = open
-range = range
-round = round3 = round
-unichr = chr
-unicode = str
-zip = zip
-
-
-def bytechr(n):
-    return bytes([n])
-
-
-def byteord(c):
-    return c if isinstance(c, int) else ord(c)
-
-
-def strjoin(iterable, joiner=""):
-    return tostr(joiner).join(iterable)
-
-
-def tobytes(s, encoding="ascii", errors="strict"):
-    if isinstance(s, str):
-        return s.encode(encoding, errors)
-    else:
-        return bytes(s)
-
-
-def tounicode(s, encoding="ascii", errors="strict"):
-    if not isinstance(s, unicode):
-        return s.decode(encoding, errors)
-    else:
-        return s
-
-
-tostr = tounicode
-
-
-class Tag(str):
-    @staticmethod
-    def transcode(blob):
-        if isinstance(blob, bytes):
-            blob = blob.decode("latin-1")
-        return blob
-
-    def __new__(self, content):
-        return str.__new__(self, self.transcode(content))
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def __eq__(self, other):
-        return str.__eq__(self, self.transcode(other))
-
-    def __hash__(self):
-        return str.__hash__(self)
-
-    def tobytes(self):
-        return self.encode("latin-1")
-
-
-def bytesjoin(iterable, joiner=b""):
-    return tobytes(joiner).join(tobytes(item) for item in iterable)
-
-
-def xrange(*args, **kwargs):
-    raise Py23Error("'xrange' is not defined. Use 'range' instead.")
-
-
-def round2(number, ndigits=None):
-    """
-    Implementation of Python 2 built-in round() function.
-    Rounds a number to a given precision in decimal digits (default
-    0 digits). The result is a floating point number. Values are rounded
-    to the closest multiple of 10 to the power minus ndigits; if two
-    multiples are equally close, rounding is done away from 0.
-    ndigits may be negative.
-    See Python 2 documentation:
-    https://docs.python.org/2/library/functions.html?highlight=round#round
-    """
-    if ndigits is None:
-        ndigits = 0
-
-    if ndigits < 0:
-        exponent = 10 ** (-ndigits)
-        quotient, remainder = divmod(number, exponent)
-        if remainder >= exponent // 2 and number >= 0:
-            quotient += 1
-        return float(quotient * exponent)
-    else:
-        exponent = _decimal.Decimal("10") ** (-ndigits)
-
-        d = _decimal.Decimal.from_float(number).quantize(
-            exponent, rounding=_decimal.ROUND_HALF_UP
-        )
-
-        return float(d)

--- a/Lib/fontTools/misc/sstruct.py
+++ b/Lib/fontTools/misc/sstruct.py
@@ -46,7 +46,7 @@ calcsize(fmt)
 	it returns the size of the data in bytes.
 """
 
-from fontTools.misc.py23 import tobytes, tostr
+from fontTools.misc._py23 import tobytes, tostr
 from fontTools.misc.fixedTools import fixedToFloat as fi2fl, floatToFixed as fl2fi
 import struct
 import re

--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -7,7 +7,7 @@ import shutil
 import sys
 import tempfile
 from unittest import TestCase as _TestCase
-from fontTools.misc.py23 import tobytes
+from fontTools.misc._py23 import tobytes
 from fontTools.misc.xmlWriter import XMLWriter
 
 

--- a/Lib/fontTools/misc/textTools.py
+++ b/Lib/fontTools/misc/textTools.py
@@ -1,7 +1,7 @@
 """fontTools.misc.textTools.py -- miscellaneous routines."""
 
 
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, strjoin, tobytes
+from fontTools.misc._py23 import bytechr, byteord, bytesjoin, strjoin, tobytes
 import ast
 import string
 

--- a/Lib/fontTools/misc/xmlWriter.py
+++ b/Lib/fontTools/misc/xmlWriter.py
@@ -1,6 +1,6 @@
 """xmlWriter.py -- Simple XML authoring class"""
 
-from fontTools.misc.py23 import byteord, strjoin, tobytes, tostr
+from fontTools.misc._py23 import byteord, strjoin, tobytes, tostr
 import sys
 import os
 import string

--- a/Lib/fontTools/svgLib/path/__init__.py
+++ b/Lib/fontTools/svgLib/path/__init__.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import tostr
+from fontTools.misc._py23 import tostr
 
 from fontTools.pens.transformPen import TransformPen
 from fontTools.misc import etree

--- a/Lib/fontTools/t1Lib/__init__.py
+++ b/Lib/fontTools/t1Lib/__init__.py
@@ -15,7 +15,7 @@ write(path, data, kind='OTHER', dohex=False)
 	part should be written as hexadecimal or binary, but only if kind
 	is 'OTHER'.
 """
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin
+from fontTools.misc._py23 import bytechr, byteord, bytesjoin
 from fontTools.misc import eexec
 from fontTools.misc.macCreatorType import getMacCreatorAndType
 import os

--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -14,7 +14,7 @@ a table's length chages you need to rewrite the whole file anyway.
 
 from io import BytesIO
 from types import SimpleNamespace
-from fontTools.misc.py23 import Tag
+from fontTools.misc._py23 import Tag
 from fontTools.misc import sstruct
 from fontTools.ttLib import TTLibError
 import struct

--- a/Lib/fontTools/ttLib/tables/C_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/C_B_D_T_.py
@@ -3,7 +3,7 @@
 # Google Author(s): Matt Fontaine
 
 
-from fontTools.misc.py23 import bytesjoin
+from fontTools.misc._py23 import bytesjoin
 from fontTools.misc import sstruct
 from . import E_B_D_T_
 from .BitmapGlyphMetrics import BigGlyphMetrics, bigGlyphMetricsFormat, SmallGlyphMetrics, smallGlyphMetricsFormat

--- a/Lib/fontTools/ttLib/tables/C_P_A_L_.py
+++ b/Lib/fontTools/ttLib/tables/C_P_A_L_.py
@@ -2,7 +2,7 @@
 #
 # Google Author(s): Behdad Esfahbod
 
-from fontTools.misc.py23 import bytesjoin
+from fontTools.misc._py23 import bytesjoin
 from fontTools.misc.textTools import safeEval
 from . import DefaultTable
 import array

--- a/Lib/fontTools/ttLib/tables/D_S_I_G_.py
+++ b/Lib/fontTools/ttLib/tables/D_S_I_G_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin, strjoin, tobytes, tostr
+from fontTools.misc._py23 import bytesjoin, strjoin, tobytes, tostr
 from fontTools.misc.textTools import safeEval
 from fontTools.misc import sstruct
 from . import DefaultTable

--- a/Lib/fontTools/ttLib/tables/DefaultTable.py
+++ b/Lib/fontTools/ttLib/tables/DefaultTable.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import Tag
+from fontTools.misc._py23 import Tag
 from fontTools.ttLib import getClassTag
 
 class DefaultTable(object):

--- a/Lib/fontTools/ttLib/tables/E_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_D_T_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, strjoin
+from fontTools.misc._py23 import bytechr, byteord, bytesjoin, strjoin
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval, readHex, hexStr, deHexStr
 from .BitmapGlyphMetrics import BigGlyphMetrics, bigGlyphMetricsFormat, SmallGlyphMetrics, smallGlyphMetricsFormat

--- a/Lib/fontTools/ttLib/tables/E_B_L_C_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_L_C_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin
+from fontTools.misc._py23 import bytesjoin
 from fontTools.misc import sstruct
 from . import DefaultTable
 from fontTools.misc.textTools import safeEval

--- a/Lib/fontTools/ttLib/tables/G_M_A_P_.py
+++ b/Lib/fontTools/ttLib/tables/G_M_A_P_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import tobytes, tostr
+from fontTools.misc._py23 import tobytes, tostr
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval
 from . import DefaultTable

--- a/Lib/fontTools/ttLib/tables/G_P_K_G_.py
+++ b/Lib/fontTools/ttLib/tables/G_P_K_G_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin
+from fontTools.misc._py23 import bytesjoin
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval, readHex
 from . import DefaultTable

--- a/Lib/fontTools/ttLib/tables/M_E_T_A_.py
+++ b/Lib/fontTools/ttLib/tables/M_E_T_A_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import byteord
+from fontTools.misc._py23 import byteord
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval
 from . import DefaultTable

--- a/Lib/fontTools/ttLib/tables/S_I_N_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_I_N_G_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytechr, byteord, tobytes, tostr
+from fontTools.misc._py23 import bytechr, byteord, tobytes, tostr
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval
 from . import DefaultTable

--- a/Lib/fontTools/ttLib/tables/S_V_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_V_G_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin, strjoin, tobytes, tostr
+from fontTools.misc._py23 import bytesjoin, strjoin, tobytes, tostr
 from fontTools.misc import sstruct
 from . import DefaultTable
 try:

--- a/Lib/fontTools/ttLib/tables/S__i_l_f.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_f.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import byteord
+from fontTools.misc._py23 import byteord
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import floatToFixedToStr
 from fontTools.misc.textTools import safeEval

--- a/Lib/fontTools/ttLib/tables/T_S_I_V_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_V_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import strjoin, tobytes, tostr
+from fontTools.misc._py23 import strjoin, tobytes, tostr
 from . import asciiTable
 
 class table_T_S_I_V_(asciiTable.asciiTable):

--- a/Lib/fontTools/ttLib/tables/T_S_I__1.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__1.py
@@ -4,7 +4,7 @@ tool to store its hinting source data.
 TSI1 contains the text of the glyph programs in the form of low-level assembly
 code, as well as the 'extra' programs 'fpgm', 'ppgm' (i.e. 'prep'), and 'cvt'.
 """
-from fontTools.misc.py23 import strjoin, tobytes, tostr
+from fontTools.misc._py23 import strjoin, tobytes, tostr
 from . import DefaultTable
 from fontTools.misc.loggingTools import LogMixin
 

--- a/Lib/fontTools/ttLib/tables/V_O_R_G_.py
+++ b/Lib/fontTools/ttLib/tables/V_O_R_G_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin
+from fontTools.misc._py23 import bytesjoin
 from fontTools.misc.textTools import safeEval
 from . import DefaultTable
 import struct

--- a/Lib/fontTools/ttLib/tables/_a_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin
+from fontTools.misc._py23 import bytesjoin
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import (
     fixedToFloat as fi2fl,

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin
+from fontTools.misc._py23 import bytesjoin
 from fontTools.misc.textTools import safeEval, readHex
 from fontTools.misc.encodingTools import getEncoding
 from fontTools.ttLib import getSearchRange

--- a/Lib/fontTools/ttLib/tables/_c_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_c_v_a_r.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin
+from fontTools.misc._py23 import bytesjoin
 from . import DefaultTable
 from fontTools.misc import sstruct
 from fontTools.ttLib.tables.TupleVariation import \

--- a/Lib/fontTools/ttLib/tables/_f_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_f_v_a_r.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import Tag, bytesjoin
+from fontTools.misc._py23 import Tag, bytesjoin
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import (
     fixedToFloat as fi2fl,

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1,7 +1,7 @@
 """_g_l_y_f.py -- Converter classes for the 'glyf' table."""
 
 from collections import namedtuple
-from fontTools.misc.py23 import tostr
+from fontTools.misc._py23 import tostr
 from fontTools.misc import sstruct
 from fontTools import ttLib
 from fontTools import version

--- a/Lib/fontTools/ttLib/tables/_h_d_m_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_d_m_x.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytechr, byteord, strjoin
+from fontTools.misc._py23 import bytechr, byteord, strjoin
 from fontTools.misc import sstruct
 from . import DefaultTable
 import array

--- a/Lib/fontTools/ttLib/tables/_l_t_a_g.py
+++ b/Lib/fontTools/ttLib/tables/_l_t_a_g.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin, tobytes
+from fontTools.misc._py23 import bytesjoin, tobytes
 from fontTools.misc.textTools import safeEval
 from . import DefaultTable
 import struct

--- a/Lib/fontTools/ttLib/tables/_m_e_t_a.py
+++ b/Lib/fontTools/ttLib/tables/_m_e_t_a.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin, strjoin
+from fontTools.misc._py23 import bytesjoin, strjoin
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import readHex
 from fontTools.ttLib import TTLibError

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, strjoin, tobytes, tostr
+from fontTools.misc._py23 import bytechr, byteord, bytesjoin, strjoin, tobytes, tostr
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval
 from fontTools.misc.encodingTools import getEncoding

--- a/Lib/fontTools/ttLib/tables/_p_o_s_t.py
+++ b/Lib/fontTools/ttLib/tables/_p_o_s_t.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytechr, byteord, tobytes, tostr
+from fontTools.misc._py23 import bytechr, byteord, tobytes, tostr
 from fontTools import ttLib
 from fontTools.ttLib.standardGlyphOrder import standardGlyphOrder
 from fontTools.misc import sstruct

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin
+from fontTools.misc._py23 import bytesjoin
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import (
 	fixedToFloat as fi2fl,

--- a/Lib/fontTools/ttLib/tables/asciiTable.py
+++ b/Lib/fontTools/ttLib/tables/asciiTable.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import strjoin, tobytes, tostr
+from fontTools.misc._py23 import strjoin, tobytes, tostr
 from . import DefaultTable
 
 

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import Tag, bytesjoin
+from fontTools.misc._py23 import Tag, bytesjoin
 from .DefaultTable import DefaultTable
 import sys
 import array

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin, tobytes, tostr
+from fontTools.misc._py23 import bytesjoin, tobytes, tostr
 from fontTools.misc.fixedTools import (
 	fixedToFloat as fi2fl,
 	floatToFixed as fl2fi,

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -9,7 +9,7 @@ import copy
 from enum import IntEnum
 import itertools
 from collections import defaultdict, namedtuple
-from fontTools.misc.py23 import bytesjoin
+from fontTools.misc._py23 import bytesjoin
 from fontTools.misc.roundTools import otRound
 from fontTools.misc.textTools import pad, safeEval
 from .otBase import (

--- a/Lib/fontTools/ttLib/tables/ttProgram.py
+++ b/Lib/fontTools/ttLib/tables/ttProgram.py
@@ -1,6 +1,6 @@
 """ttLib.tables.ttProgram.py -- Assembler/disassembler for TrueType bytecode programs."""
 
-from fontTools.misc.py23 import strjoin
+from fontTools.misc._py23 import strjoin
 from fontTools.misc.textTools import num2binary, binary2num, readHex
 import array
 from io import StringIO

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -1,5 +1,5 @@
 from fontTools.misc import xmlWriter
-from fontTools.misc.py23 import Tag, byteord, tostr
+from fontTools.misc._py23 import Tag, byteord, tostr
 from fontTools.misc.loggingTools import deprecateArgument
 from fontTools.ttLib import TTLibError
 from fontTools.ttLib.sfnt import SFNTReader, SFNTWriter

--- a/Lib/fontTools/ttLib/woff2.py
+++ b/Lib/fontTools/ttLib/woff2.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import Tag, bytechr, byteord, bytesjoin
+from fontTools.misc._py23 import Tag, bytechr, byteord, bytesjoin
 from io import BytesIO
 import sys
 import array

--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -86,7 +86,7 @@ usage: ttx [options] inputfile1 [... inputfileN]
 """
 
 
-from fontTools.misc.py23 import Tag, tostr
+from fontTools.misc._py23 import Tag, tostr
 from fontTools.ttLib import TTFont, TTLibError
 from fontTools.misc.macCreatorType import getMacCreatorAndType
 from fontTools.unicode import setUnicodeData

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -19,7 +19,7 @@ import fs.base
 import fs.errors
 import fs.osfs
 import fs.path
-from fontTools.misc.py23 import tobytes
+from fontTools.misc._py23 import tobytes
 from fontTools.misc import plistlib
 from fontTools.pens.pointPen import AbstractPointPen, PointToSegmentPen
 from fontTools.ufoLib.errors import GlifLibError

--- a/Lib/fontTools/ufoLib/plistlib.py
+++ b/Lib/fontTools/ufoLib/plistlib.py
@@ -3,7 +3,7 @@ for the old ufoLib.plistlib module, which was moved to fontTools.misc.plistlib.
 Please use the latter instead.
 """
 from fontTools.misc.plistlib import dump, dumps, load, loads
-from fontTools.misc.py23 import tobytes
+from fontTools.misc._py23 import tobytes
 
 # The following functions were part of the old py2-like ufoLib.plistlib API.
 # They are kept only for backward compatiblity.

--- a/Lib/fontTools/unicodedata/__init__.py
+++ b/Lib/fontTools/unicodedata/__init__.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import byteord, tostr
+from fontTools.misc._py23 import byteord, tostr
 
 import re
 from bisect import bisect_right

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -18,7 +18,7 @@ Then you can make a variable-font this way:
 
 API *will* change in near future.
 """
-from fontTools.misc.py23 import Tag, tostr
+from fontTools.misc._py23 import Tag, tostr
 from fontTools.misc.roundTools import noRound, otRound
 from fontTools.misc.vector import Vector
 from fontTools.ttLib import TTFont, newTable

--- a/README.rst
+++ b/README.rst
@@ -240,18 +240,17 @@ Acknowledgements
 
 In alphabetical order:
 
-Olivier Berten, Samyak Bhuta, Erik van Blokland, Petr van Blokland,
-Jelle Bosma, Sascha Brawer, Tom Byrer, Antonio Cavedoni, Frédéric 
-Coiffier, Vincent Connare, David Corbett, Simon Cozens, Dave Crossland, 
-Simon Daniels, Peter Dekkers, Behdad Esfahbod, Behnam Esfahbod, Hannes 
-Famira, Sam Fishman, Matt Fontaine, Yannis Haralambous, Greg Hitchcock, 
-Jeremie Hornus, Khaled Hosny, John Hudson, Denis Moyogo Jacquerye, Jack 
-Jansen, Tom Kacvinsky, Jens Kutilek, Antoine Leca, Werner Lemberg, Tal 
-Leming, Peter Lofting, Cosimo Lupo, Masaya Nakamura, Dave Opstad, 
-Laurence Penney, Roozbeh Pournader, Garret Rieger, Read Roberts, Guido 
-van Rossum, Just van Rossum, Andreas Seidel, Georg Seifert, Chris 
-Simpkins, Miguel Sousa, Adam Twardoch, Adrien Tétar, Vitaly Volkov, 
-Paul Wise.
+Olivier Berten, Samyak Bhuta, Erik van Blokland, Petr van Blokland, Jelle
+Bosma, Sascha Brawer, Tom Byrer, Thomas A Caswell, Antonio Cavedoni, Frédéric
+Coiffier, Vincent Connare, David Corbett, Simon Cozens, Dave Crossland, Simon
+Daniels, Peter Dekkers, Behdad Esfahbod, Behnam Esfahbod, Hannes Famira, Sam
+Fishman, Matt Fontaine, Yannis Haralambous, Greg Hitchcock, Jeremie Hornus,
+Khaled Hosny, John Hudson, Denis Moyogo Jacquerye, Jack Jansen, Tom Kacvinsky,
+Jens Kutilek, Antoine Leca, Werner Lemberg, Tal Leming, Peter Lofting, Cosimo
+Lupo, Masaya Nakamura, Dave Opstad, Laurence Penney, Roozbeh Pournader, Garret
+Rieger, Read Roberts, Guido van Rossum, Just van Rossum, Andreas Seidel, Georg
+Seifert, Chris Simpkins, Miguel Sousa, Adam Twardoch, Adrien Tétar, Vitaly
+Volkov, Paul Wise.
 
 Copyrights
 ~~~~~~~~~~

--- a/Snippets/svg2glif.py
+++ b/Snippets/svg2glif.py
@@ -4,7 +4,7 @@
 
 __requires__ = ["fontTools"]
 
-from fontTools.misc.py23 import SimpleNamespace
+from fontTools.misc._py23 import SimpleNamespace
 from fontTools.svgLib import SVGPath
 
 from fontTools.pens.pointPen import SegmentToPointPen

--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import tobytes
+from fontTools.misc._py23 import tobytes
 from fontTools.feaLib.error import FeatureLibError, IncludedFeaNotFound
 from fontTools.feaLib.lexer import IncludingLexer, Lexer
 from io import StringIO

--- a/Tests/misc/plistlib_test.py
+++ b/Tests/misc/plistlib_test.py
@@ -5,7 +5,7 @@ import codecs
 import collections
 from io import BytesIO
 from numbers import Integral
-from fontTools.misc.py23 import tostr
+from fontTools.misc._py23 import tostr
 from fontTools.misc import etree
 from fontTools.misc import plistlib
 from fontTools.ufoLib.plistlib import (

--- a/Tests/misc/py23_test.py
+++ b/Tests/misc/py23_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import tobytes
+from fontTools.misc._py23 import tobytes
 from fontTools.misc.textTools import deHexStr
 import filecmp
 from io import StringIO
@@ -8,8 +8,9 @@ import sys
 import os
 import unittest
 
-from fontTools.misc.py23 import (
-	round2, round3, isclose, redirect_stdout, redirect_stderr)
+from contextlib import redirect_stderr, redirect_stdout
+
+from fontTools.misc._py23 import (round2, round3, isclose)
 
 
 PIPE_SCRIPT = """\
@@ -53,7 +54,7 @@ class OpenFuncWrapperTest(unittest.TestCase):
 
 	def test_binary_pipe_py23_open_wrapper(self):
 		if self.diff_piped(
-				TEST_BIN_DATA, "from fontTools.misc.py23 import open"):
+				TEST_BIN_DATA, "from fontTools.misc._py23 import open"):
 			self.fail("Input and output data differ!")
 
 	def test_binary_pipe_built_in_io_open(self):

--- a/Tests/misc/xmlReader_test.py
+++ b/Tests/misc/xmlReader_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import strjoin
+from fontTools.misc._py23 import strjoin
 from io import BytesIO
 import os
 import unittest

--- a/Tests/misc/xmlWriter_test.py
+++ b/Tests/misc/xmlWriter_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin, tobytes
+from fontTools.misc._py23 import bytesjoin, tobytes
 from io import BytesIO
 import os
 import unittest

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -1,5 +1,5 @@
 import io
-from fontTools.misc.py23 import tobytes, tostr
+from fontTools.misc._py23 import tobytes, tostr
 from fontTools.misc.testTools import getXML
 from fontTools import subset
 from fontTools.fontBuilder import FontBuilder

--- a/Tests/svgLib/path/path_test.py
+++ b/Tests/svgLib/path/path_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import tobytes
+from fontTools.misc._py23 import tobytes
 from fontTools.pens.recordingPen import RecordingPen
 from fontTools.svgLib import SVGPath
 

--- a/Tests/ttLib/tables/T_S_I__1_test.py
+++ b/Tests/ttLib/tables/T_S_I__1_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import tobytes
+from fontTools.misc._py23 import tobytes
 from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.ttLib import TTFont, TTLibError
 from fontTools.ttLib.tables.T_S_I__0 import table_T_S_I__0

--- a/Tests/ttLib/tables/_m_o_r_x_test.py
+++ b/Tests/ttLib/tables/_m_o_r_x_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytechr, bytesjoin
+from fontTools.misc._py23 import bytechr, bytesjoin
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import newTable

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin, tostr
+from fontTools.misc._py23 import bytesjoin, tostr
 from fontTools.misc import sstruct
 from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.misc.testTools import FakeFont

--- a/Tests/ttLib/woff2_test.py
+++ b/Tests/ttLib/woff2_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import Tag, bytechr, byteord
+from fontTools.misc._py23 import Tag, bytechr, byteord
 from fontTools import ttLib
 from fontTools.ttLib import woff2
 from fontTools.ttLib.tables import _g_l_y_f

--- a/Tests/ufoLib/UFOZ_test.py
+++ b/Tests/ufoLib/UFOZ_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import tostr
+from fontTools.misc._py23 import tostr
 from fontTools.ufoLib import UFOReader, UFOWriter, UFOFileStructure
 from fontTools.ufoLib.errors import UFOLibError, GlifLibError
 from fontTools.misc import plistlib

--- a/Tests/varLib/instancer/instancer_test.py
+++ b/Tests/varLib/instancer/instancer_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import Tag
+from fontTools.misc._py23 import Tag
 from fontTools.misc.fixedTools import floatToFixedToFloat
 from fontTools import ttLib
 from fontTools import designspaceLib


### PR DESCRIPTION
The py23 module is deprecated, but still heavily used within fontTools.  This
means that libraries which depend on fontTools will get a deprecation warning
that they can do nothing about on import of fontTools.

This does three things:

 - move the actual py23 implementation into a private module
 - changes all of the internal imports to use the private module
 - set the stack level in the py23 warning to warn where it is imported

In particular Matplotlib has recently picked up a dependency on fontTools and we have to special-case the warning from importing fontTools in our test suite (we otherwise fail on warnings).

I've added my name to the README as the contributing guides requests, but this is such a mechanical change, I'd be perfectly happy to not do so.