### PR TITLE
bump unicodedata2 dependency to 14.0.0

### DIFF
--- a/Doc/source/optional.rst
+++ b/Doc/source/optional.rst
@@ -59,8 +59,8 @@ with ``ttx`` we use the ``unicodedata`` module in the Standard Library.
 The version included in there varies between different Python versions.
 To use the latest available data, you can install:
 
-* `unicodedata2 <https://pypi.python.org/pypi/unicodedata2>`__: ``unicodedata`` backport for Python 2.7
-  and 3.x updated to the latest Unicode version 12.0. Note this is not necessary if you use Python 3.8
+* `unicodedata2 <https://pypi.python.org/pypi/unicodedata2>`__: ``unicodedata`` backport for Python
+  3.x updated to the latest Unicode version 14.0. Note this is not necessary if you use Python 3.11
   as the latter already comes with an up-to-date ``unicodedata``.
 
 *Extra:* ``unicode``

--- a/Lib/fontTools/unicodedata/__init__.py
+++ b/Lib/fontTools/unicodedata/__init__.py
@@ -5,7 +5,7 @@ from bisect import bisect_right
 
 try:
     # use unicodedata backport compatible with python2:
-    # https://github.com/mikekap/unicodedata2
+    # https://github.com/fonttools/unicodedata2
     from unicodedata2 import *
 except ImportError:  # pragma: no cover
     # fall back to built-in unicodedata (possibly outdated)

--- a/README.rst
+++ b/README.rst
@@ -119,8 +119,8 @@ are required to unlock the extra features named "ufo", etc.
   To use the latest available data, you can install:
 
   * `unicodedata2 <https://pypi.python.org/pypi/unicodedata2>`__:
-    ``unicodedata`` backport for Python 2.7 and 3.x updated to the latest
-    Unicode version 12.0. Note this is not necessary if you use Python 3.8
+    ``unicodedata`` backport for Python 3.x updated to the latest Unicode
+    version 14.0. Note this is not necessary if you use Python 3.11
     as the latter already comes with an up-to-date ``unicodedata``.
 
   *Extra:* ``unicode``

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # extension 'brotlipy' on PyPy
 brotli==1.0.9; platform_python_implementation != "PyPy"
 brotlicffi==1.0.9.2; platform_python_implementation == "PyPy"
-unicodedata2==13.0.0.post2; python_version < '3.9' and platform_python_implementation != "PyPy"
+unicodedata2==14.0.0; python_version < '3.11'
 scipy==1.7.3; platform_python_implementation != "PyPy"
 munkres==1.1.4; platform_python_implementation == "PyPy"
 zopfli==0.1.9

--- a/setup.py
+++ b/setup.py
@@ -90,11 +90,9 @@ extras_require = {
 	# of the Unicode Character Database instead of the built-in unicodedata
 	# which varies between python versions and may be outdated.
 	"unicode": [
-		# the unicodedata2 extension module doesn't work on PyPy.
-		# Python 3.9 already has Unicode 13.0, so the backport is not needed.
+		# Python 3.11 already has Unicode 14.0, so the backport is not needed.
 		(
-			"unicodedata2 >= 13.0.0; "
-			"python_version < '3.9' and platform_python_implementation != 'PyPy'"
+			"unicodedata2 >= 14.0.0; python_version < '3.11'"
 		),
 	],
 	# for graphite type tables in ttLib/tables (Silf, Glat, Gloc)


### PR DESCRIPTION
it now supports pypy3 and Unicode 14.0

https://github.com/fonttools/unicodedata2/releases/tag/14.0.0

Python 3.11 doesn't require the backport as it already ships Unicode 14.0