### PR TITLE
[docs] Add interrogate configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,3 +52,10 @@ filterwarnings =
 	ignore:writePlist:DeprecationWarning:plistlib_test
 	ignore:some_function:DeprecationWarning:fontTools.ufoLib.utils
 	ignore::DeprecationWarning:fontTools.varLib.designspace
+
+[tool:interrogate]
+ignore-semiprivate = true
+ignore-private = true
+ignore-nested-functions = true
+ignore-regex = ^(from|to)XML$,^(de)?compile$
+ignore-module = true


### PR DESCRIPTION
[interrogate](https://interrogate.readthedocs.io/en/latest/) is a handy tool for checking documentation coverage. This configures interrogate with some project-specific defaults.