### PR TITLE
[feaLib] Add vmtx and VORG support

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1923,6 +1923,25 @@ class VheaField(Statement):
         return "{} {};".format(keywords[self.key], self.value)
 
 
+class VmtxStatement(Statement):
+    """An entry in the ``vmtx`` table."""
+
+    def __init__(self, glyph, key, value, location=None):
+        Statement.__init__(self, location)
+        self.glyph = glyph
+        self.key = key
+        self.value = value
+
+    def build(self, builder):
+        """Calls the builder object's ``add_vmtx_field`` callback."""
+        builder.add_vmtx_pos(self.key, self.glyph, self.value)
+
+    def asFea(self, indent=""):
+        fields = ("VertOriginY", "VertAdvanceY")
+        keywords = dict([(x.lower(), x) for x in fields])
+        return "{} {} {};".format(keywords[self.key], self.glyph, self.value)
+
+
 class STATDesignAxisStatement(Statement):
     """A STAT table Design Axis
 

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1,4 +1,5 @@
 from fontTools.misc import sstruct
+from fontTools.misc.roundTools import otRound
 from fontTools.misc.textTools import Tag, tostr, binary2num, safeEval
 from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.lookupDebugInfo import (
@@ -103,6 +104,7 @@ class Builder(object):
             "hhea",
             "name",
             "vhea",
+            "vmtx",
             "STAT",
         ]
     )
@@ -172,6 +174,8 @@ class Builder(object):
         self.hhea_ = {}
         # for table 'vhea'
         self.vhea_ = {}
+        # for table 'vmtx'
+        self.vmtx_ = {}
         # for table 'STAT'
         self.stat_ = {}
         # for conditionsets
@@ -205,6 +209,8 @@ class Builder(object):
             self.build_name()
         if "OS/2" in tables:
             self.build_OS_2()
+        if "vmtx" in tables:
+            self.build_vmtx()
         if "STAT" in tables:
             self.build_STAT()
         for tag in ("GPOS", "GSUB"):
@@ -373,6 +379,87 @@ class Builder(object):
             table.descent = self.vhea_["verttypodescender"]
         if "verttypolinegap" in self.vhea_:
             table.lineGap = self.vhea_["verttypolinegap"]
+
+    def build_vmtx(self):
+        if not self.vmtx_:
+            return
+        table = self.font.get("vmtx")
+        if not table:
+            # The font should already have a vmtx table to apply feature file
+            # overrides on top of. If there is no vmtx at this point then
+            # there is probably something wrong upstream
+            return
+
+        outlineTables = ("glyf", "CFF ", "CFF2")
+        if not any(k in self.font for k in outlineTables):
+            log.info(
+                "A 'glyf', 'CFF ', or 'CFF2' table is required to build vmtx."
+            )
+            return
+
+        for tableName in outlineTables:
+            if tableName in self.font:
+                outlineTable = self.font[tableName]
+                break
+
+        if outlineTable.tableTag in ("CFF ", "CFF2"):
+            glyphBounds = {}
+            vorgTable = self.font.get("VORG")
+            if not vorgTable:
+                vorgTable = self.font["VORG"] = newTable("VORG")
+                vorgTable.decompile(b"\0" * 36, self.font)
+                vorgTable.majorVersion = 1
+                vorgTable.minorVersion = 0
+                vorgTable.VOriginRecords = {}
+            # For the VORG table ufo2ft finds the most frequent
+            # verticalOrigin and uses that to set defaultVertOriginY, but
+            # makeotf uses the OS/2.TypoAscender as stated in the
+            # OpenType Feature File Specification 9.h
+            vorgTable.defaultVertOriginY = self.font['OS/2'].sTypoAscender
+
+            topDict = outlineTable.cff[0]
+            glyphSet = self.font.getGlyphSet()
+
+        for glyphName, vmtxKeys in self.vmtx_.items():
+            # This assumes that a vmtx table has already been created so
+            # height and tsb should already exist. If the user only wants to
+            # override one of VertAdvanceY or VertOriginY via feature file
+            # then the other value will come from the existing table
+            height, tsb = table.metrics[glyphName]
+            if outlineTable.tableTag == "glyf":
+                glyph = outlineTable[glyphName]
+                yMax = glyph.yMax
+            else:
+                charString = topDict.CharStrings[glyphName]
+                yMax = 0
+                bounds = charString.calcBounds(glyphSet)
+                if bounds:
+                    yMax = otRound(bounds[3])
+                    glyphBounds[glyphName] = yMax
+
+            if "vertadvancey" in vmtxKeys:
+                height = vmtxKeys["vertadvancey"]
+            if "vertoriginy" in vmtxKeys:
+                tsb = vmtxKeys['vertoriginy'] - yMax
+
+            table.metrics[glyphName] = (height, tsb)
+
+        if outlineTable.tableTag in ("CFF ", "CFF2"):
+            for glyphName, metrics in table.metrics.items():
+                _, tsb = metrics
+                yMax = 0
+                if glyphName in glyphBounds:
+                    yMax = glyphBounds[glyphName]
+                else:
+                    charString = topDict.CharStrings[glyphName]
+                    bounds = charString.calcBounds(glyphSet)
+                    if bounds:
+                        yMax = bounds[3]
+                verticalOrigin = otRound(yMax + tsb)
+                if verticalOrigin == vorgTable.defaultVertOriginY:
+                    continue
+                vorgTable.VOriginRecords[glyphName] = verticalOrigin
+            vorgTable.numVertOriginYMetrics = len(vorgTable.VOriginRecords)
 
     def get_user_name_id(self, table):
         # Try to find first unused font-specific name id
@@ -1556,6 +1643,12 @@ class Builder(object):
 
     def add_vhea_field(self, key, value):
         self.vhea_[key] = value
+
+    def add_vmtx_pos(self, key, glyph, value):
+        glyph_name = glyph.glyph
+        if glyph_name not in self.vmtx_:
+            self.vmtx_[glyph_name] = {}
+        self.vmtx_[glyph_name][key] = value
 
     def add_conditionset(self, key, value):
         if not "fvar" in self.font:

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1054,6 +1054,7 @@ class Parser(object):
             "head": self.parse_table_head_,
             "hhea": self.parse_table_hhea_,
             "vhea": self.parse_table_vhea_,
+            "vmtx": self.parse_table_vmtx_,
             "name": self.parse_table_name_,
             "BASE": self.parse_table_BASE_,
             "OS/2": self.parse_table_OS_2_,
@@ -1165,6 +1166,34 @@ class Parser(object):
                 raise FeatureLibError(
                     "Expected VertTypoAscender, "
                     "VertTypoDescender or VertTypoLineGap",
+                    self.cur_token_location_,
+                )
+
+    def parse_table_vmtx_(self, table):
+        statements = table.statements
+        fields = ("VertOriginY", "VertAdvanceY")
+        while self.next_token_ != "}" or self.cur_comments_:
+            self.advance_lexer_(comments=True)
+            if self.cur_token_type_ is Lexer.COMMENT:
+                statements.append(
+                    self.ast.Comment(self.cur_token_, location=self.cur_token_location_)
+                )
+            elif self.cur_token_type_ is Lexer.NAME and self.cur_token_ in fields:
+                key = self.cur_token_.lower()
+                glyph = self.parse_glyphclass_(accept_glyphname=True)
+                value = self.expect_number_()
+                statements.append(
+                    self.ast.VmtxStatement(glyph, key, value, location=self.cur_token_location_)
+                )
+                if self.next_token_ != ";":
+                    raise FeatureLibError(
+                        "Incomplete statement", self.next_token_location_
+                    )
+            elif self.cur_token_ == ";":
+                continue
+            else:
+                raise FeatureLibError(
+                    "Expected VertOriginY or VertAdvanceY",
                     self.cur_token_location_,
                 )
 

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -20,6 +20,8 @@ import tempfile
 import logging
 import unittest
 
+DATADIR = os.path.join(os.path.dirname(__file__), 'data')
+
 
 def makeTTFont():
     glyphs = """
