### PR TITLE
Be able to getDebugName depending on the platformID

### DIFF
--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -99,26 +99,26 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
 					return namerecord
 		return None # not found
 
-	def getDebugName(self, nameID):
-		englishName = someName = None
-		for name in self.names:
-			if name.nameID != nameID:
-				continue
+	def getDebugName(self, nameID, platformIDs=(3, 0, 1, 2)):
+		"""
+		Parameters:
+			nameID: NameID from NamingTable.
+			platformIDs: Search the name depending on the platformID order.
+		Returns:
+			Decoded nameID.
+		"""
+		def isEnglish(name: NameRecord) -> bool:
+			return (name.platformID, name.langID) in ((1, 0), (3, 0x409))
+		filteredNamingTable = filter(lambda name: name.nameID == nameID and name.platformID in platformIDs, self.names)
+		sortedNamingTable = sorted(filteredNamingTable, key=lambda name: (platformIDs.index(name.platformID), name.platEncID, -isEnglish(name), name.langID))
+
+		for name in sortedNamingTable:
 			try:
 				unistr = name.toUnicode()
 			except UnicodeDecodeError:
 				continue
-
-			someName = unistr
-			if (name.platformID, name.langID) in ((1, 0), (3, 0x409)):
-				englishName = unistr
-				break
-		if englishName:
-			return englishName
-		elif someName:
-			return someName
-		else:
-			return None
+			return unistr
+		return None
 
 	def getFirstDebugName(self, nameIDs):
 		for nameID in nameIDs:


### PR DESCRIPTION
### Why is this PR is needed?
Currently, if the for loop in the method **getDebugName** "meet" a name with a **platformID=1** and **langID=0**, it will directly return it. This mean that it can preferred a name from mac platform over a name from microsoft platform. 

However, here is what the Apple documentation mentions: [``Names with platformID 1 were required by earlier versions of macOS. Its use on modern platforms is discouraged``](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6name.html).

This is why something need to be changed in getDebugName.

### What logic is it based on?
- By default, use the same order has [FontConfig](https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/d863f6778915f7dd224c98c814247ec292904e30/src/fcfreetype.c#L1078-1083)
- The method isEnglish is inspired from [FontConfig](https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/d863f6778915f7dd224c98c814247ec292904e30/src/fcfreetype.c#L1111-1125)
- Finally, the sort logic is also from [FontConfig](https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/d863f6778915f7dd224c98c814247ec292904e30/src/fcfreetype.c#L1128-1140)