### PR TITLE
[feaLib] show all missing glyphs at once

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -126,6 +126,7 @@ class Parser(object):
                     ),
                     self.cur_token_location_,
                 )
+        # Report any missing glyphs at the end of parsing
         if self.missing:
             error = [
                 " %s (first found at %s)" % (name, loc)
@@ -2083,8 +2084,9 @@ class Parser(object):
         raise FeatureLibError("Expected a glyph name or CID", self.cur_token_location_)
 
     def check_glyph_name_in_glyph_set(self, *names):
-        """Raises if glyph name (just `start`) or glyph names of a
-        range (`start` and `end`) are not in the glyph set.
+        """Adds a glyph name (just `start`) or glyph names of a
+        range (`start` and `end`) which are not in the glyph set
+        to the "missing list" for future error reporting.
 
         If no glyph set is present, does nothing.
         """

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -316,7 +316,7 @@ class ParserTest(unittest.TestCase):
     def test_strict_glyph_name_check(self):
         self.parse("@bad = [a b ccc];", glyphNames=("a", "b", "ccc"))
 
-        with self.assertRaisesRegex(FeatureLibError, "missing from the glyph set: ccc"):
+        with self.assertRaisesRegex(FeatureLibError, "(?s)missing from the glyph set:.*ccc"):
             self.parse("@bad = [a b ccc];", glyphNames=("a", "b"))
 
     def test_glyphclass(self):


### PR DESCRIPTION
I just had a frustrating situation where the FEA parser reported a missing glyph in my source, and then I fixed it and re-ran it, and then it reported another missing glyph, and I fixed it and re-ran it, and...

With this PR, "missing glyph" errors are gathered and reported at the end of parsing:

```
ERROR: The following glyph names are referenced but are missing from the glyph set:
 ampersand (first found at source/build/features.fea:43570:16)
 asterisk (first found at source/build/features.fea:43605:14)
```