### PR TITLE
Speculatively promote lookups to extension

### DIFF
--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -1635,14 +1635,17 @@ def fixLookupOverFlows(ttf, overflowRecord):
 			return ok
 		lookup = lookups[lookupIndex]
 
-	lookup.LookupType = extType
-	for si in range(len(lookup.SubTable)):
-		subTable = lookup.SubTable[si]
-		extSubTableClass = lookupTypes[overflowRecord.tableType][extType]
-		extSubTable = extSubTableClass()
-		extSubTable.Format = 1
-		extSubTable.ExtSubTable = subTable
-		lookup.SubTable[si] = extSubTable
+	for lookupIndex in range(lookupIndex, len(lookups)):
+		lookup = lookups[lookupIndex]
+
+		lookup.LookupType = extType
+		for si in range(len(lookup.SubTable)):
+			subTable = lookup.SubTable[si]
+			extSubTableClass = lookupTypes[overflowRecord.tableType][extType]
+			extSubTable = extSubTableClass()
+			extSubTable.Format = 1
+			extSubTable.ExtSubTable = subTable
+			lookup.SubTable[si] = extSubTable
 	ok = 1
 	return ok
 

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -1637,15 +1637,15 @@ def fixLookupOverFlows(ttf, overflowRecord):
 
 	for lookupIndex in range(lookupIndex, len(lookups)):
 		lookup = lookups[lookupIndex]
-
-		lookup.LookupType = extType
-		for si in range(len(lookup.SubTable)):
-			subTable = lookup.SubTable[si]
-			extSubTableClass = lookupTypes[overflowRecord.tableType][extType]
-			extSubTable = extSubTableClass()
-			extSubTable.Format = 1
-			extSubTable.ExtSubTable = subTable
-			lookup.SubTable[si] = extSubTable
+		if lookup.LookupType != extType:
+			lookup.LookupType = extType
+			for si in range(len(lookup.SubTable)):
+				subTable = lookup.SubTable[si]
+				extSubTableClass = lookupTypes[overflowRecord.tableType][extType]
+				extSubTable = extSubTableClass()
+				extSubTable.Format = 1
+				extSubTable.ExtSubTable = subTable
+				lookup.SubTable[si] = extSubTable
 	ok = 1
 	return ok
 


### PR DESCRIPTION
I've been looking at overflow resolution this morning, as it is currently the bane of my life. My font takes around 5 minutes to build, most of which time is taken up with resolving lookup overflows. (Not subtable overflows - lookup overflows.) The reason overflow resolution takes so long is that once an overflow is resolved, fontTools goes back and starts the whole compilation process all over again.

Now. It seems to me that if the offset to lookup N is too big to fit in a ushort, the offset to lookup N+1 is going to be too big as well. In fact, all lookups from lookup N onwards are going to need handling. So rather than handling them one at a time, why not just promote the lot to extension lookups?

Doing this takes my font's build time down to 30 seconds, almost none of which is to do with overflow resolution.