### PR TITLE
remove waitForKeyPress on windows

### DIFF
--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -387,15 +387,6 @@ def process(jobs, options):
 		action(input, output, options)
 
 
-def waitForKeyPress():
-	"""Force the DOS Prompt window to stay open so the user gets
-	a chance to see what's wrong."""
-	import msvcrt
-	print('(Hit any key to exit)', file=sys.stderr)
-	while not msvcrt.kbhit():
-		pass
-
-
 def main(args=None):
 	"""Convert OpenType fonts to XML and back"""
 	from fontTools import configLogger
@@ -416,16 +407,12 @@ def main(args=None):
 		log.error("(Cancelled.)")
 		sys.exit(1)
 	except SystemExit:
-		if sys.platform == "win32":
-			waitForKeyPress()
 		raise
 	except TTLibError as e:
 		log.error(e)
 		sys.exit(1)
 	except:
 		log.exception('Unhandled exception has occurred')
-		if sys.platform == "win32":
-			waitForKeyPress()
 		sys.exit(1)
 
 

--- a/Tests/ttx/ttx_test.py
+++ b/Tests/ttx/ttx_test.py
@@ -961,10 +961,6 @@ def test_main_keyboard_interrupt(tmpdir, monkeypatch, caplog):
     assert "(Cancelled.)" in caplog.text
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="waitForKeyPress function causes test to hang on Windows platform",
-)
 def test_main_system_exit(tmpdir, monkeypatch):
     with pytest.raises(SystemExit):
         inpath = os.path.join("Tests", "ttx", "data", "TestTTF.ttx")
@@ -991,10 +987,6 @@ def test_main_ttlib_error(tmpdir, monkeypatch, caplog):
     assert "Test error" in caplog.text
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="waitForKeyPress function causes test to hang on Windows platform",
-)
 def test_main_base_exception(tmpdir, monkeypatch, caplog):
     with pytest.raises(SystemExit):
         inpath = os.path.join("Tests", "ttx", "data", "TestTTF.ttx")


### PR DESCRIPTION
One should just use 'pause' command in a batch script to wait to for key press, no need for ttx to do anything.

Fixes #2507