@@ -139,6 +141,8 @@ class BuilderTest(unittest.TestCase):
                 "STAT",
                 "hhea",
                 "vhea",
+                "vmtx",
+                "VORG",
             ],
         )
         actual = self.read_ttx(path)
@@ -147,6 +151,7 @@ class BuilderTest(unittest.TestCase):
             for i in range(len(expected)):
                 for k, v in replace.items():
                     expected[i] = expected[i].replace(k, v)
+
         if actual != expected:
             for line in difflib.unified_diff(
                 expected, actual, fromfile=expected_ttx, tofile=path
@@ -963,6 +968,51 @@ class BuilderTest(unittest.TestCase):
             "feature test { sub a by []; test};"
         )
 
+    def test_build_vmtx_CFF(self):
+        # this also tests VORG table creation since it relies on
+        # first building the vmtx
+        features = (
+            "table vmtx {"
+            "    VertOriginY cid00800 994;"
+            "    VertAdvanceY cid00800 1130;"
+            "    VertOriginY cid00801 766;"
+            "    VertAdvanceY cid00801 870;"
+            "} vmtx;"
+        )
+        font = TTFont()
+        font.importXML(os.path.join(DATADIR, 'vmtx_override_CFF_src.ttx'))
+        addOpenTypeFeaturesFromString(font, features, tables=["vmtx"])
+        self.expect_ttx(font, self.getpath("vmtx_override_CFF_expected.ttx"))
+
+    def test_build_vmtx_CFF2(self):
+        # this also tests VORG table creation since it relies on
+        # first building the vmtx
+        features = (
+            "table vmtx {"
+            "    VertOriginY cid00800 994;"
+            "    VertAdvanceY cid00800 1130;"
+            "    VertOriginY cid00801 766;"
+            "    VertAdvanceY cid00801 870;"
+            "} vmtx;"
+        )
+        font = TTFont()
+        font.importXML(os.path.join(DATADIR, 'vmtx_override_CFF2_src.ttx'))
+        addOpenTypeFeaturesFromString(font, features, tables=["vmtx"])
+        self.expect_ttx(font, self.getpath("vmtx_override_CFF2_expected.ttx"))
+
+    def test_build_vmtx_glyf(self):
+        features = (
+            "table vmtx {"
+            "    VertOriginY cid00800 994;"
+            "    VertAdvanceY cid00800 1130;"
+            "    VertOriginY cid00801 766;"
+            "    VertAdvanceY cid00801 870;"
+            "} vmtx;"
+        )
+        font = TTFont()
+        font.importXML(os.path.join(DATADIR, 'vmtx_override_glyf_src.ttx'))
+        addOpenTypeFeaturesFromString(font, features, tables=["vmtx"])
+        self.expect_ttx(font, self.getpath("vmtx_override_glyf_expected.ttx"))
 
 
 def generate_feature_file_test(name):

