### PR TITLE
Drop use of py23 module intenally

### DIFF
--- a/Doc/source/misc/index.rst
+++ b/Doc/source/misc/index.rst
@@ -25,7 +25,6 @@ utilities by fontTools, but some of which may be more generally useful.
    psCharStrings
    psLib
    psOperators
-   py23
    sstruct
    symfont
    testTools

--- a/Doc/source/misc/py23.rst
+++ b/Doc/source/misc/py23.rst
@@ -1,8 +1,0 @@
-####
-py23
-####
-
-.. automodule:: fontTools.misc.py23
-   :inherited-members:
-   :members:
-   :undoc-members:

--- a/Lib/fontTools/agl.py
+++ b/Lib/fontTools/agl.py
@@ -26,7 +26,7 @@ This is used by fontTools when it has to construct glyph names for a font which
 doesn't include any (e.g. format 3.0 post tables).
 """
 
-from fontTools.misc.py23 import tostr
+from fontTools.misc.textTools import tostr
 import re
 
 

--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -11,11 +11,10 @@ the demands of variable fonts. This module parses both original CFF and CFF2.
 
 """
 
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, tobytes, tostr
 from fontTools.misc import sstruct
 from fontTools.misc import psCharStrings
 from fontTools.misc.arrayTools import unionRect, intRect
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import bytechr, byteord, bytesjoin, tobytes, tostr, safeEval
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables.otBase import OTTableWriter
 from fontTools.ttLib.tables.otBase import OTTableReader

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from fontTools.misc.py23 import tobytes, tostr
 from fontTools.misc.loggingTools import LogMixin
+from fontTools.misc.textTools import tobytes, tostr
 import collections
 from io import BytesIO, StringIO
 import os

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1,7 +1,7 @@
-from fontTools.misc.py23 import byteord, tobytes
 from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.location import FeatureLibLocation
 from fontTools.misc.encodingTools import getEncoding
+from fontTools.misc.textTools import byteord, tobytes
 from collections import OrderedDict
 import itertools
 

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1,6 +1,5 @@
-from fontTools.misc.py23 import Tag, tostr
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import binary2num, safeEval
+from fontTools.misc.textTools import Tag, tostr, binary2num, safeEval
 from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.lookupDebugInfo import (
     LookupDebugInfo,

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1,7 +1,7 @@
 from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.lexer import Lexer, IncludingLexer, NonIncludingLexer
 from fontTools.misc.encodingTools import getEncoding
-from fontTools.misc.py23 import bytechr, tobytes, tostr
+from fontTools.misc.textTools import bytechr, tobytes, tostr
 import fontTools.feaLib.ast as ast
 import logging
 import os

--- a/Lib/fontTools/misc/eexec.py
+++ b/Lib/fontTools/misc/eexec.py
@@ -12,7 +12,7 @@ the new key at the end of the operation.
 
 """
 
-from fontTools.misc.py23 import bytechr, bytesjoin, byteord
+from fontTools.misc.textTools import bytechr, bytesjoin, byteord
 
 
 def _decryptChar(cipher, R):

--- a/Lib/fontTools/misc/etree.py
+++ b/Lib/fontTools/misc/etree.py
@@ -11,7 +11,7 @@ or subclasses built-in ElementTree classes to add features that are
 only availble in lxml, like OrderedDict for attributes, pretty_print and
 iterwalk.
 """
-from fontTools.misc.py23 import unicode, tostr
+from fontTools.misc.textTools import tostr
 
 
 XML_DECLARATION = """<?xml version='1.0' encoding='%s'?>"""
@@ -150,9 +150,7 @@ except ImportError:
                 )
                 return
 
