### PR TITLE
[docs] Split table docs into individual pages

### DIFF
--- a/Doc/source/ttLib/index.rst
+++ b/Doc/source/ttLib/index.rst
@@ -3,7 +3,7 @@ ttLib
 #####
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    macUtils
    sfnt

--- a/Doc/source/ttLib/tables.rst
+++ b/Doc/source/ttLib/tables.rst
@@ -190,11 +190,3 @@ ttProgram: TrueType bytecode assembler/disassembler
    :members:
    :undoc-members:
 
-TupleVariation
---------------
-
-.. automodule:: fontTools.ttLib.tables.TupleVariation
-   :inherited-members:
-   :members:
-   :undoc-members:
-

--- a/Doc/source/ttLib/tables.rst
+++ b/Doc/source/ttLib/tables.rst
@@ -107,7 +107,7 @@ additional methods::
 
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    tables/B_A_S_E_
    tables/C_B_D_T_

--- a/Doc/source/ttLib/tables.rst
+++ b/Doc/source/ttLib/tables.rst
@@ -174,7 +174,7 @@ additional methods::
    tables/S_V_G_
    tables/_t_r_a_k
    tables/T_T_F_A_
-   tables/V_D_M_X
+   tables/V_D_M_X_
    tables/_v_h_e_a
    tables/_v_m_t_x
    tables/V_O_R_G_

--- a/Doc/source/ttLib/tables.rst
+++ b/Doc/source/ttLib/tables.rst
@@ -99,307 +99,92 @@ additional methods::
 		# XXX
 
 
-
 .. automodule:: fontTools.ttLib.tables
    :inherited-members:
    :members:
    :undoc-members:
 
-_a_n_k_r
---------
 
-.. automodule:: fontTools.ttLib.tables._a_n_k_r
-   :inherited-members:
-   :members:
-   :undoc-members:
 
-``avar``: Axis Variations Table
--------------------------------
-
-.. automodule:: fontTools.ttLib.tables._a_v_a_r
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_b_s_l_n
---------
-
-.. automodule:: fontTools.ttLib.tables._b_s_l_n
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_c_i_d_g
---------
-
-.. automodule:: fontTools.ttLib.tables._c_i_d_g
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_c_m_a_p
---------
-
-.. automodule:: fontTools.ttLib.tables._c_m_a_p
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_c_v_a_r
---------
-
-.. automodule:: fontTools.ttLib.tables._c_v_a_r
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_c_v_t
-------
-
-.. automodule:: fontTools.ttLib.tables._c_v_t
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_f_e_a_t
---------
-
-.. automodule:: fontTools.ttLib.tables._f_e_a_t
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_f_p_g_m
---------
-
-.. automodule:: fontTools.ttLib.tables._f_p_g_m
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_f_v_a_r
---------
-
-.. automodule:: fontTools.ttLib.tables._f_v_a_r
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_g_a_s_p
---------
-
-.. automodule:: fontTools.ttLib.tables._g_a_s_p
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-
-_g_c_i_d
---------
-
-.. automodule:: fontTools.ttLib.tables._g_c_i_d
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_g_l_y_f
---------
-
-.. automodule:: fontTools.ttLib.tables._g_l_y_f
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_g_v_a_r
---------
-
-.. automodule:: fontTools.ttLib.tables._g_v_a_r
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_h_d_m_x
---------
-
-.. automodule:: fontTools.ttLib.tables._h_d_m_x
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_h_e_a_d
---------
-
-.. automodule:: fontTools.ttLib.tables._h_e_a_d
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_h_h_e_a
---------
-
-.. automodule:: fontTools.ttLib.tables._h_h_e_a
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_h_m_t_x
---------
-
-.. automodule:: fontTools.ttLib.tables._h_m_t_x
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_k_e_r_n
---------
-
-.. automodule:: fontTools.ttLib.tables._k_e_r_n
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_l_c_a_r
---------
-
-.. automodule:: fontTools.ttLib.tables._l_c_a_r
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_l_o_c_a
---------
-
-.. automodule:: fontTools.ttLib.tables._l_o_c_a
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_l_t_a_g
---------
-
-.. automodule:: fontTools.ttLib.tables._l_t_a_g
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_m_a_x_p
---------
-
-.. automodule:: fontTools.ttLib.tables._m_a_x_p
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_m_e_t_a
---------
-
-.. automodule:: fontTools.ttLib.tables._m_e_t_a
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_m_o_r_t
---------
-
-.. automodule:: fontTools.ttLib.tables._m_o_r_t
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-
-_m_o_r_x
---------
-
-.. automodule:: fontTools.ttLib.tables._m_o_r_x
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_n_a_m_e
---------
-
-.. automodule:: fontTools.ttLib.tables._n_a_m_e
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_o_p_b_d
---------
-
-.. automodule:: fontTools.ttLib.tables._o_p_b_d
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_p_o_s_t
---------
-
-.. automodule:: fontTools.ttLib.tables._p_o_s_t
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_p_r_e_p
---------
-
-.. automodule:: fontTools.ttLib.tables._p_r_e_p
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-
-_p_r_o_p
---------
-
-.. automodule:: fontTools.ttLib.tables._p_r_o_p
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_s_b_i_x
---------
-
-.. automodule:: fontTools.ttLib.tables._s_b_i_x
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_t_r_a_k
---------
-
-.. automodule:: fontTools.ttLib.tables._t_r_a_k
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_v_h_e_a
---------
-
-.. automodule:: fontTools.ttLib.tables._v_h_e_a
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-_v_m_t_x
---------
-
-.. automodule:: fontTools.ttLib.tables._v_m_t_x
-   :inherited-members:
-   :members:
-   :undoc-members:
+.. toctree::
+   :maxdepth: 2
+
+   tables/B_A_S_E_
+   tables/C_B_D_T_
+   tables/C_B_L_C_
+   tables/C_F_F_
+   tables/C_F_F__2
+   tables/C_O_L_R_
+   tables/_a_n_k_r
+   tables/_a_v_a_r
+   tables/_b_s_l_n
+   tables/_c_i_d_g
+   tables/_c_m_a_p
+   tables/_c_v_a_r
+   tables/_c_v_t
+   tables/_f_e_a_t
+   tables/_f_p_g_m
+   tables/_f_v_a_r
+   tables/_g_a_s_p
+   tables/_g_c_i_d
+   tables/_g_l_y_f
+   tables/_g_v_a_r
+   tables/_h_d_m_x
+   tables/_h_e_a_d
+   tables/_h_h_e_a
+   tables/_h_m_t_x
+   tables/_k_e_r_n
+   tables/_l_c_a_r
+   tables/_l_o_c_a
+   tables/_l_t_a_g
+   tables/_m_a_x_p
+   tables/_m_e_t_a
+   tables/_m_o_r_t
+   tables/_m_o_r_x
+   tables/_n_a_m_e
+   tables/_o_p_b_d
+   tables/_p_o_s_t
+   tables/_p_r_e_p
+   tables/_p_r_o_p
+   tables/_s_b_i_x
+   tables/_t_r_a_k
+   tables/_v_h_e_a
+   tables/_v_m_t_x
+   tables/C_P_A_L_
+   tables/D_S_I_G_
+   tables/E_B_D_T_
+   tables/E_B_L_C_
+   tables/F__e_a_t
+   tables/F_F_T_M_
+   tables/G__l_a_t
+   tables/G__l_o_c
+   tables/G_D_E_F_
+   tables/G_M_A_P_
+   tables/G_P_K_G_
+   tables/G_P_O_S_
+   tables/G_S_U_B_
+   tables/H_V_A_R_
+   tables/J_S_T_F_
+   tables/L_T_S_H_
+   tables/M_A_T_H_
+   tables/M_E_T_A_
+   tables/M_V_A_R_
+   tables/O_S_2f_2
+   tables/S__i_l_f
+   tables/S__i_l_l
+   tables/S_I_N_G_
+   tables/S_T_A_T_
+   tables/S_V_G_
+   tables/T_T_F_A_
+   tables/V_D_M_X
+   tables/V_O_R_G_
+   tables/VTT_related
+   tables/V_V_A_R_
 
 asciiTable
 ----------
 
 .. automodule:: fontTools.ttLib.tables.asciiTable
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-B_A_S_E_
---------
-
-.. automodule:: fontTools.ttLib.tables.B_A_S_E_
    :inherited-members:
    :members:
    :undoc-members:
@@ -412,61 +197,6 @@ BitmapGlyphMetrics
    :members:
    :undoc-members:
 
-C_B_D_T_
---------
-
-.. automodule:: fontTools.ttLib.tables.C_B_D_T_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-C_B_L_C_
---------
-
-.. automodule:: fontTools.ttLib.tables.C_B_L_C_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-C_F_F_
-------
-
-.. automodule:: fontTools.ttLib.tables.C_F_F_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-C_F_F__2
---------
-
-.. automodule:: fontTools.ttLib.tables.C_F_F__2
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-C_O_L_R_
---------
-
-.. automodule:: fontTools.ttLib.tables.C_O_L_R_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-C_P_A_L_
---------
-
-.. automodule:: fontTools.ttLib.tables.C_P_A_L_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-D_S_I_G_
---------
-
-.. automodule:: fontTools.ttLib.tables.D_S_I_G_
-   :inherited-members:
-   :members:
-   :undoc-members:
 
 DefaultTable
 ------------
@@ -476,95 +206,6 @@ DefaultTable
    :members:
    :undoc-members:
 
-E_B_D_T_
---------
-
-.. automodule:: fontTools.ttLib.tables.E_B_D_T_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-E_B_L_C_
---------
-
-.. automodule:: fontTools.ttLib.tables.E_B_L_C_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-F__e_a_t
---------
-
-.. automodule:: fontTools.ttLib.tables.F__e_a_t
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-
-F_F_T_M_
---------
-
-.. automodule:: fontTools.ttLib.tables.F_F_T_M_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-
-G__l_a_t
---------
-
-.. automodule:: fontTools.ttLib.tables.G__l_a_t
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-G__l_o_c
---------
-
-.. automodule:: fontTools.ttLib.tables.G__l_o_c
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-G_D_E_F_
---------
-
-.. automodule:: fontTools.ttLib.tables.G_D_E_F_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-G_M_A_P_
---------
-
-.. automodule:: fontTools.ttLib.tables.G_M_A_P_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-G_P_K_G_
---------
-
-.. automodule:: fontTools.ttLib.tables.G_P_K_G_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-G_P_O_S_
---------
-
-.. automodule:: fontTools.ttLib.tables.G_P_O_S_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-G_S_U_B_
---------
-
-.. automodule:: fontTools.ttLib.tables.G_S_U_B_
-   :inherited-members:
-   :members:
-   :undoc-members:
 
 grUtils
 -------
@@ -574,61 +215,6 @@ grUtils
    :members:
    :undoc-members:
 
-H_V_A_R_
---------
-
-.. automodule:: fontTools.ttLib.tables.H_V_A_R_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-J_S_T_F_
---------
-
-.. automodule:: fontTools.ttLib.tables.J_S_T_F_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-L_T_S_H_
---------
-
-.. automodule:: fontTools.ttLib.tables.L_T_S_H_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-M_A_T_H_
---------
-
-.. automodule:: fontTools.ttLib.tables.M_A_T_H_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-M_E_T_A_
---------
-
-.. automodule:: fontTools.ttLib.tables.M_E_T_A_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-M_V_A_R_
---------
-
-.. automodule:: fontTools.ttLib.tables.M_V_A_R_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-O_S_2f_2
---------
-
-.. automodule:: fontTools.ttLib.tables.O_S_2f_2
-   :inherited-members:
-   :members:
-   :undoc-members:
 
 otBase
 ------
@@ -662,165 +248,6 @@ otTables
    :members:
    :undoc-members:
 
-S__i_l_f
---------
-
-.. automodule:: fontTools.ttLib.tables.S__i_l_f
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-S__i_l_l
---------
-
-.. automodule:: fontTools.ttLib.tables.S__i_l_l
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-S_I_N_G_
---------
-
-.. automodule:: fontTools.ttLib.tables.S_I_N_G_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-S_T_A_T_
---------
-
-.. automodule:: fontTools.ttLib.tables.S_T_A_T_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-S_V_G_
-------
-
-.. automodule:: fontTools.ttLib.tables.S_V_G_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-sbixGlyph
----------
-
-.. automodule:: fontTools.ttLib.tables.sbixGlyph
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-sbixStrike
-----------
-
-.. automodule:: fontTools.ttLib.tables.sbixStrike
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I__0
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I__0
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I__1
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I__1
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I__2
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I__2
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I__3
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I__3
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I__5
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I__5
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I_B_
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I_B_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I_C_
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I_C_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I_D_
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I_D_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I_J_
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I_J_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I_P_
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I_P_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I_S_
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I_S_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_S_I_V_
---------
-
-.. automodule:: fontTools.ttLib.tables.T_S_I_V_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-T_T_F_A_
---------
-
-.. automodule:: fontTools.ttLib.tables.T_T_F_A_
-   :inherited-members:
-   :members:
-   :undoc-members:
 
 ttProgram
 ---------
@@ -837,29 +264,4 @@ TupleVariation
    :inherited-members:
    :members:
    :undoc-members:
-
-V_D_M_X_
---------
-
-.. automodule:: fontTools.ttLib.tables.V_D_M_X_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-V_O_R_G_
---------
-
-.. automodule:: fontTools.ttLib.tables.V_O_R_G_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-V_V_A_R_
---------
-
-.. automodule:: fontTools.ttLib.tables.V_V_A_R_
-   :inherited-members:
-   :members:
-   :undoc-members:
-
 

--- a/Doc/source/ttLib/tables.rst
+++ b/Doc/source/ttLib/tables.rst
@@ -109,74 +109,74 @@ additional methods::
 .. toctree::
    :maxdepth: 1
 
+   tables/_a_n_k_r
+   tables/_a_v_a_r
    tables/B_A_S_E_
+   tables/_b_s_l_n
    tables/C_B_D_T_
    tables/C_B_L_C_
    tables/C_F_F_
    tables/C_F_F__2
-   tables/C_O_L_R_
-   tables/_a_n_k_r
-   tables/_a_v_a_r
-   tables/_b_s_l_n
    tables/_c_i_d_g
    tables/_c_m_a_p
+   tables/C_O_L_R_
+   tables/C_P_A_L_
    tables/_c_v_a_r
    tables/_c_v_t
+   tables/D_S_I_G_
+   tables/E_B_D_T_
+   tables/E_B_L_C_
+   tables/F__e_a_t
    tables/_f_e_a_t
+   tables/F_F_T_M_
    tables/_f_p_g_m
    tables/_f_v_a_r
    tables/_g_a_s_p
    tables/_g_c_i_d
+   tables/G_D_E_F_
+   tables/G__l_a_t
+   tables/G__l_o_c
    tables/_g_l_y_f
+   tables/G_M_A_P_
+   tables/G_P_K_G_
+   tables/G_P_O_S_
+   tables/G_S_U_B_
    tables/_g_v_a_r
    tables/_h_d_m_x
    tables/_h_e_a_d
    tables/_h_h_e_a
    tables/_h_m_t_x
+   tables/H_V_A_R_
+   tables/J_S_T_F_
    tables/_k_e_r_n
    tables/_l_c_a_r
    tables/_l_o_c_a
    tables/_l_t_a_g