--- a/Tests/feaLib/data/table_vmtx.fea
+++ b/Tests/feaLib/data/table_vmtx.fea
@@ -1,0 +1,7 @@
+table vmtx {
+    VertOriginY cid00800 994;
+    VertAdvanceY cid00800 1130;
+    VertOriginY cid00801 766;
+    VertAdvanceY cid00801 870;
+} vmtx;
+

--- a/Tests/feaLib/data/vmtx_override_CFF2_expected.ttx
+++ b/Tests/feaLib/data/vmtx_override_CFF2_expected.ttx
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.33">
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0xf294accf"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Jul  1 15:54:57 2022"/>
+    <modified value="Fri Jul  1 06:54:58 2022"/>
+    <xMin value="0"/>
+    <yMin value="-136"/>
+    <xMax value="984"/>
+    <yMax value="994"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="3"/>
+    <xAvgCharWidth value="956"/>
+    <usWeightClass value="100"/>
+    <usWidthClass value="1"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="228"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="2"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="UKWN"/>
+    <fsSelection value="00000000 00000000"/>
+    <usFirstCharIndex value="12373"/>
+    <usLastCharIndex value="12373"/>
+    <sTypoAscender value="880"/>
+    <sTypoDescender value="-120"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1013"/>
+    <usWinDescent value="321"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="380"/>
+    <sCapHeight value="760"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="1"/>
+  </OS_2>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1013"/>
+    <descent value="-321"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="1130"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="0"/>
+    <xMaxExtent value="984"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="3"/>
+  </hhea>
+
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="500"/>
+    <descent value="-500"/>
+    <lineGap value="0"/>
+    <advanceHeightMax value="1130"/>
+    <minTopSideBearing value="-114"/>
+    <minBottomSideBearing value="-16"/>
+    <yMaxExtent value="1026"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="3"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="-114"/>
+    <mtx name="cid00800" height="1130" tsb="106"/>
+    <mtx name="cid00801" height="870" tsb="88"/>
+  </vmtx>
+
+  <VORG>
+    <majorVersion value="1"/>
+    <minorVersion value="0"/>
+    <defaultVertOriginY value="880"/>
+    <numVertOriginYMetrics value="2"/>
+    <VOriginRecord>
+      <glyphName value="cid00800"/>
+      <vOrigin value="994"/>
+    </VOriginRecord>
+    <VOriginRecord>
+      <glyphName value="cid00801"/>
+      <vOrigin value="766"/>
+    </VOriginRecord>
+  </VORG>
+
+</ttFont>

