### PR TITLE
[varLib] use nameIDs 2,17 and 6 for default instance

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -74,6 +74,7 @@ def _add_fvar(font, axes, instances: List[InstanceDescriptor]):
 	fvar = newTable('fvar')
 	nameTable = font['name']
 
+	dflt_axis_coordinates = {v.tag: v.default for k,v in axes.items()}
 	for a in axes.values():
 		axis = Axis()
 		axis.axisTag = Tag(a.tag)
@@ -102,11 +103,13 @@ def _add_fvar(font, axes, instances: List[InstanceDescriptor]):
 		psname = instance.postScriptFontName
 
 		inst = NamedInstance()
-		inst.subfamilyNameID = nameTable.addMultilingualName(localisedStyleName)
-		if psname is not None:
-			psname = tostr(psname)
-			inst.postscriptNameID = nameTable.addName(psname)
 		inst.coordinates = {axes[k].tag:axes[k].map_backward(v) for k,v in coordinates.items()}
+		if inst.coordinates == dflt_axis_coordinates:
+			inst.subfamilyNameID = 17 if any(r.nameID == 17 for r in nameTable.names) else 2
+			inst.postscriptNameID = 6 if psname else 0xFFFF
+		else:
+			inst.subfamilyNameID = nameTable.addMultilingualName(localisedStyleName)
+			inst.postscriptNameID = nameTable.addName(tostr(psname)) if psname else 0xFFFF
 		#inst.coordinates = {axes[k].tag:v for k,v in coordinates.items()}
 		fvar.instances.append(inst)
 


### PR DESCRIPTION
According to the spec:

> The default instance of a font is that instance for which the coordinate value of each axis is the defaultValue specified in the corresponding variation axis record. An instance record is not required for the default instance, though an instance record can be provided. When enumerating named instances, the default instance should be enumerated even if there is no corresponding instance record. If an instance record is included for the default instance (that is, an instance record has coordinates set to default values), then the nameID value should be set to either 2 or 17, and the postScriptNameID value should be set to 6.

https://docs.microsoft.com/en-us/typography/opentype/spec/fvar#instancerecord


Tests currently fail but if you're happy to include this, I'll fix them.

PR has been made due to https://github.com/googlefonts/fontbakery/issues/3703.