### PR TITLE
[colrv1] ensure base glyphs with equal layers share the same PaintColrLayers

### DIFF
--- a/Lib/fontTools/colorLib/builder.py
+++ b/Lib/fontTools/colorLib/builder.py
@@ -444,14 +444,12 @@ def _reuse_ranges(num_layers: int) -> Generator[Tuple[int, int], None, None]:
 
 
 class LayerListBuilder:
-    slices: List[ot.Paint]
     layers: List[ot.Paint]
     reusePool: Mapping[Tuple[Any, ...], int]
     tuples: Mapping[int, Tuple[Any, ...]]
     keepAlive: List[ot.Paint]  # we need id to remain valid
 
     def __init__(self):
-        self.slices = []
         self.layers = []
         self.reusePool = {}
         self.tuples = {}
@@ -496,10 +494,6 @@ class LayerListBuilder:
     # COLR layers is unusual in that it modifies shared state
     # so we need a callback into an object
     def _beforeBuildPaintColrLayers(self, dest, source):
-        paint = ot.Paint()
-        paint.Format = int(ot.PaintFormat.PaintColrLayers)
-        self.slices.append(paint)
-
         # Sketchy gymnastics: a sequence input will have dropped it's layers
         # into NumLayers; get it back
         if isinstance(source.get("NumLayers", None), collections.abc.Sequence):
@@ -557,6 +551,8 @@ class LayerListBuilder:
 
         layers = [listToColrLayers(l) for l in layers]
 
+        paint = ot.Paint()
+        paint.Format = int(ot.PaintFormat.PaintColrLayers)
         paint.NumLayers = len(layers)
         paint.FirstLayerIndex = len(self.layers)
         self.layers.extend(layers)


### PR DESCRIPTION
When building a colrv1 table and the input dictionary contains multiple base glyphs that map to the same layers (equal in content, not identity), we need to make sure the same PaintColrLayers is used for all of them.
Currently what happens is, the subsequent glyphs with same layers content get a new unique PaintColrLayers with only one child, i.e. the shared PaintColrLayers (see failing test).
Fix coming in a follow-up commit.
(Note the first commit eded2086700f3f238aec730000e867e983f3a5b8 is minor, unrelated change)