### PR TITLE
Improve error msg for building substitutions with missing glyphs

### DIFF
--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -779,6 +779,17 @@ class SingleSubst(FormatSwitchingBaseTable):
 		format = 2
 		delta = None
 		for inID, outID in gidItems:
+			if inID is None or outID is None:
+				log.error(
+					"Substitution references one or more missing glyphs. "
+					"Check any items that contain a glyph ID of None:"
+				)
+				log.error([
+						({v[0]: k[0]}, {v[1]: k[1]})
+						for k, v in sortableItems
+				])
+				raise KeyError
+
 			if delta is None:
 				delta = (outID - inID) % 65536
 


### PR DESCRIPTION
The error message was not helpful for debugging. Give a hint that missing glyphs are referenced in a substitution.

Before:
```
TypeError: ("unsupported operand type(s) for -: 'NoneType' and 'int'", 0, 'SubTable[]', 134, 'Lookup[]', 'LookupList')
```

After:
```
ERROR:fontTools.ttLib.tables.otTables:Substitution references one or more missing glyphs. Check any items that contain a glyph ID of None:
ERROR:fontTools.ttLib.tables.otTables:[({'arrowleft.alt1': 1427}, {'arrowleft.alt1.3': None}), ({'uni23AF.alt1': 1436}, {'uni23AF.alt1.3': None}), ({'arrowright.alt1': 1445}, {'arrowright.alt1.3': None}), ({'arrowup.alt1': 1455}, {'arrowup.alt1.3': None}), ({'uni23D0.alt1': 1464}, {'uni23D0.alt1.3': None}), ({'arrowdown.alt1': 1473}, {'arrowdown.alt1.3': None})]
```