--- a/Tests/feaLib/data/vmtx_override_CFF2_src.ttx
+++ b/Tests/feaLib/data/vmtx_override_CFF2_src.ttx
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.33">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="cid00800"/>
+    <GlyphID id="2" name="cid00801"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0xf294accf"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Jul  1 15:54:57 2022"/>
+    <modified value="Fri Jul  1 06:54:58 2022"/>
+    <xMin value="0"/>
+    <yMin value="-136"/>
+    <xMax value="984"/>
+    <yMax value="994"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1013"/>
+    <descent value="-321"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="1130"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="0"/>
+    <xMaxExtent value="984"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="3"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="3"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="3"/>
+    <xAvgCharWidth value="956"/>
+    <usWeightClass value="100"/>
+    <usWidthClass value="1"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="228"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="2"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="UKWN"/>
+    <fsSelection value="00000000 00000000"/>
+    <usFirstCharIndex value="12373"/>
+    <usLastCharIndex value="12373"/>
+    <sTypoAscender value="880"/>
+    <sTypoDescender value="-120"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1013"/>
+    <usWinDescent value="321"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="380"/>
+    <sCapHeight value="760"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="1"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="870" lsb="0"/>
+    <mtx name="cid00801" width="1130" lsb="148"/>
+    <mtx name="cid00800" width="870" lsb="107"/>
+  </hmtx>
+
+  <CFF2>
+    <major value="2"/>
+    <minor value="0"/>
+    <CFFFont name="CFF2Font">
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FDSelect format="0"/>
+      <FDArray>
+        <FontDict index="0">
+          <Private>
+            <BlueValues value="0 0"/>
+            <BlueScale value="0.039625"/>
+            <BlueShift value="0"/>
+            <BlueFuzz value="0"/>
+            <StdHW value="0"/>
+            <StdVW value="0"/>
+            <LanguageGroup value="0"/>
+            <ExpansionFactor value="0.06"/>
+          </Private>
+        </FontDict>
+      </FDArray>
+      <CharStrings>
+        <CharString name=".notdef" fdSelectIndex="0">
+          994 vmoveto
+          -1130 870 1130 vlineto
+          -820 -49 rmoveto
+          771 -1032 -771 hlineto
+        </CharString>
+        <CharString name="cid00801" fdSelectIndex="0">
+          148 678 -43 -41 20 18 210 -2 2 blend
+          rmoveto
+          -700 836 700 -36 -220 -19 42 -179 1 35 220 20 3 blend
+          vlineto
+          -786 -49 57 179 0 -99 0 -1 2 blend
+          rmoveto
+          736 -158 -178 1 1 blend
+          hlineto
+          0 -602 1 0 -1 164 -220 -19 2 blend
+          rlineto
+          -736 158 178 -1 1 blend
+          hlineto
+        </CharString>
+        <CharString name="cid00800" fdSelectIndex="0">
+          107 888 -23 41 -20 16 -210 2 2 blend
+          rmoveto
+          -920 657 920 -55 220 19 43 179 -1 55 -220 -20 3 blend
+          vlineto
+          -607 -49 57 -179 0 -100 0 1 2 blend
+          rmoveto
+          558 -157 178 -1 1 blend
+          hlineto
+          0 -822 0 0 1 145 220 19 2 blend
+          rlineto
+          -558 157 -178 1 1 blend
+          hlineto
+        </CharString>
+      </CharStrings>
+      <VarStore Format="1">
+        <Format value="1"/>
+        <VarRegionList>
+          <!-- RegionAxisCount=2 -->
+          <!-- RegionCount=3 -->
+          <Region index="0">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="1">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="0.0"/>
+              <EndCoord value="0.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+          <Region index="2">
+            <VarRegionAxis index="0">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+            <VarRegionAxis index="1">
+              <StartCoord value="0.0"/>
+              <PeakCoord value="1.0"/>
+              <EndCoord value="1.0"/>
+            </VarRegionAxis>
+          </Region>
+        </VarRegionList>
+        <!-- VarDataCount=1 -->
+        <VarData index="0">
+          <!-- ItemCount=0 -->
+          <NumShorts value="0"/>
+          <!-- VarRegionCount=3 -->
+          <VarRegionIndex index="0" value="0"/>
+          <VarRegionIndex index="1" value="1"/>
+          <VarRegionIndex index="2" value="2"/>
+        </VarData>
+      </VarStore>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF2>
+
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="500"/>
+    <descent value="-500"/>
+    <lineGap value="0"/>
+    <advanceHeightMax value="1130"/>
+    <minTopSideBearing value="-114"/>
+    <minBottomSideBearing value="-16"/>
+    <yMaxExtent value="1026"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="3"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="-114"/>
+    <mtx name="cid00800" height="1130" tsb="106"/>
+    <mtx name="cid00801" height="870" tsb="88"/>
+  </vmtx>
+
+</ttFont>

