### PR TITLE
[subset] fix subsetting OT-SVG when glyph id attribute is on the root <svg> element

### DIFF
--- a/Lib/fontTools/subset/svg.py
+++ b/Lib/fontTools/subset/svg.py
@@ -36,7 +36,10 @@ def xpath(path):
 
 
 def group_elements_by_id(tree: etree.Element) -> Dict[str, etree.Element]:
-    return {el.attrib["id"]: el for el in xpath(".//svg:*[@id]")(tree)}
+    # select all svg elements with 'id' attribute no matter where they are
+    # including the root element itself:
+    # https://github.com/fonttools/fonttools/issues/2548
+    return {el.attrib["id"]: el for el in xpath("//svg:*[@id]")(tree)}
 
 
 def parse_css_declarations(style_attr: str) -> Dict[str, str]:


### PR DESCRIPTION
/cc @frankrolf

Fixes https://github.com/fonttools/fonttools/issues/2548

I tested locally with [Noto Emoji OT-SVG](https://github.com/adobe-fonts/noto-emoji-svg/releases) and it works now