### PR TITLE
correct naming of dataclasses '__post_init__' method

### DIFF
--- a/Lib/fontTools/designspaceLib/types.py
+++ b/Lib/fontTools/designspaceLib/types.py
@@ -24,7 +24,7 @@ class Range:
     default: float = 0
     """Default value"""
 
-    def __post__init__(self):
+    def __post_init__(self):
         self.minimum, self.maximum = sorted((self.minimum, self.maximum))
         self.default = clamp(self.default, self.minimum, self.maximum)
 


### PR DESCRIPTION
just happened to see this in a lint check for our own code