--- a/Tests/feaLib/data/vmtx_override_CFF_expected.ttx
+++ b/Tests/feaLib/data/vmtx_override_CFF_expected.ttx
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.33">
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0x483edb61"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Jul  1 15:54:57 2022"/>
+    <modified value="Fri Jul  1 15:54:57 2022"/>
+    <xMin value="0"/>
+    <yMin value="-136"/>
+    <xMax value="984"/>
+    <yMax value="994"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="3"/>
+    <xAvgCharWidth value="956"/>
+    <usWeightClass value="100"/>
+    <usWidthClass value="8"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="228"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="2"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="UKWN"/>
+    <fsSelection value="00000000 00000000"/>
+    <usFirstCharIndex value="12373"/>
+    <usLastCharIndex value="12373"/>
+    <sTypoAscender value="880"/>
+    <sTypoDescender value="-120"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1013"/>
+    <usWinDescent value="321"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="380"/>
+    <sCapHeight value="760"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="1"/>
+  </OS_2>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1013"/>
+    <descent value="-321"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="1130"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="0"/>
+    <xMaxExtent value="984"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="3"/>
+  </hhea>
+
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="500"/>
+    <descent value="-500"/>
+    <lineGap value="0"/>
+    <advanceHeightMax value="1130"/>
+    <minTopSideBearing value="88"/>
+    <minBottomSideBearing value="82"/>
+    <yMaxExtent value="1026"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="3"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="-114"/>
+    <mtx name="cid00800" height="1130" tsb="106"/>
+    <mtx name="cid00801" height="870" tsb="88"/>
+  </vmtx>
+
+  <VORG>
+    <majorVersion value="1"/>
+    <minorVersion value="0"/>
+    <defaultVertOriginY value="880"/>
+    <numVertOriginYMetrics value="2"/>
+    <VOriginRecord>
+      <glyphName value="cid00800"/>
+      <vOrigin value="994"/>
+    </VOriginRecord>
+    <VOriginRecord>
+      <glyphName value="cid00801"/>
+      <vOrigin value="766"/>
+    </VOriginRecord>
+  </VORG>
+
+</ttFont>

