### PR TITLE
Fix ufo2ft regression by bringing back the env var for now

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -11,7 +11,11 @@ from fontTools.ttLib.tables.otBase import (
 )
 from fontTools.ttLib.tables import otBase
 from fontTools.feaLib.ast import STATNameStatement
-from fontTools.otlLib.optimize.gpos import compact_lookup
+from fontTools.otlLib.optimize.gpos import (
+    compact_lookup,
+    GPOS_COMPACT_MODE_DEFAULT,
+    GPOS_COMPACT_MODE_ENV_KEY,
+)
 from fontTools.otlLib.error import OpenTypeLibError
 from functools import reduce
 import logging
@@ -1410,7 +1414,13 @@ class PairPosBuilder(LookupBuilder):
         # Compact the lookup
         # This is a good moment to do it because the compaction should create
         # smaller subtables, which may prevent overflows from happening.
-        level = self.font.cfg["fontTools.otlLib.optimize.gpos:COMPRESSION_LEVEL"]
+        # Keep reading the value from the ENV until ufo2ft switches to the config system
+        env_level = os.environ.get(GPOS_COMPACT_MODE_ENV_KEY, GPOS_COMPACT_MODE_DEFAULT)
+        if len(env_level) == 1 and env_level in "0123456789":
+            env_level = int(env_level)
+        else:
+            raise ValueError(f"Bad {GPOS_COMPACT_MODE_ENV_KEY}={env_level}")
+        level = self.font.cfg.get("fontTools.otlLib.optimize.gpos:COMPRESSION_LEVEL", env_level)
         if level and level != 0:
             log.info("Compacting GPOS...")
             compact_lookup(self.font, level, lookup)

--- a/Lib/fontTools/otlLib/optimize/gpos.py
+++ b/Lib/fontTools/otlLib/optimize/gpos.py
@@ -15,6 +15,12 @@ log = logging.getLogger(__name__)
 COMPRESSION_LEVEL = OPTIONS[f"{__name__}:COMPRESSION_LEVEL"]
 
 
+# Kept because ufo2ft depends on it, to be removed once ufo2ft uses the config instead
+# https://github.com/fonttools/fonttools/issues/2592
+GPOS_COMPACT_MODE_ENV_KEY = "FONTTOOLS_GPOS_COMPACT_MODE"
+GPOS_COMPACT_MODE_DEFAULT = "0"
+
+
 def compact(font: TTFont, level: int) -> TTFont:
     # Ideal plan:
     #  1. Find lookups of Lookup Type 2: Pair Adjustment Positioning Subtable


### PR DESCRIPTION
Attempt to fix https://github.com/fonttools/fonttools/issues/2592 by bringing back the environment variable until ufo2ft can switch to using the new config system

@anthrotype 