### PR TITLE
Add Arm64 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,3 +89,25 @@ jobs:
       run: pip install tox
     - name: Run Tox
       run: tox -e pypy3-nolxml
+
+  arm64_job:
+    name: Build and Test for arm64
+    runs-on: ubuntu-20.04
+    steps:
+       - uses: actions/checkout@v2
+       - name: Set up QEMU
+         id: qemu
+         uses: docker/setup-qemu-action@v1
+       - name: Install and Run tests
+         run: |
+           docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+             arm64v8/ubuntu:20.04 \
+             bash -exc 'apt-get update && apt-get -y install python3 python3-pip python3-venv curl && \
+             python3 -m pip install virtualenv && python3 -m venv py38-venv && \
+             source py38-venv/bin/activate && \
+             pip install -r dev-requirements.txt && \
+             pip install -r requirements.txt && \
+             pip install tox coverage && \
+             tox -e py-cov && \
+             tox -e py-cov-nolxml && \
+             deactivate'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ scipy==1.5.4; platform_python_implementation != "PyPy"
 munkres==1.1.4; platform_python_implementation == "PyPy"
 zopfli==0.1.6
 fs==2.4.11
-skia-pathops==0.5.1.post1; platform_python_implementation != "PyPy"
+skia-pathops==0.7.1; platform_python_implementation != "PyPy"
 # this is only required to run Tests/cu2qu/{ufo,cli}_test.py
 ufoLib2==0.6.2
 pyobjc==6.2.2; sys_platform == "darwin"


### PR DESCRIPTION
Here is my PR description -

Added arm64 test support for **skia-pathops**, related to fonttools#48

The following files have been modified:

1. **Requirements.txt:** Updated the version of skia-pathops from `0.5.1.post1` to `0.7.1`
2.  **.github/workflows/test.yml:** Added Arm64 job with Python 3.8 for testing.