--- a/Tests/feaLib/data/vmtx_override_CFF_src.ttx
+++ b/Tests/feaLib/data/vmtx_override_CFF_src.ttx
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.33">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="cid00800"/>
+    <GlyphID id="2" name="cid00801"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0x483edb61"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Jul  1 15:54:57 2022"/>
+    <modified value="Fri Jul  1 15:54:57 2022"/>
+    <xMin value="0"/>
+    <yMin value="-136"/>
+    <xMax value="984"/>
+    <yMax value="994"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1013"/>
+    <descent value="-321"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="1130"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="0"/>
+    <xMaxExtent value="984"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="3"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="3"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="3"/>
+    <xAvgCharWidth value="956"/>
+    <usWeightClass value="100"/>
+    <usWidthClass value="8"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="228"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="2"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="UKWN"/>
+    <fsSelection value="00000000 00000000"/>
+    <usFirstCharIndex value="12373"/>
+    <usLastCharIndex value="12373"/>
+    <sTypoAscender value="880"/>
+    <sTypoDescender value="-120"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1013"/>
+    <usWinDescent value="321"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="380"/>
+    <sCapHeight value="760"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="1"/>
+  </OS_2>
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="CFFFont">
+      <ROS Registry="Adobe" Order="Identity" Supplement="0"/>
+      <Copyright value="c"/>
+      <FamilyName value="CFFFont"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlinePosition value="-100"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="0 -136 984 994"/>
+      <StrokeWidth value="0"/>
+      <CIDFontVersion value="1"/>
+      <CIDFontRevision value="0"/>
+      <CIDFontType value="0"/>
+      <CIDCount value="20109"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <FDSelect format="0"/>
+      <FDArray>
+        <FontDict index="0">
+          <FontName value="Test"/>
+          <Private>
+            <BlueValues value="0 0"/>
+            <BlueScale value="0.039625"/>
+            <BlueShift value="0"/>
+            <BlueFuzz value="0"/>
+            <StdHW value="0"/>
+            <StdVW value="0"/>
+            <ForceBold value="0"/>
+            <LanguageGroup value="0"/>
+            <ExpansionFactor value="0.06"/>
+            <initialRandomSeed value="0"/>
+            <defaultWidthX value="0"/>
+            <nominalWidthX value="0"/>
+          </Private>
+        </FontDict>
+      </FDArray>
+      <CharStrings>
+        <CharString name=".notdef" fdSelectIndex="0">
+          870 994 vmoveto
+          -1130 870 1130 vlineto
+          -820 -49 rmoveto
+          770.57 -1031.58 -770.57 hlineto
+          endchar
+        </CharString>
+        <CharString name="cid00801" fdSelectIndex="0">
+          1130 148 678 rmoveto
+          -700 836 700 vlineto
+          -786 -49 rmoveto
+          736 -602 -736 hlineto
+          endchar
+        </CharString>
+        <CharString name="cid00800" fdSelectIndex="0">
+          870 107 888 rmoveto
+          -920 657 920 vlineto
+          -607 -49 rmoveto
+          558 -822 -558 hlineto
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+  <VORG>
+    <majorVersion value="1"/>
+    <minorVersion value="0"/>
+    <defaultVertOriginY value="880"/>
+    <numVertOriginYMetrics value="2"/>
+    <VOriginRecord>
+      <glyphName value="cid00800"/>
+      <vOrigin value="726"/>
+    </VOriginRecord>
+    <VOriginRecord>
+      <glyphName value="cid00801"/>
+      <vOrigin value="994"/>
+    </VOriginRecord>
+  </VORG>
+
+  <hmtx>
+    <mtx name=".notdef" width="870" lsb="0"/>
+    <mtx name="cid00800" width="1130" lsb="148"/>
+    <mtx name="cid00801" width="870" lsb="107"/>
+  </hmtx>
+
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="500"/>
+    <descent value="-500"/>
+    <lineGap value="0"/>
+    <advanceHeightMax value="1130"/>
+    <minTopSideBearing value="88"/>
+    <minBottomSideBearing value="82"/>
+    <yMaxExtent value="1026"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="3"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="-114"/>
+    <mtx name="cid00800" height="1130" tsb="106"/>
+    <mtx name="cid00801" height="870" tsb="88"/>
+  </vmtx>
+
+</ttFont>

--- a/Tests/feaLib/data/vmtx_override_glyf_expected.ttx
+++ b/Tests/feaLib/data/vmtx_override_glyf_expected.ttx
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.33">
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0xf294accf"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Jul  1 15:54:57 2022"/>
+    <modified value="Fri Jul  1 06:54:58 2022"/>
+    <xMin value="0"/>
+    <yMin value="-136"/>
+    <xMax value="984"/>
+    <yMax value="994"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="3"/>
+    <xAvgCharWidth value="956"/>
+    <usWeightClass value="100"/>
+    <usWidthClass value="1"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="228"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="2"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="UKWN"/>
+    <fsSelection value="00000000 00000000"/>
+    <usFirstCharIndex value="12373"/>
+    <usLastCharIndex value="12373"/>
+    <sTypoAscender value="880"/>
+    <sTypoDescender value="-120"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1013"/>
+    <usWinDescent value="321"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="380"/>
+    <sCapHeight value="760"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="1"/>
+  </OS_2>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1013"/>
+    <descent value="-321"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="1130"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="0"/>
+    <xMaxExtent value="984"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="3"/>
+  </hhea>
+
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="500"/>
+    <descent value="-500"/>
+    <lineGap value="0"/>
+    <advanceHeightMax value="1130"/>
+    <minTopSideBearing value="-114"/>
+    <minBottomSideBearing value="-16"/>
+    <yMaxExtent value="1026"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="3"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="-114"/>
+    <mtx name="cid00800" height="1130" tsb="106"/>
+    <mtx name="cid00801" height="870" tsb="88"/>
+  </vmtx>
+
+</ttFont>

