### PR TITLE
subset: speed up subsetting of large fonts

### DIFF
--- a/Lib/fontTools/subset/cff.py
+++ b/Lib/fontTools/subset/cff.py
@@ -53,8 +53,7 @@ def _empty_charstring(font, glyphName, isCFF2, ignoreWidth=False):
 	c, fdSelectIndex = font.CharStrings.getItemAndSelector(glyphName)
 	if isCFF2 or ignoreWidth:
 		# CFF2 charstrings have no widths nor 'endchar' operators
-		c.decompile()
-		c.program = [] if isCFF2 else ['endchar']
+		c.setProgram([] if isCFF2 else ['endchar'])
 	else:
 		if hasattr(font, 'FDArray') and font.FDArray is not None:
 			private = font.FDArray[fdSelectIndex].Private
@@ -120,9 +119,12 @@ def subset_glyphs(self, s):
 				#sel.format = None
 				sel.format = 3
 				sel.gidArray = [sel.gidArray[i] for i in indices]
-			cs.charStrings = {g:indices.index(v)
-					  for g,v in cs.charStrings.items()
-					  if g in glyphs}
+			newCharStrings = {}
+			for indicesIdx, charsetIdx in enumerate(indices):
+				g = font.charset[charsetIdx]
+				if g in cs.charStrings:
+					newCharStrings[g] = indicesIdx
+			cs.charStrings = newCharStrings
 		else:
 			cs.charStrings = {g:v
 					  for g,v in cs.charStrings.items()


### PR DESCRIPTION
Two small changes that significantly speed up subsetting of large fonts such as Noto Sans CJK:

1. When emptying a charstring, simply empty its program rather than attempting to decompile it first. (Only relevant when retaining GIDs.)

2. When reindexing charstrings, swap out an accidentally-quadratic implementation for one that is linear in the number of retained glyphs.

This passes tests locally, works in my test documents, and is much faster while producing the same output (in this admittedly contrived example):

Before:
~~~
$ time pyftsubset NotoSansCJK-Regular.ttc --unicodes=U+FF21 --output-file=out.ttf --retain-gids --font-number 0 --ignore-missing-glyphs ; sha1sum out.ttf

real	0m33.038s
user	0m32.896s
sys	0m0.120s
704162b0cb62934160dd0c6e39368891762094a1  out.ttf
~~~

After:
~~~
$ time pyftsubset NotoSansCJK-Regular.ttc --unicodes=U+FF21 --output-file=out.ttf --retain-gids --font-number 0 --ignore-missing-glyphs ; sha1sum out.ttf

real	0m2.131s
user	0m2.043s
sys	0m0.081s
704162b0cb62934160dd0c6e39368891762094a1  out.ttf
~~~

(This is a small change and I don't feel I need to be included in the acknowledgements. If you need me to, let me know and I can add myself.)