### PR TITLE
Clean up svgDoc compression #2

### DIFF
--- a/Lib/fontTools/ttLib/tables/S_V_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_V_G_.py
@@ -17,9 +17,11 @@ The XML format is:
 	</SVG>
 """
 
-from fontTools.misc.textTools import bytesjoin, strjoin, tobytes, tostr
+from fontTools.misc.textTools import bytesjoin, safeEval, strjoin, tobytes, tostr
 from fontTools.misc import sstruct
 from . import DefaultTable
+from collections.abc import Sequence
+from dataclasses import dataclass, astuple
 from io import BytesIO
 import struct
 import logging
@@ -75,15 +77,18 @@ class table_S_V_G_(DefaultTable.DefaultTable):
 				start = entry.svgDocOffset + subTableStart
 				end = start + entry.svgDocLength
 				doc = data[start:end]
+				compressed = False
 				if doc.startswith(b"\x1f\x8b"):
 					import gzip
 					bytesIO = BytesIO(doc)
 					with gzip.GzipFile(None, "r", fileobj=bytesIO) as gunzipper:
 						doc = gunzipper.read()
-					self.compressed = True
 					del bytesIO
+					compressed = True
 				doc = tostr(doc, "utf_8")
-				self.docList.append( [doc, entry.startGlyphID, entry.endGlyphID] )
+				self.docList.append(
+					SVGDocument(doc, entry.startGlyphID, entry.endGlyphID, compressed)
+				)
 
 	def compile(self, ttFont):
 		version = 0
@@ -96,9 +101,13 @@ class table_S_V_G_(DefaultTable.DefaultTable):
 		entryList.append(datum)
 		curOffset = len(datum) + doc_index_entry_format_0Size*numEntries
 		seenDocs = {}
-		for doc, startGlyphID, endGlyphID in self.docList:
-			docBytes = tobytes(doc, encoding="utf_8")
-			if getattr(self, "compressed", False) and not docBytes.startswith(b"\x1f\x8b"):
+		allCompressed = getattr(self, "compressed", False)
+		for i, doc in enumerate(self.docList):
+			if isinstance(doc, (list, tuple)):
+				doc = SVGDocument(*doc)
+				self.docList[i] = doc
+			docBytes = tobytes(doc.data, encoding="utf_8")
+			if (allCompressed or doc.compressed) and not docBytes.startswith(b"\x1f\x8b"):
 				import gzip
 				bytesIO = BytesIO()
 				with gzip.GzipFile(None, "w", fileobj=bytesIO) as gzipper:
@@ -115,7 +124,7 @@ class table_S_V_G_(DefaultTable.DefaultTable):
 				curOffset += docLength
 				seenDocs[docBytes] = docOffset
 				docList.append(docBytes)
-			entry = struct.pack(">HHLL", startGlyphID, endGlyphID, docOffset, docLength)
+			entry = struct.pack(">HHLL", doc.startGlyphID, doc.endGlyphID, docOffset, docLength)
 			entryList.append(entry)
 		entryList.extend(docList)
 		svgDocData = bytesjoin(entryList)
@@ -127,10 +136,16 @@ class table_S_V_G_(DefaultTable.DefaultTable):
 		return data
 
 	def toXML(self, writer, ttFont):
-		for doc, startGID, endGID in self.docList:
-			writer.begintag("svgDoc", startGlyphID=startGID, endGlyphID=endGID)
+		for i, doc in enumerate(self.docList):
+			if isinstance(doc, (list, tuple)):
+				doc = SVGDocument(*doc)
+				self.docList[i] = doc
+			attrs = {"startGlyphID": doc.startGlyphID, "endGlyphID": doc.endGlyphID}
+			if doc.compressed:
+				attrs["compressed"] = 1
+			writer.begintag("svgDoc", **attrs)
 			writer.newline()
-			writer.writecdata(doc)
+			writer.writecdata(doc.data)
 			writer.newline()
 			writer.endtag("svgDoc")
 			writer.newline()
@@ -143,7 +158,8 @@ class table_S_V_G_(DefaultTable.DefaultTable):
 			doc = doc.strip()
 			startGID = int(attrs["startGlyphID"])
 			endGID = int(attrs["endGlyphID"])
-			self.docList.append( [doc, startGID, endGID] )
+			compressed = bool(safeEval(attrs.get("compressed", "0")))
+			self.docList.append(SVGDocument(doc, startGID, endGID, compressed))
 		else:
 			log.warning("Unknown %s %s", name, content)
 
@@ -157,3 +173,23 @@ class DocumentIndexEntry(object):
 
 	def __repr__(self):
 		return "startGlyphID: %s, endGlyphID: %s, svgDocOffset: %s, svgDocLength: %s" % (self.startGlyphID, self.endGlyphID, self.svgDocOffset, self.svgDocLength)
+
+
+@dataclass
+class SVGDocument(Sequence):
+	data: str
+	startGlyphID: int
+	endGlyphID: int
+	compressed: bool = False
+
+	# Previously, the SVG table's docList attribute contained a lists of 3 items:
+	# [doc, startGlyphID, endGlyphID]; later, we added a `compressed` attribute.
+	# For backward compatibility with code that depends of them being sequences of
+	# fixed length=3, we subclass the Sequence abstract base class and pretend only
+	# the first three items are present. 'compressed' is only accessible via named
+	# attribute lookup like regular dataclasses: i.e. `doc.compressed`, not `doc[3]`
+	def __getitem__(self, index):
+		return astuple(self)[:3][index]
+
+	def __len__(self):
+		return 3

--- a/Lib/fontTools/ttLib/tables/S_V_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_V_G_.py
@@ -110,7 +110,9 @@ class table_S_V_G_(DefaultTable.DefaultTable):
 			if (allCompressed or doc.compressed) and not docBytes.startswith(b"\x1f\x8b"):
 				import gzip
 				bytesIO = BytesIO()
-				with gzip.GzipFile(None, "w", fileobj=bytesIO) as gzipper:
+				# mtime=0 strips the useless timestamp and makes gzip output reproducible;
+				# equivalent to `gzip -n`
+				with gzip.GzipFile(None, "w", fileobj=bytesIO, mtime=0) as gzipper:
 					gzipper.write(docBytes)
 				gzipped = bytesIO.getvalue()
 				if len(gzipped) < len(docBytes):

--- a/Tests/ttLib/tables/S_V_G__test.py
+++ b/Tests/ttLib/tables/S_V_G__test.py
@@ -16,7 +16,7 @@ def dump(table, ttFont=None):
 
 def compress(data: bytes) -> bytes:
     buf = io.BytesIO()
-    with gzip.GzipFile(None, "w", fileobj=buf) as gz:
+    with gzip.GzipFile(None, "w", fileobj=buf, mtime=0) as gz:
         gz.write(data)
     return buf.getvalue()
 

--- a/Tests/ttLib/tables/S_V_G__test.py
+++ b/Tests/ttLib/tables/S_V_G__test.py
@@ -1,3 +1,5 @@
+import gzip
+import io
 import struct
 
 from fontTools.misc import etree
@@ -10,6 +12,13 @@ import pytest
 
 def dump(table, ttFont=None):
     print("\n".join(getXML(table.toXML, ttFont)))
+
+
+def compress(data: bytes) -> bytes:
+    buf = io.BytesIO()
+    with gzip.GzipFile(None, "w", fileobj=buf) as gz:
+        gz.write(data)
+    return buf.getvalue()
 
 
 def strip_xml_whitespace(xml_string):
@@ -45,7 +54,9 @@ SVG_DOCS = [
         b"""\
         <svg xmlns="http://www.w3.org/2000/svg" version="1.1">
           <g id="glyph3">
