### PR TITLE
[varLib.merger/errors] fix undefined exception name

### DIFF
--- a/Lib/fontTools/varLib/errors.py
+++ b/Lib/fontTools/varLib/errors.py
@@ -143,7 +143,7 @@ class UnsupportedFormat(VarLibMergeError):
         return self.__doc__ % self.cause["subtable"]
 
 
-class UnsupportedFormat(UnsupportedFormat):
+class InconsistentFormats(UnsupportedFormat):
     """an OpenType subtable (%s) had inconsistent formats between masters"""
 
 

--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -30,7 +30,7 @@ from .errors import (
     KeysDiffer,
     InconsistentGlyphOrder,
     InconsistentExtensions,
-    UnsupportedFormat,
+    InconsistentFormats,
     UnsupportedFormat,
     VarLibMergeError,
 )


### PR DESCRIPTION
The exception `UnsupportedFormat` was defined and then immediately redefined with the same name in varLib.errors, and imported twice from varLib.merger, probably as result of a sweeping find/replace.
Rename the duplicate to `InconsistentFormats` as originally intended.