### PR TITLE
[cmap] don't handle expected case in exception handler

### DIFF
--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -177,13 +177,11 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
 		seen = {}  # Some tables are the same object reference. Don't compile them twice.
 		done = {}  # Some tables are different objects, but compile to the same data chunk
 		for table in self.tables:
-			try:
-				offset = seen[id(table.cmap)]
-			except KeyError:
+			offset = seen.get(id(table.cmap))
+			if offset is None:
 				chunk = table.compile(ttFont)
-				if chunk in done:
-					offset = done[chunk]
-				else:
+				offset = done.get(chunk)
+				if offset is None:
 					offset = seen[id(table.cmap)] = done[chunk] = totalOffset + len(tableData)
 					tableData = tableData + chunk
 			data = data + struct.pack(">HHl", table.platformID, table.platEncID, offset)


### PR DESCRIPTION
It is bad style, and causes unnecessarily confusing tracebacks, such as seen in #2584.

Additionally, use `v = d.get(k)` instead of checking first and then getting.