### PR TITLE
Traverse when there is no layer list

### DIFF
--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -38,6 +38,14 @@ def parseXML(xmlSnippet):
     return reader.root[2]
 
 
+def parseXmlInto(font, parseInto, xmlSnippet):
+    parsed_xml = [e for e in parseXML(xmlSnippet.strip()) if not isinstance(e, str)]
+    for name, attrs, content in parsed_xml:
+      parseInto.fromXML(name, attrs, content, font)
+    parseInto.populateDefaults()
+    return parseInto
+
+
 class FakeFont:
     def __init__(self, glyphs):
         self.glyphOrder_ = glyphs

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -1516,7 +1516,11 @@ class Paint(getFormatSwitchingBaseTableClass("uint8")):
 
 	def getChildren(self, colr):
 		if self.Format == PaintFormat.PaintColrLayers:
-			return colr.LayerList.Paint[
+			# https://github.com/fonttools/fonttools/issues/2438: don't die when no LayerList exists
+			layers = []
+			if colr.LayerList is not None:
+				layers = colr.LayerList.Paint
+			return layers[
 				self.FirstLayerIndex : self.FirstLayerIndex + self.NumLayers
 			]
 

--- a/Tests/ttLib/tables/otTables_test.py
+++ b/Tests/ttLib/tables/otTables_test.py
@@ -1,4 +1,4 @@
-from fontTools.misc.testTools import getXML, parseXML, FakeFont
+from fontTools.misc.testTools import getXML, parseXML, parseXmlInto, FakeFont
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.misc.xmlWriter import XMLWriter
 from fontTools.ttLib.tables.otBase import OTTableReader, OTTableWriter
@@ -685,6 +685,33 @@ def test_splitMarkBasePos():
         '  </BaseArray>',
         '</MarkBasePos>',
     ]
+
+
+class ColrV1Test(unittest.TestCase):
+  def setUp(self):
+    self.font = FakeFont(['.notdef', 'meh'])
+
+  def test_traverseEmptyPaintColrLayersNeedsNoLayerList(self):
+    colr = parseXmlInto(self.font, otTables.COLR(),
+      '''
+      <Version value="1"/>
+      <BaseGlyphList>
+        <BaseGlyphPaintRecord index="0">
+          <BaseGlyph value="meh"/>
+          <Paint Format="1"><!-- PaintColrLayers -->
+            <NumLayers value="0"/>
+            <FirstLayerIndex value="42"/>
+          </Paint>
+        </BaseGlyphPaintRecord>
+      </BaseGlyphList>
+      ''')
+    paint = colr.BaseGlyphList.BaseGlyphPaintRecord[0].Paint
+
+    # Just want to confirm we don't crash
+    visited = []
+    paint.traverse(colr, lambda p: visited.append(p))
+    assert len(visited) == 1
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #2438. Again :D In addition to unit test `pyftsubset --output-file=/tmp/reem.ttf --gids=0,128,210,211,218,225,227,232,234,235,237,238,241,244,246,250,251,254,261,264,270,271,277,280,282,284,286,289,295,297,299,307,308,316,317,318,320,327,331,343,345,347,348,349,350,351,357,365,370,371,374,376,378,392,393,398,399 ReemKufiInk-Regular.otf` now doesn't kerplode.