-            if encoding is unicode or (
-                encoding is not None and encoding.lower() == "unicode"
-            ):
+            if encoding is not None and encoding.lower() == "unicode":
                 if xml_declaration:
                     raise ValueError(
                         "Serialisation to unicode must not request an XML declaration"

--- a/Lib/fontTools/misc/macCreatorType.py
+++ b/Lib/fontTools/misc/macCreatorType.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import Tag, bytesjoin, strjoin
+from fontTools.misc.textTools import Tag, bytesjoin, strjoin
 try:
 	import xattr
 except ImportError:
@@ -18,7 +18,7 @@ def getMacCreatorAndType(path):
 		path (str): A file path.
 
 	Returns:
-		A tuple of two :py:class:`fontTools.py23.Tag` objects, the first
+		A tuple of two :py:class:`fontTools.textTools.Tag` objects, the first
 		representing the file creator and the second representing the
 		file type.
 	"""

--- a/Lib/fontTools/misc/macRes.py
+++ b/Lib/fontTools/misc/macRes.py
@@ -1,7 +1,7 @@
-from fontTools.misc.py23 import bytesjoin, tostr
 from io import BytesIO
 import struct
 from fontTools.misc import sstruct
+from fontTools.misc.textTools import bytesjoin, tostr
 from collections import OrderedDict
 from collections.abc import MutableMapping
 

--- a/Lib/fontTools/misc/plistlib/__init__.py
+++ b/Lib/fontTools/misc/plistlib/__init__.py
@@ -23,7 +23,7 @@ from functools import singledispatch
 
 from fontTools.misc import etree
 
-from fontTools.misc.py23 import tostr
+from fontTools.misc.textTools import tostr
 
 
 # By default, we

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -2,10 +2,10 @@
 CFF dictionary data and Type1/Type2 CharStrings.
 """
 
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, strjoin
 from fontTools.misc.fixedTools import (
 	fixedToFloat, floatToFixed, floatToFixedToStr, strToFixedToFloat,
 )
+from fontTools.misc.textTools import bytechr, byteord, bytesjoin, strjoin
 from fontTools.pens.boundsPen import BoundsPen
 import struct
 import logging

--- a/Lib/fontTools/misc/psLib.py
+++ b/Lib/fontTools/misc/psLib.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, tobytes, tostr
+from fontTools.misc.textTools import bytechr, byteord, bytesjoin, tobytes, tostr
 from fontTools.misc import eexec
 from .psOperators import (
 	PSOperators,

--- a/Lib/fontTools/misc/py23.py
+++ b/Lib/fontTools/misc/py23.py
@@ -8,6 +8,8 @@ from io import BytesIO
 from io import StringIO as UnicodeIO
 from types import SimpleNamespace
 
+from .textTools import Tag, bytechr, byteord, bytesjoin, strjoin, tobytes, tostr
+
 warnings.warn(
     "The py23 module has been deprecated and will be removed in a future release. "
     "Please update your code.",
@@ -57,61 +59,7 @@ unichr = chr
 unicode = str
 zip = zip
 
-
-def bytechr(n):
-    return bytes([n])
-
-
-def byteord(c):
-    return c if isinstance(c, int) else ord(c)
-
-
-def strjoin(iterable, joiner=""):
-    return tostr(joiner).join(iterable)
-
-
-def tobytes(s, encoding="ascii", errors="strict"):
-    if isinstance(s, str):
-        return s.encode(encoding, errors)
-    else:
-        return bytes(s)
-
-
-def tounicode(s, encoding="ascii", errors="strict"):
-    if not isinstance(s, unicode):
-        return s.decode(encoding, errors)
-    else:
-        return s
-
-
-tostr = tounicode
-
-
-class Tag(str):
-    @staticmethod
-    def transcode(blob):
-        if isinstance(blob, bytes):
-            blob = blob.decode("latin-1")
-        return blob
-
-    def __new__(self, content):
-        return str.__new__(self, self.transcode(content))
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def __eq__(self, other):
-        return str.__eq__(self, self.transcode(other))
-
-    def __hash__(self):
-        return str.__hash__(self)
-
-    def tobytes(self):
-        return self.encode("latin-1")
-
-
-def bytesjoin(iterable, joiner=b""):
-    return tobytes(joiner).join(tobytes(item) for item in iterable)
+tounicode = tostr
 
 
 def xrange(*args, **kwargs):

--- a/Lib/fontTools/misc/sstruct.py
+++ b/Lib/fontTools/misc/sstruct.py
@@ -46,8 +46,8 @@ calcsize(fmt)
 	it returns the size of the data in bytes.
 """
 
-from fontTools.misc.py23 import tobytes, tostr
 from fontTools.misc.fixedTools import fixedToFloat as fi2fl, floatToFixed as fl2fi
+from fontTools.misc.textTools import tobytes, tostr
 import struct
 import re
 

--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -7,7 +7,7 @@ import shutil
 import sys
 import tempfile
 from unittest import TestCase as _TestCase
-from fontTools.misc.py23 import tobytes
+from fontTools.misc.textTools import tobytes
 from fontTools.misc.xmlWriter import XMLWriter
 
 

--- a/Lib/fontTools/misc/textTools.py
+++ b/Lib/fontTools/misc/textTools.py
@@ -1,13 +1,35 @@
 """fontTools.misc.textTools.py -- miscellaneous routines."""
 
 
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, strjoin, tobytes
 import ast
 import string
 
 
 # alias kept for backward compatibility
 safeEval = ast.literal_eval
+
+
+class Tag(str):
+    @staticmethod
+    def transcode(blob):
+        if isinstance(blob, bytes):
+            blob = blob.decode("latin-1")
+        return blob
+
+    def __new__(self, content):
+        return str.__new__(self, self.transcode(content))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __eq__(self, other):
+        return str.__eq__(self, self.transcode(other))
+
+    def __hash__(self):
+        return str.__hash__(self)
+
+    def tobytes(self):
+        return self.encode("latin-1")
 
 
 def readHex(content):
@@ -95,6 +117,36 @@ def pad(data, size):
 		if remainder:
 			data += b"\0" * (size - remainder)
 	return data
+
+
+def tostr(s, encoding="ascii", errors="strict"):
+    if not isinstance(s, str):
+        return s.decode(encoding, errors)
+    else:
+        return s
+
+
+def tobytes(s, encoding="ascii", errors="strict"):
+    if isinstance(s, str):
+        return s.encode(encoding, errors)
+    else:
+        return bytes(s)
+
+
+def bytechr(n):
+    return bytes([n])
+
+
+def byteord(c):
+    return c if isinstance(c, int) else ord(c)
+
+
+def strjoin(iterable, joiner=""):
+    return tostr(joiner).join(iterable)
+
+
+def bytesjoin(iterable, joiner=b""):
+    return tobytes(joiner).join(tobytes(item) for item in iterable)
 
 
 if __name__ == "__main__":

--- a/Lib/fontTools/misc/xmlWriter.py
+++ b/Lib/fontTools/misc/xmlWriter.py
@@ -1,6 +1,6 @@
 """xmlWriter.py -- Simple XML authoring class"""
 
-from fontTools.misc.py23 import byteord, strjoin, tobytes, tostr
+from fontTools.misc.textTools import byteord, strjoin, tobytes, tostr
 import sys
 import os
 import string

--- a/Lib/fontTools/svgLib/path/__init__.py
+++ b/Lib/fontTools/svgLib/path/__init__.py
@@ -1,7 +1,6 @@
-from fontTools.misc.py23 import tostr
-
 from fontTools.pens.transformPen import TransformPen
 from fontTools.misc import etree
+from fontTools.misc.textTools import tostr
 from .parser import parse_path
 from .shapes import PathBuilder
 

--- a/Lib/fontTools/t1Lib/__init__.py
+++ b/Lib/fontTools/t1Lib/__init__.py
@@ -15,9 +15,9 @@ write(path, data, kind='OTHER', dohex=False)
 	part should be written as hexadecimal or binary, but only if kind
 	is 'OTHER'.
 """
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin
 from fontTools.misc import eexec
 from fontTools.misc.macCreatorType import getMacCreatorAndType
+from fontTools.misc.textTools import bytechr, byteord, bytesjoin
 import os
 import re
 

--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -14,7 +14,7 @@ a table's length chages you need to rewrite the whole file anyway.
 
 from io import BytesIO
 from types import SimpleNamespace
-from fontTools.misc.py23 import Tag
+from fontTools.misc.textTools import Tag
 from fontTools.misc import sstruct
 from fontTools.ttLib import TTLibError
 import struct

--- a/Lib/fontTools/ttLib/tables/C_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/C_B_D_T_.py
@@ -3,7 +3,7 @@
 # Google Author(s): Matt Fontaine
 
 
-from fontTools.misc.py23 import bytesjoin
+from fontTools.misc.textTools import bytesjoin
 from fontTools.misc import sstruct
 from . import E_B_D_T_
 from .BitmapGlyphMetrics import BigGlyphMetrics, bigGlyphMetricsFormat, SmallGlyphMetrics, smallGlyphMetricsFormat

--- a/Lib/fontTools/ttLib/tables/C_P_A_L_.py
+++ b/Lib/fontTools/ttLib/tables/C_P_A_L_.py
@@ -2,8 +2,7 @@
 #
 # Google Author(s): Behdad Esfahbod
 
-from fontTools.misc.py23 import bytesjoin
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import bytesjoin, safeEval
 from . import DefaultTable
 import array
 from collections import namedtuple

--- a/Lib/fontTools/ttLib/tables/D_S_I_G_.py
+++ b/Lib/fontTools/ttLib/tables/D_S_I_G_.py
@@ -1,5 +1,4 @@
-from fontTools.misc.py23 import bytesjoin, strjoin, tobytes, tostr
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import bytesjoin, strjoin, tobytes, tostr, safeEval
 from fontTools.misc import sstruct
 from . import DefaultTable
 import base64

--- a/Lib/fontTools/ttLib/tables/DefaultTable.py
+++ b/Lib/fontTools/ttLib/tables/DefaultTable.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import Tag
+from fontTools.misc.textTools import Tag
 from fontTools.ttLib import getClassTag
 
 class DefaultTable(object):

--- a/Lib/fontTools/ttLib/tables/E_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_D_T_.py
@@ -1,6 +1,5 @@
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, strjoin
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval, readHex, hexStr, deHexStr
+from fontTools.misc.textTools import bytechr, byteord, bytesjoin, strjoin, safeEval, readHex, hexStr, deHexStr
 from .BitmapGlyphMetrics import BigGlyphMetrics, bigGlyphMetricsFormat, SmallGlyphMetrics, smallGlyphMetricsFormat
 from . import DefaultTable
 import itertools

--- a/Lib/fontTools/ttLib/tables/E_B_L_C_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_L_C_.py
@@ -1,7 +1,6 @@
-from fontTools.misc.py23 import bytesjoin
 from fontTools.misc import sstruct
 from . import DefaultTable
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import bytesjoin, safeEval
 from .BitmapGlyphMetrics import BigGlyphMetrics, bigGlyphMetricsFormat, SmallGlyphMetrics, smallGlyphMetricsFormat
 import struct
 import itertools

--- a/Lib/fontTools/ttLib/tables/G_M_A_P_.py
+++ b/Lib/fontTools/ttLib/tables/G_M_A_P_.py
@@ -1,6 +1,5 @@
-from fontTools.misc.py23 import tobytes, tostr
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import tobytes, tostr, safeEval
 from . import DefaultTable
 
 GMAPFormat = """

--- a/Lib/fontTools/ttLib/tables/G_P_K_G_.py
+++ b/Lib/fontTools/ttLib/tables/G_P_K_G_.py
@@ -1,6 +1,5 @@
-from fontTools.misc.py23 import bytesjoin
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval, readHex
+from fontTools.misc.textTools import bytesjoin, safeEval, readHex
 from . import DefaultTable
 import sys
 import array

--- a/Lib/fontTools/ttLib/tables/M_E_T_A_.py
+++ b/Lib/fontTools/ttLib/tables/M_E_T_A_.py
@@ -1,6 +1,5 @@
-from fontTools.misc.py23 import byteord
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import byteord, safeEval
 from . import DefaultTable
 import pdb
 import struct

--- a/Lib/fontTools/ttLib/tables/S_I_N_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_I_N_G_.py
@@ -1,6 +1,5 @@
-from fontTools.misc.py23 import bytechr, byteord, tobytes, tostr
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import bytechr, byteord, tobytes, tostr, safeEval
 from . import DefaultTable
 
 SINGFormat = """

--- a/Lib/fontTools/ttLib/tables/S_V_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_V_G_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import bytesjoin, strjoin, tobytes, tostr
+from fontTools.misc.textTools import bytesjoin, strjoin, tobytes, tostr
 from fontTools.misc import sstruct
 from . import DefaultTable
 try:

--- a/Lib/fontTools/ttLib/tables/S__i_l_f.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_f.py
@@ -1,7 +1,6 @@
-from fontTools.misc.py23 import byteord
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import floatToFixedToStr
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import byteord, safeEval
 # from itertools import *
 from . import DefaultTable
 from . import grUtils

--- a/Lib/fontTools/ttLib/tables/T_S_I_V_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_V_.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import strjoin, tobytes, tostr
+from fontTools.misc.textTools import strjoin, tobytes, tostr
 from . import asciiTable
 
 class table_T_S_I_V_(asciiTable.asciiTable):

--- a/Lib/fontTools/ttLib/tables/T_S_I__1.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__1.py
@@ -4,9 +4,9 @@ tool to store its hinting source data.
 TSI1 contains the text of the glyph programs in the form of low-level assembly
 code, as well as the 'extra' programs 'fpgm', 'ppgm' (i.e. 'prep'), and 'cvt'.
 """
-from fontTools.misc.py23 import strjoin, tobytes, tostr
 from . import DefaultTable
 from fontTools.misc.loggingTools import LogMixin
+from fontTools.misc.textTools import strjoin, tobytes, tostr
 
 
 class table_T_S_I__1(LogMixin, DefaultTable.DefaultTable):

--- a/Lib/fontTools/ttLib/tables/V_O_R_G_.py
+++ b/Lib/fontTools/ttLib/tables/V_O_R_G_.py
@@ -1,5 +1,4 @@
-from fontTools.misc.py23 import bytesjoin
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import bytesjoin, safeEval
 from . import DefaultTable
 import struct
 

--- a/Lib/fontTools/ttLib/tables/_a_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r.py
@@ -1,4 +1,3 @@
-from fontTools.misc.py23 import bytesjoin
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import (
     fixedToFloat as fi2fl,
@@ -6,6 +5,7 @@ from fontTools.misc.fixedTools import (
     floatToFixedToStr as fl2str,
     strToFixedToFloat as str2fl,
 )
+from fontTools.misc.textTools import bytesjoin
 from fontTools.ttLib import TTLibError
 from . import DefaultTable
 import struct

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -1,5 +1,4 @@
-from fontTools.misc.py23 import bytesjoin
-from fontTools.misc.textTools import safeEval, readHex
+from fontTools.misc.textTools import bytesjoin, safeEval, readHex
 from fontTools.misc.encodingTools import getEncoding
 from fontTools.ttLib import getSearchRange
 from fontTools.unicode import Unicode

--- a/Lib/fontTools/ttLib/tables/_c_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_c_v_a_r.py
@@ -1,6 +1,6 @@
-from fontTools.misc.py23 import bytesjoin
 from . import DefaultTable
 from fontTools.misc import sstruct
+from fontTools.misc.textTools import bytesjoin
 from fontTools.ttLib.tables.TupleVariation import \
     compileTupleVariationStore, decompileTupleVariationStore, TupleVariation
 

--- a/Lib/fontTools/ttLib/tables/_f_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_f_v_a_r.py
@@ -1,4 +1,3 @@
-from fontTools.misc.py23 import Tag, bytesjoin
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import (
     fixedToFloat as fi2fl,
@@ -6,7 +5,7 @@ from fontTools.misc.fixedTools import (
     floatToFixedToStr as fl2str,
     strToFixedToFloat as str2fl,
 )
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import Tag, bytesjoin, safeEval
 from fontTools.ttLib import TTLibError
 from . import DefaultTable
 import struct

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1,11 +1,10 @@
 """_g_l_y_f.py -- Converter classes for the 'glyf' table."""
 
 from collections import namedtuple
-from fontTools.misc.py23 import tostr
 from fontTools.misc import sstruct
 from fontTools import ttLib
 from fontTools import version
-from fontTools.misc.textTools import safeEval, pad
+from fontTools.misc.textTools import tostr, safeEval, pad
 from fontTools.misc.arrayTools import calcIntBounds, pointInRect
 from fontTools.misc.bezierTools import calcQuadraticBounds
 from fontTools.misc.fixedTools import (

--- a/Lib/fontTools/ttLib/tables/_h_d_m_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_d_m_x.py
@@ -1,5 +1,5 @@
-from fontTools.misc.py23 import bytechr, byteord, strjoin
 from fontTools.misc import sstruct
+from fontTools.misc.textTools import bytechr, byteord, strjoin
 from . import DefaultTable
 import array
 from collections.abc import Mapping

--- a/Lib/fontTools/ttLib/tables/_l_t_a_g.py
+++ b/Lib/fontTools/ttLib/tables/_l_t_a_g.py
@@ -1,5 +1,4 @@
-from fontTools.misc.py23 import bytesjoin, tobytes
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import bytesjoin, tobytes, safeEval
 from . import DefaultTable
 import struct
 

--- a/Lib/fontTools/ttLib/tables/_m_e_t_a.py
+++ b/Lib/fontTools/ttLib/tables/_m_e_t_a.py
@@ -1,6 +1,5 @@
-from fontTools.misc.py23 import bytesjoin, strjoin
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import readHex
+from fontTools.misc.textTools import bytesjoin, strjoin, readHex
 from fontTools.ttLib import TTLibError
 from . import DefaultTable
 

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-from fontTools.misc.py23 import bytechr, byteord, bytesjoin, strjoin, tobytes, tostr
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import bytechr, byteord, bytesjoin, strjoin, tobytes, tostr, safeEval
 from fontTools.misc.encodingTools import getEncoding
 from fontTools.ttLib import newTable
 from . import DefaultTable

--- a/Lib/fontTools/ttLib/tables/_p_o_s_t.py
+++ b/Lib/fontTools/ttLib/tables/_p_o_s_t.py
@@ -1,8 +1,7 @@
-from fontTools.misc.py23 import bytechr, byteord, tobytes, tostr
 from fontTools import ttLib
 from fontTools.ttLib.standardGlyphOrder import standardGlyphOrder
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval, readHex
+from fontTools.misc.textTools import bytechr, byteord, tobytes, tostr, safeEval, readHex
 from . import DefaultTable
 import sys
 import struct

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k.py
@@ -1,4 +1,3 @@
-from fontTools.misc.py23 import bytesjoin
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import (
 	fixedToFloat as fi2fl,
@@ -6,7 +5,7 @@ from fontTools.misc.fixedTools import (
 	floatToFixedToStr as fl2str,
 	strToFixedToFloat as str2fl,
 )
-from fontTools.misc.textTools import safeEval
+from fontTools.misc.textTools import bytesjoin, safeEval
 from fontTools.ttLib import TTLibError
 from . import DefaultTable
 import struct

--- a/Lib/fontTools/ttLib/tables/asciiTable.py
+++ b/Lib/fontTools/ttLib/tables/asciiTable.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import strjoin, tobytes, tostr
+from fontTools.misc.textTools import strjoin, tobytes, tostr
 from . import DefaultTable
 
 

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import Tag, bytesjoin
+from fontTools.misc.textTools import Tag, bytesjoin
 from .DefaultTable import DefaultTable
 import sys
 import array

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1,4 +1,3 @@
-from fontTools.misc.py23 import bytesjoin, tobytes, tostr
 from fontTools.misc.fixedTools import (
 	fixedToFloat as fi2fl,
 	floatToFixed as fl2fi,
@@ -8,7 +7,7 @@ from fontTools.misc.fixedTools import (
 	versionToFixed as ve2fi,
 )
 from fontTools.misc.roundTools import nearestMultipleShortestRepr, otRound
-from fontTools.misc.textTools import pad, safeEval
+from fontTools.misc.textTools import bytesjoin, tobytes, tostr, pad, safeEval
 from fontTools.ttLib import getSearchRange
 from .otBase import (CountReference, FormatSwitchingBaseTable,
                      OTTableReader, OTTableWriter, ValueRecordFactory)

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -9,9 +9,8 @@ import copy
 from enum import IntEnum
 import itertools
 from collections import defaultdict, namedtuple
-from fontTools.misc.py23 import bytesjoin
 from fontTools.misc.roundTools import otRound
-from fontTools.misc.textTools import pad, safeEval
+from fontTools.misc.textTools import bytesjoin, pad, safeEval
 from .otBase import (
 	BaseTable, FormatSwitchingBaseTable, ValueRecord, CountReference,
 	getFormatSwitchingBaseTableClass,

--- a/Lib/fontTools/ttLib/tables/ttProgram.py
+++ b/Lib/fontTools/ttLib/tables/ttProgram.py
@@ -1,7 +1,6 @@
 """ttLib.tables.ttProgram.py -- Assembler/disassembler for TrueType bytecode programs."""
 
-from fontTools.misc.py23 import strjoin
-from fontTools.misc.textTools import num2binary, binary2num, readHex
+from fontTools.misc.textTools import num2binary, binary2num, readHex, strjoin
 import array
 from io import StringIO
 import re

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -1,5 +1,5 @@
 from fontTools.misc import xmlWriter
-from fontTools.misc.py23 import Tag, byteord, tostr
+from fontTools.misc.textTools import Tag, byteord, tostr
 from fontTools.misc.loggingTools import deprecateArgument
 from fontTools.ttLib import TTLibError
 from fontTools.ttLib.sfnt import SFNTReader, SFNTWriter

--- a/Lib/fontTools/ttLib/woff2.py
+++ b/Lib/fontTools/ttLib/woff2.py
@@ -1,4 +1,3 @@
-from fontTools.misc.py23 import Tag, bytechr, byteord, bytesjoin
 from io import BytesIO
 import sys
 import array
@@ -6,7 +5,7 @@ import struct
 from collections import OrderedDict
 from fontTools.misc import sstruct
 from fontTools.misc.arrayTools import calcIntBounds
-from fontTools.misc.textTools import pad
+from fontTools.misc.textTools import Tag, bytechr, byteord, bytesjoin, pad
 from fontTools.ttLib import (TTFont, TTLibError, getTableModule, getTableClass,
 	getSearchRange)
 from fontTools.ttLib.sfnt import (SFNTReader, SFNTWriter, DirectoryEntry,

--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -86,10 +86,10 @@ usage: ttx [options] inputfile1 [... inputfileN]
 """
 
 
-from fontTools.misc.py23 import Tag, tostr
 from fontTools.ttLib import TTFont, TTLibError
 from fontTools.misc.macCreatorType import getMacCreatorAndType
 from fontTools.unicode import setUnicodeData
+from fontTools.misc.textTools import Tag, tostr
 from fontTools.misc.timeTools import timestampSinceEpoch
 from fontTools.misc.loggingTools import Timer
 from fontTools.misc.cliTools import makeOutputFileName

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -19,7 +19,7 @@ import fs.base
 import fs.errors
 import fs.osfs
 import fs.path
-from fontTools.misc.py23 import tobytes
+from fontTools.misc.textTools import tobytes
 from fontTools.misc import plistlib
 from fontTools.pens.pointPen import AbstractPointPen, PointToSegmentPen
 from fontTools.ufoLib.errors import GlifLibError

--- a/Lib/fontTools/ufoLib/plistlib.py
+++ b/Lib/fontTools/ufoLib/plistlib.py
@@ -3,7 +3,7 @@ for the old ufoLib.plistlib module, which was moved to fontTools.misc.plistlib.
 Please use the latter instead.
 """
 from fontTools.misc.plistlib import dump, dumps, load, loads
-from fontTools.misc.py23 import tobytes
+from fontTools.misc.textTools import tobytes
 
 # The following functions were part of the old py2-like ufoLib.plistlib API.
 # They are kept only for backward compatiblity.

--- a/Lib/fontTools/unicodedata/__init__.py
+++ b/Lib/fontTools/unicodedata/__init__.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import byteord, tostr
+from fontTools.misc.textTools import byteord, tostr
 
 import re
 from bisect import bisect_right

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -18,9 +18,9 @@ Then you can make a variable-font this way:
 
 API *will* change in near future.
 """
-from fontTools.misc.py23 import Tag, tostr
-from fontTools.misc.roundTools import noRound, otRound
 from fontTools.misc.vector import Vector
+from fontTools.misc.roundTools import noRound, otRound
+from fontTools.misc.textTools import Tag, tostr
 from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables._f_v_a_r import Axis, NamedInstance
 from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates

--- a/Snippets/svg2glif.py
+++ b/Snippets/svg2glif.py
@@ -4,7 +4,7 @@
 
 __requires__ = ["fontTools"]
 
-from fontTools.misc.py23 import SimpleNamespace
+from types import SimpleNamespace
 from fontTools.svgLib import SVGPath
 
 from fontTools.pens.pointPen import SegmentToPointPen

--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -1,6 +1,6 @@
-from fontTools.misc.py23 import tobytes
 from fontTools.feaLib.error import FeatureLibError, IncludedFeaNotFound
 from fontTools.feaLib.lexer import IncludingLexer, Lexer
+from fontTools.misc.textTools import tobytes
 from io import StringIO
 import os
 import shutil

--- a/Tests/misc/plistlib_test.py
+++ b/Tests/misc/plistlib_test.py
@@ -5,9 +5,9 @@ import codecs
 import collections
 from io import BytesIO
 from numbers import Integral
-from fontTools.misc.py23 import tostr
 from fontTools.misc import etree
 from fontTools.misc import plistlib
+from fontTools.misc.textTools import tostr
 from fontTools.ufoLib.plistlib import (
     readPlist, readPlistFromString, writePlist, writePlistToString,
 )

--- a/Tests/misc/xmlReader_test.py
+++ b/Tests/misc/xmlReader_test.py
@@ -1,8 +1,8 @@
-from fontTools.misc.py23 import strjoin
 from io import BytesIO
 import os
 import unittest
 from fontTools.ttLib import TTFont
+from fontTools.misc.textTools import strjoin
 from fontTools.misc.xmlReader import XMLReader, ProgressPrinter, BUFSIZE
 import tempfile
 

--- a/Tests/misc/xmlWriter_test.py
+++ b/Tests/misc/xmlWriter_test.py
@@ -1,7 +1,7 @@
-from fontTools.misc.py23 import bytesjoin, tobytes
 from io import BytesIO
 import os
 import unittest
+from fontTools.misc.textTools import bytesjoin, tobytes
 from fontTools.misc.xmlWriter import XMLWriter
 
 HEADER = b'<?xml version="1.0" encoding="UTF-8"?>\n'

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -1,6 +1,6 @@
 import io
-from fontTools.misc.py23 import tobytes, tostr
 from fontTools.misc.testTools import getXML
+from fontTools.misc.textTools import tobytes, tostr
 from fontTools import subset
 from fontTools.fontBuilder import FontBuilder
 from fontTools.pens.ttGlyphPen import TTGlyphPen

--- a/Tests/svgLib/path/path_test.py
+++ b/Tests/svgLib/path/path_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.py23 import tobytes
+from fontTools.misc.textTools import tobytes
 from fontTools.pens.recordingPen import RecordingPen
 from fontTools.svgLib import SVGPath
 

--- a/Tests/ttLib/tables/T_S_I__1_test.py
+++ b/Tests/ttLib/tables/T_S_I__1_test.py
@@ -1,5 +1,5 @@
-from fontTools.misc.py23 import tobytes
 from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.misc.textTools import tobytes
 from fontTools.ttLib import TTFont, TTLibError
 from fontTools.ttLib.tables.T_S_I__0 import table_T_S_I__0
 from fontTools.ttLib.tables.T_S_I__1 import table_T_S_I__1

--- a/Tests/ttLib/tables/_m_o_r_x_test.py
+++ b/Tests/ttLib/tables/_m_o_r_x_test.py
@@ -1,6 +1,5 @@
-from fontTools.misc.py23 import bytechr, bytesjoin
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
-from fontTools.misc.textTools import deHexStr, hexStr
+from fontTools.misc.textTools import bytechr, bytesjoin, deHexStr, hexStr
 from fontTools.ttLib import newTable
 import unittest
 

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -1,7 +1,7 @@
-from fontTools.misc.py23 import bytesjoin, tostr
 from fontTools.misc import sstruct
 from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.misc.testTools import FakeFont
+from fontTools.misc.textTools import bytesjoin, tostr
 from fontTools.misc.xmlWriter import XMLWriter
 from io import BytesIO
 import struct

--- a/Tests/ttLib/woff2_test.py
+++ b/Tests/ttLib/woff2_test.py
@@ -1,4 +1,3 @@
-from fontTools.misc.py23 import Tag, bytechr, byteord
 from fontTools import ttLib
 from fontTools.ttLib import woff2
 from fontTools.ttLib.tables import _g_l_y_f
@@ -10,6 +9,7 @@ from fontTools.ttLib.woff2 import (
 	WOFF2HmtxTable, WOFF2Writer, unpackBase128, unpack255UShort, pack255UShort)
 import unittest
 from fontTools.misc import sstruct
+from fontTools.misc.textTools import Tag, bytechr, byteord
 from fontTools import fontBuilder
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from io import BytesIO

--- a/Tests/ufoLib/UFOZ_test.py
+++ b/Tests/ufoLib/UFOZ_test.py
@@ -1,7 +1,7 @@
-from fontTools.misc.py23 import tostr
 from fontTools.ufoLib import UFOReader, UFOWriter, UFOFileStructure
 from fontTools.ufoLib.errors import UFOLibError, GlifLibError
 from fontTools.misc import plistlib
+from fontTools.misc.textTools import tostr
 import sys
 import os
 import fs.osfs

--- a/Tests/varLib/instancer/instancer_test.py
+++ b/Tests/varLib/instancer/instancer_test.py
@@ -1,5 +1,5 @@
-from fontTools.misc.py23 import Tag
 from fontTools.misc.fixedTools import floatToFixedToFloat
+from fontTools.misc.textTools import Tag
 from fontTools import ttLib
 from fontTools import designspaceLib
 from fontTools.feaLib.builder import addOpenTypeFeaturesFromString


### PR DESCRIPTION
Move the rest of `py23` module to `textTools`, and change all imports to use `textTools` module, except the `test_py23.py` test which is kept until we decide to remove the module (if ever).