### PR TITLE
[colrv1] use math.isclose with relative tolerance to check radial circles' inside-ness

### DIFF
--- a/Lib/fontTools/colorLib/geometry.py
+++ b/Lib/fontTools/colorLib/geometry.py
@@ -1,6 +1,6 @@
 """Helpers for manipulating 2D points and vectors in COLR table."""
 
-from math import copysign, cos, hypot, pi
+from math import copysign, cos, hypot, isclose, pi
 from fontTools.misc.roundTools import otRound
 
 
@@ -19,9 +19,7 @@ def _unit_vector(vec):
     return (vec[0] / length, vec[1] / length)
 
 
-# This is the same tolerance used by Skia's SkTwoPointConicalGradient.cpp to detect
-# when a radial gradient's focal point lies on the end circle.
-_NEARLY_ZERO = 1 / (1 << 12)  # 0.000244140625
+_CIRCLE_INSIDE_TOLERANCE = 1e-4
 
 
 # The unit vector's X and Y components are respectively
@@ -64,10 +62,10 @@ class Circle:
     def round(self):
         return Circle(_round_point(self.centre), otRound(self.radius))
 
-    def inside(self, outer_circle):
+    def inside(self, outer_circle, tolerance=_CIRCLE_INSIDE_TOLERANCE):
         dist = self.radius + hypot(*_vector_between(self.centre, outer_circle.centre))
         return (
-            abs(outer_circle.radius - dist) <= _NEARLY_ZERO
+            isclose(outer_circle.radius, dist, rel_tol=_CIRCLE_INSIDE_TOLERANCE)
             or outer_circle.radius > dist
         )
 

--- a/Tests/colorLib/builder_test.py
+++ b/Tests/colorLib/builder_test.py
@@ -1747,6 +1747,16 @@ class TrickyRadialGradientTest:
         r1 = 260.0072
         assert self.round_start_circle(c0, r0, c1, r1, inside=True) == ((386, 71), 0)
 
+    def test_noto_emoji_horns_sign_u1f918_1f3fc(self):
+        # This radial gradient is taken from noto-emoji's 'SIGNS OF THE HORNS'
+        # (1f918_1f3fc). We check that c0 is inside c1 both before and after rounding.
+        c0 = (-437.6789059060543, -2116.9237094478003)
+        r0 = 0.0
+        c1 = (-488.7330118252256, -1876.5036857045086)
+        r1 = 245.77147821915673
+        assert self.circle_inside_circle(c0, r0, c1, r1)
+        assert self.circle_inside_circle(c0, r0, c1, r1, rounded=True)
+
     @pytest.mark.parametrize(
         "c0, r0, c1, r1, inside, expected",
         [


### PR DESCRIPTION
Fixes rounding of radial gradient geometry in 'SING OF THE HORNS' (medium-light skin tone) noto emoji 🤘🏼

noto-emoji CORLv1 font **before** this patch (notice the darker knuckle):

<img width="826" alt="Screenshot 2022-01-31 at 18 08 23" src="https://user-images.githubusercontent.com/6939968/151848881-df14409b-7267-49c5-8836-654f795ec2a1.png">

And **after** this patch (all look good):

<img width="812" alt="Screenshot 2022-01-31 at 18 07 58" src="https://user-images.githubusercontent.com/6939968/151848905-1d1d6b19-d95d-4b37-bbba-03666838762c.png">

***

This is basically the same bug as https://github.com/googlefonts/picosvg/issues/158 which affected the 🦟 mosquito emoji. It turns out the tolerance we are using to consider whether start circle is inside the end circle was too strict/tight. Relaxing a bit, and making it _relative_ tolerance (as in `math.isclose` as opposed to absolute difference) makes both the 🦟 and the 🤘🏼 happy.
