### PR TITLE
Forbid empty classes (take 2)

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1331,9 +1331,15 @@ class PairPosStatement(Statement):
         """
         if self.enumerated:
             g = [self.glyphs1.glyphSet(), self.glyphs2.glyphSet()]
+            seen_pair = False
             for glyph1, glyph2 in itertools.product(*g):
+                seen_pair = True
                 builder.add_specific_pair_pos(
                     self.location, glyph1, self.valuerecord1, glyph2, self.valuerecord2
+                )
+            if not seen_pair:
+                raise FeatureLibError(
+                    "Empty glyph class in positioning rule", self.location
                 )
             return
 

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -684,6 +684,8 @@ class Parser(object):
         assert self.is_cur_keyword_("markClass")
         location = self.cur_token_location_
         glyphs = self.parse_glyphclass_(accept_glyphname=True)
+        if not glyphs.glyphSet():
+            raise FeatureLibError("Empty glyph class in mark class definition", location)
         anchor = self.parse_anchor_()
         name = self.expect_class_name_()
         self.expect_symbol_(";")
@@ -872,7 +874,7 @@ class Parser(object):
         num_lookups = len([l for l in lookups if l is not None])
 
         is_deletion = False
-        if len(new) == 1 and len(new[0].glyphSet()) == 0:
+        if len(new) == 1 and isinstance(new[0], ast.NullGlyph):
             new = []  # Deletion
             is_deletion = True
 
@@ -918,6 +920,9 @@ class Parser(object):
             and max([len(n.glyphSet()) for n in new]) == 1
             and num_lookups == 0
         ):
+            for n in new:
+                if not list(n.glyphSet()):
+                    raise FeatureLibError("Empty class in replacement", location)
             return self.ast.MultipleSubstStatement(
                 old_prefix,
                 tuple(old[0].glyphSet())[0],

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -925,6 +925,45 @@ class BuilderTest(unittest.TestCase):
         assert "GPOS" not in font
         assert "GSUB" not in font
 
+    def test_disable_empty_classes(self):
+        for test in [
+            "sub a by c []",
+            "sub f f [] by f",
+            "ignore sub a []'",
+            "ignore sub [] a'",
+            "sub a []' by b",
+            "sub [] a' by b",
+            "rsub [] by a",
+            "pos [] 120",
+            "pos a [] 120",
+            "enum pos a [] 120",
+            "pos cursive [] <anchor NULL> <anchor NULL>",
+            "pos base [] <anchor NULL> mark @TOPMARKS",
+            "pos ligature [] <anchor NULL> mark @TOPMARKS",
+            "pos mark [] <anchor NULL> mark @TOPMARKS",
+            "ignore pos a []'",
+            "ignore pos [] a'",
+        ]:
+            self.assertRaisesRegex(
+                FeatureLibError,
+                "Empty ",
+                self.build,
+                f"markClass a <anchor 150 -10> @TOPMARKS; lookup foo {{ {test}; }} foo;",
+            )
+        self.assertRaisesRegex(
+            FeatureLibError,
+            "Empty glyph class in mark class definition",
+            self.build,
+            "markClass [] <anchor 150 -10> @TOPMARKS;"
+        )
+        self.assertRaisesRegex(
+            FeatureLibError,
+            'Expected a glyph class with 1 elements after "by", but found a glyph class with 0 elements',
+            self.build,
+            "feature test { sub a by []; test};"
+        )
+
+
 
 def generate_feature_file_test(name):
     return lambda self: self.check_feature_file(name)

--- a/Tests/feaLib/data/PairPosSubtable.fea
+++ b/Tests/feaLib/data/PairPosSubtable.fea
@@ -4,7 +4,6 @@ languagesystem latn dflt;
 @group1 = [b o];
 @group2 = [c d];
 @group3 = [v w];
-@group4 = [];
 
 lookup kernlookup {
     pos A V -34;
@@ -13,9 +12,6 @@ lookup kernlookup {
     subtable;
     pos @group1 @group3 -10;
     pos @group3 @group2 -20;
-    subtable;
-    pos @group4 @group1 -10;
-    pos @group4 @group4 -10;
 } kernlookup;
 
 feature kern {


### PR DESCRIPTION
This follows on from #2445, and forbids the following FEA syntax:

```fea
markClass [] <anchor 150 -10> @TOPMARKS;

feature test {
    sub a by [];
    sub a by c [];
    sub a from [];
    sub f f [] by f;
    ignore sub a []';
    ignore sub [] a';
    sub a []' by b;
    sub [] a' by b;
    rsub [] by a;

    pos [] 120;
    pos a [] 120;
    enum pos a [] 120;
    pos cursive [] <anchor NULL> <anchor NULL>;
    pos base [] <anchor NULL> mark @TOPMARKS;
    pos mark [] <anchor NULL> mark @TOPMARKS;
    pos ligature [] <anchor NULL> mark @TOPMARKS;
    ignore pos a []';
    ignore pos [] a';

} test;
```

All of these rules were allowed before, and would fail with hard errors (i.e. non user-facing stuff, IndexErrors and the like) in the builder. Glyph deletion is still allowed with the *explicit* NULL glyph.