### PR TITLE
Demystify deduplication

### DIFF
--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -333,6 +333,12 @@ class OTTableWriter(object):
 				items[i] = item.getCountData()
 			elif hasattr(item, "getData"):
 				item._doneWriting(internedTables)
+				# At this point, all subwriters are hashable based on their items.
+				# (See hash and comparison magic methods above.) So the ``setdefault``
+				# call here will return the first writer object we've seen with
+				# equal content, or store it in the dictionary if it's not been
+				# seen yet. We therefore replace the subwriter object with an equivalent
+				# object, which deduplicates the tree.
 				if not dontShare:
 					items[i] = item = internedTables.setdefault(item, item)
 		self.items = tuple(items)


### PR DESCRIPTION
This line in `otBase.py` took me quite a while to puzzle out:

```
items[i] = item = internedTables.setdefault(item, item)
```

 I *knew* that it was deduplicating the subwriter graph, but it's wasn't immediately clear *how*.  Since the compilation/OTTableWriter code is pretty gnarly at the best of times, I figure we should be trying to help people find their way through it.