+   tables/L_T_S_H_
+   tables/M_A_T_H_
    tables/_m_a_x_p
+   tables/M_E_T_A_
    tables/_m_e_t_a
    tables/_m_o_r_t
    tables/_m_o_r_x
+   tables/M_V_A_R_
    tables/_n_a_m_e
    tables/_o_p_b_d
+   tables/O_S_2f_2
    tables/_p_o_s_t
    tables/_p_r_e_p
    tables/_p_r_o_p
    tables/_s_b_i_x
-   tables/_t_r_a_k
-   tables/_v_h_e_a
-   tables/_v_m_t_x
-   tables/C_P_A_L_
-   tables/D_S_I_G_
-   tables/E_B_D_T_
-   tables/E_B_L_C_
-   tables/F__e_a_t
-   tables/F_F_T_M_
-   tables/G__l_a_t
-   tables/G__l_o_c
-   tables/G_D_E_F_
-   tables/G_M_A_P_
-   tables/G_P_K_G_
-   tables/G_P_O_S_
-   tables/G_S_U_B_
-   tables/H_V_A_R_
-   tables/J_S_T_F_
-   tables/L_T_S_H_
-   tables/M_A_T_H_
-   tables/M_E_T_A_
-   tables/M_V_A_R_
-   tables/O_S_2f_2
    tables/S__i_l_f
    tables/S__i_l_l
    tables/S_I_N_G_
    tables/S_T_A_T_
    tables/S_V_G_
+   tables/_t_r_a_k
    tables/T_T_F_A_
    tables/V_D_M_X
+   tables/_v_h_e_a
+   tables/_v_m_t_x
    tables/V_O_R_G_
    tables/VTT_related
    tables/V_V_A_R_

--- a/Doc/source/ttLib/tables.rst
+++ b/Doc/source/ttLib/tables.rst
@@ -181,58 +181,9 @@ additional methods::
    tables/VTT_related
    tables/V_V_A_R_
 
-asciiTable
-----------
 
-.. automodule:: fontTools.ttLib.tables.asciiTable
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-
-DefaultTable
-------------
-
-.. automodule:: fontTools.ttLib.tables.DefaultTable
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-otBase
-------
-
-.. automodule:: fontTools.ttLib.tables.otBase
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-otConverters
-------------
-
-.. automodule:: fontTools.ttLib.tables.otConverters
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-otData
-------
-
-.. automodule:: fontTools.ttLib.tables.otData
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-otTables
---------
-
-.. automodule:: fontTools.ttLib.tables.otTables
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-
-ttProgram
----------
+ttProgram: TrueType bytecode assembler/disassembler
+---------------------------------------------------
 
 .. automodule:: fontTools.ttLib.tables.ttProgram
    :inherited-members:

--- a/Doc/source/ttLib/tables.rst
+++ b/Doc/source/ttLib/tables.rst
@@ -1,110 +1,13 @@
-######
-tables
-######
+###############################
+TrueType/OpenType Table Modules
+###############################
 
 This folder is a subpackage of :py:mod:`fontTools.ttLib`. Each module here is a
 specialized TT/OT table converter: they can convert raw data
 to Python objects and vice versa. Usually you don't need to
 use the modules directly: they are imported and used
