### PR TITLE
drop Python 3.6, require >= 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Set up Python pypy3
       uses: actions/setup-python@v2
       with:
-        python-version: "pypy3"
+        python-version: "pypy-3.7"
     - name: Install packages
       run: pip install tox
     - name: Run Tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,17 +27,17 @@ jobs:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         platform: [ubuntu-latest, macos-latest, windows-latest]
         exclude: # Only test on the oldest and latest supported stable Python on macOS and Windows.
           - platform: macos-latest
             python-version: 3.7
           - platform: macos-latest
-            python-version: 3.8
+            python-version: 3.9
           - platform: windows-latest
             python-version: 3.7
           - platform: windows-latest
-            python-version: 3.8
+            python-version: 3.9
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -18,14 +18,8 @@ are available at `Read the Docs <https://fonttools.readthedocs.io/>`_.
 Installation
 ~~~~~~~~~~~~
 
-FontTools 4.x requires `Python <http://www.python.org/download/>`__ 3.6
-or later. FontTools 3.x requires Python 2.7 or later.
-
-**NOTE** From August 2019, until no later than January 1 2020, the support
-for *Python 2.7* will be limited to only critical bug fixes, and no new features
-will be added to the ``py27`` branch. You can read more `here <https://python3statement.org>`__
-and `here <https://github.com/fonttools/fonttools/issues/765>`__ for the
-reasons behind this decision.
+FontTools requires `Python <http://www.python.org/download/>`__ 3.7
+or later.
 
 The package is listed in the Python Package Index (PyPI), so you can
 install it with `pip <https://pip.pypa.io>`__:

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -830,7 +830,6 @@ def test_updatePaths(tmpdir):
     assert s1.filename == name2
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason="pathlib is only tested on 3.6 and up")
 def test_read_with_path_object():
     import pathlib
     source = (pathlib.Path(__file__) / "../data/test.designspace").resolve()
@@ -839,7 +838,6 @@ def test_read_with_path_object():
     doc.read(source)
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason="pathlib is only tested on 3.6 and up")
 def test_with_with_path_object(tmpdir):
     import pathlib
     tmpdir = str(tmpdir)

--- a/Tests/t1Lib/t1Lib_test.py
+++ b/Tests/t1Lib/t1Lib_test.py
@@ -58,7 +58,6 @@ class ReadWriteTest(unittest.TestCase):
 		data = self.write(font, 'OTHER', dohex=True)
 		self.assertEqual(font.getData(), data)
 
-	@unittest.skipIf(sys.version_info[:2] < (3, 6), "pathlib is only tested on 3.6 and up")
 	def test_read_with_path(self):
 		import pathlib
 		font = t1Lib.T1Font(pathlib.Path(PFB))

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 files = Lib/fontTools/misc/plistlib
 follow_imports = silent
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -450,7 +450,7 @@ setup_params = dict(
 	url="http://github.com/fonttools/fonttools",
 	license="MIT",
 	platforms=["Any"],
-	python_requires=">=3.6",
+	python_requires=">=3.7",
 	long_description=long_description,
 	package_dir={'': 'Lib'},
 	packages=find_packages("Lib"),

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.0
-envlist = mypy, py3{6,7,8,9}-cov, htmlcov
+envlist = mypy, py3{7,8,9}-cov, htmlcov
 skip_missing_interpreters=true
 
 [testenv]


### PR DESCRIPTION
3.10 is out next week, while 3.6 reaches end of life by the end of this year.
It's time to require 3.7 or greater, so we can finally use built-in dataclasses and more.

Fixes https://github.com/fonttools/fonttools/issues/2350