### PR TITLE
Adding in code to recalculate xAvgCharWidth at the end of the merge p…

### DIFF
--- a/Lib/fontTools/merge/__init__.py
+++ b/Lib/fontTools/merge/__init__.py
@@ -125,6 +125,21 @@ class Merger(object):
 
 		self._postMerge(mega)
 
+		# merge only averages the xAvgCharWidth of the fonts being merged rather than recalculating. This code (from FontBakery) recalculates.
+
+		width_sum = 0
+		count = 0
+		for glyph_id in mega['glyf'].glyphs:  # At least .notdef must be present.
+			width = mega['hmtx'].metrics[glyph_id][0]
+			# The OpenType spec doesn't exclude negative widths, but only positive
+			# widths seems to be the assumption in the wild?
+			if width > 0:
+				count += 1
+				width_sum += width
+
+		avgCharWidth = int(round(width_sum / count))
+		mega["OS/2"].xAvgCharWidth = avgCharWidth
+
 		return mega
 
 	def mergeObjects(self, returnTable, logic, tables):

--- a/Lib/fontTools/merge/tables.py
+++ b/Lib/fontTools/merge/tables.py
@@ -132,7 +132,7 @@ ttLib.getTableClass('OS/2').mergeMap = {
 	'*': first,
 	'tableTag': equal,
 	'version': max,
-	'xAvgCharWidth': avg_int, # Apparently fontTools doesn't recalc this
+	'xAvgCharWidth': avg_int, # Apparently fontTools doesn't recalc this. Will be overwritten
 	'fsType': mergeOs2FsType, # Will be overwritten
 	'panose': first, # FIXME: should really be the first Latin font
 	'ulUnicodeRange1': bitwise_or,


### PR DESCRIPTION
As merge and fontmake don't recalculate xAvgCharWidth after merging fonts, this code addition fixes that.
Code pulled from fontbakery.

## PR Checklist
* [x] Closes #2538