-automatically when needed by :py:mod:`fontTools.ttLib`.
-
-If you are writing you own table converter the following is
-important.
-
-The modules here have pretty strange names: this is due to the
-fact that we need to map TT table tags (which are case sensitive)
-to filenames (which on Mac and Win aren't case sensitive) as well
-as to Python identifiers. The latter means it can only contain
-[A-Za-z0-9_] and cannot start with a number.
-
-:py:mod:`fontTools.ttLib` provides functions to expand a tag into the format used here::
-
-    >>> from fontTools import ttLib
-    >>> ttLib.tagToIdentifier("FOO ")
-    'F_O_O_'
-    >>> ttLib.tagToIdentifier("cvt ")
-    '_c_v_t'
-    >>> ttLib.tagToIdentifier("OS/2")
-    'O_S_2f_2'
-    >>> ttLib.tagToIdentifier("glyf")
-    '_g_l_y_f'
-    >>>
-
-And vice versa::
-
-    >>> ttLib.identifierToTag("F_O_O_")
-    'FOO '
-    >>> ttLib.identifierToTag("_c_v_t")
-    'cvt '
-    >>> ttLib.identifierToTag("O_S_2f_2")
-    'OS/2'
-    >>> ttLib.identifierToTag("_g_l_y_f")
-    'glyf'
-    >>>
-
-Eg. the 'glyf' table converter lives in a Python file called::
-
-	_g_l_y_f.py
-
-The converter itself is a class, named "table_" + expandedtag. Eg::
-
-
-	class table__g_l_y_f:
-		etc.
-
-
-Note that if you _do_ need to use such modules or classes manually,
-there are two convenient API functions that let you find them by tag::
-
-    >>> ttLib.getTableModule('glyf')
-    <module 'ttLib.tables._g_l_y_f'>
-    >>> ttLib.getTableClass('glyf')
-    <class ttLib.tables._g_l_y_f.table__g_l_y_f at 645f400>
-    >>
-
-You must subclass from :py:mod:`fontTools.ttLib.tables.DefaultTable.DefaultTable`. It provides some default
-behavior, as well as a constructor method (__init__) that you don't need to
-override.
-
-Your converter should minimally provide two methods::
-
-
-    class table_F_O_O_(DefaultTable.DefaultTable): # converter for table 'FOO '
-
-        def decompile(self, data, ttFont):
-            # 'data' is the raw table data. Unpack it into a
-            # Python data structure.
-            # 'ttFont' is a ttLib.TTfile instance, enabling you to
-            # refer to other tables. Do ***not*** keep a reference to
-            # it: it will cause a circular reference (ttFont saves
-            # a reference to us), and that means we'll be leaking
-            # memory. If you need to use it in other methods, just
-            # pass it around as a method argument.
-
-        def compile(self, ttFont):
-            # Return the raw data, as converted from the Python
-            # data structure.
-            # Again, 'ttFont' is there so you can access other tables.
-            # Same warning applies.
-
-
-If you want to support TTX import/export as well, you need to provide two
-additional methods::
-
-
-	def toXML(self, writer, ttFont):
-		# XXX
-
-	def fromXML(self, (name, attrs, content), ttFont):
-		# XXX
-
-
-.. automodule:: fontTools.ttLib.tables
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-
+automatically when needed by :py:mod:`fontTools.ttLib`. The tables currently
+supported are:
 
 .. toctree::
    :maxdepth: 1
@@ -181,6 +84,55 @@ additional methods::
    tables/VTT_related
    tables/V_V_A_R_
 
+The Python modules representing the tables have pretty strange names: this is due to the
+fact that we need to map TT table tags (which are case sensitive)
+to filenames (which on Mac and Win aren't case sensitive) as well
+as to Python identifiers. The latter means it can only contain
+``[A-Za-z0-9_]`` and cannot start with a number.
+
+:py:mod:`fontTools.ttLib` provides functions to expand a tag into the format used here::
+
+    >>> from fontTools import ttLib
+    >>> ttLib.tagToIdentifier("FOO ")
+    'F_O_O_'
+    >>> ttLib.tagToIdentifier("cvt ")
+    '_c_v_t'
+    >>> ttLib.tagToIdentifier("OS/2")
+    'O_S_2f_2'
+    >>> ttLib.tagToIdentifier("glyf")
+    '_g_l_y_f'
+    >>>
+
+And vice versa::
+
+    >>> ttLib.identifierToTag("F_O_O_")
+    'FOO '
+    >>> ttLib.identifierToTag("_c_v_t")
+    'cvt '
+    >>> ttLib.identifierToTag("O_S_2f_2")
+    'OS/2'
+    >>> ttLib.identifierToTag("_g_l_y_f")
+    'glyf'
+    >>>
+
+Eg. the 'glyf' table converter lives in a Python file called::
+
+	_g_l_y_f.py
+
+The converter itself is a class, named ``table_`` + expandedtag. Eg::
+
+
+	class table__g_l_y_f:
+		etc.
+
+Note that if you _do_ need to use such modules or classes manually,
+there are two convenient API functions that let you find them by tag::
+
+    >>> ttLib.getTableModule('glyf')
+    <module 'ttLib.tables._g_l_y_f'>
+    >>> ttLib.getTableClass('glyf')
+    <class ttLib.tables._g_l_y_f.table__g_l_y_f at 645f400>
+    >>
 
 ttProgram: TrueType bytecode assembler/disassembler
 ---------------------------------------------------
@@ -189,4 +141,50 @@ ttProgram: TrueType bytecode assembler/disassembler
    :inherited-members:
    :members:
    :undoc-members:
+
+Contributing your own table convertors
+--------------------------------------
+
+To add support for a new font table that fontTools does not currently implement,
+you must subclass from :py:mod:`fontTools.ttLib.tables.DefaultTable.DefaultTable`.
+It provides some default behavior, as well as a constructor method (``__init__``)
+that you don't need to override.
+
+Your converter should minimally provide two methods::
+
+
+    class table_F_O_O_(DefaultTable.DefaultTable): # converter for table 'FOO '
+
+        def decompile(self, data, ttFont):
+            # 'data' is the raw table data. Unpack it into a
+            # Python data structure.
+            # 'ttFont' is a ttLib.TTfile instance, enabling you to
+            # refer to other tables. Do ***not*** keep a reference to
+            # it: it will cause a circular reference (ttFont saves
+            # a reference to us), and that means we'll be leaking
+            # memory. If you need to use it in other methods, just
+            # pass it around as a method argument.
+
+        def compile(self, ttFont):
+            # Return the raw data, as converted from the Python
+            # data structure.
+            # Again, 'ttFont' is there so you can access other tables.
+            # Same warning applies.
+
+
+If you want to support TTX import/export as well, you need to provide two
+additional methods::
+
+
+   def toXML(self, writer, ttFont):
+      # XXX
+
+   def fromXML(self, (name, attrs, content), ttFont):
+      # XXX
+
+.. automodule:: fontTools.ttLib.tables
+   :inherited-members:
+   :members:
+   :undoc-members:
+
 

--- a/Doc/source/ttLib/tables.rst
+++ b/Doc/source/ttLib/tables.rst
@@ -113,8 +113,8 @@ _a_n_k_r
    :members:
    :undoc-members:
 
-_a_v_a_r
---------
+``avar``: Axis Variations Table
+-------------------------------
 
 .. automodule:: fontTools.ttLib.tables._a_v_a_r
    :inherited-members:

--- a/Doc/source/ttLib/tables.rst
+++ b/Doc/source/ttLib/tables.rst
@@ -189,14 +189,6 @@ asciiTable
    :members:
    :undoc-members:
 
-BitmapGlyphMetrics
-------------------
-
-.. automodule:: fontTools.ttLib.tables.BitmapGlyphMetrics
-   :inherited-members:
-   :members:
-   :undoc-members:
-
 
 DefaultTable
 ------------

--- a/Doc/source/ttLib/tables.rst
+++ b/Doc/source/ttLib/tables.rst
@@ -198,16 +198,6 @@ DefaultTable
    :members:
    :undoc-members:
 
-
-grUtils
--------
-
-.. automodule:: fontTools.ttLib.tables.grUtils
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-
 otBase
 ------
 

--- a/Doc/source/ttLib/tables/B_A_S_E_.rst
+++ b/Doc/source/ttLib/tables/B_A_S_E_.rst
@@ -1,0 +1,8 @@
+``BASE``: Baseline Table
+------------------------
+
+.. automodule:: fontTools.ttLib.tables.B_A_S_E_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/C_B_D_T_.rst
+++ b/Doc/source/ttLib/tables/C_B_D_T_.rst
@@ -1,0 +1,8 @@
+``CBDT``: Color Bitmap Data Table
+---------------------------------
+
+.. automodule:: fontTools.ttLib.tables.C_B_D_T_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/C_B_L_C_.rst
+++ b/Doc/source/ttLib/tables/C_B_L_C_.rst
@@ -1,0 +1,8 @@
+``CBLC``: Color Bitmap Location Table
+-------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.C_B_L_C_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/C_F_F_.rst
+++ b/Doc/source/ttLib/tables/C_F_F_.rst
@@ -1,0 +1,8 @@
+``CFF``: Compact Font Format Table
+----------------------------------
+
+.. automodule:: fontTools.ttLib.tables.C_F_F_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/C_F_F__2.rst
+++ b/Doc/source/ttLib/tables/C_F_F__2.rst
@@ -1,0 +1,8 @@
+``CFF2``: Compact Font Format (CFF) Version 2
+---------------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.C_F_F__2
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/C_O_L_R_.rst
+++ b/Doc/source/ttLib/tables/C_O_L_R_.rst
@@ -1,0 +1,7 @@
+``COLR``: Color Table
+---------------------
+
+.. automodule:: fontTools.ttLib.tables.C_O_L_R_
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/C_P_A_L_.rst
+++ b/Doc/source/ttLib/tables/C_P_A_L_.rst
@@ -1,0 +1,8 @@
+``CPAL``: Color Palette Table
+-----------------------------
+
+.. automodule:: fontTools.ttLib.tables.C_P_A_L_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/D_S_I_G_.rst
+++ b/Doc/source/ttLib/tables/D_S_I_G_.rst
@@ -1,0 +1,8 @@
+``DSIG``: Digital Signature Table
+---------------------------------
+
+.. automodule:: fontTools.ttLib.tables.D_S_I_G_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/E_B_D_T_.rst
+++ b/Doc/source/ttLib/tables/E_B_D_T_.rst
@@ -8,7 +8,7 @@
 
 
 BitmapGlyphMetrics
-------------------
+^^^^^^^^^^^^^^^^^^
 
 .. automodule:: fontTools.ttLib.tables.BitmapGlyphMetrics
    :inherited-members:

--- a/Doc/source/ttLib/tables/E_B_D_T_.rst
+++ b/Doc/source/ttLib/tables/E_B_D_T_.rst
@@ -6,3 +6,12 @@
    :members:
    :undoc-members:
 
+
+BitmapGlyphMetrics
+------------------
+
+.. automodule:: fontTools.ttLib.tables.BitmapGlyphMetrics
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/E_B_D_T_.rst
+++ b/Doc/source/ttLib/tables/E_B_D_T_.rst
@@ -1,0 +1,8 @@
+``EBDT``: Embedded Bitmap Data Table
+------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.E_B_D_T_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/E_B_L_C_.rst
+++ b/Doc/source/ttLib/tables/E_B_L_C_.rst
@@ -8,7 +8,7 @@
 
 
 BitmapGlyphMetrics
-------------------
+^^^^^^^^^^^^^^^^^^
 
 .. automodule:: fontTools.ttLib.tables.BitmapGlyphMetrics
    :inherited-members:

--- a/Doc/source/ttLib/tables/E_B_L_C_.rst
+++ b/Doc/source/ttLib/tables/E_B_L_C_.rst
@@ -6,3 +6,12 @@
    :members:
    :undoc-members:
 
+
+BitmapGlyphMetrics
+------------------
+
+.. automodule:: fontTools.ttLib.tables.BitmapGlyphMetrics
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/E_B_L_C_.rst
+++ b/Doc/source/ttLib/tables/E_B_L_C_.rst
@@ -1,0 +1,8 @@
+``EBLC``: Embedded Bitmap Location Table
+----------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.E_B_L_C_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/F_F_T_M_.rst
+++ b/Doc/source/ttLib/tables/F_F_T_M_.rst
@@ -1,0 +1,9 @@
+``FFTM``: FontForge Time Stamp Table
+------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.F_F_T_M_
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+

--- a/Doc/source/ttLib/tables/F__e_a_t.rst
+++ b/Doc/source/ttLib/tables/F__e_a_t.rst
@@ -1,0 +1,9 @@
+``Feat``: Graphite Feature Table
+--------------------------------
+
+.. automodule:: fontTools.ttLib.tables.F__e_a_t
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+

--- a/Doc/source/ttLib/tables/G_D_E_F_.rst
+++ b/Doc/source/ttLib/tables/G_D_E_F_.rst
@@ -1,0 +1,8 @@
+``GDEF``: Glyph Definition Table
+--------------------------------
+
+.. automodule:: fontTools.ttLib.tables.G_D_E_F_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/G_M_A_P_.rst
+++ b/Doc/source/ttLib/tables/G_M_A_P_.rst
@@ -1,0 +1,8 @@
+``GMAP``: SING Glyphlet Summary Table
+-------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.G_M_A_P_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/G_P_K_G_.rst
+++ b/Doc/source/ttLib/tables/G_P_K_G_.rst
@@ -1,0 +1,8 @@
+``GPKG``: SING Glyphlet Wrapper Table
+-------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.G_P_K_G_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/G_P_O_S_.rst
+++ b/Doc/source/ttLib/tables/G_P_O_S_.rst
@@ -1,0 +1,8 @@
+``GPOS``: Glyph Positioning Table
+---------------------------------
+
+.. automodule:: fontTools.ttLib.tables.G_P_O_S_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/G_S_U_B_.rst
+++ b/Doc/source/ttLib/tables/G_S_U_B_.rst
@@ -1,0 +1,8 @@
+``GSUB``: Glyph Substitution Table
+----------------------------------
+
+.. automodule:: fontTools.ttLib.tables.G_S_U_B_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/G__l_a_t.rst
+++ b/Doc/source/ttLib/tables/G__l_a_t.rst
@@ -1,0 +1,8 @@
+``Glat``: Graphite Glyph Attributes Table
+-----------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.G__l_a_t
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/G__l_o_c.rst
+++ b/Doc/source/ttLib/tables/G__l_o_c.rst
@@ -1,0 +1,8 @@
+``Gloc``: Graphite index to glyph attributes table
+--------------------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.G__l_o_c
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/H_V_A_R_.rst
+++ b/Doc/source/ttLib/tables/H_V_A_R_.rst
@@ -1,0 +1,7 @@
+``HVAR``:Horizontal Metrics Variations Table
+--------------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.H_V_A_R_
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/J_S_T_F_.rst
+++ b/Doc/source/ttLib/tables/J_S_T_F_.rst
@@ -1,0 +1,7 @@
+``JSTF``: Justification Table
+-----------------------------
+
+.. automodule:: fontTools.ttLib.tables.J_S_T_F_
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/L_T_S_H_.rst
+++ b/Doc/source/ttLib/tables/L_T_S_H_.rst
@@ -1,0 +1,8 @@
+``LTSH``: Linear Threshold
+--------------------------
+
+.. automodule:: fontTools.ttLib.tables.L_T_S_H_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/M_A_T_H_.rst
+++ b/Doc/source/ttLib/tables/M_A_T_H_.rst
@@ -1,0 +1,7 @@
+``MATH``: Mathematical Typesetting Table
+----------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.M_A_T_H_
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/M_E_T_A_.rst
+++ b/Doc/source/ttLib/tables/M_E_T_A_.rst
@@ -1,0 +1,7 @@
+``META``: SING Glyphlet Metadata Table
+--------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.M_E_T_A_
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/M_V_A_R_.rst
+++ b/Doc/source/ttLib/tables/M_V_A_R_.rst
@@ -1,0 +1,7 @@
+``MVAR``: Metrics Variations Table
+----------------------------------
+
+.. automodule:: fontTools.ttLib.tables.M_V_A_R_
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/O_S_2f_2.rst
+++ b/Doc/source/ttLib/tables/O_S_2f_2.rst
@@ -1,0 +1,7 @@
+``OS/2``: OS/2 and Windows Metrics Table
+----------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.O_S_2f_2
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/S_I_N_G_.rst
+++ b/Doc/source/ttLib/tables/S_I_N_G_.rst
@@ -1,0 +1,7 @@
+``SING``: SING Glyphlet Basic Information Table
+-----------------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.S_I_N_G_
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/S_T_A_T_.rst
+++ b/Doc/source/ttLib/tables/S_T_A_T_.rst
@@ -1,0 +1,7 @@
+``STAT``: Style Attributes Table
+--------------------------------
+
+.. automodule:: fontTools.ttLib.tables.S_T_A_T_
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/S_V_G_.rst
+++ b/Doc/source/ttLib/tables/S_V_G_.rst
@@ -1,0 +1,8 @@
+``SVG``: SVG (Scalable Vector Graphics) Table
+---------------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.S_V_G_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/S__i_l_f.rst
+++ b/Doc/source/ttLib/tables/S__i_l_f.rst
@@ -1,0 +1,7 @@
+``Silf``: Graphite Rules Table
+------------------------------
+
+.. automodule:: fontTools.ttLib.tables.S__i_l_f
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/S__i_l_l.rst
+++ b/Doc/source/ttLib/tables/S__i_l_l.rst
@@ -1,0 +1,7 @@
+``Sill``: Graphite Languages Table
+----------------------------------
+
+.. automodule:: fontTools.ttLib.tables.S__i_l_l
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/T_T_F_A_.rst
+++ b/Doc/source/ttLib/tables/T_T_F_A_.rst
@@ -1,0 +1,8 @@
+``TTFA``: ``ttfautohint`` Parameter Table
+-----------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.T_T_F_A_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/VTT_related.rst
+++ b/Doc/source/ttLib/tables/VTT_related.rst
@@ -1,0 +1,99 @@
+Visual TrueType Private Tables
+==============================
+
+``TSI0``: Glyph Program Text Indices
+------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I__0
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+``TSI1``: Glyph Program Text UTF-8 Text Dump
+--------------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I__1
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+``TSI2``: VTT Talk Text Indices
+-------------------------------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I__2
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+``TSI3``: VTT Talk UTF-8 Text Dump
+----------------------------------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I__3
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+``TSI5``: VTT Character Group Flag
+----------------------------------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I__5
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+``TSIB``
+--------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I_B_
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+``TSIC``: VTT Variation CVT Window Source
+-----------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I_C_
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+``TSID``: VTT GDEF Table Text Source
+------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I_D_
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+``TSIJ``: VTT JSTF Table Text Source
+------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I_J_
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+``TSIP``: VTT GPOS Table Text Source
+------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I_P_
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+``TSIS``: VTT GSUB Table Text Source
+------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I_S_
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+``TSIV``
+--------
+
+.. automodule:: fontTools.ttLib.tables.T_S_I_V_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/V_D_M_X_.rst
+++ b/Doc/source/ttLib/tables/V_D_M_X_.rst
@@ -1,0 +1,7 @@
+``VDMX``: Vertical Device Metrics
+---------------------------------
+
+.. automodule:: fontTools.ttLib.tables.V_D_M_X_
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/V_O_R_G_.rst
+++ b/Doc/source/ttLib/tables/V_O_R_G_.rst
@@ -1,0 +1,8 @@
+``VORG``: Vertical Origin Table
+-------------------------------
+
+.. automodule:: fontTools.ttLib.tables.V_O_R_G_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/V_V_A_R_.rst
+++ b/Doc/source/ttLib/tables/V_V_A_R_.rst
@@ -1,0 +1,8 @@
+``VVAR``: Vertical Metrics Variations Table
+-------------------------------------------
+
+.. automodule:: fontTools.ttLib.tables.V_V_A_R_
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_a_n_k_r.rst
+++ b/Doc/source/ttLib/tables/_a_n_k_r.rst
@@ -1,0 +1,7 @@
+``ankr``: Anchor Point Table
+----------------------------
+
+.. automodule:: fontTools.ttLib.tables._a_n_k_r
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/_a_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_a_v_a_r.rst
@@ -1,0 +1,8 @@
+``avar``: Axis Variations Table
+-------------------------------
+
+.. automodule:: fontTools.ttLib.tables._a_v_a_r
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_b_s_l_n.rst
+++ b/Doc/source/ttLib/tables/_b_s_l_n.rst
@@ -1,0 +1,7 @@
+``bsln``: Baseline
+------------------
+
+.. automodule:: fontTools.ttLib.tables._b_s_l_n
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/_c_i_d_g.rst
+++ b/Doc/source/ttLib/tables/_c_i_d_g.rst
@@ -1,0 +1,7 @@
+``cidg``: CID to Glyph ID table
+-------------------------------
+
+.. automodule:: fontTools.ttLib.tables._c_i_d_g
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/_c_m_a_p.rst
+++ b/Doc/source/ttLib/tables/_c_m_a_p.rst
@@ -1,0 +1,7 @@
+``cmap``: Character to Glyph Index Mapping Table
+------------------------------------------------
+
+.. automodule:: fontTools.ttLib.tables._c_m_a_p
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/_c_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_c_v_a_r.rst
@@ -8,7 +8,7 @@
 
 
 TupleVariation
---------------
+^^^^^^^^^^^^^^
 
 .. automodule:: fontTools.ttLib.tables.TupleVariation
    :inherited-members:

--- a/Doc/source/ttLib/tables/_c_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_c_v_a_r.rst
@@ -1,0 +1,7 @@
+``cvar``: CVT Variations Table
+------------------------------
+
+.. automodule:: fontTools.ttLib.tables._c_v_a_r
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/_c_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_c_v_a_r.rst
@@ -5,3 +5,12 @@
    :inherited-members:
    :members:
    :undoc-members:
+
+
+TupleVariation
+--------------
+
+.. automodule:: fontTools.ttLib.tables.TupleVariation
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/_c_v_t.rst
+++ b/Doc/source/ttLib/tables/_c_v_t.rst
@@ -1,0 +1,8 @@
+``cvt``:  Control Value Table
+-----------------------------
+
+.. automodule:: fontTools.ttLib.tables._c_v_t
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_f_e_a_t.rst
+++ b/Doc/source/ttLib/tables/_f_e_a_t.rst
@@ -1,0 +1,7 @@
+``feat``: Feature name table
+----------------------------
+
+.. automodule:: fontTools.ttLib.tables._f_e_a_t
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/_f_p_g_m.rst
+++ b/Doc/source/ttLib/tables/_f_p_g_m.rst
@@ -1,0 +1,7 @@
+``fpgm``: Font Program
+----------------------
+
+.. automodule:: fontTools.ttLib.tables._f_p_g_m
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/_f_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_f_v_a_r.rst
@@ -1,0 +1,8 @@
+``fvar``: Font Variations Table
+-------------------------------
+
+.. automodule:: fontTools.ttLib.tables._f_v_a_r
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_g_a_s_p.rst
+++ b/Doc/source/ttLib/tables/_g_a_s_p.rst
@@ -1,0 +1,8 @@
+``gasp``: Grid-fitting and Scan-conversion Procedure Table
+----------------------------------------------------------
+
+.. automodule:: fontTools.ttLib.tables._g_a_s_p
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_g_c_i_d.rst
+++ b/Doc/source/ttLib/tables/_g_c_i_d.rst
@@ -1,0 +1,7 @@
+``gcid``: Glyph ID to CID table
+-------------------------------
+
+.. automodule:: fontTools.ttLib.tables._g_c_i_d
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/_g_l_y_f.rst
+++ b/Doc/source/ttLib/tables/_g_l_y_f.rst
@@ -1,0 +1,8 @@
+``glyf``: Glyph Data
+--------------------
+
+.. automodule:: fontTools.ttLib.tables._g_l_y_f
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_g_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_g_v_a_r.rst
@@ -1,0 +1,8 @@
+``gvar``:  Glyph Variations Table
+---------------------------------
+
+.. automodule:: fontTools.ttLib.tables._g_v_a_r
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_g_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_g_v_a_r.rst
@@ -8,7 +8,7 @@
 
 
 TupleVariation
---------------
+^^^^^^^^^^^^^^
 
 .. automodule:: fontTools.ttLib.tables.TupleVariation
    :inherited-members:

--- a/Doc/source/ttLib/tables/_g_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_g_v_a_r.rst
@@ -6,3 +6,11 @@
    :members:
    :undoc-members:
 
+
+TupleVariation
+--------------
+
+.. automodule:: fontTools.ttLib.tables.TupleVariation
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/_h_d_m_x.rst
+++ b/Doc/source/ttLib/tables/_h_d_m_x.rst
@@ -1,0 +1,8 @@
+``hdmx``: Horizontal Device Metrics
+-----------------------------------
+
+.. automodule:: fontTools.ttLib.tables._h_d_m_x
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_h_e_a_d.rst
+++ b/Doc/source/ttLib/tables/_h_e_a_d.rst
@@ -1,0 +1,8 @@
+``head``: Font Header Table
+---------------------------
+
+.. automodule:: fontTools.ttLib.tables._h_e_a_d
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_h_h_e_a.rst
+++ b/Doc/source/ttLib/tables/_h_h_e_a.rst
@@ -1,0 +1,8 @@
+``hhea``: Horizontal Header Table
+---------------------------------
+
+.. automodule:: fontTools.ttLib.tables._h_h_e_a
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_h_m_t_x.rst
+++ b/Doc/source/ttLib/tables/_h_m_t_x.rst
@@ -1,0 +1,8 @@
+``hmtx``: Horizontal Metrics Table
+----------------------------------
+
+.. automodule:: fontTools.ttLib.tables._h_m_t_x
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_k_e_r_n.rst
+++ b/Doc/source/ttLib/tables/_k_e_r_n.rst
@@ -1,0 +1,8 @@
+``kern``: Kerning
+-----------------
+
+.. automodule:: fontTools.ttLib.tables._k_e_r_n
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_l_c_a_r.rst
+++ b/Doc/source/ttLib/tables/_l_c_a_r.rst
@@ -1,0 +1,8 @@
+``lcar``: Ligature Caret Table
+------------------------------
+
+.. automodule:: fontTools.ttLib.tables._l_c_a_r
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_l_o_c_a.rst
+++ b/Doc/source/ttLib/tables/_l_o_c_a.rst
@@ -1,0 +1,8 @@
+``loca``: Index to Location
+---------------------------
+
+.. automodule:: fontTools.ttLib.tables._l_o_c_a
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_l_t_a_g.rst
+++ b/Doc/source/ttLib/tables/_l_t_a_g.rst
@@ -1,0 +1,8 @@
+``ltag``: Language Tag
+----------------------
+
+.. automodule:: fontTools.ttLib.tables._l_t_a_g
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_m_a_x_p.rst
+++ b/Doc/source/ttLib/tables/_m_a_x_p.rst
@@ -1,0 +1,8 @@
+``maxp``: Maximum Profile
+-------------------------
+
+.. automodule:: fontTools.ttLib.tables._m_a_x_p
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_m_e_t_a.rst
+++ b/Doc/source/ttLib/tables/_m_e_t_a.rst
@@ -1,0 +1,8 @@
+``meta``: Metadata Table
+------------------------
+
+.. automodule:: fontTools.ttLib.tables._m_e_t_a
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_m_o_r_t.rst
+++ b/Doc/source/ttLib/tables/_m_o_r_t.rst
@@ -1,0 +1,9 @@
+``mort``: Glyph Metamorphosis Table
+-----------------------------------
+
+.. automodule:: fontTools.ttLib.tables._m_o_r_t
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+

--- a/Doc/source/ttLib/tables/_m_o_r_x.rst
+++ b/Doc/source/ttLib/tables/_m_o_r_x.rst
@@ -1,0 +1,8 @@
+``morx``: Extended Glyph Metamorphosis Table
+--------------------------------------------
+
+.. automodule:: fontTools.ttLib.tables._m_o_r_x
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_n_a_m_e.rst
+++ b/Doc/source/ttLib/tables/_n_a_m_e.rst
@@ -1,0 +1,8 @@
+``name``: Naming Table
+----------------------
+
+.. automodule:: fontTools.ttLib.tables._n_a_m_e
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_o_p_b_d.rst
+++ b/Doc/source/ttLib/tables/_o_p_b_d.rst
@@ -1,0 +1,8 @@
+``opbd``: Optical Bounds Table
+------------------------------
+
+.. automodule:: fontTools.ttLib.tables._o_p_b_d
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_p_o_s_t.rst
+++ b/Doc/source/ttLib/tables/_p_o_s_t.rst
@@ -1,0 +1,8 @@
+``post``: PostScript Table
+--------------------------
+
+.. automodule:: fontTools.ttLib.tables._p_o_s_t
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_p_r_e_p.rst
+++ b/Doc/source/ttLib/tables/_p_r_e_p.rst
@@ -1,0 +1,9 @@
+``prep``: Control Value Program
+-------------------------------
+
+.. automodule:: fontTools.ttLib.tables._p_r_e_p
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+

--- a/Doc/source/ttLib/tables/_p_r_o_p.rst
+++ b/Doc/source/ttLib/tables/_p_r_o_p.rst
@@ -1,0 +1,8 @@
+``prop``: Glyph Properties Table
+--------------------------------
+
+.. automodule:: fontTools.ttLib.tables._p_r_o_p
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_s_b_i_x.rst
+++ b/Doc/source/ttLib/tables/_s_b_i_x.rst
@@ -1,0 +1,25 @@
+``sbix``: Standard Bitmap Graphics Table
+----------------------------------------
+
+.. automodule:: fontTools.ttLib.tables._s_b_i_x
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+
+
+sbixGlyph
+---------
+
+.. automodule:: fontTools.ttLib.tables.sbixGlyph
+   :inherited-members:
+   :members:
+   :undoc-members:
+
+sbixStrike
+----------
+
+.. automodule:: fontTools.ttLib.tables.sbixStrike
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/_s_b_i_x.rst
+++ b/Doc/source/ttLib/tables/_s_b_i_x.rst
@@ -9,7 +9,7 @@
 
 
 sbixGlyph
----------
+^^^^^^^^^
 
 .. automodule:: fontTools.ttLib.tables.sbixGlyph
    :inherited-members:
@@ -17,7 +17,7 @@ sbixGlyph
    :undoc-members:
 
 sbixStrike
-----------
+^^^^^^^^^^
 
 .. automodule:: fontTools.ttLib.tables.sbixStrike
    :inherited-members:

--- a/Doc/source/ttLib/tables/_t_r_a_k.rst
+++ b/Doc/source/ttLib/tables/_t_r_a_k.rst
@@ -1,0 +1,8 @@
+``trak``: Tracking table
+------------------------
+
+.. automodule:: fontTools.ttLib.tables._t_r_a_k
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_v_h_e_a.rst
+++ b/Doc/source/ttLib/tables/_v_h_e_a.rst
@@ -1,0 +1,8 @@
+``vhea``: Vertical Header Table
+-------------------------------
+
+.. automodule:: fontTools.ttLib.tables._v_h_e_a
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/_v_m_t_x.rst
+++ b/Doc/source/ttLib/tables/_v_m_t_x.rst
@@ -1,0 +1,8 @@
+``vmtx``: Vertical Metrics Table
+--------------------------------
+
+.. automodule:: fontTools.ttLib.tables._v_m_t_x
+   :inherited-members:
+   :members:
+   :undoc-members:
+

--- a/Lib/fontTools/ttLib/tables/C_O_L_R_.py
+++ b/Lib/fontTools/ttLib/tables/C_O_L_R_.py
@@ -9,8 +9,10 @@ from . import DefaultTable
 class table_C_O_L_R_(DefaultTable.DefaultTable):
 
 	""" This table is structured so that you can treat it like a dictionary keyed by glyph name.
-	ttFont['COLR'][<glyphName>] will return the color layers for any glyph
-	ttFont['COLR'][<glyphName>] = <value> will set the color layers for any glyph.
+
+	``ttFont['COLR'][<glyphName>]`` will return the color layers for any glyph.
+
+	``ttFont['COLR'][<glyphName>] = <value>`` will set the color layers for any glyph.
 	"""
 
 	@staticmethod

--- a/Lib/fontTools/ttLib/tables/F__e_a_t.py
+++ b/Lib/fontTools/ttLib/tables/F__e_a_t.py
@@ -11,6 +11,12 @@ Feat_hdr_format='''
 '''
 
 class table_F__e_a_t(DefaultTable.DefaultTable):
+    """The ``Feat`` table is used exclusively by the Graphite shaping engine
+    to store features and possible settings specified in GDL. Graphite features
+    determine what rules are applied to transform a glyph stream.
+
+    Not to be confused with ``feat``, or the OpenType Layout tables
+    ``GSUB``/``GPOS``."""
 
     def __init__(self, tag=None):
         DefaultTable.DefaultTable.__init__(self, tag)

--- a/Lib/fontTools/ttLib/tables/V_O_R_G_.py
+++ b/Lib/fontTools/ttLib/tables/V_O_R_G_.py
@@ -5,9 +5,11 @@ import struct
 
 class table_V_O_R_G_(DefaultTable.DefaultTable):
 
-	""" This table is structured so that you can treat it like a dictionary keyed by glyph name.
-	ttFont['VORG'][<glyphName>] will return the vertical origin for any glyph
-	ttFont['VORG'][<glyphName>] = <value> will set the vertical origin for any glyph.
+	"""This table is structured so that you can treat it like a dictionary keyed by glyph name.
+
+	``ttFont['VORG'][<glyphName>]`` will return the vertical origin for any glyph.
+
+	``ttFont['VORG'][<glyphName>] = <value>`` will set the vertical origin for any glyph.
 	"""
 
 	def decompile(self, data, ttFont):

--- a/Lib/fontTools/ttLib/tables/_a_n_k_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_n_k_r.py
@@ -1,11 +1,12 @@
 from .otBase import BaseTTXConverter
 
-
-# The anchor point table provides a way to define anchor points.
-# These are points within the coordinate space of a given glyph,
-# independent of the control points used to render the glyph.
-# Anchor points are used in conjunction with the 'kerx' table.
-#
-# https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6ankr.html
 class table__a_n_k_r(BaseTTXConverter):
+    """
+    The anchor point table provides a way to define anchor points.
+    These are points within the coordinate space of a given glyph,
+    independent of the control points used to render the glyph.
+    Anchor points are used in conjunction with the 'kerx' table.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6ankr.html
+    """
     pass

--- a/Lib/fontTools/ttLib/tables/_a_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r.py
@@ -28,6 +28,28 @@ assert sstruct.calcsize(AVAR_HEADER_FORMAT) == 8, sstruct.calcsize(AVAR_HEADER_F
 
 
 class table__a_v_a_r(DefaultTable.DefaultTable):
+    """Axis Variations Table
+
+    This class represents the ``avar`` table of a variable font. The object has one
+    substantive attribute, ``segments``, which maps axis tags to a segments dictionary::
+
+        >>> font["avar"].segments
+        {'wght': {-1.0: -1.0,
+          0.0: 0.0,
+          0.125: 0.11444091796875,
+          0.25: 0.23492431640625,
+          0.5: 0.35540771484375,
+          0.625: 0.5,
+          0.75: 0.6566162109375,
+          0.875: 0.81927490234375,
+          1.0: 1.0},
+         'ital': {-1.0: -1.0, 0.0: 0.0, 1.0: 1.0}}
+
+    Notice that the segments dictionary is made up of normalized values. A valid
+    ``avar`` segment mapping must contain the entries ``-1.0: -1.0, 0.0: 0.0, 1.0: 1.0``.
+    fontTools does not enforce this, so it is your responsibility to ensure that
+    mappings are valid.
+    """
 
     dependencies = ["fvar"]
 

--- a/Lib/fontTools/ttLib/tables/_a_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r.py
@@ -33,7 +33,7 @@ class table__a_v_a_r(DefaultTable.DefaultTable):
     This class represents the ``avar`` table of a variable font. The object has one
     substantive attribute, ``segments``, which maps axis tags to a segments dictionary::
 
-        >>>> font["avar"].segments   # doctest: +SKIP
+        >>> font["avar"].segments   # doctest: +SKIP
         {'wght': {-1.0: -1.0,
           0.0: 0.0,
           0.125: 0.11444091796875,

--- a/Lib/fontTools/ttLib/tables/_a_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r.py
@@ -33,7 +33,7 @@ class table__a_v_a_r(DefaultTable.DefaultTable):
     This class represents the ``avar`` table of a variable font. The object has one
     substantive attribute, ``segments``, which maps axis tags to a segments dictionary::
 
-        >>> font["avar"].segments
+        >>>> font["avar"].segments   # doctest: +SKIP
         {'wght': {-1.0: -1.0,
           0.0: 0.0,
           0.125: 0.11444091796875,

--- a/Lib/fontTools/ttLib/tables/_c_i_d_g.py
+++ b/Lib/fontTools/ttLib/tables/_c_i_d_g.py
@@ -2,17 +2,18 @@
 from .otBase import BaseTTXConverter
 
 
-# The AAT ‘cidg’ table has almost the same structure as ‘gidc’,
-# just mapping CIDs to GlyphIDs instead of the reverse direction.
-#
-# It is useful for fonts that may be used by a PDF renderer in lieu of
-# a font reference with a known glyph collection but no subsetted
-# glyphs.  For instance, a PDF can say “please use a font conforming
-# to Adobe-Japan-1”; the ‘cidg’ mapping is necessary if the font is,
-# say, a TrueType font.  ‘gidc’ is lossy for this purpose and is
-# obsoleted by ‘cidg’.
-#
-# For example, the first font in /System/Library/Fonts/PingFang.ttc
-# (which Apple ships pre-installed on MacOS 10.12.6) has a ‘cidg’ table.
 class table__c_i_d_g(BaseTTXConverter):
+    """The AAT ``cidg`` table has almost the same structure as ``gidc``,
+just mapping CIDs to GlyphIDs instead of the reverse direction.
+
+It is useful for fonts that may be used by a PDF renderer in lieu of
+a font reference with a known glyph collection but no subsetted
+glyphs.  For instance, a PDF can say “please use a font conforming
+to Adobe-Japan-1”; the ``cidg`` mapping is necessary if the font is,
+say, a TrueType font.  ``gidc`` is lossy for this purpose and is
+obsoleted by ``cidg``.
+
+For example, the first font in ``/System/Library/Fonts/PingFang.ttc``
+(which Apple ships pre-installed on MacOS 10.12.6) has a ``cidg`` table.
+"""
     pass

--- a/Lib/fontTools/ttLib/tables/_f_e_a_t.py
+++ b/Lib/fontTools/ttLib/tables/_f_e_a_t.py
@@ -2,4 +2,10 @@ from .otBase import BaseTTXConverter
 
 
 class table__f_e_a_t(BaseTTXConverter):
+	"""The feature name table is an AAT (Apple Advanced Typography) table for
+	storing font features, settings, and their human-readable names. It should
+	not be confused with the ``Feat`` table or the OpenType Layout ``GSUB``/``GPOS``
+	tables. See `Feature Name Table <https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6feat.html>`_
+	in the TrueType Reference Manual for more information on the structure and
+	purpose of this table."""
 	pass

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -34,6 +34,7 @@ class BaseTTXConverter(DefaultTable):
 	"""
 
 	def decompile(self, data, font):
+		"""Create an object from the binary data. Called automatically on access."""
 		from . import otTables
 		reader = OTTableReader(data, tableTag=self.tableTag)
 		tableClass = getattr(otTables, self.tableTag)
@@ -41,26 +42,28 @@ class BaseTTXConverter(DefaultTable):
 		self.table.decompile(reader, font)
 
 	def compile(self, font):
-		""" Create a top-level OTTableWriter for the GPOS/GSUB table.
-			Call the compile method for the the table
-				for each 'converter' record in the table converter list
-					call converter's write method for each item in the value.
-						- For simple items, the write method adds a string to the
-						writer's self.items list.
-						- For Struct/Table/Subtable items, it add first adds new writer to the
-						to the writer's self.items, then calls the item's compile method.
-						This creates a tree of writers, rooted at the GUSB/GPOS writer, with
-						each writer representing a table, and the writer.items list containing
-						the child data strings and writers.
-			call the getAllData method
-				call _doneWriting, which removes duplicates
-				call _gatherTables. This traverses the tables, adding unique occurences to a flat list of tables
-				Traverse the flat list of tables, calling getDataLength on each to update their position
-				Traverse the flat list of tables again, calling getData each get the data in the table, now that
-				pos's and offset are known.
+		"""Compiles the table into binary. Called automatically on save."""
 
-				If a lookup subtable overflows an offset, we have to start all over.
-		"""
+		# General outline:
+		# Create a top-level OTTableWriter for the GPOS/GSUB table.
+		# 	Call the compile method for the the table
+		# 		for each 'converter' record in the table converter list
+		# 			call converter's write method for each item in the value.
+		# 				- For simple items, the write method adds a string to the
+		# 				writer's self.items list.
+		# 				- For Struct/Table/Subtable items, it add first adds new writer to the
+		# 				to the writer's self.items, then calls the item's compile method.
+		# 				This creates a tree of writers, rooted at the GUSB/GPOS writer, with
+		# 				each writer representing a table, and the writer.items list containing
+		# 				the child data strings and writers.
+		# 	call the getAllData method
+		# 		call _doneWriting, which removes duplicates
+		# 		call _gatherTables. This traverses the tables, adding unique occurences to a flat list of tables
+		# 		Traverse the flat list of tables, calling getDataLength on each to update their position
+		# 		Traverse the flat list of tables again, calling getData each get the data in the table, now that
+		# 		pos's and offset are known.
+
+		# 		If a lookup subtable overflows an offset, we have to start all over.
 		overflowRecord = None
 
 		while True:


### PR DESCRIPTION
This is the precursor to documenting each table convertor - which I started doing in the first commit, and then realised that the whole structure of the documentation would need to change if that was going to happen. The idea is to give the user an easier journey to get to the information they need about each table. Compare [this](https://fonttools.readthedocs.io/en/latest/ttLib/tables.html) with:

<img width="735" alt="Screenshot 2021-11-10 at 10 20 41" src="https://user-images.githubusercontent.com/106728/141095469-56cb39b5-46ae-4165-8048-4c65270c9c2e.png">

