### PR TITLE
define USE_HARFBUZZ_REPACKER config option

### DIFF
--- a/Lib/fontTools/config/__init__.py
+++ b/Lib/fontTools/config/__init__.py
@@ -14,7 +14,9 @@ from fontTools.misc.configTools import *
 class Config(AbstractConfig):
     options = Options()
 
+
 OPTIONS = Config.options
+
 
 Config.register_option(
     name="fontTools.otlLib.optimize.gpos:COMPRESSION_LEVEL",
@@ -38,4 +40,18 @@ Config.register_option(
     default=0,
     parse=int,
     validate=lambda v: v in range(10),
+)
+
+Config.register_option(
+    name="fontTools.ttLib.tables.otBase:USE_HARFBUZZ_REPACKER",
+    help=dedent(
+        """\
+        FontTools tries to use the HarfBuzz Repacker to serialize GPOS/GSUB tables
+        if the uharfbuzz python bindings are importable, otherwise falls back to its
+        slower, less efficient serializer. Set to False to always use the latter.
+        """
+    ),
+    default=True,
+    parse=lambda s: str(s).lower() not in {"0", "no", "false"},
+    validate=lambda v: isinstance(v, bool),
 )

--- a/Lib/fontTools/config/__init__.py
+++ b/Lib/fontTools/config/__init__.py
@@ -49,9 +49,11 @@ Config.register_option(
         FontTools tries to use the HarfBuzz Repacker to serialize GPOS/GSUB tables
         if the uharfbuzz python bindings are importable, otherwise falls back to its
         slower, less efficient serializer. Set to False to always use the latter.
+        Set to True to explicitly request the HarfBuzz Repacker (will raise an
+        error if uharfbuzz cannot be imported).
         """
     ),
-    default=True,
-    parse=lambda s: str(s).lower() not in {"0", "no", "false"},
-    validate=lambda v: isinstance(v, bool),
+    default=None,
+    parse=Option.parse_optional_bool,
+    validate=Option.validate_optional_bool,
 )

--- a/Lib/fontTools/misc/configTools.py
+++ b/Lib/fontTools/misc/configTools.py
@@ -100,6 +100,21 @@ class Option:
     validate: Optional[Callable[[Any], bool]] = None
     """Return true if the given value is an acceptable value."""
 
+    @staticmethod
+    def parse_optional_bool(v: str) -> Optional[bool]:
+        s = str(v).lower()
+        if s in {"0", "no", "false"}:
+            return False
+        if s in {"1", "yes", "true"}:
+            return True
+        if s in {"auto", "none"}:
+            return None
+        raise ValueError("invalid optional bool: {v!r}")
+
+    @staticmethod
+    def validate_optional_bool(v: Any) -> bool:
+        return v is None or isinstance(v, bool)
+
 
 class Options(Mapping):
     """Registry of available options for a given config system.

--- a/Lib/fontTools/misc/configTools.py
+++ b/Lib/fontTools/misc/configTools.py
@@ -107,8 +107,11 @@ class Options(Mapping):
 
     __options: Dict[str, Option]
 
-    def __init__(self) -> None:
+    def __init__(self, other: "Options" = None) -> None:
         self.__options = {}
+        if other is not None:
+            for name, option in other.items():
+                self.register_option(name, option)
 
     def register(
         self,
@@ -128,8 +131,8 @@ class Options(Mapping):
         self.__options[name] = option
         return option
 
-    def __getitem__(self, __k: str) -> Option:
-        return self.__options.__getitem__(__k)
+    def __getitem__(self, key: str) -> Option:
+        return self.__options.__getitem__(key)
 
     def __iter__(self) -> Iterator[str]:
         return self.__options.__iter__()

--- a/Lib/fontTools/misc/configTools.py
+++ b/Lib/fontTools/misc/configTools.py
@@ -137,6 +137,16 @@ class Options(Mapping):
     def __len__(self) -> int:
         return self.__options.__len__()
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}({{\n"
+            + "".join(
+                f"    {k!r}: Option(default={v.default!r}, ...),\n"
+                for k, v in self.__options.items()
+            )
+            + "})"
+        )
+
 
 _USE_GLOBAL_DEFAULT = object()
 

--- a/Lib/fontTools/misc/configTools.py
+++ b/Lib/fontTools/misc/configTools.py
@@ -86,7 +86,8 @@ class ConfigUnknownOptionError(ConfigError):
         super().__init__(f"Config option {name} is unknown")
 
 
-@dataclass(frozen=True)
+# eq=False because Options are unique, not fungible objects
+@dataclass(frozen=True, eq=False)
 class Option:
     name: str
     """Unique name identifying the option (e.g. package.module:MY_OPTION)."""

--- a/Lib/fontTools/misc/configTools.py
+++ b/Lib/fontTools/misc/configTools.py
@@ -110,11 +110,9 @@ class Options(Mapping):
     """
 
     __options: Dict[str, Option]
-    __cache: Set[Option]
 
     def __init__(self, other: "Options" = None) -> None:
         self.__options = {}
-        self.__cache = set()
         if other is not None:
             for option in other.values():
                 self.register_option(option)
@@ -135,15 +133,12 @@ class Options(Mapping):
         name = option.name
         if name in self.__options:
             raise ConfigAlreadyRegisteredError(name)
-        # sanity check option values are unique
-        assert option not in self.__cache
         self.__options[name] = option
-        self.__cache.add(option)
         return option
 
     def is_registered(self, option: Option) -> bool:
-        """Return True if the option object is already registered."""
-        return option in self.__cache
+        """Return True if the same option object is already registered."""
+        return self.__options.get(option.name) is option
 
     def __getitem__(self, key: str) -> Option:
         return self.__options.__getitem__(key)

--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 import tempfile
 from unittest import TestCase as _TestCase
+from fontTools.config import Config
 from fontTools.misc.textTools import tobytes
 from fontTools.misc.xmlWriter import XMLWriter
 
@@ -53,6 +54,7 @@ class FakeFont:
         self.reverseGlyphOrderDict_ = {g: i for i, g in enumerate(glyphs)}
         self.lazy = False
         self.tables = {}
+        self.cfg = Config()
 
     def __getitem__(self, tag):
         return self.tables[tag]

--- a/Lib/fontTools/otlLib/optimize/__init__.py
+++ b/Lib/fontTools/otlLib/optimize/__init__.py
@@ -1,7 +1,5 @@
 from argparse import RawTextHelpFormatter
-from fontTools.config import OPTIONS
-
-from fontTools.otlLib.optimize.gpos import compact
+from fontTools.otlLib.optimize.gpos import COMPRESSION_LEVEL, compact
 from fontTools.ttLib import TTFont
 
 
@@ -20,7 +18,6 @@ def main(args=None):
     parser.add_argument(
         "-o", metavar="OUTPUTFILE", dest="outfile", default=None, help="output file"
     )
-    COMPRESSION_LEVEL = OPTIONS["fontTools.otlLib.optimize.gpos:COMPRESSION_LEVEL"]
     parser.add_argument(
         "--gpos-compression-level",
         help=COMPRESSION_LEVEL.help,

--- a/Lib/fontTools/otlLib/optimize/gpos.py
+++ b/Lib/fontTools/otlLib/optimize/gpos.py
@@ -5,11 +5,14 @@ from itertools import chain
 from math import log2
 from typing import DefaultDict, Dict, Iterable, List, Sequence, Tuple
 
+from fontTools.config import OPTIONS
 from fontTools.misc.intTools import bit_count, bit_indices
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables import otBase, otTables
 
-log = logging.getLogger("fontTools.otlLib.optimize.gpos")
+log = logging.getLogger(__name__)
+
+COMPRESSION_LEVEL = OPTIONS[f"{__name__}:COMPRESSION_LEVEL"]
 
 
 def compact(font: TTFont, level: int) -> TTFont:

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2,9 +2,11 @@
 #
 # Google Author(s): Behdad Esfahbod
 
+from fontTools import config
 from fontTools.misc.roundTools import otRound
 from fontTools import ttLib
 from fontTools.ttLib.tables import otTables
+from fontTools.ttLib.tables.otBase import USE_HARFBUZZ_REPACKER
 from fontTools.otlLib.maxContextCalc import maxCtxFont
 from fontTools.pens.basePen import NullPen
 from fontTools.misc.loggingTools import Timer
@@ -143,6 +145,13 @@ Output options
   smaller than pure zlib, but the compression speed is much slower.
   The Zopfli Python bindings are available at:
   https://pypi.python.org/pypi/zopfli
+
+--harfbuzz-repacker [default]
+  Serialize GPOS/GSUB using the HarfBuzz Repacker if uharfbuzz can be
+  imported [default].
+
+--no-harfbuzz-repacker
+  Always use the pure-python serializer even if uharfbuzz is available.
 
 Glyph set expansion
 ^^^^^^^^^^^^^^^^^^^
@@ -2642,6 +2651,7 @@ class Options(object):
 		self.flavor = None  # May be 'woff' or 'woff2'
 		self.with_zopfli = False  # use zopfli instead of zlib for WOFF 1.0
 		self.desubroutinize = False # Desubroutinize CFF CharStrings
+		self.harfbuzz_repacker = USE_HARFBUZZ_REPACKER.default
 		self.verbose = False
 		self.timing = False
 		self.xml = False
@@ -3038,6 +3048,7 @@ def save_font(font, outfile, options):
 		from fontTools.ttLib import sfnt
 		sfnt.USE_ZOPFLI = True
 	font.flavor = options.flavor
+	font.cfg[USE_HARFBUZZ_REPACKER] = options.harfbuzz_repacker
 	font.save(outfile, reorderTables=options.canonical_order)
 
 def parse_unicodes(s):

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -146,9 +146,11 @@ Output options
   The Zopfli Python bindings are available at:
   https://pypi.python.org/pypi/zopfli
 
---harfbuzz-repacker [default]
-  Serialize GPOS/GSUB using the HarfBuzz Repacker if uharfbuzz can be
-  imported [default].
+--harfbuzz-repacker
+  By default, we serialize GPOS/GSUB using the HarfBuzz Repacker when
+  uharfbuzz can be imported and is successful, otherwise fall back to
+  the pure-python serializer. Set the option to force using the HarfBuzz
+  Repacker (raises an error if uharfbuzz can't be found or fails).
 
 --no-harfbuzz-repacker
   Always use the pure-python serializer even if uharfbuzz is available.

--- a/Tests/config_test.py
+++ b/Tests/config_test.py
@@ -39,10 +39,7 @@ def test_ttfont_has_config():
 
 def test_ttfont_can_take_superset_of_fonttools_config():
     # Create MyConfig with all options from fontTools.config plus some
-    my_options = Options()
-    for name, option in Config.options.items():
-        my_options.register_option(name, option)
-
+    my_options = Options(Config.options)
     my_options.register("custom:my_option", "help", "default", str, any)
 
     class MyConfig(AbstractConfig):

--- a/Tests/config_test.py
+++ b/Tests/config_test.py
@@ -1,6 +1,7 @@
 from fontTools.misc.configTools import AbstractConfig, Options
 import pytest
 from fontTools.config import (
+    OPTIONS,
     Config,
     ConfigUnknownOptionError,
     ConfigValueParsingError,
@@ -18,6 +19,7 @@ def test_can_register_option():
         validate=lambda v: v == True or v == False,
     )
 
+    assert MY_OPTION.name == "tests:MY_OPTION"
     assert (
         MY_OPTION.help == "Test option, value should be True or False, default = True"
     )
@@ -27,36 +29,51 @@ def test_can_register_option():
 
     ttFont = TTFont(cfg={"tests:MY_OPTION": True})
     assert True == ttFont.cfg.get("tests:MY_OPTION")
+    assert True == ttFont.cfg.get(MY_OPTION)
 
 
-COMPRESSION_LEVEL = "fontTools.otlLib.optimize.gpos:COMPRESSION_LEVEL"
+# to parametrize tests of Config mapping interface accepting either a str or Option
+@pytest.fixture(
+    params=[
+        pytest.param("fontTools.otlLib.optimize.gpos:COMPRESSION_LEVEL", id="str"),
+        pytest.param(
+            OPTIONS["fontTools.otlLib.optimize.gpos:COMPRESSION_LEVEL"], id="Option"
+        ),
+    ]
+)
+def COMPRESSION_LEVEL(request):
+    return request.param
 
 
-def test_ttfont_has_config():
+def test_ttfont_has_config(COMPRESSION_LEVEL):
     ttFont = TTFont(cfg={COMPRESSION_LEVEL: 8})
     assert 8 == ttFont.cfg.get(COMPRESSION_LEVEL)
 
 
-def test_ttfont_can_take_superset_of_fonttools_config():
+def test_ttfont_can_take_superset_of_fonttools_config(COMPRESSION_LEVEL):
     # Create MyConfig with all options from fontTools.config plus some
     my_options = Options(Config.options)
-    my_options.register("custom:my_option", "help", "default", str, any)
+    MY_OPTION = my_options.register("custom:my_option", "help", "default", str, any)
 
     class MyConfig(AbstractConfig):
         options = my_options
 
     ttFont = TTFont(cfg=MyConfig({"custom:my_option": "my_value"}))
     assert 0 == ttFont.cfg.get(COMPRESSION_LEVEL)
-    assert "my_value" == ttFont.cfg.get("custom:my_option")
+    assert "my_value" == ttFont.cfg.get(MY_OPTION)
+
+    # but the default Config doens't know about MY_OPTION
+    with pytest.raises(ConfigUnknownOptionError):
+        TTFont(cfg={MY_OPTION: "my_value"})
 
 
-def test_no_config_returns_default_values():
+def test_no_config_returns_default_values(COMPRESSION_LEVEL):
     ttFont = TTFont()
     assert 0 == ttFont.cfg.get(COMPRESSION_LEVEL)
     assert 3 == ttFont.cfg.get(COMPRESSION_LEVEL, 3)
 
 
-def test_can_set_config():
+def test_can_set_config(COMPRESSION_LEVEL):
     ttFont = TTFont()
     ttFont.cfg.set(COMPRESSION_LEVEL, 5)
     assert 5 == ttFont.cfg.get(COMPRESSION_LEVEL)
@@ -64,7 +81,7 @@ def test_can_set_config():
     assert 6 == ttFont.cfg.get(COMPRESSION_LEVEL)
 
 
-def test_different_ttfonts_have_different_configs():
+def test_different_ttfonts_have_different_configs(COMPRESSION_LEVEL):
     cfg = Config({COMPRESSION_LEVEL: 5})
     ttFont1 = TTFont(cfg=cfg)
     ttFont2 = TTFont(cfg=cfg)
@@ -78,19 +95,19 @@ def test_cannot_set_inexistent_key():
         TTFont(cfg={"notALib.notAModule.inexistent": 4})
 
 
-def test_value_not_parsed_by_default():
+def test_value_not_parsed_by_default(COMPRESSION_LEVEL):
     # Note: value given as a string
     with pytest.raises(ConfigValueValidationError):
         TTFont(cfg={COMPRESSION_LEVEL: "8"})
 
 
-def test_value_gets_parsed_if_asked():
+def test_value_gets_parsed_if_asked(COMPRESSION_LEVEL):
     # Note: value given as a string
     ttFont = TTFont(cfg=Config({COMPRESSION_LEVEL: "8"}, parse_values=True))
     assert 8 == ttFont.cfg.get(COMPRESSION_LEVEL)
 
 
-def test_value_parsing_can_error():
+def test_value_parsing_can_error(COMPRESSION_LEVEL):
     with pytest.raises(ConfigValueParsingError):
         TTFont(
             cfg=Config(
@@ -100,19 +117,19 @@ def test_value_parsing_can_error():
         )
 
 
-def test_value_gets_validated():
+def test_value_gets_validated(COMPRESSION_LEVEL):
     # Note: 12 is not a valid value for GPOS compression level (must be in 0-9)
     with pytest.raises(ConfigValueValidationError):
         TTFont(cfg={COMPRESSION_LEVEL: 12})
 
 
-def test_implements_mutable_mapping():
+def test_implements_mutable_mapping(COMPRESSION_LEVEL):
     cfg = Config()
     cfg[COMPRESSION_LEVEL] = 2
     assert 2 == cfg[COMPRESSION_LEVEL]
-    assert [COMPRESSION_LEVEL] == list(iter(cfg))
+    assert list(iter(cfg))
     assert 1 == len(cfg)
     del cfg[COMPRESSION_LEVEL]
     assert 0 == cfg[COMPRESSION_LEVEL]
-    assert [] == list(iter(cfg))
+    assert not list(iter(cfg))
     assert 0 == len(cfg)

--- a/Tests/misc/configTools_test.py
+++ b/Tests/misc/configTools_test.py
@@ -1,6 +1,12 @@
+import dataclasses
 import pytest
 
-from fontTools.misc.configTools import AbstractConfig, Options, ConfigUnknownOptionError
+from fontTools.misc.configTools import (
+    AbstractConfig,
+    Option,
+    Options,
+    ConfigUnknownOptionError,
+)
 
 
 def test_can_create_custom_config_system():
@@ -32,3 +38,22 @@ def test_can_create_custom_config_system():
     # Test that it raises on unknown option
     with pytest.raises(ConfigUnknownOptionError):
         cfg.get("test:unknown")
+
+
+def test_options_are_unique():
+    class MyConfig(AbstractConfig):
+        options = Options()
+
+    opt1 = MyConfig.register_option("test:OPT_1", "", "foo", str, any)
+    cfg = MyConfig({opt1: "bar"})
+    assert cfg[opt1] == "bar"
+
+    opt2 = Option("test:OPT_1", "", "foo", str, any)
+
+    assert dataclasses.asdict(opt1) == dataclasses.asdict(opt2)
+    assert opt1 != opt2
+
+    with pytest.raises(ConfigUnknownOptionError):
+        cfg.get(opt2)
+    with pytest.raises(ConfigUnknownOptionError):
+        cfg.set(opt2, "bar")

--- a/Tests/misc/configTools_test.py
+++ b/Tests/misc/configTools_test.py
@@ -57,3 +57,24 @@ def test_options_are_unique():
         cfg.get(opt2)
     with pytest.raises(ConfigUnknownOptionError):
         cfg.set(opt2, "bar")
+
+
+def test_optional_bool():
+    for v in ("yes", "YES", "Yes", "1", "True", "true", "TRUE"):
+        assert Option.parse_optional_bool(v) is True
+
+    for v in ("no", "NO", "No", "0", "False", "false", "FALSE"):
+        assert Option.parse_optional_bool(v) is False
+
+    for v in ("auto", "AUTO", "Auto", "None", "none", "NONE"):
+        assert Option.parse_optional_bool(v) is None
+
+    with pytest.raises(ValueError, match="invalid optional bool"):
+        Option.parse_optional_bool("foobar")
+
+    assert Option.validate_optional_bool(True)
+    assert Option.validate_optional_bool(False)
+    assert Option.validate_optional_bool(None)
+    assert not Option.validate_optional_bool(1)
+    assert not Option.validate_optional_bool(0)
+    assert not Option.validate_optional_bool("1")


### PR DESCRIPTION
As discussed in #2552, this adds a config option to disable serializing GSUB/GPOS with uharfbuzz even when the latter can be imported.

I also took this opportunity to make some changes to the configTools. The Config mapping methods accept either a str (name of an option) or the Option object itself, which I think can be handy and avoids repetition when the latter is already in scope.