### PR TITLE
Add debug logger showing the glyph name for which gvar is built

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -230,7 +230,7 @@ def _add_gvar(font, masterModel, master_ttfs, tolerance=0.5, optimize=True):
 			for m in master_ttfs]
 
 	for glyph in font.getGlyphOrder():
-
+		log.debug("building gvar for glyph '%s'", glyph)
 		isComposite = glyf[glyph].isComposite()
 
 		allData = [


### PR DESCRIPTION
When building gvar, some situations cause fontmake/varLib to fail, for example if a component has a coordinate that's >32k or <-32k. This adds a debug line that prints each glyph name for which gvar is built, so it’s easier to pinpoint where the faulty glyph is.