### PR TITLE
add ensureDecompiled method to decompile all the tables irrespective of lazy attribute

### DIFF
--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -162,7 +162,6 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
 	def ensureDecompiled(self):
 		for st in self.tables:
 			st.ensureDecompiled()
-		return self
 
 	def compile(self, ttFont):
 		self.tables.sort()  # sort according to the spec; see CmapSubtable.__lt__()
@@ -246,7 +245,6 @@ class CmapSubtable(object):
 		self.data = None	# Once this table has been decompiled, make sure we don't
 							# just return the original data. Also avoids recursion when
 							# called with an attribute that the cmap subtable doesn't have.
-		return self
 
 	def __getattr__(self, attr):
 		# allow lazy decompilation of subtables.

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -162,6 +162,7 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
 	def ensureDecompiled(self):
 		for st in self.tables:
 			st.ensureDecompiled()
+		return self
 
 	def compile(self, ttFont):
 		self.tables.sort()  # sort according to the spec; see CmapSubtable.__lt__()
@@ -245,6 +246,7 @@ class CmapSubtable(object):
 		self.data = None	# Once this table has been decompiled, make sure we don't
 							# just return the original data. Also avoids recursion when
 							# called with an attribute that the cmap subtable doesn't have.
+		return self
 
 	def __getattr__(self, attr):
 		# allow lazy decompilation of subtables.

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -110,8 +110,11 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 		if noname:
 			log.warning('%s glyphs have no name', noname)
 		if ttFont.lazy is False: # Be lazy for None and True
-			for glyph in self.glyphs.values():
-				glyph.expand(self)
+			self.ensureDecompiled()
+
+	def ensureDecompiled(self):
+		for glyph in self.glyphs.values():
+			glyph.expand(self)
 
 	def compile(self, ttFont):
 		if not hasattr(self, "glyphOrder"):

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -115,7 +115,6 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 	def ensureDecompiled(self):
 		for glyph in self.glyphs.values():
 			glyph.expand(self)
-		return self
 
 	def compile(self, ttFont):
 		if not hasattr(self, "glyphOrder"):

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -115,6 +115,7 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 	def ensureDecompiled(self):
 		for glyph in self.glyphs.values():
 			glyph.expand(self)
+		return self
 
 	def compile(self, ttFont):
 		if not hasattr(self, "glyphOrder"):

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -110,7 +110,6 @@ class BaseTTXConverter(DefaultTable):
 
 	def ensureDecompiled(self):
 		self.table.ensureDecompiled(recurse=True)
-		return self
 
 
 # https://github.com/fonttools/fonttools/pull/2285#issuecomment-834652928
@@ -610,7 +609,6 @@ class BaseTable(object):
 		if recurse:
 			for subtable in self.iterSubTables():
 				subtable.ensureDecompiled(recurse)
-		return self
 
 	@classmethod
 	def getRecordSize(cls, reader):

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -110,6 +110,7 @@ class BaseTTXConverter(DefaultTable):
 
 	def ensureDecompiled(self):
 		self.table.ensureDecompiled(recurse=True)
+		return self
 
 
 # https://github.com/fonttools/fonttools/pull/2285#issuecomment-834652928
@@ -609,6 +610,7 @@ class BaseTable(object):
 		if recurse:
 			for subtable in self.iterSubTables():
 				subtable.ensureDecompiled(recurse)
+		return self
 
 	@classmethod
 	def getRecordSize(cls, reader):

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -905,7 +905,9 @@ class FormatSwitchingBaseTable(BaseTable):
 		except AttributeError:
 			# some FormatSwitchingBaseTables (e.g. Coverage) no longer have 'Format'
 			# attribute after fully decompiled, only gain one in preWrite before being
-			# recompiled.
+			# recompiled. In the decompiled state, these hand-coded classes defined in
+			# otTables.py lose their format-specific nature and gain more high-level
+			# attributes that are not tied to converters.
 			return []
 		return self.converters.get(self.Format, [])
 

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -851,6 +851,16 @@ class BaseTable(object):
 
 		return self.__dict__ == other.__dict__
 
+	def iterSubTables(self):
+		for conv in self.getConverters():
+			value = getattr(self, conv.name, None)
+			if value is None:
+				continue
+			if isinstance(value, BaseTable):
+				yield value
+			elif isinstance(value, list):
+				yield from (v for v in value if isinstance(v, BaseTable))
+
 
 class FormatSwitchingBaseTable(BaseTable):
 
@@ -862,6 +872,13 @@ class FormatSwitchingBaseTable(BaseTable):
 		return NotImplemented
 
 	def getConverters(self):
+		try:
+			fmt = self.Format
+		except AttributeError:
+			# some FormatSwitchingBaseTables (e.g. Coverage) no longer have 'Format'
+			# attribute after fully decompiled, only gain one in preWrite before being
+			# recompiled.
+			return []
 		return self.converters.get(self.Format, [])
 
 	def getConverterByName(self, name):

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -108,6 +108,9 @@ class BaseTTXConverter(DefaultTable):
 		self.table.fromXML(name, attrs, content, font)
 		self.table.populateDefaults()
 
