### PR TITLE
FreeTypePen: fix missing RTD entry

### DIFF
--- a/Doc/docs-requirements.txt
+++ b/Doc/docs-requirements.txt
@@ -1,3 +1,4 @@
 sphinx==4.3.2
 sphinx_rtd_theme==1.0.0
 reportlab==3.6.5
+freetype-py==2.2.0

--- a/Lib/fontTools/pens/freetypePen.py
+++ b/Lib/fontTools/pens/freetypePen.py
@@ -11,17 +11,12 @@ import subprocess
 import collections
 import math
 
-have_freetype = False
-try:
-    import freetype
-    from freetype.raw import FT_Outline_Get_Bitmap, FT_Outline_Get_BBox, FT_Outline_Get_CBox
-    from freetype.ft_types import FT_Pos
-    from freetype.ft_structs import FT_Vector, FT_BBox, FT_Bitmap, FT_Outline
-    from freetype.ft_enums import FT_OUTLINE_NONE, FT_OUTLINE_EVEN_ODD_FILL, FT_PIXEL_MODE_GRAY
-    from freetype.ft_errors import FT_Exception
-    have_freetype = True
-except ImportError:
-    pass
+import freetype
+from freetype.raw import FT_Outline_Get_Bitmap, FT_Outline_Get_BBox, FT_Outline_Get_CBox
+from freetype.ft_types import FT_Pos
+from freetype.ft_structs import FT_Vector, FT_BBox, FT_Bitmap, FT_Outline
+from freetype.ft_enums import FT_OUTLINE_NONE, FT_OUTLINE_EVEN_ODD_FILL, FT_PIXEL_MODE_GRAY
+from freetype.ft_errors import FT_Exception
 
 from fontTools.pens.basePen import BasePen
 from fontTools.misc.roundTools import otRound
@@ -113,11 +108,6 @@ class FreeTypePen(BasePen):
 
     def __init__(self, glyphSet):
         BasePen.__init__(self, glyphSet)
-        if not have_freetype:
-            self.log.error(
-                'FreeTypePen requires the freetype module, available at: '
-                'https://pypi.org/project/freetype-py/')
-            raise ImportError("No module named freetype")
         self.contours = []
 
     def outline(self, transform=None, evenOdd=False):

--- a/Lib/fontTools/pens/freetypePen.py
+++ b/Lib/fontTools/pens/freetypePen.py
@@ -180,11 +180,14 @@ class FreeTypePen(BasePen):
             dimension.
 
         :Example:
-            >> pen = FreeTypePen(None)
-            >> glyph.draw(pen)
-            >> buf, size = pen.buffer(width=500, height=1000)
-            >> type(buf), len(buf), size
-            (<class 'bytes'>, 500000, (500, 1000))
+            .. code-block::
+                
+                >> pen = FreeTypePen(None)
+                >> glyph.draw(pen)
+                >> buf, size = pen.buffer(width=500, height=1000)
+                >> type(buf), len(buf), size
+                (<class 'bytes'>, 500000, (500, 1000))
+        
         """
         transform = transform or Transform()
         if not hasattr(transform, 'transformPoint'):
@@ -243,11 +246,13 @@ class FreeTypePen(BasePen):
             Each element takes a value in the range of ``[0.0, 1.0]``.
 
         :Example:
-            >> pen = FreeTypePen(None)
-            >> glyph.draw(pen)
-            >> arr = pen.array(width=500, height=1000)
-            >> type(a), a.shape
-            (<class 'numpy.ndarray'>, (1000, 500))
+            .. code-block::
+                
+                >> pen = FreeTypePen(None)
+                >> glyph.draw(pen)
+                >> arr = pen.array(width=500, height=1000)
+                >> type(a), a.shape
+                (<class 'numpy.ndarray'>, (1000, 500))
         """
         import numpy as np
         buf, size = self.buffer(width=width, height=height, transform=transform, contain=contain, evenOdd=evenOdd)
@@ -271,9 +276,11 @@ class FreeTypePen(BasePen):
             evenOdd: Pass ``True`` for even-odd fill instead of non-zero.
 
         :Example:
