### PR TITLE
Forbid empty glyph classes

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -416,6 +416,11 @@ class Parser(object):
                     self.next_token_location_,
                 )
         self.expect_symbol_("]")
+        if not glyphs.glyphSet():
+            raise FeatureLibError(
+                    "Glyph class cannot be empty",
+                    self.cur_token_location_,
+                )
         return glyphs
 
     def parse_glyph_pattern_(self, vertical):


### PR DESCRIPTION
`makeotf` forbids empty glyph classes. Given

```fea
feature test {
    sub [] a' by b;
} test;
```

`makeotf` says:

```
syntax error at "]" [foo.fea 2]
```

The feaLib parser allows them, but then chokes with an error later on:

```
  File "/usr/local/lib/python3.9/site-packages/fontTools/otlLib/builder.py", line 491, in buildFormat2Subtable
    ruleAsSubtable.Backtrack = [
  File "/usr/local/lib/python3.9/site-packages/fontTools/otlLib/builder.py", line 492, in <listcomp>
    st.BacktrackClassDef.classDefs[list(x)[0]]
IndexError: list index out of range
```

*EXCEPT WHEN IT DOESN'T*:

```
$ cat foo.fea
feature test {
    sub [a] by [];
} test;
$ fonttools feaLib -o stupid.otf foo.fea AGaramondPro-Regular.otf
$
```

While that's a cute way to delete a glyph, we now have `sub ... by NULL` so nobody should be relying on this unintended consequence, and we should follow the `makeotf` behaviour.