### PR TITLE
[varLib.interpolatable] Check for wrong contour starting point

### DIFF
--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -95,11 +95,11 @@ class Glyph:
 		self.glyphName = glyphName
 		self.glyphSet = glyphSet
 
-	def draw(self, pen):
+	def draw(self, pen, outputImpliedClosingLine=False):
 		"""
 		Draw this glyph onto a *FontTools* Pen.
 		"""
-		pointPen = PointToSegmentPen(pen)
+		pointPen = PointToSegmentPen(pen, outputImpliedClosingLine=outputImpliedClosingLine)
 		self.drawPoints(pointPen)
 
 	def drawPoints(self, pointPen):

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -166,7 +166,10 @@ def test(glyphsets, glyphs=None, names=None):
                 perContourPen = PerContourOrComponentPen(
                     RecordingPen, glyphset=glyphset
                 )
-                glyph.draw(perContourPen)
+                try:
+                    glyph.draw(perContourPen, outputImpliedClosingLine=True)
+                except TypeError:
+                    glyph.draw(perContourPen)
                 contourPens = perContourPen.value
                 del perContourPen
 

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -224,7 +224,15 @@ def test(glyphsets, glyphs=None, names=None):
                         b = ((bits << i) & mask) | ((bits >> (n - i)))
                         if b == bits:
                             isomorphisms.append(_rot_list ([complex(*pt) for pt,bl in points.value], i))
-                    # TODO Add mirrors
+                    # Add mirrored rotations
+                    mirrored = list(reversed(points.value))
+                    reversed_bits = 0
+                    for pt,b in mirrored:
+                        reversed_bits = (reversed_bits << 1) | b
+                    for i in range(n):
+                        b = ((reversed_bits << i) & mask) | ((reversed_bits >> (n - i)))
+                        if b == bits:
+                            isomorphisms.append(_rot_list ([complex(*pt) for pt,bl in mirrored], i))
 
             # Check each master against the next one in the list.
             for i, (m0, m1) in enumerate(zip(allNodeTypes[:-1], allNodeTypes[1:])):

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -305,7 +305,7 @@ def test(glyphsets, glyphs=None, names=None):
                     costs = [v for v in (_complex_vlen(_vdiff(c0, c1)) for i1,c1 in contour1)]
                     min_cost = min(costs)
                     first_cost = costs[0]
-                    if min_cost < first_cost:
+                    if min_cost < first_cost * .95:
                         add_problem(
                             glyph_name,
                             {

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -213,7 +213,6 @@ def test(glyphsets, glyphs=None, names=None):
                     # points.value is a list of pt,bool where bool is true if on-curve and false if off-curve;
                     # now check all rotations and mirror-rotations of the contour and build list of isomorphic
                     # possible starting points.
-                    #print(points.value)
                     bits = 0
                     for pt,b in points.value:
                         bits = (bits << 1) | b
@@ -294,23 +293,6 @@ def test(glyphsets, glyphs=None, names=None):
                         },
                     )
                     break
-                upem = 2048
-                item_cost = round(
-                    (matching_cost / len(m0) / len(m0[0])) ** 0.5 / upem * 100
-                )
-                hist.append(item_cost)
-                threshold = 7
-                if item_cost >= threshold:
-                    add_problem(
-                        glyph_name,
-                        {
-                            "type": "high_cost",
-                            "master_1": names[i],
-                            "master_2": names[i + 1],
-                            "value_1": item_cost,
-                            "value_2": threshold,
-                        },
-                    )
 
             for i, (m0, m1) in enumerate(zip(allContourIsomorphisms[:-1], allContourIsomorphisms[1:])):
                 if not m0:
@@ -435,16 +417,6 @@ def main(args=None):
                         % (
                             p["master_1"],
                             p["master_2"],
-                        )
-                    )
-                if p["type"] == "high_cost":
-                    print(
-                        "    Interpolation has high cost: cost of %s to %s = %i, threshold %i"
-                        % (
-                            p["master_1"],
-                            p["master_2"],
-                            p["value_1"],
-                            p["value_2"],
                         )
                     )
     if problems:

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -281,7 +281,9 @@ def test(glyphsets, glyphs=None, names=None):
                     continue
                 costs = [[_vlen(_vdiff(v0, v1)) for v1 in m1] for v0 in m0]
                 matching, matching_cost = min_cost_perfect_bipartite_matching(costs)
-                if matching != list(range(len(m0))):
+                identity_matching = list(range(len(m0)))
+                identity_cost = sum(costs[i][i] for i in range(len(m0)))
+                if matching != identity_matching and matching_cost < identity_cost * .95:
                     add_problem(
                         glyph_name,
                         {

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -308,8 +308,10 @@ def test(glyphsets, glyphs=None, names=None):
                     break
 
             for i, (m0, m1) in enumerate(zip(allContourIsomorphisms[:-1], allContourIsomorphisms[1:])):
+                if len(m0) != len(m1):
+                    # We already reported this
+                    continue
                 if not m0:
-                    assert not m1
                     continue
                 for contour0,contour1 in zip(m0,m1):
                     c0 = contour0[0]

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -209,7 +209,7 @@ def test(glyphsets, glyphs=None, names=None):
                     if nodeVecs[0] == 'addComponent':
                         continue
                     assert nodeVecs[0] == 'moveTo'
-                    assert nodeVecs[-1] == 'closePath'
+                    assert nodeVecs[-1] in ('closePath', 'endPath')
                     points = RecordingPointPen()
                     converter = SegmentToPointPen(points, False)
                     contour.replay(converter)

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -223,7 +223,7 @@ def test(glyphsets, glyphs=None, names=None):
                     for i in range(n):
                         b = ((bits << i) & mask) | ((bits >> (n - i)))
                         if b == bits:
-                            isomorphisms.append((i, _rot_list ([complex(*pt) for pt,bl in points.value], i)))
+                            isomorphisms.append(_rot_list ([complex(*pt) for pt,bl in points.value], i))
                     # TODO Add mirrors
 
             # Check each master against the next one in the list.
@@ -301,8 +301,8 @@ def test(glyphsets, glyphs=None, names=None):
                     assert not m1
                     continue
                 for contour0,contour1 in zip(m0,m1):
-                    c0 = contour0[0][1]
-                    costs = [v for v in (_complex_vlen(_vdiff(c0, c1)) for i1,c1 in contour1)]
+                    c0 = contour0[0]
+                    costs = [v for v in (_complex_vlen(_vdiff(c0, c1)) for c1 in contour1)]
                     min_cost = min(costs)
                     first_cost = costs[0]
                     if min_cost < first_cost * .95:


### PR DESCRIPTION
This seems to work already. Detects the example in the issue.
I also ran this on master-compatible UFOs built from Noto Sans,
and detected several issues. Confirmed visuall in AxisPraxis that
theta.sc for example has wrong starting point in that font, there's more...

```
Glyph theta.sc was not compatible:
    Contour start point differs: NotoSans-DisplayRegular, NotoSans-DisplaySemiBoldCondensed
    Contour start point differs: NotoSans-DisplayRegular, NotoSans-DisplaySemiBoldCondensed
    Contour start point differs: NotoSans-DisplaySemiBoldCondensed, NotoSans-DisplaySemiBold
    Contour start point differs: NotoSans-DisplaySemiBoldCondensed, NotoSans-DisplaySemiBold
```

There's a TODO item left to be done, which is to check for mirrored
contours and rotations thereof.

Towards fixing https://github.com/fonttools/fonttools/issues/1801