### PR TITLE
Fix type of fontName in suckfont

### DIFF
--- a/Lib/fontTools/misc/psLib.py
+++ b/Lib/fontTools/misc/psLib.py
@@ -365,6 +365,7 @@ def suckfont(data, encoding="ascii"):
 	m = re.search(br"/FontName\s+/([^ \t\n\r]+)\s+def", data)
 	if m:
 		fontName = m.group(1)
+		fontName = fontName.decode()
 	else:
 		fontName = None
 	interpreter = PSInterpreter(encoding=encoding)


### PR DESCRIPTION
In Python 3, `bytes` != `str`, so we explicitly convert to str, since the `fontdir.keys()` are of type `str`.

To check the behavior, for example, do as follows:

```python
>>> from fontTools.t1Lib import T1Font
>>> t1Font = T1Font('Tests/t1Lib/data/TestT1-Regular.pfa')
>>> gs = t1Font.getGlyphSet()
```