### PR TITLE
[otlLib] Fix chained contextual builder overflow

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -377,12 +377,6 @@ class ChainContextualBuilder(LookupBuilder):
             candidates = [None, None, None, []]
             for rule in ruleset.rules:
                 candidates[3].append(self.buildFormat3Subtable(rule, chaining))
-            # Check we can build it
-            try:
-                self.getCompiledSize_(candidates[3])
-            except Exception as e:
-                log.warning("Contextual format 3 at %s overflowed" % str(self.location))
-                candidates[3] = None
 
             # Can we express the whole ruleset as a format 2 subtable?
             classdefs = ruleset.format2ClassDefs()
@@ -390,21 +384,19 @@ class ChainContextualBuilder(LookupBuilder):
                 candidates[2] = [
                     self.buildFormat2Subtable(ruleset, classdefs, chaining)
                 ]
-                # Check we can build it
-                try:
-                    self.getCompiledSize_(candidates[2])
-                except Exception as e:
-                    log.warning("Contextual format 2 at %s overflowed (%s)" % (str(self.location), e))
-                    candidates[2] = None
 
             if not ruleset.hasAnyGlyphClasses:
                 candidates[1] = [self.buildFormat1Subtable(ruleset, chaining)]
-                # Check we can build it
+
+            for i in [1, 2, 3]:
                 try:
-                    self.getCompiledSize_(candidates[1])
+                    self.getCompiledSize_(candidates[i])
                 except Exception as e:
-                    log.warning("Contextual format 1 at %s overflowed" % str(self.location))
-                    candidates[1] = None
+                    log.warning(
+                        "Contextual format %i at %s overflowed (%s)"
+                        % (i, str(self.location), e)
+                    )
+                    candidates[i] = None
 
             candidates = [x for x in candidates if x is not None]
             if not candidates:

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -377,6 +377,12 @@ class ChainContextualBuilder(LookupBuilder):
             candidates = [None, None, None, []]
             for rule in ruleset.rules:
                 candidates[3].append(self.buildFormat3Subtable(rule, chaining))
+            # Check we can build it
+            try:
+                self.getCompiledSize_(candidates[3])
+            except Exception as e:
+                log.warning("Contextual format 3 at %s overflowed" % str(self.location))
+                candidates[3] = None
 
             # Can we express the whole ruleset as a format 2 subtable?
             classdefs = ruleset.format2ClassDefs()
@@ -384,11 +390,26 @@ class ChainContextualBuilder(LookupBuilder):
                 candidates[2] = [
                     self.buildFormat2Subtable(ruleset, classdefs, chaining)
                 ]
+                # Check we can build it
+                try:
+                    self.getCompiledSize_(candidates[2])
+                except Exception as e:
+                    log.warning("Contextual format 2 at %s overflowed (%s)" % (str(self.location), e))
+                    candidates[2] = None
 
             if not ruleset.hasAnyGlyphClasses:
                 candidates[1] = [self.buildFormat1Subtable(ruleset, chaining)]
+                # Check we can build it
+                try:
+                    self.getCompiledSize_(candidates[1])
+                except Exception as e:
+                    log.warning("Contextual format 1 at %s overflowed" % str(self.location))
+                    candidates[1] = None
 
             candidates = [x for x in candidates if x is not None]
+            if not candidates:
+                raise OpenTypeLibError("All candidates overflowed", self.location)
+
             winner = min(candidates, key=self.getCompiledSize_)
             subtables.extend(winner)
 


### PR DESCRIPTION
The chained contextual builder tries building up to three subtable formats, and then returns the smallest. If one of these builds overflows, the whole thing crashes, even though another subtable would work fine. This mitigates the crash by emptying out subtable formats which do not build correctly.

The reason I could not catch a more specific exception is because the symptom of the build overflowing is obscure (See #2290):

```
'OTTableWriter' object has no attribute 'name'
```
