### PR TITLE
Add windowsNames and macNames parameters to buildStatTable

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2826,7 +2826,7 @@ def _buildAxisValuesFormat4(locations, axes, nameTable, windowsNames, macNames):
     return axisValues
 
 
-def _addName(nameTable, value, minNameID=0, windows=True, mac=True):
+def _addName(nameTable, value, minNameID=0, windows, mac):
     if isinstance(value, int):
         # Already a nameID
         return value

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2802,7 +2802,7 @@ def _buildAxisRecords(axes, nameTable, windowsNames, macNames):
     return axisRecords, axisValues
 
 
-def _buildAxisValuesFormat4(locations, axes, nameTable, windowsNames=True, macNames=True):
+def _buildAxisValuesFormat4(locations, axes, nameTable, windowsNames, macNames):
     axisTagToIndex = {}
     for axisRecordIndex, axisDict in enumerate(axes):
         axisTagToIndex[axisDict["tag"]] = axisRecordIndex

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2763,7 +2763,7 @@ def buildStatTable(ttFont, axes, locations=None, elidedFallbackName=2, windowsNa
         statTable.AxisValueCount = len(axisValues)
 
 
-def _buildAxisRecords(axes, nameTable, windowsNames=True, macNames=True):
+def _buildAxisRecords(axes, nameTable, windowsNames, macNames):
     axisRecords = []
     axisValues = []
     for axisRecordIndex, axisDict in enumerate(axes):

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2649,7 +2649,7 @@ AXIS_VALUE_NEGATIVE_INFINITY = fixedToFloat(-0x80000000, 16)
 AXIS_VALUE_POSITIVE_INFINITY = fixedToFloat(0x7FFFFFFF, 16)
 
 
-def buildStatTable(ttFont, axes, locations=None, elidedFallbackName=2, windows=True, mac=True):
+def buildStatTable(ttFont, axes, locations=None, elidedFallbackName=2, windowsNames=True, macNames=True):
     """Add a 'STAT' table to 'ttFont'.
 
     'axes' is a list of dictionaries describing axes and their
@@ -2734,17 +2734,17 @@ def buildStatTable(ttFont, axes, locations=None, elidedFallbackName=2, windows=T
     ttFont["STAT"] = ttLib.newTable("STAT")
     statTable = ttFont["STAT"].table = ot.STAT()
     nameTable = ttFont["name"]
-    statTable.ElidedFallbackNameID = _addName(nameTable, elidedFallbackName, windows=windows, mac=mac)
+    statTable.ElidedFallbackNameID = _addName(nameTable, elidedFallbackName, windows=windowsNames, mac=macNames)
 
     # 'locations' contains data for AxisValue Format 4
-    axisRecords, axisValues = _buildAxisRecords(axes, nameTable, windows=windows, mac=mac)
+    axisRecords, axisValues = _buildAxisRecords(axes, nameTable, windowsNames=windowsNames, macNames=macNames)
     if not locations:
         statTable.Version = 0x00010001
     else:
         # We'll be adding Format 4 AxisValue records, which
         # requires a higher table version
         statTable.Version = 0x00010002
-        multiAxisValues = _buildAxisValuesFormat4(locations, axes, nameTable, windows=windows, mac=mac)
+        multiAxisValues = _buildAxisValuesFormat4(locations, axes, nameTable, windowsNames=windowsNames, macNames=macNames)
         axisValues = multiAxisValues + axisValues
 
     # Store AxisRecords
@@ -2763,13 +2763,13 @@ def buildStatTable(ttFont, axes, locations=None, elidedFallbackName=2, windows=T
         statTable.AxisValueCount = len(axisValues)
 
 
-def _buildAxisRecords(axes, nameTable, windows=True, mac=True):
+def _buildAxisRecords(axes, nameTable, windowsNames=True, macNames=True):
     axisRecords = []
     axisValues = []
     for axisRecordIndex, axisDict in enumerate(axes):
         axis = ot.AxisRecord()
         axis.AxisTag = axisDict["tag"]
-        axis.AxisNameID = _addName(nameTable, axisDict["name"], 256, windows=windows, mac=mac)
+        axis.AxisNameID = _addName(nameTable, axisDict["name"], 256, windows=windowsNames, mac=macNames)
         axis.AxisOrdering = axisDict.get("ordering", axisRecordIndex)
         axisRecords.append(axis)
 
@@ -2777,7 +2777,7 @@ def _buildAxisRecords(axes, nameTable, windows=True, mac=True):
             axisValRec = ot.AxisValue()
             axisValRec.AxisIndex = axisRecordIndex
             axisValRec.Flags = axisVal.get("flags", 0)
-            axisValRec.ValueNameID = _addName(nameTable, axisVal["name"], windows=windows, mac=mac)
+            axisValRec.ValueNameID = _addName(nameTable, axisVal["name"], windows=windowsNames, mac=macNames)
 
             if "value" in axisVal:
                 axisValRec.Value = axisVal["value"]
@@ -2802,7 +2802,7 @@ def _buildAxisRecords(axes, nameTable, windows=True, mac=True):
     return axisRecords, axisValues
 
 
-def _buildAxisValuesFormat4(locations, axes, nameTable, windows=True, mac=True):
+def _buildAxisValuesFormat4(locations, axes, nameTable, windowsNames=True, macNames=True):
     axisTagToIndex = {}
     for axisRecordIndex, axisDict in enumerate(axes):
         axisTagToIndex[axisDict["tag"]] = axisRecordIndex
@@ -2811,7 +2811,7 @@ def _buildAxisValuesFormat4(locations, axes, nameTable, windows=True, mac=True):
     for axisLocationDict in locations:
         axisValRec = ot.AxisValue()
         axisValRec.Format = 4
-        axisValRec.ValueNameID = _addName(nameTable, axisLocationDict["name"], windows=windows, mac=mac)
+        axisValRec.ValueNameID = _addName(nameTable, axisLocationDict["name"], windows=windowsNames, mac=macNames)
         axisValRec.Flags = axisLocationDict.get("flags", 0)
         axisValueRecords = []
         for tag, value in axisLocationDict["location"].items():

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2831,7 +2831,7 @@ def _addName(nameTable, value, minNameID=0):
         # Already a nameID
         return value
     if isinstance(value, str):
-        nameID = nameTable.addName(value, platforms=((3, 1, 0x409), ), minNameID=minNameID)
+        nameID = nameTable.addName(value, platforms=((3, 1, 0x409), ), minNameID=256)
         if nameID is not None:
             return nameID
         names = dict(en=value)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2831,6 +2831,9 @@ def _addName(nameTable, value, minNameID=0):
         # Already a nameID
         return value
     if isinstance(value, str):
+        nameID = nameTable.addName(value, platforms=((3, 1, 0x409), ), minNameID=minNameID)
+        if nameID is not None:
+            return nameID
         names = dict(en=value)
     elif isinstance(value, dict):
         names = value

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2763,7 +2763,7 @@ def buildStatTable(ttFont, axes, locations=None, elidedFallbackName=2, windowsNa
         statTable.AxisValueCount = len(axisValues)
 
 
-def _buildAxisRecords(axes, nameTable, windowsNames, macNames):
+def _buildAxisRecords(axes, nameTable, windowsNames=True, macNames=True):
     axisRecords = []
     axisValues = []
     for axisRecordIndex, axisDict in enumerate(axes):
@@ -2802,7 +2802,7 @@ def _buildAxisRecords(axes, nameTable, windowsNames, macNames):
     return axisRecords, axisValues
 
 
-def _buildAxisValuesFormat4(locations, axes, nameTable, windowsNames, macNames):
+def _buildAxisValuesFormat4(locations, axes, nameTable, windowsNames=True, macNames=True):
     axisTagToIndex = {}
     for axisRecordIndex, axisDict in enumerate(axes):
         axisTagToIndex[axisDict["tag"]] = axisRecordIndex
@@ -2826,7 +2826,7 @@ def _buildAxisValuesFormat4(locations, axes, nameTable, windowsNames, macNames):
     return axisValues
 
 
-def _addName(nameTable, value, minNameID=0, windows, mac):
+def _addName(nameTable, value, minNameID=0, windows=True, mac=True):
     if isinstance(value, int):
         # Already a nameID
         return value
@@ -2850,5 +2850,4 @@ def _addName(nameTable, value, minNameID=0, windows, mac):
         return nameID
     else:
         raise TypeError("value must be int, str, dict or list")
-
     return nameTable.addMultilingualName(names, windows=windows, mac=mac, minNameID=minNameID)

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -11,7 +11,11 @@ from fontTools.ttLib.tables.otBase import (
 )
 from fontTools.ttLib.tables import otBase
 from fontTools.feaLib.ast import STATNameStatement
-from fontTools.otlLib.optimize.gpos import GPOS_COMPACT_MODE_DEFAULT, GPOS_COMPACT_MODE_ENV_KEY, compact_lookup
+from fontTools.otlLib.optimize.gpos import (
+    GPOS_COMPACT_MODE_DEFAULT,
+    GPOS_COMPACT_MODE_ENV_KEY,
+    compact_lookup,
+)
 from fontTools.otlLib.error import OpenTypeLibError
 from functools import reduce
 import logging
@@ -962,14 +966,18 @@ class MarkBasePosBuilder(LookupBuilder):
         marks = {}
         for mark, (mc, anchor) in self.marks.items():
             if mc not in markClasses:
-                raise ValueError("Mark class %s not found for mark glyph %s" % (mc, mark))
+                raise ValueError(
+                    "Mark class %s not found for mark glyph %s" % (mc, mark)
+                )
             marks[mark] = (markClasses[mc], anchor)
         bases = {}
         for glyph, anchors in self.bases.items():
             bases[glyph] = {}
             for mc, anchor in anchors.items():
                 if mc not in markClasses:
-                    raise ValueError("Mark class %s not found for base glyph %s" % (mc, mark))
+                    raise ValueError(
+                        "Mark class %s not found for base glyph %s" % (mc, mark)
+                    )
                 bases[glyph][markClasses[mc]] = anchor
         subtables = buildMarkBasePos(marks, bases, self.glyphMap)
         return self.buildLookup_(subtables)
@@ -2123,8 +2131,16 @@ def buildPairPosClassesSubtable(pairs, glyphMap, valueFormat1=None, valueFormat2
         for c2 in classes2:
             rec2 = ot.Class2Record()
             val1, val2 = pairs.get((c1, c2), (None, None))
-            rec2.Value1 = ValueRecord(src=val1, valueFormat=valueFormat1) if valueFormat1 else None
-            rec2.Value2 = ValueRecord(src=val2, valueFormat=valueFormat2) if valueFormat2 else None
+            rec2.Value1 = (
+                ValueRecord(src=val1, valueFormat=valueFormat1)
+                if valueFormat1
+                else None
+            )
+            rec2.Value2 = (
+                ValueRecord(src=val2, valueFormat=valueFormat2)
+                if valueFormat2
+                else None
+            )
             rec1.Class2Record.append(rec2)
     self.Class1Count = len(self.Class1Record)
     self.Class2Count = len(classes2)
@@ -2223,8 +2239,16 @@ def buildPairPosGlyphsSubtable(pairs, glyphMap, valueFormat1=None, valueFormat2=
         for glyph2, val1, val2 in sorted(p[glyph], key=lambda x: glyphMap[x[0]]):
             pvr = ot.PairValueRecord()
             pvr.SecondGlyph = glyph2
-            pvr.Value1 = ValueRecord(src=val1, valueFormat=valueFormat1) if valueFormat1 else None
-            pvr.Value2 = ValueRecord(src=val2, valueFormat=valueFormat2) if valueFormat2 else None
+            pvr.Value1 = (
+                ValueRecord(src=val1, valueFormat=valueFormat1)
+                if valueFormat1
+                else None
+            )
+            pvr.Value2 = (
+                ValueRecord(src=val2, valueFormat=valueFormat2)
+                if valueFormat2
+                else None
+            )
             ps.PairValueRecord.append(pvr)
         ps.PairValueCount = len(ps.PairValueRecord)
     self.PairSetCount = len(self.PairSet)
@@ -2345,8 +2369,13 @@ def buildSinglePosSubtable(values, glyphMap):
     """
     self = ot.SinglePos()
     self.Coverage = buildCoverage(values.keys(), glyphMap)
-    valueFormat = self.ValueFormat = reduce(int.__or__, [v.getFormat() for v in values.values()], 0)
-    valueRecords = [ValueRecord(src=values[g], valueFormat=valueFormat) for g in self.Coverage.glyphs]
+    valueFormat = self.ValueFormat = reduce(
+        int.__or__, [v.getFormat() for v in values.values()], 0
+    )
+    valueRecords = [
+        ValueRecord(src=values[g], valueFormat=valueFormat)
+        for g in self.Coverage.glyphs
+    ]
     if all(v == valueRecords[0] for v in valueRecords):
         self.Format = 1
         if self.ValueFormat != 0:
@@ -2649,7 +2678,9 @@ AXIS_VALUE_NEGATIVE_INFINITY = fixedToFloat(-0x80000000, 16)
 AXIS_VALUE_POSITIVE_INFINITY = fixedToFloat(0x7FFFFFFF, 16)
 
 
-def buildStatTable(ttFont, axes, locations=None, elidedFallbackName=2, windowsNames=True, macNames=True):
+def buildStatTable(
+    ttFont, axes, locations=None, elidedFallbackName=2, windowsNames=True, macNames=True
+):
     """Add a 'STAT' table to 'ttFont'.
 
     'axes' is a list of dictionaries describing axes and their
@@ -2734,17 +2765,23 @@ def buildStatTable(ttFont, axes, locations=None, elidedFallbackName=2, windowsNa
     ttFont["STAT"] = ttLib.newTable("STAT")
     statTable = ttFont["STAT"].table = ot.STAT()
     nameTable = ttFont["name"]
-    statTable.ElidedFallbackNameID = _addName(nameTable, elidedFallbackName, windows=windowsNames, mac=macNames)
+    statTable.ElidedFallbackNameID = _addName(
+        nameTable, elidedFallbackName, windows=windowsNames, mac=macNames
+    )
 
     # 'locations' contains data for AxisValue Format 4
-    axisRecords, axisValues = _buildAxisRecords(axes, nameTable, windowsNames=windowsNames, macNames=macNames)
+    axisRecords, axisValues = _buildAxisRecords(
+        axes, nameTable, windowsNames=windowsNames, macNames=macNames
+    )
     if not locations:
         statTable.Version = 0x00010001
     else:
         # We'll be adding Format 4 AxisValue records, which
         # requires a higher table version
         statTable.Version = 0x00010002
-        multiAxisValues = _buildAxisValuesFormat4(locations, axes, nameTable, windowsNames=windowsNames, macNames=macNames)
+        multiAxisValues = _buildAxisValuesFormat4(
+            locations, axes, nameTable, windowsNames=windowsNames, macNames=macNames
+        )
         axisValues = multiAxisValues + axisValues
 
     # Store AxisRecords
@@ -2769,7 +2806,9 @@ def _buildAxisRecords(axes, nameTable, windowsNames=True, macNames=True):
     for axisRecordIndex, axisDict in enumerate(axes):
         axis = ot.AxisRecord()
         axis.AxisTag = axisDict["tag"]
-        axis.AxisNameID = _addName(nameTable, axisDict["name"], 256, windows=windowsNames, mac=macNames)
+        axis.AxisNameID = _addName(
+            nameTable, axisDict["name"], 256, windows=windowsNames, mac=macNames
+        )
         axis.AxisOrdering = axisDict.get("ordering", axisRecordIndex)
         axisRecords.append(axis)
 
@@ -2777,7 +2816,9 @@ def _buildAxisRecords(axes, nameTable, windowsNames=True, macNames=True):
             axisValRec = ot.AxisValue()
             axisValRec.AxisIndex = axisRecordIndex
             axisValRec.Flags = axisVal.get("flags", 0)
-            axisValRec.ValueNameID = _addName(nameTable, axisVal["name"], windows=windowsNames, mac=macNames)
+            axisValRec.ValueNameID = _addName(
+                nameTable, axisVal["name"], windows=windowsNames, mac=macNames
+            )
 
             if "value" in axisVal:
                 axisValRec.Value = axisVal["value"]
@@ -2802,7 +2843,9 @@ def _buildAxisRecords(axes, nameTable, windowsNames=True, macNames=True):
     return axisRecords, axisValues
 
 
-def _buildAxisValuesFormat4(locations, axes, nameTable, windowsNames=True, macNames=True):
+def _buildAxisValuesFormat4(
+    locations, axes, nameTable, windowsNames=True, macNames=True
+):
     axisTagToIndex = {}
     for axisRecordIndex, axisDict in enumerate(axes):
         axisTagToIndex[axisDict["tag"]] = axisRecordIndex
@@ -2811,7 +2854,9 @@ def _buildAxisValuesFormat4(locations, axes, nameTable, windowsNames=True, macNa
     for axisLocationDict in locations:
         axisValRec = ot.AxisValue()
         axisValRec.Format = 4
-        axisValRec.ValueNameID = _addName(nameTable, axisLocationDict["name"], windows=windowsNames, mac=macNames)
+        axisValRec.ValueNameID = _addName(
+            nameTable, axisLocationDict["name"], windows=windowsNames, mac=macNames
+        )
         axisValRec.Flags = axisLocationDict.get("flags", 0)
         axisValueRecords = []
         for tag, value in axisLocationDict["location"].items():
@@ -2850,4 +2895,6 @@ def _addName(nameTable, value, minNameID=0, windows=True, mac=True):
         return nameID
     else:
         raise TypeError("value must be int, str, dict or list")
-    return nameTable.addMultilingualName(names, windows=windows, mac=mac, minNameID=minNameID)
+    return nameTable.addMultilingualName(
+        names, windows=windows, mac=mac, minNameID=minNameID
+    )

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2831,12 +2831,6 @@ def _addName(nameTable, value, minNameID=0, platforms=((1, 0, 0), (3, 1, 0x409))
         # Already a nameID
         return value
     if isinstance(value, str):
-        #nameID = nameTable.addName(value, platforms=platforms, minNameID=256, force=False)
-        #addMultilingualName(self, names, ttFont=None, nameID=None,
-        #                    windows=True, mac=True, minNameID=0)
-        #print('nameID: ', nameID)
-        #if nameID is not None:
-        #    return nameID
         names = dict(en=value)
     elif isinstance(value, dict):
         names = value

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2831,7 +2831,7 @@ def _addName(nameTable, value, minNameID=0):
         # Already a nameID
         return value
     if isinstance(value, str):
-        nameID = nameTable.addName(value, platforms=((3, 1, 0x409), ), minNameID=256)
+        nameID = nameTable.addName(value, platforms=((3, 1, 0x409), ), minNameID=256, force=False)
         if nameID is not None:
             return nameID
         names = dict(en=value)

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -329,7 +329,7 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 					self.names.append(macName)
 		return nameID
 
-	def addName(self, string, platforms=((1, 0, 0), (3, 1, 0x409)), minNameID=255, force=True):
+	def addName(self, string, platforms=((1, 0, 0), (3, 1, 0x409)), minNameID=255):
 		""" Add a new name record containing 'string' for each (platformID, platEncID,
 		langID) tuple specified in the 'platforms' list.
 
@@ -350,18 +350,6 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 		if not isinstance(string, str):
 			raise TypeError(
 				"expected str, found %s: %r" % (type(string).__name__, string))
-
-		if not force:
-			for platform in platforms:
-				for name_rec in self.names:
-					name_rec_platform = (name_rec.platformID, name_rec.platEncID, name_rec.langID)
-					if name_rec_platform != platform:
-						continue
-					if name_rec.string == string:
-						# if name ID exists already, don't create a new one.
-						# Instead return the name ID of the existing one.
-						return name_rec.nameID
-
 		nameID = self._findUnusedNameID(minNameID + 1)
 		for platformID, platEncID, langID in platforms:
 			self.names.append(makeName(string, nameID, platformID, platEncID, langID))

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -311,16 +311,6 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 			if nameID is not None:
 				return nameID
 			nameID = self._findUnusedNameID()
-
-			nameID_win = self.findMultilingualName(names, windows=True, mac=False)
-			nameID_mac = self.findMultilingualName(names, windows=False, mac=True)
-			if nameID_win and nameID_mac is None:
-				nameID = nameID_win
-				windows = False
-			if nameID_mac and nameID_win is None:
-				nameID = nameID_mac
-				mac = False
-
 		# TODO: Should minimize BCP 47 language codes.
 		# https://github.com/fonttools/fonttools/issues/930
 		for lang, name in sorted(names.items()):

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -329,7 +329,7 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 					self.names.append(macName)
 		return nameID
 
-	def addName(self, string, platforms=((1, 0, 0), (3, 1, 0x409)), minNameID=255):
+	def addName(self, string, platforms=((1, 0, 0), (3, 1, 0x409)), minNameID=255, force=True):
 		""" Add a new name record containing 'string' for each (platformID, platEncID,
 		langID) tuple specified in the 'platforms' list.
 
@@ -351,15 +351,16 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 			raise TypeError(
 				"expected str, found %s: %r" % (type(string).__name__, string))
 
-		for platform in platforms:
-			for name_rec in self.names:
-				name_rec_platform = (name_rec.platformID, name_rec.platEncID, name_rec.langID)
-				if name_rec_platform != platform:
-					continue
-				if name_rec.string == string:
-					# if name ID exists already, don't create a new one.
-					# Instead return the name ID of the existing one.
-					return name_rec.nameID
+		if not force:
+			for platform in platforms:
+				for name_rec in self.names:
+					name_rec_platform = (name_rec.platformID, name_rec.platEncID, name_rec.langID)
+					if name_rec_platform != platform:
+						continue
+					if name_rec.string == string:
+						# if name ID exists already, don't create a new one.
+						# Instead return the name ID of the existing one.
+						return name_rec.nameID
 
 		nameID = self._findUnusedNameID(minNameID + 1)
 		for platformID, platEncID, langID in platforms:

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -221,21 +221,6 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 			raise ValueError("nameID must be less than 32768")
 		return nameID
 
-	def findName(self, nameStr, platform=(3, 1, 0x409)):
-		someName = None
-		for name in self.names:
-			if (name.platformID, name.platEncID, name.langID) != platform:
-				continue
-			try:
-				unistr = name.toUnicode()
-			except UnicodeDecodeError:
-				continue
-			someName = unistr
-			if someName == nameStr:
-				return name.nameID
-
-		return someName
-
 	def findMultilingualName(self, names, windows=True, mac=True, minNameID=0):
 		"""Return the name ID of an existing multilingual name that
 		matches the 'names' dictionary, or None if not found.
@@ -319,21 +304,6 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 		"""
 		if not hasattr(self, 'names'):
 			self.names = []
-		if windows and mac:
-			for lang, name in sorted(names.items()):
-				langID_win = _WINDOWS_LANGUAGE_CODES.get(lang.lower())
-				nameID_win = self.findName(name, platform=(3, 1, langID_win))
-				langID_mac = _MAC_LANGUAGE_CODES.get(lang.lower())
-				nameID_mac = self.findName(name, platform=(1, 0, langID_mac))
-				if nameID_win and nameID_mac is None:
-					# create Mac name, equal to Windows Name
-					self.setName(name, nameID_win, 1, 0, langID_mac)
-					return nameID_win
-				if nameID_mac and nameID_win is None:
-					# create Windows name, equal to Mac Name
-					self.setName(name, nameID_mac, 3, 1, langID_win)
-					return nameID_mac
-
 		if nameID is None:
 			# Reuse nameID if possible
 			nameID = self.findMultilingualName(
@@ -341,6 +311,16 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 			if nameID is not None:
 				return nameID
 			nameID = self._findUnusedNameID()
+
+			nameID_win = self.findMultilingualName(names, windows=True, mac=False)
+			nameID_mac = self.findMultilingualName(names, windows=False, mac=True)
+			if nameID_win and nameID_mac is None:
+				nameID = nameID_win
+				windows = False
+			if nameID_mac and nameID_win is None:
+				nameID = nameID_mac
+				mac = False
+
 		# TODO: Should minimize BCP 47 language codes.
 		# https://github.com/fonttools/fonttools/issues/930
 		for lang, name in sorted(names.items()):

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -350,6 +350,17 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 		if not isinstance(string, str):
 			raise TypeError(
 				"expected str, found %s: %r" % (type(string).__name__, string))
+
+		for platform in platforms:
+			for name_rec in self.names:
+				name_rec_platform = (name_rec.platformID, name_rec.platEncID, name_rec.langID)
+				if name_rec_platform != platform:
+					continue
+				if name_rec.string == string:
+					# if name ID exists already, don't create a new one.
+					# Instead return the name ID of the existing one.
+					return name_rec.nameID
+
 		nameID = self._findUnusedNameID(minNameID + 1)
 		for platformID, platEncID, langID in platforms:
 			self.names.append(makeName(string, nameID, platformID, platEncID, langID))

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1471,7 +1471,7 @@ def test_buildStatTable_name_duplicates():
                       'ExtraBold', 'ExtraBold',
                       'Black', 'Black']
     # Multiple name records were added by buildStatTable
-    assert expected_names == actual_names
+    assert sorted(expected_names) == sorted(actual_names)
 
 
 

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1462,15 +1462,16 @@ def test_buildStatTable_name_duplicates():
 
     builder.buildStatTable(font_obj, AXES, windowsNames=True, macNames=True)
     actual_names = [x.string for x in font_obj["name"].names]
-    expected_names = ['Weight', 'Weight',
-                      'ExtraLight', 'ExtraLight',
-                      'Light', 'Light',
-                      'Regular', 'Regular',
-                      'Medium', 'Medium',
-                      'Bold', 'Bold',
-                      'ExtraBold', 'ExtraBold',
-                      'Black', 'Black']
-    # Multiple name records were added by buildStatTable
+    expected_names = ['Weight', 'Weight', 'Weight',
+                      'ExtraLight', 'ExtraLight', 'ExtraLight',
+                      'Light', 'Light', 'Light',
+                      'Regular', 'Regular', 'Regular',
+                      'Medium', 'Medium', 'Medium',
+                      'Bold', 'Bold', 'Bold',
+                      'ExtraBold', 'ExtraBold', 'ExtraBold',
+                      'Black', 'Black', 'Black']
+    # Because there is an inconsistency in the names add new name IDs
+    # for each platform -> windowsNames=True, macNames=True
     assert sorted(expected_names) == sorted(actual_names)
 
 

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1404,21 +1404,15 @@ def test_buildStatTable(axes, axisValues, elidedFallbackName, expected_ttx):
 
 def test_buildStatTable_name_duplicates():
     '''
-    Create a failing unittest first.
-    Currently 'buildStatTable' creates name table entries,
-    even if the name exists in the name table already.
+    PR: https://github.com/fonttools/fonttools/pull/2528
+    Introduce new 'platform' feature for creating a STAT table.
+    Set windowsNames and or macNames to create name table entries
+    in the specified platforms
     '''
 
     font_obj = ttLib.TTFont()
     font_obj["name"] = ttLib.newTable("name")
     font_obj["name"].names = []
-
-    opsz_values = [
-        dict(nominalValue=6, rangeMinValue=fixedToFloat(-0x80000000, 16), rangeMaxValue=9, name="Micro"),
-        dict(nominalValue=12, rangeMinValue=9, rangeMaxValue=16, name="Text"),
-        dict(nominalValue=18, rangeMinValue=16, rangeMaxValue=22, name="Headline"),
-        dict(nominalValue=24, rangeMinValue=22, rangeMaxValue=fixedToFloat(0x7FFFFFFF, 16), name="Poster"),
-    ]
 
     wght_values = [
         dict(nominalValue=200, rangeMinValue=200, rangeMaxValue=250, name="ExtraLight"),
@@ -1428,31 +1422,14 @@ def test_buildStatTable_name_duplicates():
         dict(nominalValue=700, rangeMinValue=650, rangeMaxValue=750, name="Bold"),
         dict(nominalValue=800, rangeMinValue=750, rangeMaxValue=850, name="ExtraBold"),
         dict(nominalValue=900, rangeMinValue=850, rangeMaxValue=900, name="Black"),
-        dict(value=400, linkedValue=700, name="Regular", flags=0x2, ),  # Regular
-    ]
-
-    ital_value = [
-        dict(value=0, linkedValue=1, name="Regular", flags=0x2, ),
     ]
 
     AXES = [
-        dict(
-            tag="opsz",
-            name="Optical Size",
-            ordering=0,
-            values=opsz_values,
-        ),
         dict(
             tag="wght",
             name="Weight",
             ordering=1,
             values=wght_values,
-        ),
-        dict(
-            tag="ital",
-            name="Italic",
-            ordering=2,
-            values=ital_value,
         ),
     ]
 
@@ -1464,14 +1441,7 @@ def test_buildStatTable_name_duplicates():
     font_obj["name"].setName('ExtraBold', 265, 3, 1, 0x409)
     font_obj["name"].setName('Black', 266, 3, 1, 0x409)
 
-    font_obj["name"].setName('Micro', 270, 3, 1, 0x409)
-    font_obj["name"].setName('Text', 271, 3, 1, 0x409)
-    font_obj["name"].setName('Headline', 272, 3, 1, 0x409)
-    font_obj["name"].setName('Poster', 273, 3, 1, 0x409)
-
-    font_obj["name"].setName('Optical Size', 280, 3, 1, 0x409)
-    font_obj["name"].setName('Weight', 281, 3, 1, 0x409)
-    font_obj["name"].setName('Italic', 282, 3, 1, 0x409)
+    font_obj["name"].setName('Weight', 270, 3, 1, 0x409)
 
     expected_names = [x.string for x in font_obj["name"].names]
 

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1475,7 +1475,7 @@ def test_buildStatTable_name_duplicates():
 
     expected_names = [x.string for x in font_obj["name"].names]
 
-    builder.buildStatTable(font_obj, AXES, windows=True, mac=False)
+    builder.buildStatTable(font_obj, AXES, windowsNames=True, macNames=False)
     actual_names = [x.string for x in font_obj["name"].names]
 
     assert expected_names == actual_names

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1,6 +1,6 @@
 import io
 import struct
-from fontTools.misc.fixedTools import floatToFixed
+from fontTools.misc.fixedTools import floatToFixed, fixedToFloat
 from fontTools.misc.testTools import getXML
 from fontTools.otlLib import builder, error
 from fontTools import ttLib
@@ -1409,8 +1409,6 @@ def test_buildStatTable_name_duplicates():
     even if the name exists in the name table already.
     '''
 
-    from fontTools.misc.fixedTools import fixedToFloat
-
     font_obj = ttLib.TTFont()
     font_obj["name"] = ttLib.newTable("name")
     font_obj["name"].names = []
@@ -1458,27 +1456,29 @@ def test_buildStatTable_name_duplicates():
         ),
     ]
 
-    font_obj["name"].setName('ExtraLight', 260, 1, 0, 0)
-    font_obj["name"].setName('Light', 261, 1, 0, 0)
-    font_obj["name"].setName('Regular', 262, 1, 0, 0)
-    font_obj["name"].setName('Medium', 263, 1, 0, 0)
-    font_obj["name"].setName('Bold', 264, 1, 0, 0)
-    font_obj["name"].setName('ExtraBold', 265, 1, 0, 0)
-    font_obj["name"].setName('Black', 266, 1, 0, 0)
+    font_obj["name"].setName('ExtraLight', 260, 3, 1, 0x409)
+    font_obj["name"].setName('Light', 261, 3, 1, 0x409)
+    font_obj["name"].setName('Regular', 262, 3, 1, 0x409)
+    font_obj["name"].setName('Medium', 263, 3, 1, 0x409)
+    font_obj["name"].setName('Bold', 264, 3, 1, 0x409)
+    font_obj["name"].setName('ExtraBold', 265, 3, 1, 0x409)
+    font_obj["name"].setName('Black', 266, 3, 1, 0x409)
 
-    font_obj["name"].setName('Micro', 270, 1, 0, 0)
-    font_obj["name"].setName('Text', 271, 1, 0, 0)
-    font_obj["name"].setName('Headline', 272, 1, 0, 0)
-    font_obj["name"].setName('Poster', 273, 1, 0, 0)
+    font_obj["name"].setName('Micro', 270, 3, 1, 0x409)
+    font_obj["name"].setName('Text', 271, 3, 1, 0x409)
+    font_obj["name"].setName('Headline', 272, 3, 1, 0x409)
+    font_obj["name"].setName('Poster', 273, 3, 1, 0x409)
 
-    font_obj["name"].setName('Optical Size', 280, 1, 0, 0)
-    font_obj["name"].setName('Weight', 281, 1, 0, 0)
-    font_obj["name"].setName('Italic', 281, 1, 0, 0)
+    font_obj["name"].setName('Optical Size', 280, 3, 1, 0x409)
+    font_obj["name"].setName('Weight', 281, 3, 1, 0x409)
+    font_obj["name"].setName('Italic', 282, 3, 1, 0x409)
 
-    expected_names_len = len(font_obj["name"].names)
+    expected_names = [x.string for x in font_obj["name"].names]
+
     builder.buildStatTable(font_obj, AXES)
+    actual_names = [x.string for x in font_obj["name"].names]
 
-    assert expected_names_len == len(font_obj["name"].names)
+    assert expected_names == actual_names
 
 
 def test_stat_infinities():

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1403,13 +1403,10 @@ def test_buildStatTable(axes, axisValues, elidedFallbackName, expected_ttx):
 
 
 def test_buildStatTable_name_duplicates():
-    '''
-    PR: https://github.com/fonttools/fonttools/pull/2528
-    Introduce new 'platform' feature for creating a STAT table.
-    Set windowsNames and or macNames to create name table entries
-    in the specified platforms
-    '''
-
+    # PR: https://github.com/fonttools/fonttools/pull/2528
+    # Introduce new 'platform' feature for creating a STAT table.
+    # Set windowsNames and or macNames to create name table entries
+    # in the specified platforms
     font_obj = ttLib.TTFont()
     font_obj["name"] = ttLib.newTable("name")
     font_obj["name"].names = []
@@ -1473,8 +1470,6 @@ def test_buildStatTable_name_duplicates():
     # Because there is an inconsistency in the names add new name IDs
     # for each platform -> windowsNames=True, macNames=True
     assert sorted(expected_names) == sorted(actual_names)
-
-
 
 
 def test_stat_infinities():

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -918,7 +918,6 @@ class BuilderTest(object):
                 ("A", "zero"): (d0, d50),
                 ("A", "one"): (None, d20),
                 ("B", "five"): (d8020, d50),
-
             },
             self.GLYPHMAP,
         )
@@ -1120,262 +1119,309 @@ class ClassDefBuilderTest(object):
 
 
 buildStatTable_test_data = [
-    ([
-        dict(
-            tag="wght",
-            name="Weight",
-            values=[
-                dict(value=100, name='Thin'),
-                dict(value=400, name='Regular', flags=0x2),
-                dict(value=900, name='Black')])], None, "Regular", [
-        '  <STAT>',
-        '    <Version value="0x00010001"/>',
-        '    <DesignAxisRecordSize value="8"/>',
-        '    <!-- DesignAxisCount=1 -->',
-        '    <DesignAxisRecord>',
-        '      <Axis index="0">',
-        '        <AxisTag value="wght"/>',
-        '        <AxisNameID value="257"/>  <!-- Weight -->',
-        '        <AxisOrdering value="0"/>',
-        '      </Axis>',
-        '    </DesignAxisRecord>',
-        '    <!-- AxisValueCount=3 -->',
-        '    <AxisValueArray>',
-        '      <AxisValue index="0" Format="1">',
-        '        <AxisIndex value="0"/>',
-        '        <Flags value="0"/>',
-        '        <ValueNameID value="258"/>  <!-- Thin -->',
-        '        <Value value="100.0"/>',
-        '      </AxisValue>',
-        '      <AxisValue index="1" Format="1">',
-        '        <AxisIndex value="0"/>',
-        '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
-        '        <ValueNameID value="256"/>  <!-- Regular -->',
-        '        <Value value="400.0"/>',
-        '      </AxisValue>',
-        '      <AxisValue index="2" Format="1">',
-        '        <AxisIndex value="0"/>',
-        '        <Flags value="0"/>',
-        '        <ValueNameID value="259"/>  <!-- Black -->',
-        '        <Value value="900.0"/>',
-        '      </AxisValue>',
-        '    </AxisValueArray>',
-        '    <ElidedFallbackNameID value="256"/>  <!-- Regular -->',
-        '  </STAT>']),
-    ([
-        dict(
-            tag="wght",
-            name=dict(en="Weight", nl="Gewicht"),
-            values=[
-                dict(value=100, name=dict(en='Thin', nl='Dun')),
-                dict(value=400, name='Regular', flags=0x2),
-                dict(value=900, name='Black'),
-            ]),
-        dict(
-            tag="wdth",
-            name="Width",
-            values=[
-                dict(value=50, name='Condensed'),
-                dict(value=100, name='Regular', flags=0x2),
-                dict(value=200, name='Extended')])], None, 2, [
-        '  <STAT>',
-        '    <Version value="0x00010001"/>',
-        '    <DesignAxisRecordSize value="8"/>',
-        '    <!-- DesignAxisCount=2 -->',
-        '    <DesignAxisRecord>',
-        '      <Axis index="0">',
-        '        <AxisTag value="wght"/>',
-        '        <AxisNameID value="256"/>  <!-- Weight -->',
-        '        <AxisOrdering value="0"/>',
-        '      </Axis>',
-        '      <Axis index="1">',
-        '        <AxisTag value="wdth"/>',
-        '        <AxisNameID value="260"/>  <!-- Width -->',
-        '        <AxisOrdering value="1"/>',
-        '      </Axis>',
-        '    </DesignAxisRecord>',
-        '    <!-- AxisValueCount=6 -->',
-        '    <AxisValueArray>',
-        '      <AxisValue index="0" Format="1">',
-        '        <AxisIndex value="0"/>',
-        '        <Flags value="0"/>',
-        '        <ValueNameID value="257"/>  <!-- Thin -->',
-        '        <Value value="100.0"/>',
-        '      </AxisValue>',
-        '      <AxisValue index="1" Format="1">',
-        '        <AxisIndex value="0"/>',
-        '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
-        '        <ValueNameID value="258"/>  <!-- Regular -->',
-        '        <Value value="400.0"/>',
-        '      </AxisValue>',
-        '      <AxisValue index="2" Format="1">',
-        '        <AxisIndex value="0"/>',
-        '        <Flags value="0"/>',
-        '        <ValueNameID value="259"/>  <!-- Black -->',
-        '        <Value value="900.0"/>',
-        '      </AxisValue>',
-        '      <AxisValue index="3" Format="1">',
-        '        <AxisIndex value="1"/>',
-        '        <Flags value="0"/>',
-        '        <ValueNameID value="261"/>  <!-- Condensed -->',
-        '        <Value value="50.0"/>',
-        '      </AxisValue>',
-        '      <AxisValue index="4" Format="1">',
-        '        <AxisIndex value="1"/>',
-        '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
-        '        <ValueNameID value="258"/>  <!-- Regular -->',
-        '        <Value value="100.0"/>',
-        '      </AxisValue>',
-        '      <AxisValue index="5" Format="1">',
-        '        <AxisIndex value="1"/>',
-        '        <Flags value="0"/>',
-        '        <ValueNameID value="262"/>  <!-- Extended -->',
-        '        <Value value="200.0"/>',
-        '      </AxisValue>',
-        '    </AxisValueArray>',
-        '    <ElidedFallbackNameID value="2"/>  <!-- missing from name table -->',
-        '  </STAT>']),
-    ([
-        dict(
-            tag="wght",
-            name="Weight",
-            values=[
-                dict(value=400, name='Regular', flags=0x2),
-                dict(value=600, linkedValue=650, name='Bold')])], None, 18, [
-        '  <STAT>',
-        '    <Version value="0x00010001"/>',
-        '    <DesignAxisRecordSize value="8"/>',
-        '    <!-- DesignAxisCount=1 -->',
-        '    <DesignAxisRecord>',
-        '      <Axis index="0">',
-        '        <AxisTag value="wght"/>',
-        '        <AxisNameID value="256"/>  <!-- Weight -->',
-        '        <AxisOrdering value="0"/>',
-        '      </Axis>',
-        '    </DesignAxisRecord>',
-        '    <!-- AxisValueCount=2 -->',
-        '    <AxisValueArray>',
-        '      <AxisValue index="0" Format="1">',
-        '        <AxisIndex value="0"/>',
-        '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
-        '        <ValueNameID value="257"/>  <!-- Regular -->',
-        '        <Value value="400.0"/>',
-        '      </AxisValue>',
-        '      <AxisValue index="1" Format="3">',
-        '        <AxisIndex value="0"/>',
-        '        <Flags value="0"/>',
-        '        <ValueNameID value="258"/>  <!-- Bold -->',
-        '        <Value value="600.0"/>',
-        '        <LinkedValue value="650.0"/>',
-        '      </AxisValue>',
-        '    </AxisValueArray>',
-        '    <ElidedFallbackNameID value="18"/>  <!-- missing from name table -->',
-        '  </STAT>']),
-    ([
-        dict(
-            tag="opsz",
-            name="Optical Size",
-            values=[
-                dict(nominalValue=6, rangeMaxValue=10, name='Small'),
-                dict(rangeMinValue=10, nominalValue=14, rangeMaxValue=24, name='Text', flags=0x2),
-                dict(rangeMinValue=24, nominalValue=600, name='Display')])], None, 2, [
-        '  <STAT>',
-        '    <Version value="0x00010001"/>',
-        '    <DesignAxisRecordSize value="8"/>',
-        '    <!-- DesignAxisCount=1 -->',
-        '    <DesignAxisRecord>',
-        '      <Axis index="0">',
-        '        <AxisTag value="opsz"/>',
-        '        <AxisNameID value="256"/>  <!-- Optical Size -->',
-        '        <AxisOrdering value="0"/>',
-        '      </Axis>',
-        '    </DesignAxisRecord>',
-        '    <!-- AxisValueCount=3 -->',
-        '    <AxisValueArray>',
-        '      <AxisValue index="0" Format="2">',
-        '        <AxisIndex value="0"/>',
-        '        <Flags value="0"/>',
-        '        <ValueNameID value="257"/>  <!-- Small -->',
-        '        <NominalValue value="6.0"/>',
-        '        <RangeMinValue value="-32768.0"/>',
-        '        <RangeMaxValue value="10.0"/>',
-        '      </AxisValue>',
-        '      <AxisValue index="1" Format="2">',
-        '        <AxisIndex value="0"/>',
-        '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
-        '        <ValueNameID value="258"/>  <!-- Text -->',
-        '        <NominalValue value="14.0"/>',
-        '        <RangeMinValue value="10.0"/>',
-        '        <RangeMaxValue value="24.0"/>',
-        '      </AxisValue>',
-        '      <AxisValue index="2" Format="2">',
-        '        <AxisIndex value="0"/>',
-        '        <Flags value="0"/>',
-        '        <ValueNameID value="259"/>  <!-- Display -->',
-        '        <NominalValue value="600.0"/>',
-        '        <RangeMinValue value="24.0"/>',
-        '        <RangeMaxValue value="32767.99998"/>',
-        '      </AxisValue>',
-        '    </AxisValueArray>',
-        '    <ElidedFallbackNameID value="2"/>  <!-- missing from name table -->',
-        '  </STAT>']),
-    ([
-        dict(
-            tag="wght",
-            name="Weight",
-            ordering=1,
-            values=[]),
-        dict(
-            tag="ABCD",
-            name="ABCDTest",
-            ordering=0,
-            values=[
-                dict(value=100, name="Regular", flags=0x2)])],
-     [dict(location=dict(wght=300, ABCD=100), name='Regular ABCD')], 18, [
-        '  <STAT>',
-        '    <Version value="0x00010002"/>',
-        '    <DesignAxisRecordSize value="8"/>',
-        '    <!-- DesignAxisCount=2 -->',
-        '    <DesignAxisRecord>',
-        '      <Axis index="0">',
-        '        <AxisTag value="wght"/>',
-        '        <AxisNameID value="256"/>  <!-- Weight -->',
-        '        <AxisOrdering value="1"/>',
-        '      </Axis>',
-        '      <Axis index="1">',
-        '        <AxisTag value="ABCD"/>',
-        '        <AxisNameID value="257"/>  <!-- ABCDTest -->',
-        '        <AxisOrdering value="0"/>',
-        '      </Axis>',
-        '    </DesignAxisRecord>',
-        '    <!-- AxisValueCount=2 -->',
-        '    <AxisValueArray>',
-        '      <AxisValue index="0" Format="4">',
-        '        <!-- AxisCount=2 -->',
-        '        <Flags value="0"/>',
-        '        <ValueNameID value="259"/>  <!-- Regular ABCD -->',
-        '        <AxisValueRecord index="0">',
-        '          <AxisIndex value="0"/>',
-        '          <Value value="300.0"/>',
-        '        </AxisValueRecord>',
-        '        <AxisValueRecord index="1">',
-        '          <AxisIndex value="1"/>',
-        '          <Value value="100.0"/>',
-        '        </AxisValueRecord>',
-        '      </AxisValue>',
-        '      <AxisValue index="1" Format="1">',
-        '        <AxisIndex value="1"/>',
-        '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
-        '        <ValueNameID value="258"/>  <!-- Regular -->',
-        '        <Value value="100.0"/>',
-        '      </AxisValue>',
-        '    </AxisValueArray>',
-        '    <ElidedFallbackNameID value="18"/>  <!-- missing from name table -->',
-        '  </STAT>']),
+    (
+        [
+            dict(
+                tag="wght",
+                name="Weight",
+                values=[
+                    dict(value=100, name="Thin"),
+                    dict(value=400, name="Regular", flags=0x2),
+                    dict(value=900, name="Black"),
+                ],
+            )
+        ],
+        None,
+        "Regular",
+        [
+            "  <STAT>",
+            '    <Version value="0x00010001"/>',
+            '    <DesignAxisRecordSize value="8"/>',
+            "    <!-- DesignAxisCount=1 -->",
+            "    <DesignAxisRecord>",
+            '      <Axis index="0">',
+            '        <AxisTag value="wght"/>',
+            '        <AxisNameID value="257"/>  <!-- Weight -->',
+            '        <AxisOrdering value="0"/>',
+            "      </Axis>",
+            "    </DesignAxisRecord>",
+            "    <!-- AxisValueCount=3 -->",
+            "    <AxisValueArray>",
+            '      <AxisValue index="0" Format="1">',
+            '        <AxisIndex value="0"/>',
+            '        <Flags value="0"/>',
+            '        <ValueNameID value="258"/>  <!-- Thin -->',
+            '        <Value value="100.0"/>',
+            "      </AxisValue>",
+            '      <AxisValue index="1" Format="1">',
+            '        <AxisIndex value="0"/>',
+            '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
+            '        <ValueNameID value="256"/>  <!-- Regular -->',
+            '        <Value value="400.0"/>',
+            "      </AxisValue>",
+            '      <AxisValue index="2" Format="1">',
+            '        <AxisIndex value="0"/>',
+            '        <Flags value="0"/>',
+            '        <ValueNameID value="259"/>  <!-- Black -->',
+            '        <Value value="900.0"/>',
+            "      </AxisValue>",
+            "    </AxisValueArray>",
+            '    <ElidedFallbackNameID value="256"/>  <!-- Regular -->',
+            "  </STAT>",
+        ],
+    ),
+    (
+        [
+            dict(
+                tag="wght",
+                name=dict(en="Weight", nl="Gewicht"),
+                values=[
+                    dict(value=100, name=dict(en="Thin", nl="Dun")),
+                    dict(value=400, name="Regular", flags=0x2),
+                    dict(value=900, name="Black"),
+                ],
+            ),
+            dict(
+                tag="wdth",
+                name="Width",
+                values=[
+                    dict(value=50, name="Condensed"),
+                    dict(value=100, name="Regular", flags=0x2),
+                    dict(value=200, name="Extended"),
+                ],
+            ),
+        ],
+        None,
+        2,
+        [
+            "  <STAT>",
+            '    <Version value="0x00010001"/>',
+            '    <DesignAxisRecordSize value="8"/>',
+            "    <!-- DesignAxisCount=2 -->",
+            "    <DesignAxisRecord>",
+            '      <Axis index="0">',
+            '        <AxisTag value="wght"/>',
+            '        <AxisNameID value="256"/>  <!-- Weight -->',
+            '        <AxisOrdering value="0"/>',
+            "      </Axis>",
+            '      <Axis index="1">',
+            '        <AxisTag value="wdth"/>',
+            '        <AxisNameID value="260"/>  <!-- Width -->',
+            '        <AxisOrdering value="1"/>',
+            "      </Axis>",
+            "    </DesignAxisRecord>",
+            "    <!-- AxisValueCount=6 -->",
+            "    <AxisValueArray>",
+            '      <AxisValue index="0" Format="1">',
+            '        <AxisIndex value="0"/>',
+            '        <Flags value="0"/>',
+            '        <ValueNameID value="257"/>  <!-- Thin -->',
+            '        <Value value="100.0"/>',
+            "      </AxisValue>",
+            '      <AxisValue index="1" Format="1">',
+            '        <AxisIndex value="0"/>',
+            '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
+            '        <ValueNameID value="258"/>  <!-- Regular -->',
+            '        <Value value="400.0"/>',
+            "      </AxisValue>",
+            '      <AxisValue index="2" Format="1">',
+            '        <AxisIndex value="0"/>',
+            '        <Flags value="0"/>',
+            '        <ValueNameID value="259"/>  <!-- Black -->',
+            '        <Value value="900.0"/>',
+            "      </AxisValue>",
+            '      <AxisValue index="3" Format="1">',
+            '        <AxisIndex value="1"/>',
+            '        <Flags value="0"/>',
+            '        <ValueNameID value="261"/>  <!-- Condensed -->',
+            '        <Value value="50.0"/>',
+            "      </AxisValue>",
+            '      <AxisValue index="4" Format="1">',
+            '        <AxisIndex value="1"/>',
+            '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
+            '        <ValueNameID value="258"/>  <!-- Regular -->',
+            '        <Value value="100.0"/>',
+            "      </AxisValue>",
+            '      <AxisValue index="5" Format="1">',
+            '        <AxisIndex value="1"/>',
+            '        <Flags value="0"/>',
+            '        <ValueNameID value="262"/>  <!-- Extended -->',
+            '        <Value value="200.0"/>',
+            "      </AxisValue>",
+            "    </AxisValueArray>",
+            '    <ElidedFallbackNameID value="2"/>  <!-- missing from name table -->',
+            "  </STAT>",
+        ],
+    ),
+    (
+        [
+            dict(
+                tag="wght",
+                name="Weight",
+                values=[
+                    dict(value=400, name="Regular", flags=0x2),
+                    dict(value=600, linkedValue=650, name="Bold"),
+                ],
+            )
+        ],
+        None,
+        18,
+        [
+            "  <STAT>",
+            '    <Version value="0x00010001"/>',
+            '    <DesignAxisRecordSize value="8"/>',
+            "    <!-- DesignAxisCount=1 -->",
+            "    <DesignAxisRecord>",
+            '      <Axis index="0">',
+            '        <AxisTag value="wght"/>',
+            '        <AxisNameID value="256"/>  <!-- Weight -->',
+            '        <AxisOrdering value="0"/>',
+            "      </Axis>",
+            "    </DesignAxisRecord>",
+            "    <!-- AxisValueCount=2 -->",
+            "    <AxisValueArray>",
+            '      <AxisValue index="0" Format="1">',
+            '        <AxisIndex value="0"/>',
+            '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
+            '        <ValueNameID value="257"/>  <!-- Regular -->',
+            '        <Value value="400.0"/>',
+            "      </AxisValue>",
+            '      <AxisValue index="1" Format="3">',
+            '        <AxisIndex value="0"/>',
+            '        <Flags value="0"/>',
+            '        <ValueNameID value="258"/>  <!-- Bold -->',
+            '        <Value value="600.0"/>',
+            '        <LinkedValue value="650.0"/>',
+            "      </AxisValue>",
+            "    </AxisValueArray>",
+            '    <ElidedFallbackNameID value="18"/>  <!-- missing from name table -->',
+            "  </STAT>",
+        ],
+    ),
+    (
+        [
+            dict(
+                tag="opsz",
+                name="Optical Size",
+                values=[
+                    dict(nominalValue=6, rangeMaxValue=10, name="Small"),
+                    dict(
+                        rangeMinValue=10,
+                        nominalValue=14,
+                        rangeMaxValue=24,
+                        name="Text",
+                        flags=0x2,
+                    ),
+                    dict(rangeMinValue=24, nominalValue=600, name="Display"),
+                ],
+            )
+        ],
+        None,
+        2,
+        [
+            "  <STAT>",
+            '    <Version value="0x00010001"/>',
+            '    <DesignAxisRecordSize value="8"/>',
+            "    <!-- DesignAxisCount=1 -->",
+            "    <DesignAxisRecord>",
+            '      <Axis index="0">',
+            '        <AxisTag value="opsz"/>',
+            '        <AxisNameID value="256"/>  <!-- Optical Size -->',
+            '        <AxisOrdering value="0"/>',
+            "      </Axis>",
+            "    </DesignAxisRecord>",
+            "    <!-- AxisValueCount=3 -->",
+            "    <AxisValueArray>",
+            '      <AxisValue index="0" Format="2">',
+            '        <AxisIndex value="0"/>',
+            '        <Flags value="0"/>',
+            '        <ValueNameID value="257"/>  <!-- Small -->',
+            '        <NominalValue value="6.0"/>',
+            '        <RangeMinValue value="-32768.0"/>',
+            '        <RangeMaxValue value="10.0"/>',
+            "      </AxisValue>",
+            '      <AxisValue index="1" Format="2">',
+            '        <AxisIndex value="0"/>',
+            '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
+            '        <ValueNameID value="258"/>  <!-- Text -->',
+            '        <NominalValue value="14.0"/>',
+            '        <RangeMinValue value="10.0"/>',
+            '        <RangeMaxValue value="24.0"/>',
+            "      </AxisValue>",
+            '      <AxisValue index="2" Format="2">',
+            '        <AxisIndex value="0"/>',
+            '        <Flags value="0"/>',
+            '        <ValueNameID value="259"/>  <!-- Display -->',
+            '        <NominalValue value="600.0"/>',
+            '        <RangeMinValue value="24.0"/>',
+            '        <RangeMaxValue value="32767.99998"/>',
+            "      </AxisValue>",
+            "    </AxisValueArray>",
+            '    <ElidedFallbackNameID value="2"/>  <!-- missing from name table -->',
+            "  </STAT>",
+        ],
+    ),
+    (
+        [
+            dict(tag="wght", name="Weight", ordering=1, values=[]),
+            dict(
+                tag="ABCD",
+                name="ABCDTest",
+                ordering=0,
+                values=[dict(value=100, name="Regular", flags=0x2)],
+            ),
+        ],
+        [dict(location=dict(wght=300, ABCD=100), name="Regular ABCD")],
+        18,
+        [
+            "  <STAT>",
+            '    <Version value="0x00010002"/>',
+            '    <DesignAxisRecordSize value="8"/>',
+            "    <!-- DesignAxisCount=2 -->",
+            "    <DesignAxisRecord>",
+            '      <Axis index="0">',
+            '        <AxisTag value="wght"/>',
+            '        <AxisNameID value="256"/>  <!-- Weight -->',
+            '        <AxisOrdering value="1"/>',
+            "      </Axis>",
+            '      <Axis index="1">',
+            '        <AxisTag value="ABCD"/>',
+            '        <AxisNameID value="257"/>  <!-- ABCDTest -->',
+            '        <AxisOrdering value="0"/>',
+            "      </Axis>",
+            "    </DesignAxisRecord>",
+            "    <!-- AxisValueCount=2 -->",
+            "    <AxisValueArray>",
+            '      <AxisValue index="0" Format="4">',
+            "        <!-- AxisCount=2 -->",
+            '        <Flags value="0"/>',
+            '        <ValueNameID value="259"/>  <!-- Regular ABCD -->',
+            '        <AxisValueRecord index="0">',
+            '          <AxisIndex value="0"/>',
+            '          <Value value="300.0"/>',
+            "        </AxisValueRecord>",
+            '        <AxisValueRecord index="1">',
+            '          <AxisIndex value="1"/>',
+            '          <Value value="100.0"/>',
+            "        </AxisValueRecord>",
+            "      </AxisValue>",
+            '      <AxisValue index="1" Format="1">',
+            '        <AxisIndex value="1"/>',
+            '        <Flags value="2"/>  <!-- ElidableAxisValueName -->',
+            '        <ValueNameID value="258"/>  <!-- Regular -->',
+            '        <Value value="100.0"/>',
+            "      </AxisValue>",
+            "    </AxisValueArray>",
+            '    <ElidedFallbackNameID value="18"/>  <!-- missing from name table -->',
+            "  </STAT>",
+        ],
+    ),
 ]
 
 
-@pytest.mark.parametrize("axes, axisValues, elidedFallbackName, expected_ttx", buildStatTable_test_data)
+@pytest.mark.parametrize(
+    "axes, axisValues, elidedFallbackName, expected_ttx", buildStatTable_test_data
+)
 def test_buildStatTable(axes, axisValues, elidedFallbackName, expected_ttx):
     font = ttLib.TTFont()
     font["name"] = ttLib.newTable("name")
@@ -1414,7 +1460,13 @@ def test_buildStatTable_platform_specific_names():
     wght_values = [
         dict(nominalValue=200, rangeMinValue=200, rangeMaxValue=250, name="ExtraLight"),
         dict(nominalValue=300, rangeMinValue=250, rangeMaxValue=350, name="Light"),
-        dict(nominalValue=400, rangeMinValue=350, rangeMaxValue=450, name="Regular", flags=0x2),
+        dict(
+            nominalValue=400,
+            rangeMinValue=350,
+            rangeMaxValue=450,
+            name="Regular",
+            flags=0x2,
+        ),
         dict(nominalValue=500, rangeMinValue=450, rangeMaxValue=650, name="Medium"),
         dict(nominalValue=700, rangeMinValue=650, rangeMaxValue=750, name="Bold"),
         dict(nominalValue=800, rangeMinValue=750, rangeMaxValue=850, name="ExtraBold"),
@@ -1430,15 +1482,15 @@ def test_buildStatTable_platform_specific_names():
         ),
     ]
 
-    font_obj["name"].setName('ExtraLight', 260, 3, 1, 0x409)
-    font_obj["name"].setName('Light', 261, 3, 1, 0x409)
-    font_obj["name"].setName('Regular', 262, 3, 1, 0x409)
-    font_obj["name"].setName('Medium', 263, 3, 1, 0x409)
-    font_obj["name"].setName('Bold', 264, 3, 1, 0x409)
-    font_obj["name"].setName('ExtraBold', 265, 3, 1, 0x409)
-    font_obj["name"].setName('Black', 266, 3, 1, 0x409)
+    font_obj["name"].setName("ExtraLight", 260, 3, 1, 0x409)
+    font_obj["name"].setName("Light", 261, 3, 1, 0x409)
+    font_obj["name"].setName("Regular", 262, 3, 1, 0x409)
+    font_obj["name"].setName("Medium", 263, 3, 1, 0x409)
+    font_obj["name"].setName("Bold", 264, 3, 1, 0x409)
+    font_obj["name"].setName("ExtraBold", 265, 3, 1, 0x409)
+    font_obj["name"].setName("Black", 266, 3, 1, 0x409)
 
-    font_obj["name"].setName('Weight', 270, 3, 1, 0x409)
+    font_obj["name"].setName("Weight", 270, 3, 1, 0x409)
 
     expected_names = [x.string for x in font_obj["name"].names]
 
@@ -1450,7 +1502,7 @@ def test_buildStatTable_platform_specific_names():
     assert expected_names == actual_names
 
     font_obj["name"].removeNames(nameID=270)
-    expected_names = [x.string for x in font_obj["name"].names] + ['Weight']
+    expected_names = [x.string for x in font_obj["name"].names] + ["Weight"]
 
     builder.buildStatTable(font_obj, AXES, windowsNames=True, macNames=False)
     actual_names = [x.string for x in font_obj["name"].names]
@@ -1459,14 +1511,32 @@ def test_buildStatTable_platform_specific_names():
 
     builder.buildStatTable(font_obj, AXES, windowsNames=True, macNames=True)
     actual_names = [x.string for x in font_obj["name"].names]
-    expected_names = ['Weight', 'Weight', 'Weight',
-                      'ExtraLight', 'ExtraLight', 'ExtraLight',
-                      'Light', 'Light', 'Light',
-                      'Regular', 'Regular', 'Regular',
-                      'Medium', 'Medium', 'Medium',
-                      'Bold', 'Bold', 'Bold',
-                      'ExtraBold', 'ExtraBold', 'ExtraBold',
-                      'Black', 'Black', 'Black']
+    expected_names = [
+        "Weight",
+        "Weight",
+        "Weight",
+        "ExtraLight",
+        "ExtraLight",
+        "ExtraLight",
+        "Light",
+        "Light",
+        "Light",
+        "Regular",
+        "Regular",
+        "Regular",
+        "Medium",
+        "Medium",
+        "Medium",
+        "Bold",
+        "Bold",
+        "Bold",
+        "ExtraBold",
+        "ExtraBold",
+        "ExtraBold",
+        "Black",
+        "Black",
+        "Black",
+    ]
     # Because there is an inconsistency in the names add new name IDs
     # for each platform -> windowsNames=True, macNames=True
     assert sorted(expected_names) == sorted(actual_names)
@@ -1482,7 +1552,7 @@ def test_stat_infinities():
 class ChainContextualRulesetTest(object):
     def test_makeRulesets(self):
         font = ttLib.TTFont()
-        font.setGlyphOrder(["a","b","c","d","A","B","C","D","E"])
+        font.setGlyphOrder(["a", "b", "c", "d", "A", "B", "C", "D", "E"])
         sb = builder.ChainContextSubstBuilder(font, None)
         prefix, input_, suffix, lookups = [["a"], ["b"]], [["c"]], [], [None]
         sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
@@ -1495,7 +1565,7 @@ class ChainContextualRulesetTest(object):
         # Second subtable has some glyph classes
         prefix, input_, suffix, lookups = [["A"]], [["E"]], [], [None]
         sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
-        prefix, input_, suffix, lookups = [["A"]], [["C","D"]], [], [None]
+        prefix, input_, suffix, lookups = [["A"]], [["C", "D"]], [], [None]
         sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
         prefix, input_, suffix, lookups = [["A", "B"]], [["E"]], [], [None]
         sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
@@ -1505,7 +1575,7 @@ class ChainContextualRulesetTest(object):
         # Third subtable has no pre/post context
         prefix, input_, suffix, lookups = [], [["E"]], [], [None]
         sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
-        prefix, input_, suffix, lookups = [], [["C","D"]], [], [None]
+        prefix, input_, suffix, lookups = [], [["C", "D"]], [], [None]
         sb.rules.append(builder.ChainContextualRule(prefix, input_, suffix, lookups))
 
         rulesets = sb.rulesets()
@@ -1513,7 +1583,7 @@ class ChainContextualRulesetTest(object):
         assert rulesets[0].hasPrefixOrSuffix
         assert not rulesets[0].hasAnyGlyphClasses
         cd = rulesets[0].format2ClassDefs()
-        assert set(cd[0].classes()[1:]) == set([("d",),("b",),("a",)])
+        assert set(cd[0].classes()[1:]) == set([("d",), ("b",), ("a",)])
         assert set(cd[1].classes()[1:]) == set([("c",)])
         assert set(cd[2].classes()[1:]) == set()
 
@@ -1526,7 +1596,7 @@ class ChainContextualRulesetTest(object):
         assert rulesets[2].format2ClassDefs()
         cd = rulesets[2].format2ClassDefs()
         assert set(cd[0].classes()[1:]) == set()
-        assert set(cd[1].classes()[1:]) == set([("C","D"), ("E",)])
+        assert set(cd[1].classes()[1:]) == set([("C", "D"), ("E",)])
         assert set(cd[2].classes()[1:]) == set()
 
 

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1403,6 +1403,12 @@ def test_buildStatTable(axes, axisValues, elidedFallbackName, expected_ttx):
 
 
 def test_buildStatTable_name_duplicates():
+    '''
+    Create a failing unittest first.
+    Currently 'buildStatTable' creates name table entries,
+    even if the name exists in the name table already.
+    '''
+
     from fontTools.misc.fixedTools import fixedToFloat
 
     font_obj = ttLib.TTFont()

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1475,7 +1475,7 @@ def test_buildStatTable_name_duplicates():
 
     expected_names = [x.string for x in font_obj["name"].names]
 
-    builder.buildStatTable(font_obj, AXES)
+    builder.buildStatTable(font_obj, AXES, platforms=((3, 1, 0x409),))
     actual_names = [x.string for x in font_obj["name"].names]
 
     assert expected_names == actual_names

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1448,7 +1448,32 @@ def test_buildStatTable_name_duplicates():
     builder.buildStatTable(font_obj, AXES, windowsNames=True, macNames=False)
     actual_names = [x.string for x in font_obj["name"].names]
 
+    # no new name records were added by buildStatTable
+    # because windows-only names with the same strings were already present
     assert expected_names == actual_names
+
+    font_obj["name"].removeNames(nameID=270)
+    expected_names = [x.string for x in font_obj["name"].names] + ['Weight']
+
+    builder.buildStatTable(font_obj, AXES, windowsNames=True, macNames=False)
+    actual_names = [x.string for x in font_obj["name"].names]
+    # One new name records 'Weight' were added by buildStatTable
+    assert expected_names == actual_names
+
+    builder.buildStatTable(font_obj, AXES, windowsNames=True, macNames=True)
+    actual_names = [x.string for x in font_obj["name"].names]
+    expected_names = ['Weight', 'Weight',
+                      'ExtraLight', 'ExtraLight',
+                      'Light', 'Light',
+                      'Regular', 'Regular',
+                      'Medium', 'Medium',
+                      'Bold', 'Bold',
+                      'ExtraBold', 'ExtraBold',
+                      'Black', 'Black']
+    # Multiple name records were added by buildStatTable
+    assert expected_names == actual_names
+
+
 
 
 def test_stat_infinities():

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1475,7 +1475,7 @@ def test_buildStatTable_name_duplicates():
 
     expected_names = [x.string for x in font_obj["name"].names]
 
-    builder.buildStatTable(font_obj, AXES, platforms=((3, 1, 0x409),))
+    builder.buildStatTable(font_obj, AXES, windows=True, mac=False)
     actual_names = [x.string for x in font_obj["name"].names]
 
     assert expected_names == actual_names

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1402,7 +1402,7 @@ def test_buildStatTable(axes, axisValues, elidedFallbackName, expected_ttx):
     assert expected_ttx == ttx
 
 
-def test_buildStatTable_name_duplicates():
+def test_buildStatTable_platform_specific_names():
     # PR: https://github.com/fonttools/fonttools/pull/2528
     # Introduce new 'platform' feature for creating a STAT table.
     # Set windowsNames and or macNames to create name table entries

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -317,10 +317,23 @@ class NameTableTest(unittest.TestCase):
 		font_obj["name"].names = []
 
 		font_obj["name"].setName('Weight', 270, 3, 1, 0x409)
+		font_obj["name"].setName('Weight', 270, 1, 0, 0)
 		names = {'en': 'Weight', }
 		nameID = font_obj["name"].addMultilingualName(names, minNameID=256)
-
 		self.assertEqual(270, nameID)
+
+		font_obj["name"].removeNames(nameID=270, platformID=1)  # remove Mac name
+		nameID = font_obj["name"].addMultilingualName(names, minNameID=256)
+		# Because there is an inconsistency in the names add a new name ID
+		self.assertEqual(271, nameID)
+
+		font_obj["name"].removeNames(platformID=3)  # remove all Windows names
+		font_obj["name"].removeNames(platformID=1)  # remove all Mac names
+		nameID = font_obj["name"].addMultilingualName(names, minNameID=256)
+		#Because there is no name ID with the name 'Weight',
+		# take the next available name ID -> minNameID=256
+		self.assertEqual(256, nameID)
+
 
 
 	def test_decompile_badOffset(self):

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -6,7 +6,6 @@ from fontTools.misc.xmlWriter import XMLWriter
 from io import BytesIO
 import struct
 import unittest
-from fontTools import ttLib
 from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables._n_a_m_e import (
 	table__n_a_m_e, NameRecord, nameRecordFormat, nameRecordSize, makeName, log)
@@ -313,7 +312,7 @@ class NameTableTest(unittest.TestCase):
 		'''
 
 		font_obj = TTFont()
-		font_obj["name"] = ttLib.newTable("name")
+		font_obj["name"] = newTable("name")
 		font_obj["name"].names = []
 
 		font_obj["name"].setName('Weight', 270, 3, 1, 0x409)
@@ -330,11 +329,9 @@ class NameTableTest(unittest.TestCase):
 		font_obj["name"].removeNames(platformID=3)  # remove all Windows names
 		font_obj["name"].removeNames(platformID=1)  # remove all Mac names
 		nameID = font_obj["name"].addMultilingualName(names, minNameID=256)
-		#Because there is no name ID with the name 'Weight',
+		# Because there is no name ID with the name 'Weight',
 		# take the next available name ID -> minNameID=256
 		self.assertEqual(256, nameID)
-
-
 
 	def test_decompile_badOffset(self):
                 # https://github.com/fonttools/fonttools/issues/525

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -312,7 +312,7 @@ class NameTableTest(unittest.TestCase):
 		a Mac name table entry equal to Windows entry.
 		'''
 
-		font_obj = ttLib.TTFont()
+		font_obj = TTFont()
 		font_obj["name"] = ttLib.newTable("name")
 		font_obj["name"].names = []
 

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -7,7 +7,7 @@ from io import BytesIO
 import struct
 import unittest
 from fontTools import ttLib
-from fontTools.ttLib import newTable
+from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables._n_a_m_e import (
 	table__n_a_m_e, NameRecord, nameRecordFormat, nameRecordSize, makeName, log)
 

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -6,6 +6,7 @@ from fontTools.misc.xmlWriter import XMLWriter
 from io import BytesIO
 import struct
 import unittest
+from fontTools import ttLib
 from fontTools.ttLib import newTable
 from fontTools.ttLib.tables._n_a_m_e import (
 	table__n_a_m_e, NameRecord, nameRecordFormat, nameRecordSize, makeName, log)
@@ -304,6 +305,23 @@ class NameTableTest(unittest.TestCase):
 		nameID = table.addMultilingualName(names, minNameID=256)
 		self.assertGreaterEqual(nameID, 256)
 		self.assertEqual(nameID, table.findMultilingualName(names, minNameID=256))
+
+	def test_addMultilingualName_no_mac_but_win(self):
+		'''
+		Test if addMultilingualName adds
+		a Mac name table entry equal to Windows entry.
+		'''
+
+		font_obj = ttLib.TTFont()
+		font_obj["name"] = ttLib.newTable("name")
+		font_obj["name"].names = []
+
+		font_obj["name"].setName('Weight', 270, 3, 1, 0x409)
+		names = {'en': 'Weight', }
+		nameID = font_obj["name"].addMultilingualName(names, minNameID=256)
+
+		self.assertEqual(270, nameID)
+
 
 	def test_decompile_badOffset(self):
                 # https://github.com/fonttools/fonttools/issues/525

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -305,30 +305,16 @@ class NameTableTest(unittest.TestCase):
 		self.assertGreaterEqual(nameID, 256)
 		self.assertEqual(nameID, table.findMultilingualName(names, minNameID=256))
 
-	def test_addMultilingualName_no_mac_but_win(self):
-		# Test if addMultilingualName adds
-		# a Mac name table entry equal to Windows entry.
-		font_obj = TTFont()
-		font_obj["name"] = newTable("name")
-		font_obj["name"].names = []
-
-		font_obj["name"].setName('Weight', 270, 3, 1, 0x409)
-		font_obj["name"].setName('Weight', 270, 1, 0, 0)
+	def test_addMultilingualName_name_inconsistencies(self):
+		# Check what happens, when there are
+		# inconsistencies in the name table
+		table = table__n_a_m_e()
+		table.setName('Weight', 270, 3, 1, 0x409)
 		names = {'en': 'Weight', }
-		nameID = font_obj["name"].addMultilingualName(names, minNameID=256)
-		self.assertEqual(270, nameID)
-
-		font_obj["name"].removeNames(nameID=270, platformID=1)  # remove Mac name
-		nameID = font_obj["name"].addMultilingualName(names, minNameID=256)
-		# Because there is an inconsistency in the names add a new name ID
+		nameID = table.addMultilingualName(names, minNameID=256)
+		# Because there is an inconsistency in the names,
+		# addMultilingualName adds a new name ID
 		self.assertEqual(271, nameID)
-
-		font_obj["name"].removeNames(platformID=3)  # remove all Windows names
-		font_obj["name"].removeNames(platformID=1)  # remove all Mac names
-		nameID = font_obj["name"].addMultilingualName(names, minNameID=256)
-		# Because there is no name ID with the name 'Weight',
-		# take the next available name ID -> minNameID=256
-		self.assertEqual(256, nameID)
 
 	def test_decompile_badOffset(self):
                 # https://github.com/fonttools/fonttools/issues/525

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -306,11 +306,8 @@ class NameTableTest(unittest.TestCase):
 		self.assertEqual(nameID, table.findMultilingualName(names, minNameID=256))
 
 	def test_addMultilingualName_no_mac_but_win(self):
-		'''
-		Test if addMultilingualName adds
-		a Mac name table entry equal to Windows entry.
-		'''
-
+		# Test if addMultilingualName adds
+		# a Mac name table entry equal to Windows entry.
 		font_obj = TTFont()
 		font_obj["name"] = newTable("name")
 		font_obj["name"].names = []


### PR DESCRIPTION
The function to create a STAT table created duplicate name table entries, because it did not take care about existing name table entries with the name name. This PullRequest takes care about it.

EDIT(anthrotype): `buildStatTable` calls `nameTable.addMultilingualName` which by default creates both mac and windows names; if the name table only contains one of the two (usually only windows, no mac ones), then `addMultilingualName` can't reuse the existing name IDs (or else it would produce inconsistent nameIDs between mac and windows platforms) and thus it creates duplicate records. This PR adds `windowsNames` and `macNames` parameters to `buildStatTable` so that one can select whether to only add one or both of the two sets. This way, when calling buildStatTable with a name able that only contains windows (or mac) names and there are some that are already present, they won't be unnecessarily duplicated provided that `macNames` (or `windowsNames`) is set to `False`.