-            <path d="M0,0 L100,0 L50,100 Z"/>
+            <path d="M0,0 L100,0 L50,100 Z" fill="#red"/>
+            <path d="M10,10 L110,10 L60,110 Z" fill="#blue"/>
+            <path d="M20,20 L120,20 L70,120 Z" fill="#green"/>
           </g>
         </svg>""",
     )
@@ -65,25 +76,25 @@ OTSVG_DATA = b"".join(
         b"\x00\x02"  # endGlyphID (2)
         b"\x00\x00\x00\x26"  # svgDocOffset (2 + 12*3 == 38 == 0x26)
         + struct.pack(">L", len(SVG_DOCS[0]))  # svgDocLength
-        # SVGDocumentRecord[1]
+        # SVGDocumentRecord[1] (compressed)
         + b"\x00\x03"  # startGlyphID (3)
         b"\x00\x03"  # endGlyphID (3)
         + struct.pack(">L", 0x26 + len(SVG_DOCS[0]))  # svgDocOffset
-        + struct.pack(">L", len(SVG_DOCS[1]))  # svgDocLength
+        + struct.pack(">L", len(compress(SVG_DOCS[1])))  # svgDocLength
         # SVGDocumentRecord[2]
         + b"\x00\x04"  # startGlyphID (4)
         b"\x00\x04"  # endGlyphID (4)
         b"\x00\x00\x00\x26"  # svgDocOffset (38); records 0 and 2 point to same SVG doc
         + struct.pack(">L", len(SVG_DOCS[0]))  # svgDocLength
     ]
-    + SVG_DOCS
+    + [SVG_DOCS[0], compress(SVG_DOCS[1])]
 )
 
 OTSVG_TTX = [
     '<svgDoc endGlyphID="2" startGlyphID="1">',
     f"  <![CDATA[{SVG_DOCS[0].decode()}]]>",
     "</svgDoc>",
-    '<svgDoc endGlyphID="3" startGlyphID="3">',
+    '<svgDoc compressed="1" endGlyphID="3" startGlyphID="3">',
     f"  <![CDATA[{SVG_DOCS[1].decode()}]]>",
     "</svgDoc>",
     '<svgDoc endGlyphID="4" startGlyphID="4">',
@@ -129,3 +140,19 @@ def test_round_trip_ttx(font):
     table = table_S_V_G_()
     table.decompile(compiled, font)
     assert getXML(table.toXML, font) == OTSVG_TTX
+
+
+def test_unpack_svg_doc_as_3_tuple():
+    # test that the legacy docList as list of 3-tuples interface still works
+    # even after the new SVGDocument class with extra `compressed` attribute
+    # was added
+    table = table_S_V_G_()
+    table.decompile(OTSVG_DATA, font)
+
+    for doc, compressed in zip(table.docList, (False, True, False)):
+        assert len(doc) == 3
+        data, startGID, endGID = doc
+        assert doc.data == data
+        assert doc.startGlyphID == startGID
+        assert doc.endGlyphID == endGID
+        assert doc.compressed == compressed


### PR DESCRIPTION
This is based on @bungeman's https://github.com/fonttools/fonttools/pull/2627 and it's supposed to supersede that one.

The difference is this tries to ensure that existing code that depends on `docList` containing sequences of three items `(doc, startGID, endGID)` continues to work without modification.

I define a new SVGDocument dataclass that exports a Sequence-like interface, only the first three elements can be read by their position in the fake tuple.