### PR TITLE
Update how table packing falls back to fontTools from harfbuzz.

### DIFF
--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -589,8 +589,6 @@ class OTTableWriter(object):
                 https://github.com/harfbuzz/uharfbuzz/blob/main/src/uharfbuzz/_harfbuzz.pyx#L1149
                 """
 		internedTables = {}
-		# TODO: Restore shareExtension=True after we fix
-		# https://github.com/fonttools/fonttools/issues/2661
 		self._doneWriting(internedTables, shareExtension=True)
 		tables = []
 		obj_list = []

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -879,8 +879,8 @@ class SubsetTest:
         # test we emit a log.error if hb.repack fails (and we don't if successful)
         assert (
                 (
-                "hb.repack failed to serialize 'GSUB', reverting to "
-                "pure-python serializer; the error message was: RepackerError: mocking"
+                "hb.repack failed to serialize 'GSUB', attempting fonttools resolutions "
+                "; the error message was: RepackerError: mocking"
             ) in caplog.text
         ) ^ ok
 


### PR DESCRIPTION
Refactor control flow of the packer to use a state machine with three states:
1. Pure python: only uses the existing fonttools packing and overflow resolution.
2. Harfbuzz+python: uses harfbuzz packing and python overflow resolution. Extensions are allowed to be shared.
3. Python fallback: if harfbuzz+python runs out of resolution options, this disables extension sharing and only uses python packing. Once it succeeds control is passed back to the harfbuzz packer to produce the final packing with extension sharing enabled.

Fixes #2661 while allowing extension sharing to be re-enabled.