### PR TITLE
Clean up svgDoc compression

### DIFF
--- a/Lib/fontTools/subset/svg.py
+++ b/Lib/fontTools/subset/svg.py
@@ -202,7 +202,7 @@ def subset_glyphs(self, s) -> bool:
     glyph_index_map: Dict[int, int] = s.glyph_index_map
 
     new_docs: List[Tuple[bytes, int, int]] = []
-    for doc, start, end in self.docList:
+    for doc, start, end, compressed in self.docList:
 
         glyphs = {glyph_order[i] for i in range(start, end + 1)}.intersection(s.glyphs)
         if not glyphs:
@@ -241,7 +241,7 @@ def subset_glyphs(self, s) -> bool:
 
         new_gids = (glyph_index_map[i] for i in gids)
         for start, end in ranges(new_gids):
-            new_docs.append((new_doc, start, end))
+            new_docs.append((new_doc, start, end, compressed))
 
     self.docList = new_docs
 

--- a/Tests/subset/svg_test.py
+++ b/Tests/subset/svg_test.py
@@ -55,7 +55,7 @@ def simple_svg_table_glyph_ids_on_children(empty_svg_font):
     for i in range(1, 11):
         svg = new_svg()
         etree.SubElement(svg, "path", {"id": f"glyph{i}", "d": f"M{i},{i}"})
-        svg_docs.append((etree.tostring(svg).decode(), i, i))
+        svg_docs.append((etree.tostring(svg).decode(), i, i, False))
     return font
 
 
@@ -65,7 +65,7 @@ def simple_svg_table_glyph_ids_on_roots(empty_svg_font):
     for i in range(1, 11):
         svg = new_svg(id=f"glyph{i}")
         etree.SubElement(svg, "path", {"d": f"M{i},{i}"})
-        svg_docs.append((etree.tostring(svg).decode(), i, i))
+        svg_docs.append((etree.tostring(svg).decode(), i, i, False))
     return font
 
 
@@ -466,7 +466,7 @@ def test_subset_svg_with_references(
 ):
     font = empty_svg_font
 
-    font["SVG "].docList.append((COMPLEX_SVG, 1, 12))
+    font["SVG "].docList.append((COMPLEX_SVG, 1, 12, False))
     svg_font_path = tmp_path / "TestSVG.ttf"
     font.save(svg_font_path)
     subset_path = svg_font_path.with_suffix(".subset.ttf")
@@ -492,7 +492,7 @@ def test_subset_svg_empty_table(empty_svg_font, tmp_path):
 
     svg = new_svg()
     etree.SubElement(svg, "rect", {"id": "glyph1", "x": "1", "y": "2"})
-    font["SVG "].docList.append((etree.tostring(svg).decode(), 1, 1))
+    font["SVG "].docList.append((etree.tostring(svg).decode(), 1, 1, False))
 
     svg_font_path = tmp_path / "TestSVG.ttf"
     font.save(svg_font_path)
@@ -517,6 +517,7 @@ def test_subset_svg_missing_glyph(empty_svg_font, tmp_path):
             # only one glyph element with id="glyph1", the "glyph2" one is absent.
             # Techically this would be invalid according to the OT-SVG spec.
             2,
+            False,
         )
     )
     svg_font_path = tmp_path / "TestSVG.ttf"


### PR DESCRIPTION
Previously, an entire `SVG ` table would be marked as compressed if any
of the decoded SVG documents in it were compressed. Then on encoding all
SVG documents would be considered for compression. The XML format had no
means to indicate if compression was desired.

Instead, mark each svgDoc with its compression status. When decoding
mark the svgDoc as compressed if the data was compressed. When encoding
try to compress the svgDoc if it is marked as compressed. In the XML
format the data itself is always uncompressed, but allow an optional
`compressed` boolean attribute (defaults to false) to indicate the
svgDoc should be compressed when encoded.