### PR TITLE
Protect SVG path parsing from negative rx ry on arc commands

### DIFF
--- a/Lib/fontTools/svgLib/path/parser.py
+++ b/Lib/fontTools/svgLib/path/parser.py
@@ -278,8 +278,8 @@ def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):
             last_control = control
 
         elif command == 'A':
-            rx = float(elements.pop())
-            ry = float(elements.pop())
+            rx = abs(float(elements.pop()))
+            ry = abs(float(elements.pop()))
             rotation = float(elements.pop())
             arc_large = bool(int(elements.pop()))
             arc_sweep = bool(int(elements.pop()))

--- a/Tests/svgLib/path/parser_test.py
+++ b/Tests/svgLib/path/parser_test.py
@@ -360,7 +360,7 @@ def test_arc_pen_with_arcTo():
             "M1-2A3-4-1.0 01.5.7",
             [
                 ("moveTo", ((1.0, -2.0),)),
-                ("arcTo", (3.0, -4.0, -1.0, False, True, (0.5, 0.7))),
+                ("arcTo", (3.0, 4.0, -1.0, False, True, (0.5, 0.7))),
                 ("endPath", ()),
             ],
         ),


### PR DESCRIPTION
SVG documentation has an explicit requirement that _consumers_
of path arc commands accept and *correct* certain bad values.
This includes using the absolute value of the arc command's rx
and ry radius parameters.

See "9.5.1. Out-of-range elliptical arc parameters"
https://www.w3.org/TR/SVG/paths.html#ArcOutOfRangeParameters

Lib\fontTools\svgLib\path\parser.py is missing any guard against
negative values for rx and ry parameter. Adding an abs() to each
value read will implement the SVG specification.

A problem was seen here while most programs and browsers handle
bad arc commands just fine. A bug report has been registered with
Inkscape (!) to protect any other non-SVG compliant programs.
See https://gitlab.com/inkscape/inbox/-/issues/6857 for more details.

This fix was tested and found to correct the distorted glyphs resulting from the bad arc commands produced by Inkscape <1.2  

While no program _should_ generate arc commands like "A 12.50125,-12.50125 0 0 1 0,800", this fix is quite minimal and brings the code into compliance with SVG specs.