### PR TITLE
[otBase] demote repacker ERROR to WARNING, only 1 per loop; don't exit at first failure

### DIFF
--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -847,18 +847,11 @@ class SubsetTest:
             args.append("--no-harfbuzz-repacker")
         # elif enabled is None: ... is the default
 
-        if enabled is True:
-            if not installed:
-                # raise if enabled but not installed
-                with pytest.raises(ImportError, match="uharfbuzz"):
-                    subset.main(args)
-                return
-
-            elif not ok:
-                # raise if enabled but fails
-                with pytest.raises(hb.RepackerError, match="mocking"):
-                    subset.main(args)
-                return
+        if enabled is True and not installed:
+            # raise if enabled but not installed
+            with pytest.raises(ImportError, match="uharfbuzz"):
+                subset.main(args)
+            return
 
         with caplog.at_level(logging.DEBUG, "fontTools.ttLib.tables.otBase"):
             subset.main(args)


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/2594

* when hb repacker fails, we now emit a WARNING logging message, no longer an ERROR
* we only emit the warning message once, not multiple times at each iteration of the offset overflow resolution loop; it's always going to be the same anyway and it doesn't currently add any additional information besides the fact that it failed
* we no longer let the uharfbuzz error propagate (and thus stop execution if unhandled by client) even when the USE_HARFBUZZ_REPACKER option was explicitly set to True by the user, but we continue with the hybrid approach of trying hb first and if that fails attempt to fix offset overflow with pure-python serializer then re-trying until it completes. This is the normal state of things until hb repacker implements support for table splitting.

