### PR TITLE
[tox/pytest] Fix some warnings in tests

### DIFF
--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -372,11 +372,13 @@ class GlyfTableTest(unittest.TestCase):
         font["glyf"] = newTable("glyf")
         font["glyf"].decompile(b"\x00", font)
         font["hmtx"] = newTable("hmtx")
-        font["hmtx"].metrics = {".notdef": (100,0)}
+        font["hmtx"].metrics = {".notdef": (100, 0)}
         font["head"] = newTable("head")
         font["head"].unitsPerEm = 1000
+        font["vmtx"] = newTable("vmtx")
+        font["vmtx"].metrics = {".notdef": (font["head"].unitsPerEm, 0)}
         self.assertEqual(
-            font["glyf"].getPhantomPoints(".notdef", font, 0), 
+            font["glyf"]._getPhantomPoints(".notdef", font["hmtx"], font["vmtx"]),
             [(0, 0), (100, 0), (0, 0), (0, -1000)]
         )
 

--- a/Tests/varLib/instancer/instancer_test.py
+++ b/Tests/varLib/instancer/instancer_test.py
@@ -50,7 +50,7 @@ def fvarAxes():
 def _get_coordinates(varfont, glyphname):
     # converts GlyphCoordinates to a list of (x, y) tuples, so that pytest's
     # assert will give us a nicer diff
-    return list(varfont["glyf"].getCoordinatesAndControls(glyphname, varfont)[0])
+    return list(varfont["glyf"]._getCoordinatesAndControls(glyphname, varfont["hmtx"], varfont["vmtx"])[0])
 
 
 class InstantiateGvarTest(object):

--- a/Tests/varLib/instancer/names_test.py
+++ b/Tests/varLib/instancer/names_test.py
@@ -1,3 +1,5 @@
+import re
+
 from fontTools.ttLib.tables import otTables
 from fontTools.otlLib.builder import buildStatTable
 from fontTools.varLib import instancer
@@ -215,7 +217,7 @@ def test_updateNameTable_with_multilingual_names(varfont, limits, expected, isNo
 
 
 def test_updateNameTable_missing_axisValues(varfont):
-    with pytest.raises(ValueError, match="Cannot find Axis Values \['wght=200'\]"):
+    with pytest.raises(ValueError, match=re.escape("Cannot find Axis Values ['wght=200']")):
         instancer.names.updateNameTable(varfont, {"wght": 200})
 
 


### PR DESCRIPTION
Fixes three warnings—

```
Tests/ttLib/tables/_g_l_y_f_test.py::GlyfTableTest::test_getPhantomPoints
  /home/fred/Workspace/fonttools/Tests/ttLib/tables/_g_l_y_f_test.py:379: DeprecationWarning: 'getPhantomPoints' is deprecated; use '_getPhantomPoints' instead
    font["glyf"].getPhantomPoints(".notdef", font, 0),

Tests/varLib/instancer/names_test.py:218
  /home/fred/Workspace/fonttools/Tests/varLib/instancer/names_test.py:218: DeprecationWarning: invalid escape sequence \[
    with pytest.raises(ValueError, match="Cannot find Axis Values \['wght=200'\]"):

Tests/varLib/instancer/instancer_test.py: 12 warnings
  /home/fred/Workspace/fonttools/Tests/varLib/instancer/instancer_test.py:53: DeprecationWarning: 'getCoordinatesAndControls' is deprecated; use '_getCoordinatesAndControls' instead
    return list(varfont["glyf"].getCoordinatesAndControls(glyphname, varfont)[0])
```