### PR TITLE
[feaLib] Let the parser set nameIDs 1 through 6

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1253,14 +1253,6 @@ class Parser(object):
             raise FeatureLibError(
                 "Name id value cannot be greater than 32767", self.cur_token_location_
             )
-        if 1 <= nameID <= 6:
-            log.warning(
-                "Name id %d cannot be set from the feature file. "
-                "Ignoring record" % nameID
-            )
-            self.parse_name_()  # skip to the next record
-            return None
-
         platformID, platEncID, langID, string = self.parse_name_()
         return self.ast.NameRecord(
             nameID, platformID, platEncID, langID, string, location=location

--- a/Tests/feaLib/data/name.fea
+++ b/Tests/feaLib/data/name.fea
@@ -1,16 +1,16 @@
 table name {
 #test-fea2fea:
-  nameid 1 "Ignored-1";
+  nameid 1 "Test1";
 #test-fea2fea:
-  nameid 2 "Ignored-2";
+  nameid 2 "Test2";
 #test-fea2fea:
-  nameid 3 "Ignored-3";
+  nameid 3 "Test3";
 #test-fea2fea:
-  nameid 4 "Ignored-4";
+  nameid 4 "Test4";
 #test-fea2fea:
-  nameid 5 "Ignored-5";
+  nameid 5 "Test5";
 #test-fea2fea:
-    nameid 6 "Ignored-6";
+    nameid 6 "Test6";
 #test-fea2fea: nameid 7 "Test7";
   nameid 7 3 "Test7";
     nameid 8 1 "Test8";

--- a/Tests/feaLib/data/name.ttx
+++ b/Tests/feaLib/data/name.ttx
@@ -2,6 +2,24 @@
 <ttFont>
 
   <name>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Test1
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Test2
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      Test3
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Test4
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Test5
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      Test6
+    </namerecord>
     <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
       Test7
     </namerecord>


### PR DESCRIPTION
Since https://github.com/adobe-type-tools/afdko/commit/3fa06c51db37d3a2fb967552d61c47c9fbb8584c, only nameIDs 2 and 6 are reserved.