### PR TITLE
Fix overflow check (again)

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -389,14 +389,15 @@ class ChainContextualBuilder(LookupBuilder):
                 candidates[1] = [self.buildFormat1Subtable(ruleset, chaining)]
 
             for i in [1, 2, 3]:
-                try:
-                    self.getCompiledSize_(candidates[i])
-                except Exception as e:
-                    log.warning(
-                        "Contextual format %i at %s overflowed (%s)"
-                        % (i, str(self.location), e)
-                    )
-                    candidates[i] = None
+                if candidates[i]:
+                    try:
+                        self.getCompiledSize_(candidates[i])
+                    except Exception as e:
+                        log.warning(
+                            "Contextual format %i at %s overflowed (%s)"
+                            % (i, str(self.location), e)
+                        )
+                        candidates[i] = None
 
             candidates = [x for x in candidates if x is not None]
             if not candidates:


### PR DESCRIPTION
My fix to @anthrotype's review comment in #2404 was premature. If a lookup could not be expressed as a particular format, the value in the `candidates` array would be `None`. The overflow check would try building it *anyway*, leading to ridiculous warnings:

```
WARNING: Contextual format 1 at foo.fea:5:5 overflowed ('NoneType' object is not iterable)
```

This skips over non-existent subtables when doing the overflow check.