-            >> pen = FreeTypePen(None)
-            >> glyph.draw(pen)
-            >> pen.show(width=500, height=1000)
+            .. code-block::
+                
+                >> pen = FreeTypePen(None)
+                >> glyph.draw(pen)
+                >> pen.show(width=500, height=1000)
         """
         from matplotlib import pyplot as plt
         a = self.array(width=width, height=height, transform=transform, contain=contain, evenOdd=evenOdd)
@@ -302,11 +309,13 @@ class FreeTypePen(BasePen):
             channel obtained from the rendered bitmap.
 
         :Example:
-            >> pen = FreeTypePen(None)
-            >> glyph.draw(pen)
-            >> img = pen.image(width=500, height=1000)
-            >> type(img), img.size
-            (<class 'PIL.Image.Image'>, (500, 1000))
+            .. code-block::
+                
+                >> pen = FreeTypePen(None)
+                >> glyph.draw(pen)
+                >> img = pen.image(width=500, height=1000)
+                >> type(img), img.size
+                (<class 'PIL.Image.Image'>, (500, 1000))
         """
         from PIL import Image
         buf, size = self.buffer(width=width, height=height, transform=transform, contain=contain, evenOdd=evenOdd)

--- a/Lib/fontTools/pens/freetypePen.py
+++ b/Lib/fontTools/pens/freetypePen.py
@@ -11,12 +11,17 @@ import subprocess
 import collections
 import math
 
-import freetype
-from freetype.raw import FT_Outline_Get_Bitmap, FT_Outline_Get_BBox, FT_Outline_Get_CBox
-from freetype.ft_types import FT_Pos
-from freetype.ft_structs import FT_Vector, FT_BBox, FT_Bitmap, FT_Outline
-from freetype.ft_enums import FT_OUTLINE_NONE, FT_OUTLINE_EVEN_ODD_FILL, FT_PIXEL_MODE_GRAY
-from freetype.ft_errors import FT_Exception
+have_freetype = False
+try:
+    import freetype
+    from freetype.raw import FT_Outline_Get_Bitmap, FT_Outline_Get_BBox, FT_Outline_Get_CBox
+    from freetype.ft_types import FT_Pos
+    from freetype.ft_structs import FT_Vector, FT_BBox, FT_Bitmap, FT_Outline
+    from freetype.ft_enums import FT_OUTLINE_NONE, FT_OUTLINE_EVEN_ODD_FILL, FT_PIXEL_MODE_GRAY
+    from freetype.ft_errors import FT_Exception
+    have_freetype = True
+except ImportError:
+    pass
 
 from fontTools.pens.basePen import BasePen
 from fontTools.misc.roundTools import otRound
@@ -108,6 +113,11 @@ class FreeTypePen(BasePen):
 
     def __init__(self, glyphSet):
         BasePen.__init__(self, glyphSet)
+        if not have_freetype:
+            self.log.error(
+                'FreeTypePen requires the freetype module, available at: '
+                'https://pypi.org/project/freetype-py/')
+            raise ImportError("No module named freetype")
         self.contours = []
 
     def outline(self, transform=None, evenOdd=False):

--- a/Tests/pens/freetypePen_test.py
+++ b/Tests/pens/freetypePen_test.py
@@ -3,7 +3,6 @@ import os
 
 try:
     from fontTools.pens.freetypePen import FreeTypePen
-    import freetype
     FREETYPE_PY_AVAILABLE = True
 except ImportError:
     FREETYPE_PY_AVAILABLE = False

--- a/Tests/pens/freetypePen_test.py
+++ b/Tests/pens/freetypePen_test.py
@@ -3,6 +3,7 @@ import os
 
 try:
     from fontTools.pens.freetypePen import FreeTypePen
+    import freetype
     FREETYPE_PY_AVAILABLE = True
 except ImportError:
     FREETYPE_PY_AVAILABLE = False


### PR DESCRIPTION
#2494 fails to generate the corresponding RTD entry due to the lack of the dependency:

https://readthedocs.org/api/v2/build/15748934.txt
```
WARNING: autodoc: failed to import module 'freetypePen' from module 'fontTools.pens'; the following exception was raised:
No module named 'freetype'
```

This PR solves the issue by raising ImportError in `__init__`, rather than by adding a line to `Doc/docs-requirements.txt`.
