### PR TITLE
Sort naming table to get the same name has FontConfig

### DIFF
--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -469,7 +469,7 @@ class FontBuilder(object):
             variationsPostScriptNamePrefix (nameID 25)
         """
         nameTable = self.font["name"] = newTable("name")
-        nameTable.names = []
+        nameTable.initializeNames()
 
         for nameName, nameValue in nameStrings.items():
             if isinstance(nameName, int):

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -108,13 +108,13 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 
 		return (name.platformID, name.langID) in ((1, 0), (3, 0x409))
 
-	def getDebugName(self, nameID: int):
+	def getDebugName(self, nameID: int) -> str:
 		"""
-		Get unicode name from the naming table (https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-ids)
+		Get str name from the naming table
 
 		This method is inspired by: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/d863f6778915f7dd224c98c814247ec292904e30/src/fcfreetype.c#L1448-1604
 		Parameters:
-			nameID (List[Path]): List of path that contains font. The list can contains directory and/or file
+			nameID (int): NameID from the naming table (https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-ids)
 		Returns:
 			First decoded name that matches the nameID
 		"""

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -82,7 +82,9 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 		return data + stringData
 
 	def toXML(self, writer, ttFont):
-		for name in self.names:
+		names = [name for name in self.names]
+		names.sort() # sort according to the spec; see NameRecord.__lt__()
+		for name in names:
 			name.toXML(writer, ttFont)
 
 	def fromXML(self, name, attrs, content, ttFont):

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -91,8 +91,8 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 		if not hasattr(self, "names"):
 			self.initializeNames()
 		name = NameRecord()
-		self.names.add(name)
 		name.fromXML(name, attrs, content, ttFont)
+		self.names.add(name)
 
 	def getName(self, nameID, platformID, platEncID, langID=None):
 		for namerecord in self.names:

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -115,7 +115,7 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 		return None # not found
 
 
-	def FcFreeTypeGetFirstName (self, platformID, nameID, name, count):
+	def FcFreeTypeGetFirstName (self, platformID, nameID, count):
 		# From https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/d863f6778915f7dd224c98c814247ec292904e30/src/fcfreetype.c#L1143
 
 		min = 0
@@ -124,24 +124,25 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 		while min <= max:
 		
 			mid = floor((min + max) / 2)
-			print(mid)
 
-		if (platformID < name.platformID or
-			(platformID == name.platformID and
-			(name.nameID < name.nameID or
-			(name.nameID == name.nameID and
-			(mid and
-			platformID == self.names[mid - 1].platformID and
-			name.nameID == self.names[mid - 1].nameID
-			))))):
-			max = mid - 1
-		elif (platformID > name.platformID or
-			(platformID == name.platformID and
-			nameID > name.nameID)):
-			min = mid + 1
-		else:
-			return mid
-		
+			name = self.names[mid]
+
+			if (platformID < name.platformID or
+				(platformID == name.platformID and
+				(name.nameID < name.nameID or
+				(name.nameID == name.nameID and
+				(mid and
+				platformID == self.names[mid - 1].platformID and
+				name.nameID == self.names[mid - 1].nameID
+				))))):
+				max = mid - 1
+			elif (platformID > name.platformID or
+				(platformID == name.platformID and
+				nameID > name.nameID)):
+				min = mid + 1
+			else:
+				return mid
+			
 
 		return -1
 
@@ -186,7 +187,15 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 			platformName = self._getNameIdFromPlatform(platformID)
 			
 			for name in platformName:
-				print(self.FcFreeTypeGetFirstName(platformID, nameID, name, len(self.names)))
+				nameidx = self.FcFreeTypeGetFirstName(platformID, nameID, len(self.names))
+				
+				nameidx += 1
+				while (nameidx < len(self.names) and
+				platformID == self.names[nameidx].platformID and nameID == self.names[nameidx].nameID):
+					nameidx += 1
+				nameidx -= 1
+				print(self.names[nameidx])
+
 
 	def getDebugName(self, nameID):
 		englishName = someName = None

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -216,13 +216,15 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 		if not args:
 			# no arguments, nothing to do
 			return
-		self.names = [
+		names = [
 			rec for rec in self.names
 			if any(
 				argValue != getattr(rec, argName)
 				for argName, argValue in args.items()
 			)
 		]
+		self.names.clear()
+		self.names.update(names)
 
 	def _findUnusedNameID(self, minNameID=256):
 		"""Finds an unused name id.

--- a/Lib/fontTools/varLib/instancer/names.py
+++ b/Lib/fontTools/varLib/instancer/names.py
@@ -51,9 +51,9 @@ def pruningUnusedNames(varfont):
 
     log.info("Pruning name table")
     exclude = origNameIDs - getVariationNameIDs(varfont)
-    varfont["name"].names[:] = [
-        record for record in varfont["name"].names if record.nameID not in exclude
-    ]
+    names = [record for record in varfont["name"].names if record.nameID not in exclude]
+    varfont["name"].names.clear()
+    varfont["name"].names.update(names)
     if "ltag" in varfont:
         # Drop the whole 'ltag' table if all the language-dependent Unicode name
         # records that reference it have been dropped.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ ufoLib2==0.13.0
 pyobjc==8.1; sys_platform == "darwin"
 freetype-py==2.2.0
 uharfbuzz==0.24.1
+sortedcontainers==2.4.0


### PR DESCRIPTION
This should close: https://github.com/fonttools/fonttools/issues/2623

I inspired myself from FontConfig.

This is still not perfect, because FontConfig use freetype for the postscript name. I am not able to fully understand what does freetype, but I know that freetype choose the right postscript name here: https://github.com/freetype/freetype/blob/c26f0d0d7e1b24863193ab2808f67798456dfc9c/src/sfnt/sfdriver.c#L1045-L1087

I added a new dependency, sortedcontainers. It is very usefull to always have a sortedlist.