+	def ensureDecompiled(self):
+		self.table.ensureDecompiled(recurse=True)
+
 
 # https://github.com/fonttools/fonttools/pull/2285#issuecomment-834652928
 assert len(struct.pack('i', 0)) == 4
@@ -596,13 +599,16 @@ class BaseTable(object):
 
 		raise AttributeError(attr)
 
-	def ensureDecompiled(self):
+	def ensureDecompiled(self, recurse=False):
 		reader = self.__dict__.get("reader")
 		if reader:
 			del self.reader
 			font = self.font
 			del self.font
 			self.decompile(reader, font)
+		if recurse:
+			for subtable in self.iterSubTables():
+				subtable.ensureDecompiled(recurse)
 
 	@classmethod
 	def getRecordSize(cls, reader):

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -129,7 +129,7 @@ class TTFont(object):
 			closeStream = False
 			file.seek(0)
 
-		if self.lazy is None:
+		if not self.lazy:
 			# read input file in memory and wrap a stream around it to allow overwriting
 			file.seek(0)
 			tmp = BytesIO(file.read())
@@ -139,18 +139,11 @@ class TTFont(object):
 			if closeStream:
 				file.close()
 			file = tmp
-
 		self._tableCache = _tableCache
 		self.reader = SFNTReader(file, checkChecksums, fontNumber=fontNumber)
 		self.sfntVersion = self.reader.sfntVersion
 		self.flavor = self.reader.flavor
 		self.flavorData = self.reader.flavorData
-
-		if self.lazy is False:
-			# if lazy=False immediately load all the tables
-			self.ensureDecompiled()
-			if closeStream:
-				file.close()
 
 	def __enter__(self):
 		return self

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -379,12 +379,16 @@ class TTFont(object):
 		return ["GlyphOrder"] + keys
 
 	def ensureDecompiled(self):
-		"""Decompile all the tables, even if a TTFont was opened in 'lazy' mode."""
+		"""Decompile all the tables, even if a TTFont was opened in 'lazy' mode.
+
+		Returns the same TTFont instance, fully decompiled.
+		"""
 		for tag in self.keys():
 			table = self[tag]
 			if self.lazy is not False and hasattr(table, "ensureDecompiled"):
 				table.ensureDecompiled()
 		self.lazy = False
+		return self
 
 	def __len__(self):
 		return len(list(self.keys()))

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -379,16 +379,12 @@ class TTFont(object):
 		return ["GlyphOrder"] + keys
 
 	def ensureDecompiled(self):
-		"""Decompile all the tables, even if a TTFont was opened in 'lazy' mode.
-
-		Returns the same TTFont instance, fully decompiled.
-		"""
+		"""Decompile all the tables, even if a TTFont was opened in 'lazy' mode."""
 		for tag in self.keys():
 			table = self[tag]
 			if self.lazy is not False and hasattr(table, "ensureDecompiled"):
 				table.ensureDecompiled()
 		self.lazy = False
-		return self
 
 	def __len__(self):
 		return len(list(self.keys()))


### PR DESCRIPTION
While attempting to tackle glyph reordering in https://github.com/fonttools/fonttools/issues/2060, I needed a way to say "decompile everything in the font". The lazy=False unfortunately does not exactly do what it says to be doing, and that's confusing for people who are not familiar with the fonttools internals (some colleagues did stumble on this). Not only one has to set lazy=False, but one also has to iterate over all the tables and actually decompile them using silly loop like:

```python
for tag in font.keys():
    _ = font[tag]
```

A quick recap about `TTFont.lazy` attribute. It has three states: it defaults to None, and can be optionally be set to True or False.
When it is set to True, the font keeps a reference to the original input file (inside its SFTNReader); when it's None (or False), it copies the raw bytes of the input files to in-memory stream (allows overwriting input, or reading from unseekable streams). A TTFont decompiles a given table only when requested (in `__getitem__`) -- confusingly even when lazy=False.
Then, some tables take into account the lazy attribute to decide whether to load or not all their data upfront. In particular:
1) the glyf table decompile all the glyphs if lazy is False; it keeps them in compact (raw data) form if lazy is True or None (default), so they get expanded upon getting them.
2) All tables that are generated through the otData.py machinery are loaded lazily when lazy=True (`BaseTable.__getattr__` triggeres decompiling upon getting any attribute); they are fully decompiled if lazy is None (default) or False.
3) cmap completely ignores lazy attribute, and always loads its subtables lazily.

***

What this PR proposes to change is:

1) ~~have `TTFont(path, lazy=False)` immediately decompile all the tables' data, everything, like it says on the tin, so one doesn't need to then also decompile individual tables;~~ (decided to reverted this change)
2) add an `ensureDecompiled` method to TTFont, cmap, glyf and the otTables that allows to un-lazify them even when a font had been loaded with lazy=True or None; they get the same as opening it with lazy=False.
3) fix the fact that cmap doesn't respect lazy; make it load everything when lazy=False. 

