### PR TITLE
Handle merging SinglePos with valueformat=0

### DIFF
--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -264,7 +264,8 @@ def merge(merger, self, lst):
 	coverageGlyphs = self.Coverage.glyphs
 	if all(v.Format == 1 for v in lst) and all(coverageGlyphs == v.Coverage.glyphs for v in lst):
 		self.Value = otBase.ValueRecord(valueFormat)
-		merger.mergeThings(self.Value, [v.Value for v in lst])
+		if valueFormat != 0:
+			merger.mergeThings(self.Value, [v.Value for v in lst])
 		self.ValueFormat = self.Value.getFormat()
 		return
 
@@ -297,7 +298,7 @@ def merge(merger, self, lst):
 
 	# Merge everything else; though, there shouldn't be anything else. :)
 	merger.mergeObjects(self, lst,
-			    exclude=('Format', 'Coverage', 'Value', 'ValueCount'))
+			    exclude=('Format', 'Coverage', 'Value', 'ValueCount', 'ValueFormat'))
 	self.ValueFormat = reduce(int.__or__, [v.getEffectiveFormat() for v in self.Value], 0)
 
 @AligningMerger.merger(ot.PairSet)


### PR DESCRIPTION
I had a situation where I instanced a variable font, fiddled with the instances, and put it back together into a variable font; but the merge step was not working. It turned out this was because the font had a single positioning rule (called by a contextual positioning rule) which was only effective for some locations. At other locations, the rule had no effect, so it had a ValueFormat=0.

Although the merger has code to set the output value format of a single pos to be the highest format of its constituent subtables, it still attempts to merge the ValueFormat attributes. These should be added to the exclude list.

Additionally, I came across a lookup where *all* the value formats of a subtable were zero. (I was splitting a variable font with a ital axis into separate Upright/Italic VFs, and the positioning rule only applied to the italic.) That didn't work well; the first hunk fixes that condition.