--- a/Tests/feaLib/data/vmtx_override_glyf_src.ttx
+++ b/Tests/feaLib/data/vmtx_override_glyf_src.ttx
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.33">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="cid00800"/>
+    <GlyphID id="2" name="cid00801"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0xf294accf"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Jul  1 15:54:57 2022"/>
+    <modified value="Fri Jul  1 06:54:58 2022"/>
+    <xMin value="0"/>
+    <yMin value="-136"/>
+    <xMax value="984"/>
+    <yMax value="994"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1013"/>
+    <descent value="-321"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="1130"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="0"/>
+    <xMaxExtent value="984"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="3"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="3"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="3"/>
+    <xAvgCharWidth value="956"/>
+    <usWeightClass value="100"/>
+    <usWidthClass value="1"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="228"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="2"/>
+      <bSerifStyle value="11"/>
+      <bWeight value="2"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="UKWN"/>
+    <fsSelection value="00000000 00000000"/>
+    <usFirstCharIndex value="12373"/>
+    <usLastCharIndex value="12373"/>
+    <sTypoAscender value="880"/>
+    <sTypoDescender value="-120"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="1013"/>
+    <usWinDescent value="321"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="380"/>
+    <sCapHeight value="760"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="1"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="870" lsb="0"/>
+    <mtx name="cid00801" width="1130" lsb="148"/>
+    <mtx name="cid00800" width="870" lsb="107"/>
+  </hmtx>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="0" yMin="-136" xMax="870" yMax="994">
+      <contour>
+        <pt x="0" y="994" on="1"/>
+        <pt x="870" y="994" on="1"/>
+        <pt x="870" y="-136" on="1"/>
+        <pt x="0" y="-136" on="1"/>
+      </contour>
+      <contour>
+        <pt x="50" y="945" on="1"/>
+        <pt x="50" y="-87" on="1"/>
+        <pt x="821" y="-87" on="1"/>
+        <pt x="821" y="945" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="cid00801" xMin="148" yMin="-22" xMax="984" yMax="678">
+      <contour>
+        <pt x="148" y="678" on="1"/>
+        <pt x="984" y="678" on="1"/>
+        <pt x="984" y="-22" on="1"/>
+        <pt x="148" y="-22" on="1"/>
+      </contour>
+      <contour>
+        <pt x="198" y="629" on="1"/>
+        <pt x="198" y="27" on="1"/>
+        <pt x="934" y="27" on="1"/>
+        <pt x="934" y="629" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="cid00800" xMin="107" yMin="-32" xMax="764" yMax="888">
+      <contour>
+        <pt x="107" y="888" on="1"/>
+        <pt x="764" y="888" on="1"/>
+        <pt x="764" y="-32" on="1"/>
+        <pt x="107" y="-32" on="1"/>
+      </contour>
+      <contour>
+        <pt x="157" y="839" on="1"/>
+        <pt x="157" y="17" on="1"/>
+        <pt x="715" y="17" on="1"/>
+        <pt x="715" y="839" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="500"/>
+    <descent value="-500"/>
+    <lineGap value="0"/>
+    <advanceHeightMax value="1130"/>
+    <minTopSideBearing value="-114"/>
+    <minBottomSideBearing value="-16"/>
+    <yMaxExtent value="1026"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="3"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="-114"/>
+    <mtx name="cid00800" height="1130" tsb="106"/>
+    <mtx name="cid00801" height="870" tsb="88"/>
+  </vmtx>
+
+</ttFont>


### PR DESCRIPTION
This adds vmtx support to feaLib. And to match makeotf this also fills out the VORG table for CFF or CFF2 fonts. Unlike everything else in feaLib this requires access to the outlines to get the bounds which can be expensive which is one reason to do it all in one go. Since we are only reading overrides here instead of building a vmtx from scratch it is assumed that the vmtx table already exists (probably from ufo2ft in most cases). This is one approach, but another possible approach would be to add builders to otlLib like `buildStatTable` where users could also build a vmtx and/or VORG from scratch if necessary. If that's more desireable I can change the PR, but this feaLib only setup is working well. 