### PR TITLE
Fix tests for Python 3.11

### DIFF
--- a/Tests/pens/cu2quPen_test.py
+++ b/Tests/pens/cu2quPen_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import unittest
 
 from fontTools.pens.cu2quPen import Cu2QuPen, Cu2QuPointPen
@@ -257,8 +258,12 @@ class TestCu2QuPen(unittest.TestCase, _TestPenMixin):
         quadpen.closePath()
 
         self.assertGreaterEqual(len(log.records), 1)
-        self.assertIn("ignore_single_points is deprecated",
-                      log.records[0].args[0])
+        if sys.version_info < (3, 11):
+            self.assertIn("ignore_single_points is deprecated",
+                          log.records[0].args[0])
+        else:
+            self.assertIn("ignore_single_points is deprecated",
+                          log.records[0].msg)
 
         # single-point contours were ignored, so the pen commands are empty
         self.assertFalse(pen.commands)

--- a/Tests/ufoLib/ufoLib_test.py
+++ b/Tests/ufoLib/ufoLib_test.py
@@ -35,7 +35,7 @@ def test_formatVersionTuple(ufo_path):
     assert reader.formatVersionTuple == (3, 0)
     assert reader.formatVersionTuple.major == 3
     assert reader.formatVersionTuple.minor == 0
-    assert str(reader.formatVersionTuple) == "3.0"
+    assert str(reader.formatVersionTuple) in ("3.0", "UFOFormatVersion.FORMAT_3_0")
 
 
 def test_readMetaInfo_errors(ufo_path):


### PR DESCRIPTION
Submitting this Fedora 37 downstream patch by @hroncok (Miro Hrončok) 
This will fix running some tests against Python 3.11