### PR TITLE
Add type hints to feaLib.ast

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -2,7 +2,11 @@ from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.location import FeatureLibLocation
 from fontTools.misc.encodingTools import getEncoding
 from fontTools.misc.textTools import byteord, tobytes
+from fontTools.feaLib.variableScalar import VariableScalar
 from collections import OrderedDict
+from collections.abc import Sequence
+from typing import Tuple, List, Optional, Union, Dict, Callable
+from typing_extensions import Protocol
 import itertools
 
 SHIFT = " " * 4
@@ -153,19 +157,29 @@ def asFea(g):
         return g
 
 
+class GlyphContainer(Protocol):
+    def glyphSet(self) -> Tuple[str, ...]:
+        ...
+
+    def asFea(self) -> str:
+        ...
+
+
 class Element(object):
     """A base class representing "something" in a feature file."""
 
-    def __init__(self, location=None):
+    def __init__(
+        self, location: Union[FeatureLibLocation, Tuple[str, int, int]] = None
+    ):
         #: location of this element as a `FeatureLibLocation` object.
         if location and not isinstance(location, FeatureLibLocation):
             location = FeatureLibLocation(*location)
         self.location = location
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         pass
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         """Returns this element as a string of feature code. For block-type
         elements (such as :class:`FeatureBlock`), the `indent` string is
         added to the start of each line in the output."""
@@ -186,61 +200,64 @@ class Expression(Element):
 class Comment(Element):
     """A comment in a feature file."""
 
-    def __init__(self, text, location=None):
+    def __init__(self, text: str, location: Optional[FeatureLibLocation] = None):
         super(Comment, self).__init__(location)
         #: Text of the comment
         self.text = text
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return self.text
 
 
 class NullGlyph(Expression):
     """The NULL glyph, used in glyph deletion substitutions."""
 
-    def __init__(self, location=None):
+    def __init__(self, location: Optional[FeatureLibLocation] = None):
         Expression.__init__(self, location)
         #: The name itself as a string
 
-    def glyphSet(self):
-        """The glyphs in this class as a tuple of :class:`GlyphName` objects."""
+    def glyphSet(self) -> Tuple:
+        """The glyphs in this class."""
         return ()
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "NULL"
 
 
 class GlyphName(Expression):
     """A single glyph name, such as ``cedilla``."""
 
-    def __init__(self, glyph, location=None):
+    def __init__(self, glyph: str, location: Optional[FeatureLibLocation] = None):
         Expression.__init__(self, location)
-        #: The name itself as a string
+        #: The name itself
         self.glyph = glyph
 
-    def glyphSet(self):
+    def glyphSet(self) -> Tuple[str]:
         """The glyphs in this class as a tuple of :class:`GlyphName` objects."""
         return (self.glyph,)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return asFea(self.glyph)
 
 
 class GlyphClass(Expression):
     """A glyph class, such as ``[acute cedilla grave]``."""
 
-    def __init__(self, glyphs=None, location=None):
+    def __init__(
+        self, glyphs: Sequence[str] = None, location: FeatureLibLocation = None
+    ):
         Expression.__init__(self, location)
-        #: The list of glyphs in this class, as :class:`GlyphName` objects.
-        self.glyphs = glyphs if glyphs is not None else []
-        self.original = []
+        #: The list of glyphs in this class, as strings.
+        self.glyphs: List[str] = list(glyphs) if glyphs is not None else []
+        self.original: List[str] = []
         self.curr = 0
 
-    def glyphSet(self):
-        """The glyphs in this class as a tuple of :class:`GlyphName` objects."""
+    def glyphSet(self) -> Tuple[str, ...]:
+        """The glyphs in this class."""
         return tuple(self.glyphs)
+        # return tuple([x.glyph for x in self.glyphs])
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         if len(self.original):
             if self.curr < len(self.glyphs):
                 self.original.extend(self.glyphs[self.curr :])
@@ -249,308 +266,79 @@ class GlyphClass(Expression):
         else:
             return "[" + " ".join(map(asFea, self.glyphs)) + "]"
 
-    def extend(self, glyphs):
-        """Add a list of :class:`GlyphName` objects to the class."""
+    def extend(self, glyphs: Sequence[str]):
+        """Add a list of :class:`str` objects to the class."""
         self.glyphs.extend(glyphs)
 
-    def append(self, glyph):
-        """Add a single :class:`GlyphName` object to the class."""
+    def append(self, glyph: str):
+        """Add a single :class:`str` object to the class."""
         self.glyphs.append(glyph)
 
-    def add_range(self, start, end, glyphs):
-        """Add a range (e.g. ``A-Z``) to the class. ``start`` and ``end``
-        are either :class:`GlyphName` objects or strings representing the
-        start and end glyphs in the class, and ``glyphs`` is the full list of
-        :class:`GlyphName` objects in the range."""
+    def _add_things(self, glyphs: Sequence[str], original: str):
         if self.curr < len(self.glyphs):
             self.original.extend(self.glyphs[self.curr :])
-        self.original.append((start, end))
+            # self.original.extend([x.glyph for x in self.glyphs[self.curr :]])
+        self.original.append(original)
         self.glyphs.extend(glyphs)
         self.curr = len(self.glyphs)
 
-    def add_cid_range(self, start, end, glyphs):
+    def add_range(self, start: str, end: str, glyphs: Sequence[str]):
+        """Add a range (e.g. ``A-Z``) to the class. ``start`` and ``end``
+        are strings representing the start and end glyphs in the class,
+        and ``glyphs`` is the full list of strs representing glyphs in the range."""
+        self._add_things(glyphs, start + " - " + end)
+
+    def add_cid_range(self, start: int, end: int, glyphs: Sequence[str]):
         """Add a range to the class by glyph ID. ``start`` and ``end`` are the
         initial and final IDs, and ``glyphs`` is the full list of
-        :class:`GlyphName` objects in the range."""
-        if self.curr < len(self.glyphs):
-            self.original.extend(self.glyphs[self.curr :])
-        self.original.append(("\\{}".format(start), "\\{}".format(end)))
-        self.glyphs.extend(glyphs)
-        self.curr = len(self.glyphs)
+        :class:`str` objects in the range."""
+        self._add_things(glyphs, "\\{} - \\{}".format(start, end))
 
-    def add_class(self, gc):
+    def add_class(self, gc: "Union[GlyphClassName, MarkClassName]"):
         """Add glyphs from the given :class:`GlyphClassName` object to the
         class."""
-        if self.curr < len(self.glyphs):
-            self.original.extend(self.glyphs[self.curr :])
-        self.original.append(gc)
-        self.glyphs.extend(gc.glyphSet())
-        self.curr = len(self.glyphs)
+        self._add_things(gc.glyphSet(), gc.asFea())
+
+
+class GlyphClassDefinition(Statement):
+    """Example: ``@UPPERCASE = [A-Z];``."""
+
+    def __init__(
+        self,
+        name: str,
+        glyphs: GlyphClass,
+        location: Optional[FeatureLibLocation] = None,
+    ):
+        Statement.__init__(self, location)
+        self.name = name  #: class name as a string, without initial ``@``
+        self.glyphs = glyphs
+
+    def glyphSet(self) -> Tuple[str, ...]:
+        """The glyphs in this class."""
+        return tuple(self.glyphs.glyphSet())
+
+    def asFea(self, indent="") -> str:
+        return "@" + self.name + " = " + self.glyphs.asFea() + ";"
 
 
 class GlyphClassName(Expression):
     """A glyph class name, such as ``@FRENCH_MARKS``. This must be instantiated
     with a :class:`GlyphClassDefinition` object."""
 
-    def __init__(self, glyphclass, location=None):
+    def __init__(
+        self,
+        glyphclass: GlyphClassDefinition,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Expression.__init__(self, location)
-        assert isinstance(glyphclass, GlyphClassDefinition)
         self.glyphclass = glyphclass
 
-    def glyphSet(self):
-        """The glyphs in this class as a tuple of :class:`GlyphName` objects."""
+    def glyphSet(self) -> Tuple[str, ...]:
+        """The glyphs in this class."""
         return tuple(self.glyphclass.glyphSet())
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "@" + self.glyphclass.name
-
-
-class MarkClassName(Expression):
-    """A mark class name, such as ``@FRENCH_MARKS`` defined with ``markClass``.
-    This must be instantiated with a :class:`MarkClass` object."""
-
-    def __init__(self, markClass, location=None):
-        Expression.__init__(self, location)
-        assert isinstance(markClass, MarkClass)
-        self.markClass = markClass
-
-    def glyphSet(self):
-        """The glyphs in this class as a tuple of :class:`GlyphName` objects."""
-        return self.markClass.glyphSet()
-
-    def asFea(self, indent=""):
-        return "@" + self.markClass.name
-
-
-class AnonymousBlock(Statement):
-    """An anonymous data block."""
-
-    def __init__(self, tag, content, location=None):
-        Statement.__init__(self, location)
-        self.tag = tag  #: string containing the block's "tag"
-        self.content = content  #: block data as string
-
-    def asFea(self, indent=""):
-        res = "anon {} {{\n".format(self.tag)
-        res += self.content
-        res += "}} {};\n\n".format(self.tag)
-        return res
-
-
-class Block(Statement):
-    """A block of statements: feature, lookup, etc."""
-
-    def __init__(self, location=None):
-        Statement.__init__(self, location)
-        self.statements = []  #: Statements contained in the block
-
-    def build(self, builder):
-        """When handed a 'builder' object of comparable interface to
-        :class:`fontTools.feaLib.builder`, walks the statements in this
-        block, calling the builder callbacks."""
-        for s in self.statements:
-            s.build(builder)
-
-    def asFea(self, indent=""):
-        indent += SHIFT
-        return (
-            indent
-            + ("\n" + indent).join([s.asFea(indent=indent) for s in self.statements])
-            + "\n"
-        )
-
-
-class FeatureFile(Block):
-    """The top-level element of the syntax tree, containing the whole feature
-    file in its ``statements`` attribute."""
-
-    def __init__(self):
-        Block.__init__(self, location=None)
-        self.markClasses = {}  # name --> ast.MarkClass
-
-    def asFea(self, indent=""):
-        return "\n".join(s.asFea(indent=indent) for s in self.statements)
-
-
-class FeatureBlock(Block):
-    """A named feature block."""
-
-    def __init__(self, name, use_extension=False, location=None):
-        Block.__init__(self, location)
-        self.name, self.use_extension = name, use_extension
-
-    def build(self, builder):
-        """Call the ``start_feature`` callback on the builder object, visit
-        all the statements in this feature, and then call ``end_feature``."""
-        # TODO(sascha): Handle use_extension.
-        builder.start_feature(self.location, self.name)
-        # language exclude_dflt statements modify builder.features_
-        # limit them to this block with temporary builder.features_
-        features = builder.features_
-        builder.features_ = {}
-        Block.build(self, builder)
-        for key, value in builder.features_.items():
-            features.setdefault(key, []).extend(value)
-        builder.features_ = features
-        builder.end_feature()
-
-    def asFea(self, indent=""):
-        res = indent + "feature %s " % self.name.strip()
-        if self.use_extension:
-            res += "useExtension "
-        res += "{\n"
-        res += Block.asFea(self, indent=indent)
-        res += indent + "} %s;\n" % self.name.strip()
-        return res
-
-
-class NestedBlock(Block):
-    """A block inside another block, for example when found inside a
-    ``cvParameters`` block."""
-
-    def __init__(self, tag, block_name, location=None):
-        Block.__init__(self, location)
-        self.tag = tag
-        self.block_name = block_name
-
-    def build(self, builder):
-        Block.build(self, builder)
-        if self.block_name == "ParamUILabelNameID":
-            builder.add_to_cv_num_named_params(self.tag)
-
-    def asFea(self, indent=""):
-        res = "{}{} {{\n".format(indent, self.block_name)
-        res += Block.asFea(self, indent=indent)
-        res += "{}}};\n".format(indent)
-        return res
-
-
-class LookupBlock(Block):
-    """A named lookup, containing ``statements``."""
-
-    def __init__(self, name, use_extension=False, location=None):
-        Block.__init__(self, location)
-        self.name, self.use_extension = name, use_extension
-
-    def build(self, builder):
-        # TODO(sascha): Handle use_extension.
-        builder.start_lookup_block(self.location, self.name)
-        Block.build(self, builder)
-        builder.end_lookup_block()
-
-    def asFea(self, indent=""):
-        res = "lookup {} ".format(self.name)
-        if self.use_extension:
-            res += "useExtension "
-        res += "{\n"
-        res += Block.asFea(self, indent=indent)
-        res += "{}}} {};\n".format(indent, self.name)
-        return res
-
-
-class TableBlock(Block):
-    """A ``table ... { }`` block."""
-
-    def __init__(self, name, location=None):
-        Block.__init__(self, location)
-        self.name = name
-
-    def asFea(self, indent=""):
-        res = "table {} {{\n".format(self.name.strip())
-        res += super(TableBlock, self).asFea(indent=indent)
-        res += "}} {};\n".format(self.name.strip())
-        return res
-
-
-class GlyphClassDefinition(Statement):
-    """Example: ``@UPPERCASE = [A-Z];``."""
-
-    def __init__(self, name, glyphs, location=None):
-        Statement.__init__(self, location)
-        self.name = name  #: class name as a string, without initial ``@``
-        self.glyphs = glyphs  #: a :class:`GlyphClass` object
-
-    def glyphSet(self):
-        """The glyphs in this class as a tuple of :class:`GlyphName` objects."""
-        return tuple(self.glyphs.glyphSet())
-
-    def asFea(self, indent=""):
-        return "@" + self.name + " = " + self.glyphs.asFea() + ";"
-
-
-class GlyphClassDefStatement(Statement):
-    """Example: ``GlyphClassDef @UPPERCASE, [B], [C], [D];``. The parameters
-    must be either :class:`GlyphClass` or :class:`GlyphClassName` objects, or
-    ``None``."""
-
-    def __init__(
-        self, baseGlyphs, markGlyphs, ligatureGlyphs, componentGlyphs, location=None
-    ):
-        Statement.__init__(self, location)
-        self.baseGlyphs, self.markGlyphs = (baseGlyphs, markGlyphs)
-        self.ligatureGlyphs = ligatureGlyphs
-        self.componentGlyphs = componentGlyphs
-
-    def build(self, builder):
-        """Calls the builder's ``add_glyphClassDef`` callback."""
-        base = self.baseGlyphs.glyphSet() if self.baseGlyphs else tuple()
-        liga = self.ligatureGlyphs.glyphSet() if self.ligatureGlyphs else tuple()
-        mark = self.markGlyphs.glyphSet() if self.markGlyphs else tuple()
-        comp = self.componentGlyphs.glyphSet() if self.componentGlyphs else tuple()
-        builder.add_glyphClassDef(self.location, base, liga, mark, comp)
-
-    def asFea(self, indent=""):
-        return "GlyphClassDef {}, {}, {}, {};".format(
-            self.baseGlyphs.asFea() if self.baseGlyphs else "",
-            self.ligatureGlyphs.asFea() if self.ligatureGlyphs else "",
-            self.markGlyphs.asFea() if self.markGlyphs else "",
-            self.componentGlyphs.asFea() if self.componentGlyphs else "",
-        )
-
-
-class MarkClass(object):
-    """One `or more` ``markClass`` statements for the same mark class.
-
-    While glyph classes can be defined only once, the feature file format
-    allows expanding mark classes with multiple definitions, each using
-    different glyphs and anchors. The following are two ``MarkClassDefinitions``
-    for the same ``MarkClass``::
-
-        markClass [acute grave] <anchor 350 800> @FRENCH_ACCENTS;
-        markClass [cedilla] <anchor 350 -200> @FRENCH_ACCENTS;
-
-    The ``MarkClass`` object is therefore just a container for a list of
-    :class:`MarkClassDefinition` statements.
-    """
-
-    def __init__(self, name):
-        self.name = name
-        self.definitions = []
-        self.glyphs = OrderedDict()  # glyph --> ast.MarkClassDefinitions
-
-    def addDefinition(self, definition):
-        """Add a :class:`MarkClassDefinition` statement to this mark class."""
-        assert isinstance(definition, MarkClassDefinition)
-        self.definitions.append(definition)
-        for glyph in definition.glyphSet():
-            if glyph in self.glyphs:
-                otherLoc = self.glyphs[glyph].location
-                if otherLoc is None:
-                    end = ""
-                else:
-                    end = f" at {otherLoc}"
-                raise FeatureLibError(
-                    "Glyph %s already defined%s" % (glyph, end), definition.location
-                )
-            self.glyphs[glyph] = definition
-
-    def glyphSet(self):
-        """The glyphs in this class as a tuple of :class:`GlyphName` objects."""
-        return tuple(self.glyphs.keys())
-
-    def asFea(self, indent=""):
-        res = "\n".join(d.asFea() for d in self.definitions)
-        return res
 
 
 class MarkClassDefinition(Statement):
@@ -576,44 +364,313 @@ class MarkClassDefinition(Statement):
 
     """
 
-    def __init__(self, markClass, anchor, glyphs, location=None):
+    def __init__(
+        self,
+        markClass: "MarkClass",
+        anchor: "Anchor",
+        glyphs: GlyphContainer,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
-        assert isinstance(markClass, MarkClass)
-        assert isinstance(anchor, Anchor) and isinstance(glyphs, Expression)
-        self.markClass, self.anchor, self.glyphs = markClass, anchor, glyphs
+        self.markClass = markClass
+        self.anchor = anchor
+        self.glyphs = glyphs
 
-    def glyphSet(self):
-        """The glyphs in this class as a tuple of :class:`GlyphName` objects."""
+    def glyphSet(self) -> Tuple[str, ...]:
+        """The glyphs in this class."""
         return self.glyphs.glyphSet()
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "markClass {} {} @{};".format(
             self.glyphs.asFea(), self.anchor.asFea(), self.markClass.name
+        )
+
+
+class MarkClass(object):
+    """One `or more` ``markClass`` statements for the same mark class.
+
+    While glyph classes can be defined only once, the feature file format
+    allows expanding mark classes with multiple definitions, each using
+    different glyphs and anchors. The following are two ``MarkClassDefinitions``
+    for the same ``MarkClass``::
+
+        markClass [acute grave] <anchor 350 800> @FRENCH_ACCENTS;
+        markClass [cedilla] <anchor 350 -200> @FRENCH_ACCENTS;
+
+    The ``MarkClass`` object is therefore just a container for a list of
+    :class:`MarkClassDefinition` statements.
+    """
+
+    def __init__(self, name: str):
+        self.name = name
+        self.definitions: List[MarkClassDefinition] = []
+        self.glyphs: Dict[
+            str, MarkClassDefinition
+        ] = OrderedDict()  # glyph --> ast.MarkClassDefinitions
+
+    def addDefinition(self, definition):
+        """Add a :class:`MarkClassDefinition` statement to this mark class."""
+        assert isinstance(definition, MarkClassDefinition)
+        self.definitions.append(definition)
+        for glyph in definition.glyphSet():
+            if glyph in self.glyphs:
+                otherLoc = self.glyphs[glyph].location
+                if otherLoc is None:
+                    end = ""
+                else:
+                    end = f" at {otherLoc}"
+                raise FeatureLibError(
+                    "Glyph %s already defined%s" % (glyph, end), definition.location
+                )
+            self.glyphs[glyph] = definition
+
+    def glyphSet(self) -> Tuple[str, ...]:
+        """The glyphs in this class."""
+        return tuple(self.glyphs.keys())
+
+    def asFea(self, indent="") -> str:
+        res = "\n".join(d.asFea() for d in self.definitions)
+        return res
+
+
+class MarkClassName(Expression):
+    """A mark class name, such as ``@FRENCH_MARKS`` defined with ``markClass``."""
+
+    def __init__(
+        self, markClass: MarkClass, location: Optional[FeatureLibLocation] = None
+    ):
+        Expression.__init__(self, location)
+        assert isinstance(markClass, MarkClass)
+        self.markClass = markClass
+
+    def glyphSet(self) -> Tuple[str, ...]:
+        """The glyphs in this class."""
+        return self.markClass.glyphSet()
+
+    def asFea(self, indent="") -> str:
+        return "@" + self.markClass.name
+
+
+class AnonymousBlock(Statement):
+    """An anonymous data block."""
+
+    def __init__(
+        self, tag: str, content: str, location: Optional[FeatureLibLocation] = None
+    ):
+        Statement.__init__(self, location)
+        self.tag = tag  #: the block's "tag"
+        self.content = content  #: block data
+
+    def asFea(self, indent="") -> str:
+        res = "anon {} {{\n".format(self.tag)
+        res += self.content
+        res += "}} {};\n\n".format(self.tag)
+        return res
+
+
+class Block(Statement):
+    """A block of statements: feature, lookup, etc."""
+
+    def __init__(self, location: Optional[FeatureLibLocation] = None):
+        Statement.__init__(self, location)
+        self.statements: List[Statement] = []  #: Statements contained in the block
+
+    def build(self, builder) -> None:
+        """When handed a 'builder' object of comparable interface to
+        :class:`fontTools.feaLib.builder`, walks the statements in this
+        block, calling the builder callbacks."""
+        for s in self.statements:
+            s.build(builder)
+
+    def asFea(self, indent="") -> str:
+        indent += SHIFT
+        return (
+            indent
+            + ("\n" + indent).join([s.asFea(indent=indent) for s in self.statements])
+            + "\n"
+        )
+
+
+class FeatureFile(Block):
+    """The top-level element of the syntax tree, containing the whole feature
+    file in its ``statements`` attribute."""
+
+    def __init__(self):
+        Block.__init__(self, location=None)
+        self.markClasses: Dict[str, MarkClass] = {}
+
+    def asFea(self, indent="") -> str:
+        return "\n".join(s.asFea(indent=indent) for s in self.statements)
+
+
+class FeatureBlock(Block):
+    """A named feature block."""
+
+    def __init__(
+        self,
+        name: str,
+        use_extension: bool = False,
+        location: Optional[FeatureLibLocation] = None,
+    ):
+        Block.__init__(self, location)
+        self.name, self.use_extension = name, use_extension
+
+    def build(self, builder) -> None:
+        """Call the ``start_feature`` callback on the builder object, visit
+        all the statements in this feature, and then call ``end_feature``."""
+        # TODO(sascha): Handle use_extension.
+        builder.start_feature(self.location, self.name)
+        # language exclude_dflt statements modify builder.features_
+        # limit them to this block with temporary builder.features_
+        features = builder.features_
+        builder.features_ = {}
+        Block.build(self, builder)
+        for key, value in builder.features_.items():
+            features.setdefault(key, []).extend(value)
+        builder.features_ = features
+        builder.end_feature()
+
+    def asFea(self, indent="") -> str:
+        res = indent + "feature %s " % self.name.strip()
+        if self.use_extension:
+            res += "useExtension "
+        res += "{\n"
+        res += Block.asFea(self, indent=indent)
+        res += indent + "} %s;\n" % self.name.strip()
+        return res
+
+
+class NestedBlock(Block):
+    """A block inside another block, for example when found inside a
+    ``cvParameters`` block."""
+
+    def __init__(
+        self, tag: str, block_name: str, location: Optional[FeatureLibLocation] = None
+    ):
+        Block.__init__(self, location)
+        self.tag = tag
+        self.block_name = block_name
+
+    def build(self, builder) -> None:
+        Block.build(self, builder)
+        if self.block_name == "ParamUILabelNameID":
+            builder.add_to_cv_num_named_params(self.tag)
+
+    def asFea(self, indent="") -> str:
+        res = "{}{} {{\n".format(indent, self.block_name)
+        res += Block.asFea(self, indent=indent)
+        res += "{}}};\n".format(indent)
+        return res
+
+
+class LookupBlock(Block):
+    """A named lookup, containing ``statements``."""
+
+    def __init__(
+        self,
+        name: str,
+        use_extension: bool = False,
+        location: Optional[FeatureLibLocation] = None,
+    ):
+        Block.__init__(self, location)
+        self.name, self.use_extension = name, use_extension
+
+    def build(self, builder) -> None:
+        # TODO(sascha): Handle use_extension.
+        builder.start_lookup_block(self.location, self.name)
+        Block.build(self, builder)
+        builder.end_lookup_block()
+
+    def asFea(self, indent="") -> str:
+        res = "lookup {} ".format(self.name)
+        if self.use_extension:
+            res += "useExtension "
+        res += "{\n"
+        res += Block.asFea(self, indent=indent)
+        res += "{}}} {};\n".format(indent, self.name)
+        return res
+
+
+class TableBlock(Block):
+    """A ``table ... { }`` block."""
+
+    def __init__(self, name: str, location: Optional[FeatureLibLocation] = None):
+        Block.__init__(self, location)
+        self.name = name
+
+    def asFea(self, indent="") -> str:
+        res = "table {} {{\n".format(self.name.strip())
+        res += super(TableBlock, self).asFea(indent=indent)
+        res += "}} {};\n".format(self.name.strip())
+        return res
+
+
+class GlyphClassDefStatement(Statement):
+    """Example: ``GlyphClassDef @UPPERCASE, [B], [C], [D];``. The parameters
+    must be either :class:`GlyphClass` or :class:`GlyphClassName` objects, or
+    ``None``."""
+
+    def __init__(
+        self,
+        baseGlyphs: Optional[GlyphContainer],
+        markGlyphs: Optional[GlyphContainer],
+        ligatureGlyphs: Optional[GlyphContainer],
+        componentGlyphs: Optional[GlyphContainer],
+        location: Optional[FeatureLibLocation] = None,
+    ):
+        Statement.__init__(self, location)
+        self.baseGlyphs, self.markGlyphs = (baseGlyphs, markGlyphs)
+        self.ligatureGlyphs = ligatureGlyphs
+        self.componentGlyphs = componentGlyphs
+
+    def build(self, builder) -> None:
+        """Calls the builder's ``add_glyphClassDef`` callback."""
+        base = self.baseGlyphs.glyphSet() if self.baseGlyphs else tuple()
+        liga = self.ligatureGlyphs.glyphSet() if self.ligatureGlyphs else tuple()
+        mark = self.markGlyphs.glyphSet() if self.markGlyphs else tuple()
+        comp = self.componentGlyphs.glyphSet() if self.componentGlyphs else tuple()
+        builder.add_glyphClassDef(self.location, base, liga, mark, comp)
+
+    def asFea(self, indent="") -> str:
+        return "GlyphClassDef {}, {}, {}, {};".format(
+            self.baseGlyphs.asFea() if self.baseGlyphs else "",
+            self.ligatureGlyphs.asFea() if self.ligatureGlyphs else "",
+            self.markGlyphs.asFea() if self.markGlyphs else "",
+            self.componentGlyphs.asFea() if self.componentGlyphs else "",
         )
 
 
 class AlternateSubstStatement(Statement):
     """A ``sub ... from ...`` statement.
 
-    ``prefix``, ``glyph``, ``suffix`` and ``replacement`` should be lists of
-    `glyph-containing objects`_. ``glyph`` should be a `one element list`."""
+    ``prefix`` and ``suffix`` should be lists of `glyph-containing objects`_;
+    ``glyph`` and ``replacement`` should be glyph-containing objects."""
 
-    def __init__(self, prefix, glyph, suffix, replacement, location=None):
+    def __init__(
+        self,
+        prefix: Sequence[GlyphContainer],
+        glyph: GlyphContainer,
+        suffix: Sequence[GlyphContainer],
+        replacement: GlyphContainer,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.prefix, self.glyph, self.suffix = (prefix, glyph, suffix)
         self.replacement = replacement
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder's ``add_alternate_subst`` callback."""
         glyph = self.glyph.glyphSet()
         assert len(glyph) == 1, glyph
-        glyph = list(glyph)[0]
+        single_glyph = list(glyph)[0]
         prefix = [p.glyphSet() for p in self.prefix]
         suffix = [s.glyphSet() for s in self.suffix]
         replacement = self.replacement.glyphSet()
-        builder.add_alternate_subst(self.location, prefix, glyph, suffix, replacement)
+        builder.add_alternate_subst(
+            self.location, prefix, single_glyph, suffix, replacement
+        )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "sub "
         if len(self.prefix) or len(self.suffix):
             if len(self.prefix):
@@ -638,20 +695,20 @@ class Anchor(Expression):
 
     def __init__(
         self,
-        x,
-        y,
+        x: int,
+        y: int,
         name=None,
-        contourpoint=None,
+        contourpoint: int = None,
         xDeviceTable=None,
         yDeviceTable=None,
-        location=None,
+        location: Optional[FeatureLibLocation] = None,
     ):
         Expression.__init__(self, location)
         self.name = name
         self.x, self.y, self.contourpoint = x, y, contourpoint
         self.xDeviceTable, self.yDeviceTable = xDeviceTable, yDeviceTable
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         if self.name is not None:
             return "<anchor {}>".format(self.name)
         res = "<anchor {} {}".format(self.x, self.y)
@@ -669,11 +726,18 @@ class Anchor(Expression):
 class AnchorDefinition(Statement):
     """A named anchor definition. (2.e.viii). ``name`` should be a string."""
 
-    def __init__(self, name, x, y, contourpoint=None, location=None):
+    def __init__(
+        self,
+        name: str,
+        x: int,
+        y: int,
+        contourpoint=None,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.name, self.x, self.y, self.contourpoint = name, x, y, contourpoint
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "anchorDef {} {}".format(self.x, self.y)
         if self.contourpoint:
             res += " contourpoint {}".format(self.contourpoint)
@@ -684,23 +748,75 @@ class AnchorDefinition(Statement):
 class AttachStatement(Statement):
     """A ``GDEF`` table ``Attach`` statement."""
 
-    def __init__(self, glyphs, contourPoints, location=None):
+    def __init__(
+        self,
+        glyphs: GlyphContainer,
+        contourPoints: List[int],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.glyphs = glyphs  #: A `glyph-containing object`_
         self.contourPoints = contourPoints  #: A list of integer contour points
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder's ``add_attach_points`` callback."""
         glyphs = self.glyphs.glyphSet()
         builder.add_attach_points(self.location, glyphs, self.contourPoints)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "Attach {} {};".format(
             self.glyphs.asFea(), " ".join(str(c) for c in self.contourPoints)
         )
 
 
-class ChainContextPosStatement(Statement):
+class ChainContextStatement(Statement):
+    table = ""
+
+    def __init__(
+        self,
+        prefix: Sequence[GlyphContainer],
+        glyphs: Sequence[GlyphContainer],
+        suffix: Sequence[GlyphContainer],
+        lookups: Sequence[Union[LookupBlock, Sequence[LookupBlock], None]],
+        location: Optional[FeatureLibLocation] = None,
+    ):
+        Statement.__init__(self, location)
+        self.prefix, self.glyphs, self.suffix = prefix, glyphs, suffix
+        # Ensure we have a list of lists
+        self.lookups: List[List[LookupBlock]] = []
+        for i, lookup in enumerate(list(lookups)):
+            if lookup and not isinstance(lookup, Sequence):
+                self.lookups.append([lookup])
+            elif isinstance(lookup, Sequence):
+                self.lookups.append(list(lookup))
+            else:
+                self.lookups.append([])
+
+    def asFea(self, indent="") -> str:
+        res = self.table + " "
+        if (
+            len(self.prefix)
+            or len(self.suffix)
+            or any([x is not None for x in self.lookups])
+        ):
+            if len(self.prefix):
+                res += " ".join(g.asFea() for g in self.prefix) + " "
+            for i, g in enumerate(self.glyphs):
+                res += g.asFea() + "'"
+                if self.lookups[i]:
+                    for lu in self.lookups[i]:
+                        res += " lookup " + lu.name
+                if i < len(self.glyphs) - 1:
+                    res += " "
+            if len(self.suffix):
+                res += " " + " ".join(map(asFea, self.suffix))
+        else:
+            res += " ".join(map(asFea, self.glyphs))
+        res += ";"
+        return res
+
+
+class ChainContextPosStatement(ChainContextStatement):
     r"""A chained contextual positioning statement.
 
     ``prefix``, ``glyphs``, and ``suffix`` should be lists of
@@ -714,18 +830,9 @@ class ChainContextPosStatement(Statement):
     list should equal the length of ``glyphs``; the inner lists can be
     of variable length."""
 
-    def __init__(self, prefix, glyphs, suffix, lookups, location=None):
-        Statement.__init__(self, location)
-        self.prefix, self.glyphs, self.suffix = prefix, glyphs, suffix
-        self.lookups = list(lookups)
-        for i, lookup in enumerate(lookups):
-            if lookup:
-                try:
-                    (_ for _ in lookup)
-                except TypeError:
-                    self.lookups[i] = [lookup]
+    table = "pos"
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder's ``add_chain_context_pos`` callback."""
         prefix = [p.glyphSet() for p in self.prefix]
         glyphs = [g.glyphSet() for g in self.glyphs]
@@ -734,31 +841,8 @@ class ChainContextPosStatement(Statement):
             self.location, prefix, glyphs, suffix, self.lookups
         )
 
-    def asFea(self, indent=""):
-        res = "pos "
-        if (
-            len(self.prefix)
-            or len(self.suffix)
-            or any([x is not None for x in self.lookups])
-        ):
-            if len(self.prefix):
-                res += " ".join(g.asFea() for g in self.prefix) + " "
-            for i, g in enumerate(self.glyphs):
-                res += g.asFea() + "'"
-                if self.lookups[i]:
-                    for lu in self.lookups[i]:
-                        res += " lookup " + lu.name
-                if i < len(self.glyphs) - 1:
-                    res += " "
-            if len(self.suffix):
-                res += " " + " ".join(map(asFea, self.suffix))
-        else:
-            res += " ".join(map(asFea, self.glyph))
-        res += ";"
-        return res
 
-
-class ChainContextSubstStatement(Statement):
+class ChainContextSubstStatement(ChainContextStatement):
     r"""A chained contextual substitution statement.
 
     ``prefix``, ``glyphs``, and ``suffix`` should be lists of
@@ -772,18 +856,9 @@ class ChainContextSubstStatement(Statement):
     list should equal the length of ``glyphs``; the inner lists can be
     of variable length."""
 
-    def __init__(self, prefix, glyphs, suffix, lookups, location=None):
-        Statement.__init__(self, location)
-        self.prefix, self.glyphs, self.suffix = prefix, glyphs, suffix
-        self.lookups = list(lookups)
-        for i, lookup in enumerate(lookups):
-            if lookup:
-                try:
-                    (_ for _ in lookup)
-                except TypeError:
-                    self.lookups[i] = [lookup]
+    table = "sub"
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder's ``add_chain_context_subst`` callback."""
         prefix = [p.glyphSet() for p in self.prefix]
         glyphs = [g.glyphSet() for g in self.glyphs]
@@ -792,46 +867,29 @@ class ChainContextSubstStatement(Statement):
             self.location, prefix, glyphs, suffix, self.lookups
         )
 
-    def asFea(self, indent=""):
-        res = "sub "
-        if (
-            len(self.prefix)
-            or len(self.suffix)
-            or any([x is not None for x in self.lookups])
-        ):
-            if len(self.prefix):
-                res += " ".join(g.asFea() for g in self.prefix) + " "
-            for i, g in enumerate(self.glyphs):
-                res += g.asFea() + "'"
-                if self.lookups[i]:
-                    for lu in self.lookups[i]:
-                        res += " lookup " + lu.name
-                if i < len(self.glyphs) - 1:
-                    res += " "
-            if len(self.suffix):
-                res += " " + " ".join(map(asFea, self.suffix))
-        else:
-            res += " ".join(map(asFea, self.glyph))
-        res += ";"
-        return res
-
 
 class CursivePosStatement(Statement):
     """A cursive positioning statement. Entry and exit anchors can either
     be :class:`Anchor` objects or ``None``."""
 
-    def __init__(self, glyphclass, entryAnchor, exitAnchor, location=None):
+    def __init__(
+        self,
+        glyphclass: GlyphClassDefinition,
+        entryAnchor: Optional[Anchor],
+        exitAnchor: Optional[Anchor],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.glyphclass = glyphclass
         self.entryAnchor, self.exitAnchor = entryAnchor, exitAnchor
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_cursive_pos`` callback."""
         builder.add_cursive_pos(
             self.location, self.glyphclass.glyphSet(), self.entryAnchor, self.exitAnchor
         )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         entry = self.entryAnchor.asFea() if self.entryAnchor else "<anchor NULL>"
         exit = self.exitAnchor.asFea() if self.exitAnchor else "<anchor NULL>"
         return "pos cursive {} {} {};".format(self.glyphclass.asFea(), entry, exit)
@@ -840,96 +898,94 @@ class CursivePosStatement(Statement):
 class FeatureReferenceStatement(Statement):
     """Example: ``feature salt;``"""
 
-    def __init__(self, featureName, location=None):
+    def __init__(self, featureName: str, location: Optional[FeatureLibLocation] = None):
         Statement.__init__(self, location)
-        self.location, self.featureName = (location, featureName)
+        self.location, self.featureName = location, featureName
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_feature_reference`` callback."""
         builder.add_feature_reference(self.location, self.featureName)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "feature {};".format(self.featureName)
 
 
-class IgnorePosStatement(Statement):
+GlyphContext = Tuple[
+    Sequence[GlyphContainer], Sequence[GlyphContainer], Sequence[GlyphContainer]
+]
+
+
+class IgnoreStatement(Statement):
+    table = ""
+
+    def __init__(
+        self,
+        chainContexts: Sequence[GlyphContext],
+        location: Optional[FeatureLibLocation] = None,
+    ):
+        Statement.__init__(self, location)
+        self.chainContexts = chainContexts
+
+    def asFea(self, indent="") -> str:
+        contexts = []
+        for prefix, glyphs, suffix in self.chainContexts:
+            res = ""
+            if len(prefix) or len(suffix):
+                if len(prefix):
+                    res += " ".join(map(asFea, prefix)) + " "
+                res += " ".join(g.asFea() + "'" for g in glyphs)
+                if len(suffix):
+                    res += " " + " ".join(map(asFea, suffix))
+            else:
+                res += " ".join(map(asFea, glyphs))
+            contexts.append(res)
+        return f"ignore {self.table} " + ", ".join(contexts) + ";"
+
+
+class IgnorePosStatement(IgnoreStatement):
     """An ``ignore pos`` statement, containing `one or more` contexts to ignore.
 
     ``chainContexts`` should be a list of ``(prefix, glyphs, suffix)`` tuples,
-    with each of ``prefix``, ``glyphs`` and ``suffix`` being
+    with each of ``prefix``, ``glyphs`` and ``suffix`` being sequences of
     `glyph-containing objects`_ ."""
 
-    def __init__(self, chainContexts, location=None):
-        Statement.__init__(self, location)
-        self.chainContexts = chainContexts
+    table = "pos"
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_chain_context_pos`` callback on each
         rule context."""
-        for prefix, glyphs, suffix in self.chainContexts:
-            prefix = [p.glyphSet() for p in prefix]
-            glyphs = [g.glyphSet() for g in glyphs]
-            suffix = [s.glyphSet() for s in suffix]
+        for prefix_container, glyphs_container, suffix_container in self.chainContexts:
+            prefix = [p.glyphSet() for p in prefix_container]
+            glyphs = [g.glyphSet() for g in glyphs_container]
+            suffix = [s.glyphSet() for s in suffix_container]
             builder.add_chain_context_pos(self.location, prefix, glyphs, suffix, [])
 
-    def asFea(self, indent=""):
-        contexts = []
-        for prefix, glyphs, suffix in self.chainContexts:
-            res = ""
-            if len(prefix) or len(suffix):
-                if len(prefix):
-                    res += " ".join(map(asFea, prefix)) + " "
-                res += " ".join(g.asFea() + "'" for g in glyphs)
-                if len(suffix):
-                    res += " " + " ".join(map(asFea, suffix))
-            else:
-                res += " ".join(map(asFea, glyphs))
-            contexts.append(res)
-        return "ignore pos " + ", ".join(contexts) + ";"
 
-
-class IgnoreSubstStatement(Statement):
+class IgnoreSubstStatement(IgnoreStatement):
     """An ``ignore sub`` statement, containing `one or more` contexts to ignore.
 
     ``chainContexts`` should be a list of ``(prefix, glyphs, suffix)`` tuples,
-    with each of ``prefix``, ``glyphs`` and ``suffix`` being
+    with each of ``prefix``, ``glyphs`` and ``suffix`` being sequences of
     `glyph-containing objects`_ ."""
 
-    def __init__(self, chainContexts, location=None):
-        Statement.__init__(self, location)
-        self.chainContexts = chainContexts
+    table = "sub"
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_chain_context_subst`` callback on
         each rule context."""
-        for prefix, glyphs, suffix in self.chainContexts:
-            prefix = [p.glyphSet() for p in prefix]
-            glyphs = [g.glyphSet() for g in glyphs]
-            suffix = [s.glyphSet() for s in suffix]
+        for prefix_container, glyphs_container, suffix_container in self.chainContexts:
+            prefix = [p.glyphSet() for p in prefix_container]
+            glyphs = [g.glyphSet() for g in glyphs_container]
+            suffix = [s.glyphSet() for s in suffix_container]
             builder.add_chain_context_subst(self.location, prefix, glyphs, suffix, [])
-
-    def asFea(self, indent=""):
-        contexts = []
-        for prefix, glyphs, suffix in self.chainContexts:
-            res = ""
-            if len(prefix) or len(suffix):
-                if len(prefix):
-                    res += " ".join(map(asFea, prefix)) + " "
-                res += " ".join(g.asFea() + "'" for g in glyphs)
-                if len(suffix):
-                    res += " " + " ".join(map(asFea, suffix))
-            else:
-                res += " ".join(map(asFea, glyphs))
-            contexts.append(res)
-        return "ignore sub " + ", ".join(contexts) + ";"
 
 
 class IncludeStatement(Statement):
     """An ``include()`` statement."""
 
-    def __init__(self, filename, location=None):
+    def __init__(self, filename: str, location: Optional[FeatureLibLocation] = None):
         super(IncludeStatement, self).__init__(location)
-        self.filename = filename  #: String containing name of file to include
+        self.filename = filename  #: Name of file to include
 
     def build(self):
         # TODO: consider lazy-loading the including parser/lexer?
@@ -939,21 +995,27 @@ class IncludeStatement(Statement):
             self.location,
         )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return indent + "include(%s);" % self.filename
 
 
 class LanguageStatement(Statement):
     """A ``language`` statement within a feature."""
 
-    def __init__(self, language, include_default=True, required=False, location=None):
+    def __init__(
+        self,
+        language: str,
+        include_default: bool = True,
+        required: bool = False,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         assert len(language) == 4
         self.language = language  #: A four-character language tag
         self.include_default = include_default  #: If false, "exclude_dflt"
         self.required = required
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Call the builder object's ``set_language`` callback."""
         builder.set_language(
             location=self.location,
@@ -962,7 +1024,7 @@ class LanguageStatement(Statement):
             required=self.required,
         )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "language {}".format(self.language.strip())
         if not self.include_default:
             res += " exclude_dflt"
@@ -975,15 +1037,17 @@ class LanguageStatement(Statement):
 class LanguageSystemStatement(Statement):
     """A top-level ``languagesystem`` statement."""
 
-    def __init__(self, script, language, location=None):
+    def __init__(
+        self, script: str, language: str, location: Optional[FeatureLibLocation] = None
+    ):
         Statement.__init__(self, location)
         self.script, self.language = (script, language)
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_language_system`` callback."""
         builder.add_language_system(self.location, self.script, self.language)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "languagesystem {} {};".format(self.script, self.language.strip())
 
 
@@ -991,14 +1055,14 @@ class FontRevisionStatement(Statement):
     """A ``head`` table ``FontRevision`` statement. ``revision`` should be a
     number, and will be formatted to three significant decimal places."""
 
-    def __init__(self, revision, location=None):
+    def __init__(self, revision, location: Optional[FeatureLibLocation] = None):
         Statement.__init__(self, location)
         self.revision = revision
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         builder.set_font_revision(self.location, self.revision)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "FontRevision {:.3f};".format(self.revision)
 
 
@@ -1006,16 +1070,21 @@ class LigatureCaretByIndexStatement(Statement):
     """A ``GDEF`` table ``LigatureCaretByIndex`` statement. ``glyphs`` should be
     a `glyph-containing object`_, and ``carets`` should be a list of integers."""
 
-    def __init__(self, glyphs, carets, location=None):
+    def __init__(
+        self,
+        glyphs: GlyphContainer,
+        carets: Sequence[int],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.glyphs, self.carets = (glyphs, carets)
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_ligatureCaretByIndex_`` callback."""
         glyphs = self.glyphs.glyphSet()
         builder.add_ligatureCaretByIndex_(self.location, glyphs, set(self.carets))
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "LigatureCaretByIndex {} {};".format(
             self.glyphs.asFea(), " ".join(str(x) for x in self.carets)
         )
@@ -1025,16 +1094,21 @@ class LigatureCaretByPosStatement(Statement):
     """A ``GDEF`` table ``LigatureCaretByPos`` statement. ``glyphs`` should be
     a `glyph-containing object`_, and ``carets`` should be a list of integers."""
 
-    def __init__(self, glyphs, carets, location=None):
+    def __init__(
+        self,
+        glyphs: GlyphContainer,
+        carets: Sequence[int],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.glyphs, self.carets = (glyphs, carets)
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_ligatureCaretByPos_`` callback."""
         glyphs = self.glyphs.glyphSet()
         builder.add_ligatureCaretByPos_(self.location, glyphs, set(self.carets))
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "LigatureCaretByPos {} {};".format(
             self.glyphs.asFea(), " ".join(str(x) for x in self.carets)
         )
@@ -1050,12 +1124,20 @@ class LigatureSubstStatement(Statement):
     If ``forceChain`` is True, this is expressed as a chaining rule
     (e.g. ``sub f' i' by f_i``) even when no context is given."""
 
-    def __init__(self, prefix, glyphs, suffix, replacement, forceChain, location=None):
+    def __init__(
+        self,
+        prefix: Sequence[GlyphContainer],
+        glyphs: Sequence[GlyphContainer],
+        suffix: Sequence[GlyphContainer],
+        replacement: GlyphContainer,
+        forceChain: bool,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.prefix, self.glyphs, self.suffix = (prefix, glyphs, suffix)
         self.replacement, self.forceChain = replacement, forceChain
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         prefix = [p.glyphSet() for p in self.prefix]
         glyphs = [g.glyphSet() for g in self.glyphs]
         suffix = [s.glyphSet() for s in self.suffix]
@@ -1063,7 +1145,7 @@ class LigatureSubstStatement(Statement):
             self.location, prefix, glyphs, suffix, self.replacement, self.forceChain
         )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "sub "
         if len(self.prefix) or len(self.suffix) or self.forceChain:
             if len(self.prefix):
@@ -1086,14 +1168,18 @@ class LookupFlagStatement(Statement):
     glyph-containing objects."""
 
     def __init__(
-        self, value=0, markAttachment=None, markFilteringSet=None, location=None
+        self,
+        value: int = 0,
+        markAttachment: Optional[GlyphContainer] = None,
+        markFilteringSet: Optional[GlyphContainer] = None,
+        location: Optional[FeatureLibLocation] = None,
     ):
         Statement.__init__(self, location)
         self.value = value
         self.markAttachment = markAttachment
         self.markFilteringSet = markFilteringSet
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``set_lookup_flag`` callback."""
         markAttach = None
         if self.markAttachment is not None:
@@ -1103,7 +1189,7 @@ class LookupFlagStatement(Statement):
             markFilter = self.markFilteringSet.glyphSet()
         builder.set_lookup_flag(self.location, self.value, markAttach, markFilter)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = []
         flags = ["RightToLeft", "IgnoreBaseGlyphs", "IgnoreLigatures", "IgnoreMarks"]
         curr = 1
@@ -1125,32 +1211,37 @@ class LookupReferenceStatement(Statement):
 
     The ``lookup`` should be a :class:`LookupBlock` object."""
 
-    def __init__(self, lookup, location=None):
+    def __init__(
+        self, lookup: LookupBlock, location: Optional[FeatureLibLocation] = None
+    ):
         Statement.__init__(self, location)
         self.location, self.lookup = (location, lookup)
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_lookup_call`` callback."""
         builder.add_lookup_call(self.lookup.name)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "lookup {};".format(self.lookup.name)
 
 
 class MarkBasePosStatement(Statement):
-    """A mark-to-base positioning rule. The ``base`` should be a
-    `glyph-containing object`_. The ``marks`` should be a list of
-    (:class:`Anchor`, :class:`MarkClass`) tuples."""
+    """A mark-to-base positioning rule."""
 
-    def __init__(self, base, marks, location=None):
+    def __init__(
+        self,
+        base: GlyphContainer,
+        marks: Sequence[Tuple[Anchor, MarkClass]],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.base, self.marks = base, marks
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_mark_base_pos`` callback."""
         builder.add_mark_base_pos(self.location, self.base.glyphSet(), self.marks)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "pos base {}".format(self.base.asFea())
         for a, m in self.marks:
             res += "\n" + indent + SHIFT + "{} mark @{}".format(a.asFea(), m.name)
@@ -1185,15 +1276,20 @@ class MarkLigPosStatement(Statement):
 
     """
 
-    def __init__(self, ligatures, marks, location=None):
+    def __init__(
+        self,
+        ligatures: GlyphContainer,
+        marks: Sequence[Sequence[Tuple[Anchor, MarkClass]]],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.ligatures, self.marks = ligatures, marks
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_mark_lig_pos`` callback."""
         builder.add_mark_lig_pos(self.location, self.ligatures.glyphSet(), self.marks)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "pos ligature {}".format(self.ligatures.asFea())
         ligs = []
         for l in self.marks:
@@ -1219,15 +1315,20 @@ class MarkMarkPosStatement(Statement):
     `glyph-containing object`_. The ``marks`` should be a list of
     (:class:`Anchor`, :class:`MarkClass`) tuples."""
 
-    def __init__(self, baseMarks, marks, location=None):
+    def __init__(
+        self,
+        baseMarks: GlyphContainer,
+        marks: List[Tuple[Anchor, MarkClass]],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.baseMarks, self.marks = baseMarks, marks
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_mark_mark_pos`` callback."""
         builder.add_mark_mark_pos(self.location, self.baseMarks.glyphSet(), self.marks)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "pos mark {}".format(self.baseMarks.asFea())
         for a, m in self.marks:
             res += "\n" + indent + SHIFT + "{} mark @{}".format(a.asFea(), m.name)
@@ -1248,14 +1349,20 @@ class MultipleSubstStatement(Statement):
     """
 
     def __init__(
-        self, prefix, glyph, suffix, replacement, forceChain=False, location=None
+        self,
+        prefix: Sequence[GlyphContainer],
+        glyph: GlyphContainer,
+        suffix: Sequence[GlyphContainer],
+        replacement: Sequence[GlyphContainer],
+        forceChain=False,
+        location: Optional[FeatureLibLocation] = None,
     ):
         Statement.__init__(self, location)
         self.prefix, self.glyph, self.suffix = prefix, glyph, suffix
         self.replacement = replacement
         self.forceChain = forceChain
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_multiple_subst`` callback."""
         prefix = [p.glyphSet() for p in self.prefix]
         suffix = [s.glyphSet() for s in self.suffix]
@@ -1279,7 +1386,7 @@ class MultipleSubstStatement(Statement):
                 self.forceChain,
             )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "sub "
         if len(self.prefix) or len(self.suffix) or self.forceChain:
             if len(self.prefix):
@@ -1308,19 +1415,19 @@ class PairPosStatement(Statement):
 
     def __init__(
         self,
-        glyphs1,
-        valuerecord1,
-        glyphs2,
-        valuerecord2,
+        glyphs1: GlyphContainer,
+        valuerecord1: "ValueRecord",
+        glyphs2: GlyphContainer,
+        valuerecord2: Optional["ValueRecord"],
         enumerated=False,
-        location=None,
+        location: Optional[FeatureLibLocation] = None,
     ):
         Statement.__init__(self, location)
         self.enumerated = enumerated
         self.glyphs1, self.valuerecord1 = glyphs1, valuerecord1
         self.glyphs2, self.valuerecord2 = glyphs2, valuerecord2
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls a callback on the builder object:
 
         * If the rule is enumerated, calls ``add_specific_pair_pos`` on each
@@ -1347,6 +1454,8 @@ class PairPosStatement(Statement):
             self.glyphs2, GlyphName
         )
         if is_specific:
+            assert isinstance(self.glyphs1, GlyphName)  # Keep mypy happy
+            assert isinstance(self.glyphs2, GlyphName)
             builder.add_specific_pair_pos(
                 self.location,
                 self.glyphs1.glyph,
@@ -1363,7 +1472,7 @@ class PairPosStatement(Statement):
                 self.valuerecord2,
             )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "enum " if self.enumerated else ""
         if self.valuerecord2:
             res += "pos {} {} {} {};".format(
@@ -1388,13 +1497,20 @@ class ReverseChainSingleSubstStatement(Statement):
     be one-item lists.
     """
 
-    def __init__(self, old_prefix, old_suffix, glyphs, replacements, location=None):
+    def __init__(
+        self,
+        old_prefix: Sequence[GlyphContainer],
+        old_suffix: Sequence[GlyphContainer],
+        glyphs: Sequence[GlyphContainer],
+        replacements: Sequence[GlyphContainer],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.old_prefix, self.old_suffix = old_prefix, old_suffix
         self.glyphs = glyphs
         self.replacements = replacements
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         prefix = [p.glyphSet() for p in self.old_prefix]
         suffix = [s.glyphSet() for s in self.old_suffix]
         originals = self.glyphs[0].glyphSet()
@@ -1405,7 +1521,7 @@ class ReverseChainSingleSubstStatement(Statement):
             self.location, prefix, suffix, dict(zip(originals, replaces))
         )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "rsub "
         if len(self.old_prefix) or len(self.old_suffix):
             if len(self.old_prefix):
@@ -1428,14 +1544,22 @@ class SingleSubstStatement(Statement):
     ``replace`` should be one-item lists.
     """
 
-    def __init__(self, glyphs, replace, prefix, suffix, forceChain, location=None):
+    def __init__(
+        self,
+        glyphs: Sequence[GlyphContainer],
+        replace: Sequence[GlyphContainer],
+        prefix: Sequence[GlyphContainer],
+        suffix: Sequence[GlyphContainer],
+        forceChain: bool,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.prefix, self.suffix = prefix, suffix
         self.forceChain = forceChain
         self.glyphs = glyphs
         self.replacements = replace
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_single_subst`` callback."""
         prefix = [p.glyphSet() for p in self.prefix]
         suffix = [s.glyphSet() for s in self.suffix]
@@ -1451,7 +1575,7 @@ class SingleSubstStatement(Statement):
             self.forceChain,
         )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "sub "
         if len(self.prefix) or len(self.suffix) or self.forceChain:
             if len(self.prefix):
@@ -1468,15 +1592,15 @@ class SingleSubstStatement(Statement):
 class ScriptStatement(Statement):
     """A ``script`` statement."""
 
-    def __init__(self, script, location=None):
+    def __init__(self, script: str, location: Optional[FeatureLibLocation] = None):
         Statement.__init__(self, location)
         self.script = script  #: the script code
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder's ``set_script`` callback."""
         builder.set_script(self.location, self.script)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "script {};".format(self.script.strip())
 
 
@@ -1487,19 +1611,26 @@ class SinglePosStatement(Statement):
     ``pos`` should be a one-element list containing a (`glyph-containing object`_,
     :class:`ValueRecord`) tuple."""
 
-    def __init__(self, pos, prefix, suffix, forceChain, location=None):
+    def __init__(
+        self,
+        pos: Sequence[Tuple[GlyphContainer, "ValueRecord"]],
+        prefix: Sequence[GlyphContainer],
+        suffix: Sequence[GlyphContainer],
+        forceChain: bool,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.pos, self.prefix, self.suffix = pos, prefix, suffix
         self.forceChain = forceChain
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_single_pos`` callback."""
         prefix = [p.glyphSet() for p in self.prefix]
         suffix = [s.glyphSet() for s in self.suffix]
         pos = [(g.glyphSet(), value) for g, value in self.pos]
         builder.add_single_pos(self.location, prefix, suffix, pos, self.forceChain)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "pos "
         if len(self.prefix) or len(self.suffix) or self.forceChain:
             if len(self.prefix):
@@ -1523,14 +1654,14 @@ class SinglePosStatement(Statement):
 class SubtableStatement(Statement):
     """Represents a subtable break."""
 
-    def __init__(self, location=None):
+    def __init__(self, location: Optional[FeatureLibLocation] = None):
         Statement.__init__(self, location)
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder objects's ``add_subtable_break`` callback."""
         builder.add_subtable_break(self.location)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "subtable;"
 
 
@@ -1539,16 +1670,16 @@ class ValueRecord(Expression):
 
     def __init__(
         self,
-        xPlacement=None,
-        yPlacement=None,
-        xAdvance=None,
-        yAdvance=None,
+        xPlacement: Union[int, VariableScalar, None] = None,
+        yPlacement: Union[int, VariableScalar, None] = None,
+        xAdvance: Union[int, VariableScalar, None] = None,
+        yAdvance: Union[int, VariableScalar, None] = None,
         xPlaDevice=None,
         yPlaDevice=None,
         xAdvDevice=None,
         yAdvDevice=None,
         vertical=False,
-        location=None,
+        location: Optional[FeatureLibLocation] = None,
     ):
         Expression.__init__(self, location)
         self.xPlacement, self.yPlacement = (xPlacement, yPlacement)
@@ -1582,7 +1713,7 @@ class ValueRecord(Expression):
             ^ hash(self.yAdvDevice)
         )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         if not self:
             return "<NULL>"
 
@@ -1647,12 +1778,17 @@ class ValueRecord(Expression):
 class ValueRecordDefinition(Statement):
     """Represents a named value record definition."""
 
-    def __init__(self, name, value, location=None):
+    def __init__(
+        self,
+        name: str,
+        value: ValueRecord,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.name = name  #: Value record name as string
         self.value = value  #: :class:`ValueRecord` object
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "valueRecordDef {} {};".format(self.value.asFea(), self.name)
 
 
@@ -1668,15 +1804,23 @@ def simplify_name_attributes(pid, eid, lid):
 class NameRecord(Statement):
     """Represents a name record. (`Section 9.e. <https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#9.e>`_)"""
 
-    def __init__(self, nameID, platformID, platEncID, langID, string, location=None):
+    def __init__(
+        self,
+        nameID: Union[int, Tuple],  # See CVParametersNameStatement.build
+        platformID: int,
+        platEncID: int,
+        langID: int,
+        string: str,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
-        self.nameID = nameID  #: Name ID as integer (e.g. 9 for designer's name)
-        self.platformID = platformID  #: Platform ID as integer
-        self.platEncID = platEncID  #: Platform encoding ID as integer
-        self.langID = langID  #: Language ID as integer
+        self.nameID = nameID  #: Name ID (e.g. 9 for designer's name)
+        self.platformID = platformID  #: Platform ID
+        self.platEncID = platEncID  #: Platform encoding ID
+        self.langID = langID  #: Language ID
         self.string = string  #: Name record value
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_name_record`` callback."""
         builder.add_name_record(
             self.location,
@@ -1687,7 +1831,7 @@ class NameRecord(Statement):
             self.string,
         )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         def escape(c, escape_pattern):
             # Also escape U+0022 QUOTATION MARK and U+005C REVERSE SOLIDUS
             if c >= 0x20 and c <= 0x7E and c not in (0x22, 0x5C):
@@ -1717,12 +1861,12 @@ class NameRecord(Statement):
 class FeatureNameStatement(NameRecord):
     """Represents a ``sizemenuname`` or ``name`` statement."""
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_featureName`` callback."""
         NameRecord.build(self, builder)
         builder.add_featureName(self.nameID)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         if self.nameID == "size":
             tag = "sizemenuname"
         else:
@@ -1736,7 +1880,7 @@ class FeatureNameStatement(NameRecord):
 class STATNameStatement(NameRecord):
     """Represents a STAT table ``name`` statement."""
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         plat = simplify_name_attributes(self.platformID, self.platEncID, self.langID)
         if plat != "":
             plat += " "
@@ -1746,14 +1890,21 @@ class STATNameStatement(NameRecord):
 class SizeParameters(Statement):
     """A ``parameters`` statement."""
 
-    def __init__(self, DesignSize, SubfamilyID, RangeStart, RangeEnd, location=None):
+    def __init__(
+        self,
+        DesignSize: float,
+        SubfamilyID: int,
+        RangeStart: float,
+        RangeEnd: float,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.DesignSize = DesignSize
         self.SubfamilyID = SubfamilyID
         self.RangeStart = RangeStart
         self.RangeEnd = RangeEnd
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``set_size_parameters`` callback."""
         builder.set_size_parameters(
             self.location,
@@ -1763,7 +1914,7 @@ class SizeParameters(Statement):
             self.RangeEnd,
         )
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "parameters {:.1f} {}".format(self.DesignSize, self.SubfamilyID)
         if self.RangeStart != 0 or self.RangeEnd != 0:
             res += " {} {}".format(int(self.RangeStart * 10), int(self.RangeEnd * 10))
@@ -1774,14 +1925,21 @@ class CVParametersNameStatement(NameRecord):
     """Represent a name statement inside a ``cvParameters`` block."""
 
     def __init__(
-        self, nameID, platformID, platEncID, langID, string, block_name, location=None
+        self,
+        nameID: int,
+        platformID: int,
+        platEncID: int,
+        langID: int,
+        string: str,
+        block_name: str,
+        location: Optional[FeatureLibLocation] = None,
     ):
         NameRecord.__init__(
             self, nameID, platformID, platEncID, langID, string, location=location
         )
         self.block_name = block_name
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_cv_parameter`` callback."""
         item = ""
         if self.block_name == "ParamUILabelNameID":
@@ -1790,7 +1948,7 @@ class CVParametersNameStatement(NameRecord):
         self.nameID = (self.nameID, self.block_name + item)
         NameRecord.build(self, builder)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         plat = simplify_name_attributes(self.platformID, self.platEncID, self.langID)
         if plat != "":
             plat += " "
@@ -1805,16 +1963,18 @@ class CharacterStatement(Statement):
     The largest Unicode value allowed is 0xFFFFFF.
     """
 
-    def __init__(self, character, tag, location=None):
+    def __init__(
+        self, character: int, tag: str, location: Optional[FeatureLibLocation] = None
+    ):
         Statement.__init__(self, location)
         self.character = character
         self.tag = tag
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_cv_character`` callback."""
         builder.add_cv_character(self.character, self.tag)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return "Character {:#x};".format(self.character)
 
 
@@ -1822,17 +1982,23 @@ class BaseAxis(Statement):
     """An axis definition, being either a ``VertAxis.BaseTagList/BaseScriptList``
     pair or a ``HorizAxis.BaseTagList/BaseScriptList`` pair."""
 
-    def __init__(self, bases, scripts, vertical, location=None):
+    def __init__(
+        self,
+        bases: Sequence[str],
+        scripts: Sequence[Tuple[str, str, Sequence]],
+        vertical: bool,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.bases = bases  #: A list of baseline tag names as strings
         self.scripts = scripts  #: A list of script record tuplets (script tag, default baseline tag, base coordinate)
         self.vertical = vertical  #: Boolean; VertAxis if True, HorizAxis if False
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``set_base_axis`` callback."""
         builder.set_base_axis(self.bases, self.scripts, self.vertical)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         direction = "Vert" if self.vertical else "Horiz"
         scripts = [
             "{} {} {}".format(a[0], a[1], " ".join(map(str, a[2])))
@@ -1848,16 +2014,21 @@ class OS2Field(Statement):
     strings, apart from when the key is ``UnicodeRange``, ``CodePageRange``
     or ``Panose``, in which case it should be an array of integers."""
 
-    def __init__(self, key, value, location=None):
+    def __init__(
+        self,
+        key: str,
+        value: Union[str, Sequence[int]],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.key = key
         self.value = value
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_os2_field`` callback."""
         builder.add_os2_field(self.key, self.value)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         def intarr2str(x):
             return " ".join(map(str, x))
 
@@ -1876,10 +2047,12 @@ class OS2Field(Statement):
             "UpperOpSize",
         )
         ranges = ("UnicodeRange", "CodePageRange")
-        keywords = dict([(x.lower(), [x, str]) for x in numbers])
-        keywords.update([(x.lower(), [x, intarr2str]) for x in ranges])
-        keywords["panose"] = ["Panose", intarr2str]
-        keywords["vendor"] = ["Vendor", lambda y: '"{}"'.format(y)]
+        keywords: Dict[str, Tuple[str, Callable]] = dict(
+            [(x.lower(), (x, str)) for x in numbers]
+        )
+        keywords.update([(x.lower(), (x, intarr2str)) for x in ranges])
+        keywords["panose"] = ("Panose", intarr2str)
+        keywords["vendor"] = ("Vendor", lambda y: '"{}"'.format(y))
         if self.key in keywords:
             return "{} {};".format(
                 keywords[self.key][0], keywords[self.key][1](self.value)
@@ -1890,16 +2063,16 @@ class OS2Field(Statement):
 class HheaField(Statement):
     """An entry in the ``hhea`` table."""
 
-    def __init__(self, key, value, location=None):
+    def __init__(self, key: str, value, location: Optional[FeatureLibLocation] = None):
         Statement.__init__(self, location)
         self.key = key
         self.value = value
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_hhea_field`` callback."""
         builder.add_hhea_field(self.key, self.value)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         fields = ("CaretOffset", "Ascender", "Descender", "LineGap")
         keywords = dict([(x.lower(), x) for x in fields])
         return "{} {};".format(keywords[self.key], self.value)
@@ -1908,16 +2081,16 @@ class HheaField(Statement):
 class VheaField(Statement):
     """An entry in the ``vhea`` table."""
 
-    def __init__(self, key, value, location=None):
+    def __init__(self, key: str, value, location: Optional[FeatureLibLocation] = None):
         Statement.__init__(self, location)
         self.key = key
         self.value = value
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Calls the builder object's ``add_vhea_field`` callback."""
         builder.add_vhea_field(self.key, self.value)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         fields = ("VertTypoAscender", "VertTypoDescender", "VertTypoLineGap")
         keywords = dict([(x.lower(), x) for x in fields])
         return "{} {};".format(keywords[self.key], self.value)
@@ -1932,17 +2105,23 @@ class STATDesignAxisStatement(Statement):
         names (list): a list of :class:`STATNameStatement` objects
     """
 
-    def __init__(self, tag, axisOrder, names, location=None):
+    def __init__(
+        self,
+        tag: str,
+        axisOrder: int,
+        names: Sequence[STATNameStatement],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.tag = tag
         self.axisOrder = axisOrder
         self.names = names
         self.location = location
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         builder.addDesignAxis(self, self.location)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         indent += SHIFT
         res = f"DesignAxis {self.tag} {self.axisOrder} {{ \n"
         res += ("\n" + indent).join([s.asFea(indent=indent) for s in self.names]) + "\n"
@@ -1957,15 +2136,19 @@ class ElidedFallbackName(Statement):
         names: a list of :class:`STATNameStatement` objects
     """
 
-    def __init__(self, names, location=None):
+    def __init__(
+        self,
+        names: Sequence[STATNameStatement],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.names = names
         self.location = location
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         builder.setElidedFallbackName(self.names, self.location)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         indent += SHIFT
         res = "ElidedFallbackName { \n"
         res += ("\n" + indent).join([s.asFea(indent=indent) for s in self.names]) + "\n"
@@ -1980,15 +2163,15 @@ class ElidedFallbackNameID(Statement):
         value: an int pointing to an existing name table name ID
     """
 
-    def __init__(self, value, location=None):
+    def __init__(self, value: int, location: Optional[FeatureLibLocation] = None):
         Statement.__init__(self, location)
         self.value = value
         self.location = location
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         builder.setElidedFallbackName(self.value, self.location)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         return f"ElidedFallbackNameID {self.value};"
 
 
@@ -2001,16 +2184,22 @@ class STATAxisValueStatement(Statement):
         flags (int): an int
     """
 
-    def __init__(self, names, locations, flags, location=None):
+    def __init__(
+        self,
+        names: Sequence[STATNameStatement],
+        locations: Sequence["AxisValueLocationStatement"],
+        flags,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.names = names
         self.locations = locations
         self.flags = flags
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         builder.addAxisValueRecord(self, self.location)
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = "AxisValue {\n"
         for location in self.locations:
             res += location.asFea()
@@ -2041,13 +2230,18 @@ class AxisValueLocationStatement(Statement):
         values (list): a list of ints and/or floats
     """
 
-    def __init__(self, tag, values, location=None):
+    def __init__(
+        self,
+        tag: str,
+        values: Sequence[Union[int, float]],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.tag = tag
         self.values = values
 
-    def asFea(self, res=""):
-        res += f"location {self.tag} "
+    def asFea(self):
+        res = f"location {self.tag} "
         res += f"{' '.join(str(i) for i in self.values)};\n"
         return res
 
@@ -2062,16 +2256,21 @@ class ConditionsetStatement(Statement):
             tuple of (min,max) userspace coordinates.
     """
 
-    def __init__(self, name, conditions, location=None):
+    def __init__(
+        self,
+        name: str,
+        conditions: Dict[str, Tuple[float, float]],
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Statement.__init__(self, location)
         self.name = name
         self.conditions = conditions
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         builder.add_conditionset(self.name, self.conditions)
 
-    def asFea(self, res="", indent=""):
-        res += indent + f"conditionset {self.name} " + "{\n"
+    def asFea(self, indent="") -> str:
+        res = indent + f"conditionset {self.name} " + "{\n"
         for tag, (minvalue, maxvalue) in self.conditions.items():
             res += indent + SHIFT + f"{tag} {minvalue} {maxvalue};\n"
         res += indent + "}" + f" {self.name};\n"
@@ -2081,7 +2280,13 @@ class ConditionsetStatement(Statement):
 class VariationBlock(Block):
     """A variation feature block, applicable in a given set of conditions."""
 
-    def __init__(self, name, conditionset, use_extension=False, location=None):
+    def __init__(
+        self,
+        name: str,
+        conditionset: str,
+        use_extension=False,
+        location: Optional[FeatureLibLocation] = None,
+    ):
         Block.__init__(self, location)
         self.name, self.conditionset, self.use_extension = (
             name,
@@ -2089,7 +2294,7 @@ class VariationBlock(Block):
             use_extension,
         )
 
-    def build(self, builder):
+    def build(self, builder) -> None:
         """Call the ``start_feature`` callback on the builder object, visit
         all the statements in this feature, and then call ``end_feature``."""
         builder.start_feature(self.location, self.name)
@@ -2117,7 +2322,7 @@ class VariationBlock(Block):
         builder.features_ = features
         builder.end_feature()
 
-    def asFea(self, indent=""):
+    def asFea(self, indent="") -> str:
         res = indent + "variation %s " % self.name.strip()
         res += self.conditionset + " "
         if self.use_extension:

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -2289,7 +2289,7 @@ class ConditionsetStatement(Statement):
         self.conditions = conditions
 
     def build(self, builder) -> None:
-        builder.add_conditionset(self.name, self.conditions)
+        builder.add_conditionset(self.location, self.name, self.conditions)
 
     def asFea(self, indent="") -> str:
         res = indent + f"conditionset {self.name} " + "{\n"

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1385,23 +1385,24 @@ class MultipleSubstStatement(Statement):
         """Calls the builder object's ``add_multiple_subst`` callback."""
         prefix = [p.glyphSet() for p in self.prefix]
         suffix = [s.glyphSet() for s in self.suffix]
-        if not self.replacement and hasattr(self.glyph, "glyphSet"):
+        replacement = [s.glyphSet()[0] for s in self.replacement]
+        if not replacement:
             for glyph in self.glyph.glyphSet():
                 builder.add_multiple_subst(
                     self.location,
                     prefix,
                     glyph,
                     suffix,
-                    self.replacement,
+                    replacement,
                     self.forceChain,
                 )
         else:
             builder.add_multiple_subst(
                 self.location,
                 prefix,
-                self.glyph,
+                self.glyph.glyphSet()[0],
                 suffix,
-                self.replacement,
+                tuple(replacement),
                 self.forceChain,
             )
 

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1409,10 +1409,10 @@ class MultipleSubstStatement(Statement):
         res = "sub "
         if len(self.prefix) or len(self.suffix) or self.forceChain:
             if len(self.prefix):
-                res += " ".join(map(asFea, self.prefix)) + " "
+                res += " ".join(map(lambda x: x.asFea(), self.prefix)) + " "
             res += asFea(self.glyph) + "'"
             if len(self.suffix):
-                res += " " + " ".join(map(asFea, self.suffix))
+                res += " " + " ".join(map(lambda x: x.asFea(), self.suffix))
         else:
             res += asFea(self.glyph)
         replacement = self.replacement or [NullGlyph()]

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1581,7 +1581,7 @@ class Builder(object):
 
     def makeOpenTypeAnchor(self, location, anchor):
         """ast.Anchor --> otTables.Anchor"""
-        if anchor is None:
+        if anchor is None or anchor.isNull():
             return None
         variable = False
         deviceX, deviceY = None, None

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -7,8 +7,15 @@ from fontTools.feaLib.lookupDebugInfo import (
     LOOKUP_DEBUG_ENV_VAR,
 )
 from fontTools.feaLib.parser import Parser
-from fontTools.feaLib.ast import FeatureFile
+from fontTools.feaLib.ast import (
+    FeatureFile,
+    ValueRecord,
+    Anchor,
+    ContextualLookupList,
+    MarkClass,
+)
 from fontTools.feaLib.variableScalar import VariableScalar
+from fontTools.feaLib.location import FeatureLibLocation
 from fontTools.otlLib import builder as otl
 from fontTools.otlLib.maxContextCalc import maxCtxFont
 from fontTools.ttLib import newTable, getTableModule
@@ -31,11 +38,15 @@ from fontTools.otlLib.builder import (
     ChainContextualRule,
 )
 from fontTools.otlLib.error import OpenTypeLibError
+from fontTools.otlLib import builder as otl
+from fontTools.ttLib import newTable, getTableModule
 from fontTools.varLib.varStore import OnlineVarStoreBuilder
 from fontTools.varLib.builder import buildVarDevTable
 from fontTools.varLib.featureVars import addFeatureVariationsRaw
 from fontTools.varLib.models import normalizeValue
+from fontTools.ttLib.tables import otBase, otTables
 from collections import defaultdict
+from typing import Sequence, Dict, Optional, Tuple, Set, List, Any, FrozenSet, Union
 import itertools
 from io import StringIO
 import logging
@@ -107,10 +118,12 @@ class Builder(object):
         ]
     )
 
-    def __init__(self, font, featurefile):
+    def __init__(self, font, featurefile) -> None:
         self.font = font
         # 'featurefile' can be either a path or file object (in which case we
         # parse it into an AST), or a pre-parsed AST instance
+        self.parseTree: Optional[FeatureFile] = None
+        self.file: Optional[str] = None
         if isinstance(featurefile, FeatureFile):
             self.parseTree, self.file = featurefile, None
         else:
@@ -122,62 +135,91 @@ class Builder(object):
             self.varstorebuilder = OnlineVarStoreBuilder(
                 [ax.axisTag for ax in self.axes]
             )
-        self.default_language_systems_ = set()
-        self.script_ = None
+        self.default_language_systems_: Set[Tuple[str, str]] = set()
+        self.script_: Optional[str] = None
         self.lookupflag_ = 0
         self.lookupflag_markFilterSet_ = None
-        self.language_systems = set()
+        self.language_systems: Optional[
+            Union[FrozenSet[Tuple[str, str]], Set[Tuple[str, str]]]
+        ] = set()
         self.seen_non_DFLT_script_ = False
-        self.named_lookups_ = {}
+        self.named_lookups_: Dict[str, Optional[otl.LookupBuilder]] = {}
         self.cur_lookup_ = None
-        self.cur_lookup_name_ = None
-        self.cur_feature_name_ = None
-        self.lookups_ = []
-        self.lookup_locations = {"GSUB": {}, "GPOS": {}}
-        self.features_ = {}  # ('latn', 'DEU ', 'smcp') --> [LookupBuilder*]
-        self.required_features_ = {}  # ('latn', 'DEU ') --> 'scmp'
-        self.feature_variations_ = {}
+        self.cur_lookup_name_: Optional[str] = None
+        self.cur_feature_name_: Optional[str] = None
+        self.lookups_: List[otl.LookupBuilder] = []
+        self.lookup_locations: Dict[str, Dict[str, LookupDebugInfo]] = {
+            "GSUB": {},
+            "GPOS": {},
+        }
+
+        self.features_: Dict[
+            Tuple[str, str, str], List[List[otl.LookupBuilder]]
+        ] = {}  # ('latn', 'DEU ', 'smcp') --> [LookupBuilder*]
+
+        self.required_features_: Dict[
+            Tuple[str, str], str
+        ] = {}  # ('latn', 'DEU ') --> 'scmp'
+
+        self.feature_variations_: Dict[
+            Tuple[str, str, str], Dict[str, List[otl.LookupBuilder]]
+        ] = {}
+        # (script_, language, feature_tag) --> { conditionset --> builders }
+
         # for feature 'aalt'
-        self.aalt_features_ = []  # [(location, featureName)*], for 'aalt'
+        self.aalt_features_: List[
+            Tuple[Optional[FeatureLibLocation], str]
+        ] = []  # [(location, featureName)*], for 'aalt'
         self.aalt_location_ = None
-        self.aalt_alternates_ = {}
+        self.aalt_alternates_: Dict[str, Set[str]] = {}
         # for 'featureNames'
-        self.featureNames_ = set()
-        self.featureNames_ids_ = {}
+        self.featureNames_: Set[str] = set()
+        self.featureNames_ids_: Dict[str, int] = {}
         # for 'cvParameters'
-        self.cv_parameters_ = set()
-        self.cv_parameters_ids_ = {}
-        self.cv_num_named_params_ = {}
-        self.cv_characters_ = defaultdict(list)
+        self.cv_parameters_: Set[str] = set()
+        self.cv_parameters_ids_: Dict[str, int] = {}
+        self.cv_num_named_params_: Dict[str, int] = {}
+        self.cv_characters_: Dict[str, List[int]] = defaultdict(list)
         # for feature 'size'
         self.size_parameters_ = None
         # for table 'head'
-        self.fontRevision_ = None  # 2.71
+        self.fontRevision_: Optional[float] = None  # 2.71
+
         # for table 'name'
-        self.names_ = []
+        self.names_: List[Tuple[int, int, int, int, str]] = []
+        # nameID, platformID, platEncID, langID, string
+
         # for table 'BASE'
         self.base_horiz_axis_ = None
         self.base_vert_axis_ = None
         # for table 'GDEF'
-        self.attachPoints_ = {}  # "a" --> {3, 7}
-        self.ligCaretCoords_ = {}  # "f_f_i" --> {300, 600}
-        self.ligCaretPoints_ = {}  # "f_f_i" --> {3, 7}
-        self.glyphClassDefs_ = {}  # "fi" --> (2, (file, line, column))
-        self.markAttach_ = {}  # "acute" --> (4, (file, line, column))
-        self.markAttachClassID_ = {}  # frozenset({"acute", "grave"}) --> 4
-        self.markFilterSets_ = {}  # frozenset({"acute", "grave"}) --> 4
+        self.attachPoints_: Dict[str, Set[int]] = {}  # "a" --> {3, 7}
+        self.ligCaretCoords_: Dict[str, Set[int]] = {}  # "f_f_i" --> {300, 600}
+        self.ligCaretPoints_: Dict[str, Set[int]] = {}  # "f_f_i" --> {3, 7}
+        self.glyphClassDefs_: Dict[
+            str, Tuple[int, Tuple[str, int, int]]
+        ] = {}  # "fi" --> (2, (file, line, column))
+        self.markAttach_: Dict[
+            str, Tuple[int, Tuple[str, int, int]]
+        ] = {}  # "acute" --> (4, (file, line, column))
+        self.markAttachClassID_: Dict[
+            frozenset, int
+        ] = {}  # frozenset({"acute", "grave"}) --> 4
+        self.markFilterSets_: Dict[
+            frozenset, int
+        ] = {}  # frozenset({"acute", "grave"}) --> 4
         # for table 'OS/2'
-        self.os2_ = {}
+        self.os2_: Dict[str, Any] = {}
         # for table 'hhea'
-        self.hhea_ = {}
+        self.hhea_: Dict[str, Any] = {}
         # for table 'vhea'
-        self.vhea_ = {}
+        self.vhea_: Dict[str, Any] = {}
         # for table 'STAT'
-        self.stat_ = {}
+        self.stat_: Dict[str, Any] = {}
         # for conditionsets
-        self.conditionsets_ = {}
+        self.conditionsets_: Dict[str, Dict[str, Tuple[float, float]]] = {}
 
-    def build(self, tables=None, debug=False):
+    def build(self, tables=None, debug=False) -> None:
         if self.parseTree is None:
             self.parseTree = Parser(self.file, self.glyphMap).parse()
         self.parseTree.build(self)
@@ -253,7 +295,7 @@ class Builder(object):
             key = (script, lang, feature_name)
             self.features_.setdefault(key, []).append(lookup)
 
-    def get_lookup_(self, location, builder_class):
+    def get_lookup_(self, location, builder_class) -> otl.LookupBuilder:
         if (
             self.cur_lookup_
             and type(self.cur_lookup_) == builder_class
@@ -268,6 +310,7 @@ class Builder(object):
                 location,
             )
         self.cur_lookup_ = builder_class(self.font, location)
+        assert self.cur_lookup_
         self.cur_lookup_.lookupflag = self.lookupflag_
         self.cur_lookup_.markFilterSet = self.lookupflag_markFilterSet_
         self.lookups_.append(self.cur_lookup_)
@@ -280,22 +323,22 @@ class Builder(object):
             self.add_lookup_to_feature_(self.cur_lookup_, self.cur_feature_name_)
         return self.cur_lookup_
 
-    def build_feature_aalt_(self):
+    def build_feature_aalt_(self) -> None:
         if not self.aalt_features_ and not self.aalt_alternates_:
             return
         alternates = {g: set(a) for g, a in self.aalt_alternates_.items()}
         for location, name in self.aalt_features_ + [(None, "aalt")]:
-            feature = [
+            feature_list = [
                 (script, lang, feature, lookups)
                 for (script, lang, feature), lookups in self.features_.items()
                 if feature == name
             ]
             # "aalt" does not have to specify its own lookups, but it might.
-            if not feature and name != "aalt":
+            if not feature_list and name != "aalt":
                 raise FeatureLibError(
                     "Feature %s has not been defined" % name, location
                 )
-            for script, lang, feature, lookups in feature:
+            for script, lang, feature, lookups in feature_list:
                 for lookuplist in lookups:
                     if not isinstance(lookuplist, list):
                         lookuplist = [lookuplist]
@@ -324,14 +367,16 @@ class Builder(object):
         self.start_feature(self.aalt_location_, "aalt")
         if single:
             single_lookup = self.get_lookup_(location, SingleSubstBuilder)
+            assert isinstance(single_lookup, SingleSubstBuilder)
             single_lookup.mapping = single
         if multi:
             multi_lookup = self.get_lookup_(location, AlternateSubstBuilder)
+            assert isinstance(multi_lookup, AlternateSubstBuilder)
             multi_lookup.alternates = multi
         self.end_feature()
         self.lookups_.extend(old_lookups)
 
-    def build_head(self):
+    def build_head(self) -> None:
         if not self.fontRevision_:
             return
         table = self.font.get("head")
@@ -342,7 +387,7 @@ class Builder(object):
             table.created = table.modified = 3406620153  # 2011-12-13 11:22:33
         table.fontRevision = self.fontRevision_
 
-    def build_hhea(self):
+    def build_hhea(self) -> None:
         if not self.hhea_:
             return
         table = self.font.get("hhea")
@@ -359,7 +404,7 @@ class Builder(object):
         if "linegap" in self.hhea_:
             table.lineGap = self.hhea_["linegap"]
 
-    def build_vhea(self):
+    def build_vhea(self) -> None:
         if not self.vhea_:
             return
         table = self.font.get("vhea")
@@ -374,36 +419,39 @@ class Builder(object):
         if "verttypolinegap" in self.vhea_:
             table.lineGap = self.vhea_["verttypolinegap"]
 
-    def get_user_name_id(self, table):
+    def get_user_name_id(self, table) -> Optional[int]:
         # Try to find first unused font-specific name id
         nameIDs = [name.nameID for name in table.names]
         for user_name_id in range(256, 32767):
             if user_name_id not in nameIDs:
                 return user_name_id
+        return None
 
     def buildFeatureParams(self, tag):
-        params = None
         if tag == "size":
-            params = otTables.FeatureParamsSize()
+            assert self.size_parameters_
+            sizeparam = otTables.FeatureParamsSize()
             (
-                params.DesignSize,
-                params.SubfamilyID,
-                params.RangeStart,
-                params.RangeEnd,
+                sizeparam.DesignSize,
+                sizeparam.SubfamilyID,
+                sizeparam.RangeStart,
+                sizeparam.RangeEnd,
             ) = self.size_parameters_
             if tag in self.featureNames_ids_:
-                params.SubfamilyNameID = self.featureNames_ids_[tag]
+                sizeparam.SubfamilyNameID = self.featureNames_ids_[tag]
             else:
-                params.SubfamilyNameID = 0
+                sizeparam.SubfamilyNameID = 0
+            return sizeparam
         elif tag in self.featureNames_:
             if not self.featureNames_ids_:
                 # name table wasn't selected among the tables to build; skip
                 pass
             else:
                 assert tag in self.featureNames_ids_
-                params = otTables.FeatureParamsStylisticSet()
-                params.Version = 0
-                params.UINameID = self.featureNames_ids_[tag]
+                ss_params = otTables.FeatureParamsStylisticSet()
+                ss_params.Version = 0
+                ss_params.UINameID = self.featureNames_ids_[tag]
+                return ss_params
         elif tag in self.cv_parameters_:
             params = otTables.FeatureParamsCharacterVariants()
             params.Format = 0
@@ -422,9 +470,10 @@ class Builder(object):
             )
             params.CharCount = len(self.cv_characters_[tag])
             params.Character = self.cv_characters_[tag]
-        return params
+            return params
+        return None
 
-    def build_name(self):
+    def build_name(self) -> None:
         if not self.names_:
             return
         table = self.font.get("name")
@@ -449,7 +498,7 @@ class Builder(object):
                     nameID = self.cv_parameters_ids_[tag]
             table.setName(string, nameID, platformID, platEncID, langID)
 
-    def build_OS_2(self):
+    def build_OS_2(self) -> None:
         if not self.os2_:
             return
         table = self.font.get("OS/2")
@@ -533,7 +582,7 @@ class Builder(object):
         if version >= 5:
             checkattr(table, ("usLowerOpticalPointSize", "usUpperOpticalPointSize"))
 
-    def setElidedFallbackName(self, value, location):
+    def setElidedFallbackName(self, value, location: FeatureLibLocation) -> None:
         # ElidedFallbackName is a convenience method for setting
         # ElidedFallbackNameID so only one can be allowed
         for token in ("ElidedFallbackName", "ElidedFallbackNameID"):
@@ -549,7 +598,7 @@ class Builder(object):
         else:
             raise AssertionError(value)
 
-    def addDesignAxis(self, designAxis, location):
+    def addDesignAxis(self, designAxis, location) -> None:
         if "DesignAxes" not in self.stat_:
             self.stat_["DesignAxes"] = []
         if designAxis.tag in (r.tag for r in self.stat_["DesignAxes"]):
@@ -564,7 +613,7 @@ class Builder(object):
             )
         self.stat_["DesignAxes"].append(designAxis)
 
-    def addAxisValueRecord(self, axisValueRecord, location):
+    def addAxisValueRecord(self, axisValueRecord, location) -> None:
         if "AxisValueRecords" not in self.stat_:
             self.stat_["AxisValueRecords"] = []
         # Check for duplicate AxisValueRecords
@@ -582,7 +631,7 @@ class Builder(object):
                 )
         self.stat_["AxisValueRecords"].append(axisValueRecord)
 
-    def build_STAT(self):
+    def build_STAT(self) -> None:
         if not self.stat_:
             return
 
@@ -590,7 +639,7 @@ class Builder(object):
         if not axes:
             raise FeatureLibError("DesignAxes not defined", None)
         axisValueRecords = self.stat_.get("AxisValueRecords")
-        axisValues = {}
+        axisValues: Dict[str, List[Dict]] = {}
         format4_locations = []
         for tag in axes:
             axisValues[tag.tag] = []
@@ -770,8 +819,8 @@ class Builder(object):
                 varidx_map = store.optimize()
 
                 gdef.remap_device_varidxes(varidx_map)
-                if 'GPOS' in self.font:
-                    self.font['GPOS'].table.remap_device_varidxes(varidx_map)
+                if "GPOS" in self.font:
+                    self.font["GPOS"].table.remap_device_varidxes(varidx_map)
         if any(
             (
                 gdef.GlyphClassDef,
@@ -821,7 +870,7 @@ class Builder(object):
             sets.append(glyphs)
         return otl.buildMarkGlyphSetsDef(sets, self.glyphMap)
 
-    def buildDebg(self):
+    def buildDebg(self) -> None:
         if "Debg" not in self.font:
             self.font["Debg"] = newTable("Debg")
             self.font["Debg"].data = {}
@@ -943,8 +992,8 @@ class Builder(object):
         table.LookupList.LookupCount = len(table.LookupList.Lookup)
         return table
 
-    def makeFeatureVariations(self, table, table_tag):
-        feature_vars = {}
+    def makeFeatureVariations(self, table, table_tag) -> None:
+        feature_vars: Dict[str, List[Tuple[Any, Sequence[int]]]] = {}
         has_any_variations = False
         # Sort out which lookups to build, gather their indices
         for (
@@ -970,7 +1019,7 @@ class Builder(object):
                     self.font, table, conditions_and_lookups, feature_tag
                 )
 
-    def any_feature_variations(self, feature_tag, table_tag):
+    def any_feature_variations(self, feature_tag, table_tag) -> bool:
         for (_, _, feature), variations in self.feature_variations_.items():
             if feature != feature_tag:
                 continue
@@ -979,13 +1028,15 @@ class Builder(object):
                     return True
         return False
 
-    def get_lookup_name_(self, lookup):
+    def get_lookup_name_(self, lookup) -> Optional[str]:
         rev = {v: k for k, v in self.named_lookups_.items()}
         if lookup in rev:
             return rev[lookup]
         return None
 
-    def add_language_system(self, location, script, language):
+    def add_language_system(
+        self, location: FeatureLibLocation, script: str, language: str
+    ):
         # OpenType Feature File Specification, section 4.b.i
         if script == "DFLT" and language == "dflt" and self.default_language_systems_:
             raise FeatureLibError(
@@ -1010,7 +1061,7 @@ class Builder(object):
             )
         self.default_language_systems_.add((script, language))
 
-    def get_default_language_systems_(self):
+    def get_default_language_systems_(self) -> FrozenSet[Tuple[str, str]]:
         # OpenType Feature File specification, 4.b.i. languagesystem:
         # If no "languagesystem" statement is present, then the
         # implementation must behave exactly as though the following
@@ -1021,7 +1072,7 @@ class Builder(object):
         else:
             return frozenset({("DFLT", "dflt")})
 
-    def start_feature(self, location, name):
+    def start_feature(self, location, name) -> None:
         self.language_systems = self.get_default_language_systems_()
         self.script_ = "DFLT"
         self.cur_lookup_ = None
@@ -1031,7 +1082,7 @@ class Builder(object):
         if name == "aalt":
             self.aalt_location_ = location
 
-    def end_feature(self):
+    def end_feature(self) -> None:
         assert self.cur_feature_name_ is not None
         self.cur_feature_name_ = None
         self.language_systems = None
@@ -1039,7 +1090,7 @@ class Builder(object):
         self.lookupflag_ = 0
         self.lookupflag_markFilterSet_ = None
 
-    def start_lookup_block(self, location, name):
+    def start_lookup_block(self, location: FeatureLibLocation, name: str):
         if name in self.named_lookups_:
             raise FeatureLibError(
                 'Lookup "%s" has already been defined' % name, location
@@ -1057,7 +1108,7 @@ class Builder(object):
             self.lookupflag_ = 0
             self.lookupflag_markFilterSet_ = None
 
-    def end_lookup_block(self):
+    def end_lookup_block(self) -> None:
         assert self.cur_lookup_name_ is not None
         self.cur_lookup_name_ = None
         self.cur_lookup_ = None
@@ -1065,17 +1116,23 @@ class Builder(object):
             self.lookupflag_ = 0
             self.lookupflag_markFilterSet_ = None
 
-    def add_lookup_call(self, lookup_name):
+    def add_lookup_call(self, lookup_name) -> None:
         assert lookup_name in self.named_lookups_, lookup_name
         self.cur_lookup_ = None
         lookup = self.named_lookups_[lookup_name]
         if lookup is not None:  # skip empty named lookup
             self.add_lookup_to_feature_(lookup, self.cur_feature_name_)
 
-    def set_font_revision(self, location, revision):
+    def set_font_revision(self, location: FeatureLibLocation, revision: float) -> None:
         self.fontRevision_ = revision
 
-    def set_language(self, location, language, include_default, required):
+    def set_language(
+        self,
+        location: FeatureLibLocation,
+        language: str,
+        include_default: bool,
+        required: bool,
+    ):
         assert len(language) == 4
         if self.cur_feature_name_ in ("aalt", "size"):
             raise FeatureLibError(
@@ -1090,6 +1147,7 @@ class Builder(object):
                 location,
             )
         self.cur_lookup_ = None
+        assert self.script_ is not None
 
         key = (self.script_, language, self.cur_feature_name_)
         lookups = self.features_.get((key[0], "dflt", key[2]))
@@ -1100,28 +1158,28 @@ class Builder(object):
         self.language_systems = frozenset([(self.script_, language)])
 
         if required:
-            key = (self.script_, language)
-            if key in self.required_features_:
+            required_key = (self.script_, language)
+            if required_key in self.required_features_:
                 raise FeatureLibError(
                     "Language %s (script %s) has already "
                     "specified feature %s as its required feature"
                     % (
                         language.strip(),
                         self.script_.strip(),
-                        self.required_features_[key].strip(),
+                        self.required_features_[required_key].strip(),
                     ),
                     location,
                 )
-            self.required_features_[key] = self.cur_feature_name_
+            self.required_features_[required_key] = self.cur_feature_name_
 
-    def getMarkAttachClass_(self, location, glyphs):
-        glyphs = frozenset(glyphs)
-        id_ = self.markAttachClassID_.get(glyphs)
+    def getMarkAttachClass_(self, location: FeatureLibLocation, glyphs: Sequence[str]):
+        glyphset = frozenset(glyphs)
+        id_ = self.markAttachClassID_.get(glyphset)
         if id_ is not None:
             return id_
         id_ = len(self.markAttachClassID_) + 1
-        self.markAttachClassID_[glyphs] = id_
-        for glyph in glyphs:
+        self.markAttachClassID_[glyphset] = id_
+        for glyph in glyphset:
             if glyph in self.markAttach_:
                 _, loc = self.markAttach_[glyph]
                 raise FeatureLibError(
@@ -1202,13 +1260,13 @@ class Builder(object):
             )
         self.aalt_features_.append((location, featureName))
 
-    def add_featureName(self, tag):
+    def add_featureName(self, tag: str) -> None:
         self.featureNames_.add(tag)
 
-    def add_cv_parameter(self, tag):
+    def add_cv_parameter(self, tag: str) -> None:
         self.cv_parameters_.add(tag)
 
-    def add_to_cv_num_named_params(self, tag):
+    def add_to_cv_num_named_params(self, tag: str) -> None:
         """Adds new items to ``self.cv_num_named_params_``
         or increments the count of existing items."""
         if tag in self.cv_num_named_params_:
@@ -1216,7 +1274,7 @@ class Builder(object):
         else:
             self.cv_num_named_params_[tag] = 1
 
-    def add_cv_character(self, character, tag):
+    def add_cv_character(self, character: int, tag: str) -> None:
         self.cv_characters_[tag].append(character)
 
     def set_base_axis(self, bases, scripts, vertical):
@@ -1242,16 +1300,24 @@ class Builder(object):
     # GSUB rules
 
     # GSUB 1
-    def add_single_subst(self, location, prefix, suffix, mapping, forceChain):
+    def add_single_subst(
+        self,
+        location: FeatureLibLocation,
+        prefix: Sequence[Sequence[str]],
+        suffix: Sequence[Sequence[str]],
+        mapping: Dict[str, str],
+        forceChain,
+    ):
         if self.cur_feature_name_ == "aalt":
             for (from_glyph, to_glyph) in mapping.items():
-                alts = self.aalt_alternates_.setdefault(from_glyph, set())
+                alts: Set[str] = self.aalt_alternates_.setdefault(from_glyph, set())
                 alts.add(to_glyph)
             return
         if prefix or suffix or forceChain:
             self.add_single_subst_chained_(location, prefix, suffix, mapping)
             return
         lookup = self.get_lookup_(location, SingleSubstBuilder)
+        assert isinstance(lookup, SingleSubstBuilder)
         for (from_glyph, to_glyph) in mapping.items():
             if from_glyph in lookup.mapping:
                 if to_glyph == lookup.mapping[from_glyph]:
@@ -1272,15 +1338,23 @@ class Builder(object):
 
     # GSUB 2
     def add_multiple_subst(
-        self, location, prefix, glyph, suffix, replacements, forceChain=False
+        self,
+        location,
+        prefix: Sequence[Sequence[str]],
+        glyph: str,
+        suffix: Sequence[Sequence[str]],
+        replacements: Tuple[str],
+        forceChain=False,
     ):
         if prefix or suffix or forceChain:
             chain = self.get_lookup_(location, ChainContextSubstBuilder)
+            assert isinstance(chain, ChainContextSubstBuilder)
             sub = self.get_chained_lookup_(location, MultipleSubstBuilder)
             sub.mapping[glyph] = replacements
             chain.rules.append(ChainContextualRule(prefix, [{glyph}], suffix, [sub]))
             return
         lookup = self.get_lookup_(location, MultipleSubstBuilder)
+        assert isinstance(lookup, MultipleSubstBuilder)
         if glyph in lookup.mapping:
             if replacements == lookup.mapping[glyph]:
                 log.info(
@@ -1297,17 +1371,26 @@ class Builder(object):
         lookup.mapping[glyph] = replacements
 
     # GSUB 3
-    def add_alternate_subst(self, location, prefix, glyph, suffix, replacement):
+    def add_alternate_subst(
+        self,
+        location: FeatureLibLocation,
+        prefix: Sequence[Sequence[str]],
+        glyph: str,
+        suffix: Sequence[Sequence[str]],
+        replacement: Sequence[str],
+    ) -> None:
         if self.cur_feature_name_ == "aalt":
-            alts = self.aalt_alternates_.setdefault(glyph, set())
+            alts: Set[str] = self.aalt_alternates_.setdefault(glyph, set())
             alts.update(replacement)
             return
         if prefix or suffix:
             chain = self.get_lookup_(location, ChainContextSubstBuilder)
+            assert isinstance(chain, ChainContextSubstBuilder)
             lookup = self.get_chained_lookup_(location, AlternateSubstBuilder)
             chain.rules.append(ChainContextualRule(prefix, [{glyph}], suffix, [lookup]))
         else:
             lookup = self.get_lookup_(location, AlternateSubstBuilder)
+        assert isinstance(lookup, AlternateSubstBuilder)
         if glyph in lookup.alternates:
             raise FeatureLibError(
                 'Already defined alternates for glyph "%s"' % glyph, location
@@ -1317,14 +1400,22 @@ class Builder(object):
 
     # GSUB 4
     def add_ligature_subst(
-        self, location, prefix, glyphs, suffix, replacement, forceChain
-    ):
+        self,
+        location: FeatureLibLocation,
+        prefix: Sequence[Sequence[str]],
+        glyphs: Sequence[str],
+        suffix: Sequence[Sequence[str]],
+        replacement: str,
+        forceChain: bool,
+    ) -> None:
         if prefix or suffix or forceChain:
             chain = self.get_lookup_(location, ChainContextSubstBuilder)
+            assert isinstance(chain, ChainContextSubstBuilder)
             lookup = self.get_chained_lookup_(location, LigatureSubstBuilder)
             chain.rules.append(ChainContextualRule(prefix, glyphs, suffix, [lookup]))
         else:
             lookup = self.get_lookup_(location, LigatureSubstBuilder)
+        assert isinstance(lookup, LigatureSubstBuilder)
 
         if not all(glyphs):
             raise FeatureLibError("Empty glyph class in substitution", location)
@@ -1338,21 +1429,40 @@ class Builder(object):
             lookup.ligatures[g] = replacement
 
     # GSUB 5/6
-    def add_chain_context_subst(self, location, prefix, glyphs, suffix, lookups):
+    def add_chain_context_subst(
+        self,
+        location: FeatureLibLocation,
+        prefix: Sequence[Sequence[str]],
+        glyphs: Sequence[Sequence[str]],
+        suffix: Sequence[Sequence[str]],
+        lookups: ContextualLookupList,
+    ):
         if not all(glyphs) or not all(prefix) or not all(suffix):
-            raise FeatureLibError("Empty glyph class in contextual substitution", location)
+            raise FeatureLibError(
+                "Empty glyph class in contextual substitution", location
+            )
         lookup = self.get_lookup_(location, ChainContextSubstBuilder)
+        assert isinstance(lookup, ChainContextSubstBuilder)
         lookup.rules.append(
             ChainContextualRule(
                 prefix, glyphs, suffix, self.find_lookup_builders_(lookups)
             )
         )
 
-    def add_single_subst_chained_(self, location, prefix, suffix, mapping):
+    def add_single_subst_chained_(
+        self,
+        location: FeatureLibLocation,
+        prefix: Sequence[Sequence[str]],
+        suffix: Sequence[Sequence[str]],
+        mapping: Dict[str, str],
+    ):
         if not mapping or not all(prefix) or not all(suffix):
-            raise FeatureLibError("Empty glyph class in contextual substitution", location)
+            raise FeatureLibError(
+                "Empty glyph class in contextual substitution", location
+            )
         # https://github.com/fonttools/fonttools/issues/512
         chain = self.get_lookup_(location, ChainContextSubstBuilder)
+        assert isinstance(chain, ChainContextSubstBuilder)
         sub = chain.find_chainable_single_subst(set(mapping.keys()))
         if sub is None:
             sub = self.get_chained_lookup_(location, SingleSubstBuilder)
@@ -1362,24 +1472,43 @@ class Builder(object):
         )
 
     # GSUB 8
-    def add_reverse_chain_single_subst(self, location, old_prefix, old_suffix, mapping):
+    def add_reverse_chain_single_subst(
+        self,
+        location: FeatureLibLocation,
+        old_prefix: Sequence[Sequence[str]],
+        old_suffix: Sequence[Sequence[str]],
+        mapping: Dict[str, str],
+    ):
         if not mapping:
             raise FeatureLibError("Empty glyph class in substitution", location)
         lookup = self.get_lookup_(location, ReverseChainSingleSubstBuilder)
+        assert isinstance(lookup, ReverseChainSingleSubstBuilder)
         lookup.rules.append((old_prefix, old_suffix, mapping))
 
     # GPOS rules
 
     # GPOS 1
-    def add_single_pos(self, location, prefix, suffix, pos, forceChain):
+    def add_single_pos(
+        self,
+        location: FeatureLibLocation,
+        prefix: Sequence[Sequence[str]],
+        suffix: Sequence[Sequence[str]],
+        pos: Sequence[Tuple[str, ValueRecord]],
+        forceChain,
+    ) -> None:
         if prefix or suffix or forceChain:
             self.add_single_pos_chained_(location, prefix, suffix, pos)
         else:
             lookup = self.get_lookup_(location, SinglePosBuilder)
+            assert isinstance(lookup, SinglePosBuilder)
             for glyphs, value in pos:
                 if not glyphs:
-                    raise FeatureLibError("Empty glyph class in positioning rule", location)
-                otValueRecord = self.makeOpenTypeValueRecord(location, value, pairPosContext=False)
+                    raise FeatureLibError(
+                        "Empty glyph class in positioning rule", location
+                    )
+                otValueRecord = self.makeOpenTypeValueRecord(
+                    location, value, pairPosContext=False
+                )
                 for glyph in glyphs:
                     try:
                         lookup.add_pos(location, glyph, otValueRecord)
@@ -1387,29 +1516,50 @@ class Builder(object):
                         raise FeatureLibError(str(e), e.location) from e
 
     # GPOS 2
-    def add_class_pair_pos(self, location, glyphclass1, value1, glyphclass2, value2):
+    def add_class_pair_pos(
+        self,
+        location: FeatureLibLocation,
+        glyphclass1: Sequence[str],
+        value1: Optional[ValueRecord],
+        glyphclass2: Sequence[str],
+        value2: Optional[ValueRecord],
+    ):
         if not glyphclass1 or not glyphclass2:
-            raise FeatureLibError(
-                "Empty glyph class in positioning rule", location
-            )
+            raise FeatureLibError("Empty glyph class in positioning rule", location)
         lookup = self.get_lookup_(location, PairPosBuilder)
+        assert isinstance(lookup, PairPosBuilder)
         v1 = self.makeOpenTypeValueRecord(location, value1, pairPosContext=True)
         v2 = self.makeOpenTypeValueRecord(location, value2, pairPosContext=True)
         lookup.addClassPair(location, glyphclass1, v1, glyphclass2, v2)
 
-    def add_specific_pair_pos(self, location, glyph1, value1, glyph2, value2):
+    def add_specific_pair_pos(
+        self,
+        location: FeatureLibLocation,
+        glyph1: str,
+        value1: Optional[ValueRecord],
+        glyph2: str,
+        value2: Optional[ValueRecord],
+    ):
         if not glyph1 or not glyph2:
             raise FeatureLibError("Empty glyph class in positioning rule", location)
         lookup = self.get_lookup_(location, PairPosBuilder)
+        assert isinstance(lookup, PairPosBuilder)
         v1 = self.makeOpenTypeValueRecord(location, value1, pairPosContext=True)
         v2 = self.makeOpenTypeValueRecord(location, value2, pairPosContext=True)
         lookup.addGlyphPair(location, glyph1, v1, glyph2, v2)
 
     # GPOS 3
-    def add_cursive_pos(self, location, glyphclass, entryAnchor, exitAnchor):
+    def add_cursive_pos(
+        self,
+        location: FeatureLibLocation,
+        glyphclass: Sequence[str],
+        entryAnchor: Anchor,
+        exitAnchor: Anchor,
+    ):
         if not glyphclass:
             raise FeatureLibError("Empty glyph class in positioning rule", location)
         lookup = self.get_lookup_(location, CursivePosBuilder)
+        assert isinstance(lookup, CursivePosBuilder)
         lookup.add_attachment(
             location,
             glyphclass,
@@ -1418,8 +1568,14 @@ class Builder(object):
         )
 
     # GPOS 4
-    def add_mark_base_pos(self, location, bases, marks):
+    def add_mark_base_pos(
+        self,
+        location: FeatureLibLocation,
+        bases: Sequence[str],
+        marks: Sequence[Tuple[Anchor, MarkClass]],
+    ):
         builder = self.get_lookup_(location, MarkBasePosBuilder)
+        assert isinstance(builder, MarkBasePosBuilder)
         self.add_marks_(location, builder, marks)
         if not bases:
             raise FeatureLibError("Empty glyph class in positioning rule", location)
@@ -1429,8 +1585,14 @@ class Builder(object):
                 builder.bases.setdefault(base, {})[markClass.name] = otBaseAnchor
 
     # GPOS 5
-    def add_mark_lig_pos(self, location, ligatures, components):
+    def add_mark_lig_pos(
+        self,
+        location: FeatureLibLocation,
+        ligatures: Sequence[str],
+        components: Sequence[Sequence[Tuple[Anchor, MarkClass]]],
+    ):
         builder = self.get_lookup_(location, MarkLigPosBuilder)
+        assert isinstance(builder, MarkLigPosBuilder)
         componentAnchors = []
         if not ligatures:
             raise FeatureLibError("Empty glyph class in positioning rule", location)
@@ -1444,8 +1606,14 @@ class Builder(object):
             builder.ligatures[glyph] = componentAnchors
 
     # GPOS 6
-    def add_mark_mark_pos(self, location, baseMarks, marks):
+    def add_mark_mark_pos(
+        self,
+        location: FeatureLibLocation,
+        baseMarks: Sequence[str],
+        marks: Sequence[Tuple[Anchor, MarkClass]],
+    ):
         builder = self.get_lookup_(location, MarkMarkPosBuilder)
+        assert isinstance(builder, MarkMarkPosBuilder)
         self.add_marks_(location, builder, marks)
         if not baseMarks:
             raise FeatureLibError("Empty glyph class in positioning rule", location)
@@ -1457,21 +1625,40 @@ class Builder(object):
                 ] = otBaseAnchor
 
     # GPOS 7/8
-    def add_chain_context_pos(self, location, prefix, glyphs, suffix, lookups):
+    def add_chain_context_pos(
+        self,
+        location: FeatureLibLocation,
+        prefix: Sequence[Sequence[str]],
+        glyphs: Sequence[Sequence[str]],
+        suffix: Sequence[Sequence[str]],
+        lookups: ContextualLookupList,
+    ):
         if not all(glyphs) or not all(prefix) or not all(suffix):
-            raise FeatureLibError("Empty glyph class in contextual positioning rule", location)
+            raise FeatureLibError(
+                "Empty glyph class in contextual positioning rule", location
+            )
         lookup = self.get_lookup_(location, ChainContextPosBuilder)
+        assert isinstance(lookup, ChainContextPosBuilder)
         lookup.rules.append(
             ChainContextualRule(
                 prefix, glyphs, suffix, self.find_lookup_builders_(lookups)
             )
         )
 
-    def add_single_pos_chained_(self, location, prefix, suffix, pos):
+    def add_single_pos_chained_(
+        self,
+        location: FeatureLibLocation,
+        prefix: Sequence[Sequence[str]],
+        suffix: Sequence[Sequence[str]],
+        pos: Sequence[Tuple[str, ValueRecord]],
+    ):
         if not pos or not all(prefix) or not all(suffix):
-            raise FeatureLibError("Empty glyph class in contextual positioning rule", location)
+            raise FeatureLibError(
+                "Empty glyph class in contextual positioning rule", location
+            )
         # https://github.com/fonttools/fonttools/issues/514
         chain = self.get_lookup_(location, ChainContextPosBuilder)
+        assert isinstance(chain, ChainContextPosBuilder)
         targets = []
         for _, _, _, lookups in chain.rules:
             targets.extend(lookups)
@@ -1480,7 +1667,9 @@ class Builder(object):
             if value is None:
                 subs.append(None)
                 continue
-            otValue = self.makeOpenTypeValueRecord(location, value, pairPosContext=False)
+            otValue = self.makeOpenTypeValueRecord(
+                location, value, pairPosContext=False
+            )
             sub = chain.find_chainable_single_pos(targets, glyphs, otValue)
             if sub is None:
                 sub = self.get_chained_lookup_(location, SinglePosBuilder)
@@ -1493,13 +1682,23 @@ class Builder(object):
             ChainContextualRule(prefix, [g for g, v in pos], suffix, subs)
         )
 
-    def add_marks_(self, location, lookupBuilder, marks):
+    def add_marks_(
+        self,
+        location: FeatureLibLocation,
+        lookupBuilder: otl.LookupBuilder,
+        marks: Sequence[Tuple[Anchor, MarkClass]],
+    ):
         """Helper for add_mark_{base,liga,mark}_pos."""
+        assert isinstance(
+            lookupBuilder, (MarkBasePosBuilder, MarkLigPosBuilder, MarkMarkPosBuilder)
+        )
         for _, markClass in marks:
             for markClassDef in markClass.definitions:
                 for mark in markClassDef.glyphs.glyphSet():
                     if mark not in lookupBuilder.marks:
-                        otMarkAnchor = self.makeOpenTypeAnchor(location, markClassDef.anchor)
+                        otMarkAnchor = self.makeOpenTypeAnchor(
+                            location, markClassDef.anchor
+                        )
                         lookupBuilder.marks[mark] = (markClass.name, otMarkAnchor)
                     else:
                         existingMarkClass = lookupBuilder.marks[mark][0]
@@ -1513,7 +1712,7 @@ class Builder(object):
     def add_subtable_break(self, location):
         self.cur_lookup_.add_subtable_break(location)
 
-    def setGlyphClass_(self, location, glyph, glyphClass):
+    def setGlyphClass_(self, location: FeatureLibLocation, glyph: str, glyphClass: int):
         oldClass, oldLocation = self.glyphClassDefs_.get(glyph, (None, None))
         if oldClass and oldClass != glyphClass:
             raise FeatureLibError(
@@ -1524,7 +1723,12 @@ class Builder(object):
         self.glyphClassDefs_[glyph] = (glyphClass, location)
 
     def add_glyphClassDef(
-        self, location, baseGlyphs, ligatureGlyphs, markGlyphs, componentGlyphs
+        self,
+        location: FeatureLibLocation,
+        baseGlyphs: Sequence[str],
+        ligatureGlyphs: Sequence[str],
+        markGlyphs: Sequence[str],
+        componentGlyphs: Sequence[str],
     ):
         for glyph in baseGlyphs:
             self.setGlyphClass_(location, glyph, 1)
@@ -1535,12 +1739,16 @@ class Builder(object):
         for glyph in componentGlyphs:
             self.setGlyphClass_(location, glyph, 4)
 
-    def add_ligatureCaretByIndex_(self, location, glyphs, carets):
+    def add_ligatureCaretByIndex_(
+        self, location: FeatureLibLocation, glyphs: Sequence[str], carets: Set[int]
+    ):
         for glyph in glyphs:
             if glyph not in self.ligCaretPoints_:
                 self.ligCaretPoints_[glyph] = carets
 
-    def add_ligatureCaretByPos_(self, location, glyphs, carets):
+    def add_ligatureCaretByPos_(
+        self, location: FeatureLibLocation, glyphs: Sequence[str], carets: Set[int]
+    ):
         for glyph in glyphs:
             if glyph not in self.ligCaretCoords_:
                 self.ligCaretCoords_[glyph] = carets
@@ -1548,7 +1756,7 @@ class Builder(object):
     def add_name_record(self, location, nameID, platformID, platEncID, langID, string):
         self.names_.append([nameID, platformID, platEncID, langID, string])
 
-    def add_os2_field(self, key, value):
+    def add_os2_field(self, key, value) -> None:
         self.os2_[key] = value
 
     def add_hhea_field(self, key, value):
@@ -1557,7 +1765,7 @@ class Builder(object):
     def add_vhea_field(self, key, value):
         self.vhea_[key] = value
 
-    def add_conditionset(self, key, value):
+    def add_conditionset(self, key: str, value: Dict[str, Tuple[float, float]]):
         if not "fvar" in self.font:
             raise FeatureLibError(
                 "Cannot add feature variations to a font without an 'fvar' table"
@@ -1579,7 +1787,7 @@ class Builder(object):
 
         self.conditionsets_[key] = value
 
-    def makeOpenTypeAnchor(self, location, anchor):
+    def makeOpenTypeAnchor(self, location: FeatureLibLocation, anchor: Anchor):
         """ast.Anchor --> otTables.Anchor"""
         if anchor is None or anchor.isNull():
             return None
@@ -1592,11 +1800,15 @@ class Builder(object):
         for dim in ("x", "y"):
             if not isinstance(getattr(anchor, dim), VariableScalar):
                 continue
-            if getattr(anchor, dim+"DeviceTable") is not None:
-                raise FeatureLibError("Can't define a device coordinate and variable scalar", location)
+            if getattr(anchor, dim + "DeviceTable") is not None:
+                raise FeatureLibError(
+                    "Can't define a device coordinate and variable scalar", location
+                )
             if not self.varstorebuilder:
-                raise FeatureLibError("Can't define a variable scalar in a non-variable font", location)
-            varscalar = getattr(anchor,dim)
+                raise FeatureLibError(
+                    "Can't define a variable scalar in a non-variable font", location
+                )
+            varscalar = getattr(anchor, dim)
             varscalar.axes = self.axes
             default, index = varscalar.add_to_variation_store(self.varstorebuilder)
             setattr(anchor, dim, default)
@@ -1607,7 +1819,9 @@ class Builder(object):
                     deviceY = buildVarDevTable(index)
                 variable = True
 
-        otlanchor = otl.buildAnchor(anchor.x, anchor.y, anchor.contourpoint, deviceX, deviceY)
+        otlanchor = otl.buildAnchor(
+            anchor.x, anchor.y, anchor.contourpoint, deviceX, deviceY
+        )
         if variable:
             otlanchor.Format = 3
         return otlanchor
@@ -1618,8 +1832,12 @@ class Builder(object):
         if not name.startswith("Reserved")
     }
 
-
-    def makeOpenTypeValueRecord(self, location, v, pairPosContext):
+    def makeOpenTypeValueRecord(
+        self,
+        location: FeatureLibLocation,
+        v: Optional[ValueRecord],
+        pairPosContext: bool,
+    ) -> Optional[otBase.ValueRecord]:
         """ast.ValueRecord --> otBase.ValueRecord"""
         if not v:
             return None
@@ -1636,9 +1854,14 @@ class Builder(object):
                 otDeviceName = otName[0:4] + "Device"
                 feaDeviceName = otDeviceName[0].lower() + otDeviceName[1:]
                 if getattr(v, feaDeviceName):
-                    raise FeatureLibError("Can't define a device coordinate and variable scalar", location)
+                    raise FeatureLibError(
+                        "Can't define a device coordinate and variable scalar", location
+                    )
                 if not self.varstorebuilder:
-                    raise FeatureLibError("Can't define a variable scalar in a non-variable font", location)
+                    raise FeatureLibError(
+                        "Can't define a variable scalar in a non-variable font",
+                        location,
+                    )
                 val.axes = self.axes
                 default, index = val.add_to_variation_store(self.varstorebuilder)
                 vr[otName] = default

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1765,10 +1765,16 @@ class Builder(object):
     def add_vhea_field(self, key, value):
         self.vhea_[key] = value
 
-    def add_conditionset(self, key: str, value: Dict[str, Tuple[float, float]]):
+    def add_conditionset(
+        self,
+        location: FeatureLibLocation,
+        key: str,
+        value: Dict[str, Tuple[float, float]],
+    ):
         if not "fvar" in self.font:
             raise FeatureLibError(
-                "Cannot add feature variations to a font without an 'fvar' table"
+                "Cannot add feature variations to a font without an 'fvar' table",
+                location,
             )
 
         # Normalize

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1,8 +1,10 @@
 from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.lexer import Lexer, IncludingLexer, NonIncludingLexer
+from fontTools.feaLib.location import FeatureLibLocation
 from fontTools.feaLib.variableScalar import VariableScalar
 from fontTools.misc.encodingTools import getEncoding
 from fontTools.misc.textTools import bytechr, tobytes, tostr
+from typing import Callable, Dict, Sequence, List, Tuple, Optional, Union, Set
 import fontTools.feaLib.ast as ast
 import logging
 import os
@@ -37,13 +39,18 @@ class Parser(object):
     in.
     """
 
-    extensions = {}
+    extensions: Dict[str, Callable] = {}
     ast = ast
     SS_FEATURE_TAGS = {"ss%02d" % i for i in range(1, 20 + 1)}
     CV_FEATURE_TAGS = {"cv%02d" % i for i in range(1, 99 + 1)}
 
     def __init__(
-        self, featurefile, glyphNames=(), followIncludes=True, includeDir=None, **kwargs
+        self,
+        featurefile,
+        glyphNames: Sequence[str] = (),
+        followIncludes=True,
+        includeDir=None,
+        **kwargs,
     ):
 
         if "glyphMap" in kwargs:
@@ -68,21 +75,24 @@ class Parser(object):
         self.lookups_ = SymbolTable()
         self.valuerecords_ = SymbolTable()
         self.symbol_tables_ = {self.anchors_, self.valuerecords_}
-        self.next_token_type_, self.next_token_ = (None, None)
-        self.cur_comments_ = []
+        self.next_token_type_: Optional[str] = None
+        self.next_token_: Optional[str] = None
+        self.cur_token_: Optional[str] = None  # Usually
+        self.cur_comments_: List[Tuple[str, FeatureLibLocation]] = []
         self.next_token_location_ = None
         lexerClass = IncludingLexer if followIncludes else NonIncludingLexer
         self.lexer_ = lexerClass(featurefile, includeDir=includeDir)
-        self.missing = {}
+        self.missing: Dict[str, FeatureLibLocation] = {}
         self.advance_lexer_(comments=True)
 
-    def parse(self):
+    def parse(self) -> ast.FeatureFile:
         """Parse the file, and return a :class:`fontTools.feaLib.ast.FeatureFile`
         object representing the root of the abstract syntax tree containing the
         parsed contents of the file."""
         statements = self.doc_.statements
         while self.next_token_type_ is not None or self.cur_comments_:
             self.advance_lexer_(comments=True)
+            assert self.cur_token_ is not None
             if self.cur_token_type_ is Lexer.COMMENT:
                 statements.append(
                     self.ast.Comment(self.cur_token_, location=self.cur_token_location_)
@@ -134,11 +144,12 @@ class Parser(object):
             ]
             raise FeatureLibError(
                 "The following glyph names are referenced but are missing from the "
-                "glyph set:\n" + ("\n".join(error)), None
+                "glyph set:\n" + ("\n".join(error)),
+                None,
             )
         return self.doc_
 
-    def parse_anchor_(self):
+    def parse_anchor_(self) -> ast.Anchor:
         # Parses an anchor in any of the four formats given in the feature
         # file specification (2.e.vii).
         self.expect_symbol_("<")
@@ -168,12 +179,12 @@ class Parser(object):
                 location=location,
             )
 
-        x, y = self.expect_number_(variable=True), self.expect_number_(variable=True)
+        x, y = self.expect_number_or_variable_(), self.expect_number_or_variable_()
 
         contourpoint = None
         if self.next_token_ == "contourpoint":  # Format B
             self.expect_keyword_("contourpoint")
-            contourpoint = self.expect_number_()
+            contourpoint = int(self.expect_number_())
 
         if self.next_token_ == "<":  # Format C
             xDeviceTable = self.parse_device_()
@@ -192,19 +203,21 @@ class Parser(object):
             location=location,
         )
 
-    def parse_anchor_marks_(self):
+    def parse_anchor_marks_(
+        self,
+    ) -> List[Tuple[ast.Anchor, ast.MarkClass]]:
         # Parses a sequence of ``[<anchor> mark @MARKCLASS]*.``
-        anchorMarks = []  # [(self.ast.Anchor, markClassName)*]
+        anchorMarks = []  # [(self.ast.Anchor, markClass)*]
         while self.next_token_ == "<":
             anchor = self.parse_anchor_()
-            if anchor is None and self.next_token_ != "mark":
+            if anchor.isNull() and self.next_token_ != "mark":
                 continue  # <anchor NULL> without mark, eg. in GPOS type 5
             self.expect_keyword_("mark")
             markClass = self.expect_markClass_reference_()
             anchorMarks.append((anchor, markClass))
         return anchorMarks
 
-    def parse_anchordef_(self):
+    def parse_anchordef_(self) -> ast.AnchorDefinition:
         # Parses a named anchor definition (`section 2.e.viii <https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#2.e.vii>`_).
         assert self.is_cur_keyword_("anchorDef")
         location = self.cur_token_location_
@@ -221,7 +234,7 @@ class Parser(object):
         self.anchors_.define(name, anchordef)
         return anchordef
 
-    def parse_anonymous_(self):
+    def parse_anonymous_(self) -> ast.AnonymousBlock:
         # Parses an anonymous data block (`section 10 <https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#10>`_).
         assert self.is_cur_keyword_(("anon", "anonymous"))
         tag = self.expect_tag_()
@@ -233,24 +246,24 @@ class Parser(object):
         self.expect_symbol_(";")
         return self.ast.AnonymousBlock(tag, content, location=location)
 
-    def parse_attach_(self):
+    def parse_attach_(self) -> ast.AttachStatement:
         # Parses a GDEF Attach statement (`section 9.b <https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#9.b>`_)
         assert self.is_cur_keyword_("Attach")
         location = self.cur_token_location_
         glyphs = self.parse_glyphclass_(accept_glyphname=True)
-        contourPoints = {self.expect_number_()}
+        contourPoints = {int(self.expect_number_())}
         while self.next_token_ != ";":
-            contourPoints.add(self.expect_number_())
+            contourPoints.add(int(self.expect_number_()))
         self.expect_symbol_(";")
         return self.ast.AttachStatement(glyphs, contourPoints, location=location)
 
-    def parse_enumerate_(self, vertical):
+    def parse_enumerate_(self, vertical) -> ast.Statement:
         # Parse an enumerated pair positioning rule (`section 6.b.ii <https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#6.b.ii>`_).
         assert self.cur_token_ in {"enumerate", "enum"}
         self.advance_lexer_()
         return self.parse_position_(enumerated=True, vertical=vertical)
 
-    def parse_GlyphClassDef_(self):
+    def parse_GlyphClassDef_(self) -> ast.GlyphClassDefStatement:
         # Parses 'GlyphClassDef @BASE, @LIGATURES, @MARKS, @COMPONENTS;'
         assert self.is_cur_keyword_("GlyphClassDef")
         location = self.cur_token_location_
@@ -278,9 +291,10 @@ class Parser(object):
             baseGlyphs, markGlyphs, ligatureGlyphs, componentGlyphs, location=location
         )
 
-    def parse_glyphclass_definition_(self):
+    def parse_glyphclass_definition_(self) -> ast.GlyphClassDefinition:
         # Parses glyph class definitions such as '@UPPERCASE = [A-Z];'
         location, name = self.cur_token_location_, self.cur_token_
+        assert name is not None
         self.expect_symbol_("=")
         glyphs = self.parse_glyphclass_(accept_glyphname=False)
         self.expect_symbol_(";")
@@ -288,7 +302,9 @@ class Parser(object):
         self.glyphclasses_.define(name, glyphclass)
         return glyphclass
 
-    def split_glyph_range_(self, name, location):
+    def split_glyph_range_(
+        self, name: str, location: FeatureLibLocation
+    ) -> Tuple[str, str]:
         # Since v1.20, the OpenType Feature File specification allows
         # for dashes in glyph names. A sequence like "a-b-c-d" could
         # therefore mean a single glyph whose name happens to be
@@ -330,7 +346,9 @@ class Parser(object):
                 location,
             )
 
-    def parse_glyphclass_(self, accept_glyphname, accept_null=False):
+    def parse_glyphclass_(
+        self, accept_glyphname: bool, accept_null=False
+    ) -> Union[ast.NullGlyph, ast.NamedOrInlineClass, ast.GlyphName]:
         # Parses a glyph class, either named or anonymous, or (if
         # ``bool(accept_glyphname)``) a glyph name. If ``bool(accept_null)`` then
         # also accept the special NULL glyph.
@@ -392,11 +410,12 @@ class Parser(object):
                 glyph = self.expect_glyph_()
                 if self.next_token_ == "-":
                     range_location = self.cur_token_location_
-                    range_start = self.cur_token_
+                    range_start = int(self.cur_token_)  # type: ignore
                     self.expect_symbol_("-")
                     range_end = self.expect_cid_()
                     self.check_glyph_name_in_glyph_set(
-                        f"cid{range_start:05d}", f"cid{range_end:05d}",
+                        f"cid{range_start:05d}",
+                        f"cid{range_end:05d}",
                     )
                     glyphs.add_cid_range(
                         range_start,
@@ -429,13 +448,26 @@ class Parser(object):
         self.expect_symbol_("]")
         return glyphs
 
-    def parse_glyph_pattern_(self, vertical):
+    def parse_glyph_pattern_(
+        self, vertical
+    ) -> Tuple[
+        List[ast.GlyphContainer],
+        List[ast.GlyphContainer],
+        ast.ContextualLookupList,
+        List[Optional[ast.ValueRecord]],
+        List[ast.GlyphContainer],
+        bool,
+    ]:
         # Parses a glyph pattern, including lookups and context, e.g.::
         #
         #    a b
         #    a b c' d e
         #    a b c' lookup ChangeC d e
-        prefix, glyphs, lookups, values, suffix = ([], [], [], [], [])
+        prefix: List[ast.GlyphContainer] = []
+        glyphs: List[ast.GlyphContainer] = []
+        lookups = []
+        values: List[Optional[ast.ValueRecord]] = []
+        suffix: List[ast.GlyphContainer] = []
         hasMarks = False
         while self.next_token_ not in {"by", "from", ";", ","}:
             gc = self.parse_glyphclass_(accept_glyphname=True)
@@ -522,7 +554,18 @@ class Parser(object):
                 )
             return (prefix, glyphs, lookups, values, suffix, hasMarks)
 
-    def parse_chain_context_(self):
+    def parse_chain_context_(
+        self,
+    ) -> Tuple[
+        List[
+            Tuple[
+                List[ast.GlyphContainer],
+                List[ast.GlyphContainer],
+                List[ast.GlyphContainer],
+            ]
+        ],
+        bool,
+    ]:
         location = self.cur_token_location_
         prefix, glyphs, lookups, values, suffix, hasMarks = self.parse_glyph_pattern_(
             vertical=False
@@ -544,7 +587,7 @@ class Parser(object):
         self.expect_symbol_(";")
         return chainContext, hasLookups
 
-    def parse_ignore_(self):
+    def parse_ignore_(self) -> ast.IgnoreStatement:
         # Parses an ignore sub/pos rule.
         assert self.is_cur_keyword_("ignore")
         location = self.cur_token_location_
@@ -567,14 +610,14 @@ class Parser(object):
             'Expected "substitute" or "position"', self.cur_token_location_
         )
 
-    def parse_include_(self):
+    def parse_include_(self) -> ast.IncludeStatement:
         assert self.cur_token_ == "include"
         location = self.cur_token_location_
         filename = self.expect_filename_()
         # self.expect_symbol_(";")
         return ast.IncludeStatement(filename, location=location)
 
-    def parse_language_(self):
+    def parse_language_(self) -> ast.LanguageStatement:
         assert self.is_cur_keyword_("language")
         location = self.cur_token_location_
         language = self.expect_language_tag_()
@@ -589,7 +632,7 @@ class Parser(object):
             language, include_default, required, location=location
         )
 
-    def parse_ligatureCaretByIndex_(self):
+    def parse_ligatureCaretByIndex_(self) -> ast.LigatureCaretByIndexStatement:
         assert self.is_cur_keyword_("LigatureCaretByIndex")
         location = self.cur_token_location_
         glyphs = self.parse_glyphclass_(accept_glyphname=True)
@@ -599,7 +642,7 @@ class Parser(object):
         self.expect_symbol_(";")
         return self.ast.LigatureCaretByIndexStatement(glyphs, carets, location=location)
 
-    def parse_ligatureCaretByPos_(self):
+    def parse_ligatureCaretByPos_(self) -> ast.LigatureCaretByPosStatement:
         assert self.is_cur_keyword_("LigatureCaretByPos")
         location = self.cur_token_location_
         glyphs = self.parse_glyphclass_(accept_glyphname=True)
@@ -609,7 +652,9 @@ class Parser(object):
         self.expect_symbol_(";")
         return self.ast.LigatureCaretByPosStatement(glyphs, carets, location=location)
 
-    def parse_lookup_(self, vertical):
+    def parse_lookup_(
+        self, vertical
+    ) -> Union[ast.LookupReferenceStatement, ast.LookupBlock]:
         # Parses a ``lookup`` - either a lookup block, or a lookup reference
         # inside a feature.
         assert self.is_cur_keyword_("lookup")
@@ -634,7 +679,7 @@ class Parser(object):
         self.lookups_.define(name, block)
         return block
 
-    def parse_lookupflag_(self):
+    def parse_lookupflag_(self) -> ast.LookupFlagStatement:
         # Parses a ``lookupflag`` statement, either specified by number or
         # in words.
         assert self.is_cur_keyword_("lookupflag")
@@ -655,11 +700,16 @@ class Parser(object):
             "IgnoreLigatures": 4,
             "IgnoreMarks": 8,
         }
-        seen = set()
+        seen: Set[str] = set()
         while self.next_token_ != ";":
             if self.next_token_ in seen:
                 raise FeatureLibError(
                     "%s can be specified only once" % self.next_token_,
+                    self.next_token_location_,
+                )
+            if self.next_token_ is None:
+                raise FeatureLibError(
+                    "End of file while parsing lookupflag",
                     self.next_token_location_,
                 )
             seen.add(self.next_token_)
@@ -691,12 +741,14 @@ class Parser(object):
             location=location,
         )
 
-    def parse_markClass_(self):
+    def parse_markClass_(self) -> ast.MarkClassDefinition:
         assert self.is_cur_keyword_("markClass")
         location = self.cur_token_location_
         glyphs = self.parse_glyphclass_(accept_glyphname=True)
         if not glyphs.glyphSet():
-            raise FeatureLibError("Empty glyph class in mark class definition", location)
+            raise FeatureLibError(
+                "Empty glyph class in mark class definition", location
+            )
         anchor = self.parse_anchor_()
         name = self.expect_class_name_()
         self.expect_symbol_(";")
@@ -711,7 +763,7 @@ class Parser(object):
         markClass.addDefinition(mcdef)
         return mcdef
 
-    def parse_position_(self, enumerated, vertical):
+    def parse_position_(self, enumerated, vertical) -> ast.Statement:
         assert self.cur_token_ in {"position", "pos"}
         if self.next_token_ == "cursive":  # GPOS type 3
             return self.parse_position_cursive_(enumerated, vertical)
@@ -743,6 +795,7 @@ class Parser(object):
         if not prefix and not suffix and len(glyphs) == 2 and not hasMarks:
             if values[0] is None:  # Format B: "pos V A -20;"
                 values.reverse()
+                assert values[0]
             return self.ast.PairPosStatement(
                 glyphs[0],
                 values[0],
@@ -764,7 +817,7 @@ class Parser(object):
             location=location,
         )
 
-    def parse_position_cursive_(self, enumerated, vertical):
+    def parse_position_cursive_(self, enumerated, vertical) -> ast.CursivePosStatement:
         location = self.cur_token_location_
         self.expect_keyword_("cursive")
         if enumerated:
@@ -780,7 +833,7 @@ class Parser(object):
             glyphclass, entryAnchor, exitAnchor, location=location
         )
 
-    def parse_position_base_(self, enumerated, vertical):
+    def parse_position_base_(self, enumerated, vertical) -> ast.MarkBasePosStatement:
         location = self.cur_token_location_
         self.expect_keyword_("base")
         if enumerated:
@@ -794,7 +847,7 @@ class Parser(object):
         self.expect_symbol_(";")
         return self.ast.MarkBasePosStatement(base, marks, location=location)
 
-    def parse_position_ligature_(self, enumerated, vertical):
+    def parse_position_ligature_(self, enumerated, vertical) -> ast.MarkLigPosStatement:
         location = self.cur_token_location_
         self.expect_keyword_("ligature")
         if enumerated:
@@ -811,7 +864,7 @@ class Parser(object):
         self.expect_symbol_(";")
         return self.ast.MarkLigPosStatement(ligatures, marks, location=location)
 
-    def parse_position_mark_(self, enumerated, vertical):
+    def parse_position_mark_(self, enumerated, vertical) -> ast.MarkMarkPosStatement:
         location = self.cur_token_location_
         self.expect_keyword_("mark")
         if enumerated:
@@ -825,13 +878,13 @@ class Parser(object):
         self.expect_symbol_(";")
         return self.ast.MarkMarkPosStatement(baseMarks, marks, location=location)
 
-    def parse_script_(self):
+    def parse_script_(self) -> ast.ScriptStatement:
         assert self.is_cur_keyword_("script")
         location, script = self.cur_token_location_, self.expect_script_tag_()
         self.expect_symbol_(";")
         return self.ast.ScriptStatement(script, location=location)
 
-    def parse_substitute_(self):
+    def parse_substitute_(self) -> ast.Statement:
         assert self.cur_token_ in {"substitute", "sub", "reversesub", "rsub"}
         location = self.cur_token_location_
         reverse = self.cur_token_ in {"reversesub", "rsub"}
@@ -936,9 +989,9 @@ class Parser(object):
                     raise FeatureLibError("Empty class in replacement", location)
             return self.ast.MultipleSubstStatement(
                 old_prefix,
-                tuple(old[0].glyphSet())[0],
+                self.ast.GlyphName(tuple(old[0].glyphSet())[0]),
                 old_suffix,
-                tuple([list(n.glyphSet())[0] for n in new]),
+                new,
                 forceChain=hasMarks,
                 location=location,
             )
@@ -1012,13 +1065,13 @@ class Parser(object):
         )
         return rule
 
-    def parse_subtable_(self):
+    def parse_subtable_(self) -> ast.SubtableStatement:
         assert self.is_cur_keyword_("subtable")
         location = self.cur_token_location_
         self.expect_symbol_(";")
         return self.ast.SubtableStatement(location=location)
 
-    def parse_size_parameters_(self):
+    def parse_size_parameters_(self) -> ast.SizeParameters:
         # Parses a ``parameters`` statement used in ``size`` features. See
         # `section 8.b <https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#8.b>`_.
         assert self.is_cur_keyword_("parameters")
@@ -1036,7 +1089,7 @@ class Parser(object):
             DesignSize, SubfamilyID, RangeStart, RangeEnd, location=location
         )
 
-    def parse_size_menuname_(self):
+    def parse_size_menuname_(self) -> ast.FeatureNameStatement:
         assert self.is_cur_keyword_("sizemenuname")
         location = self.cur_token_location_
         platformID, platEncID, langID, string = self.parse_name_()
@@ -1044,7 +1097,7 @@ class Parser(object):
             "size", platformID, platEncID, langID, string, location=location
         )
 
-    def parse_table_(self):
+    def parse_table_(self) -> ast.TableBlock:
         assert self.is_cur_keyword_("table")
         location, name = self.cur_token_location_, self.expect_tag_()
         table = self.ast.TableBlock(name, location=location)
@@ -1074,11 +1127,12 @@ class Parser(object):
         self.expect_symbol_(";")
         return table
 
-    def parse_table_GDEF_(self, table):
+    def parse_table_GDEF_(self, table: ast.TableBlock) -> None:
         statements = table.statements
         while self.next_token_ != "}" or self.cur_comments_:
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
+                assert self.cur_token_ is not None
                 statements.append(
                     self.ast.Comment(self.cur_token_, location=self.cur_token_location_)
                 )
@@ -1098,11 +1152,12 @@ class Parser(object):
                     self.cur_token_location_,
                 )
 
-    def parse_table_head_(self, table):
+    def parse_table_head_(self, table: ast.TableBlock) -> None:
         statements = table.statements
         while self.next_token_ != "}" or self.cur_comments_:
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
+                assert self.cur_token_ is not None
                 statements.append(
                     self.ast.Comment(self.cur_token_, location=self.cur_token_location_)
                 )
@@ -1113,12 +1168,13 @@ class Parser(object):
             else:
                 raise FeatureLibError("Expected FontRevision", self.cur_token_location_)
 
-    def parse_table_hhea_(self, table):
+    def parse_table_hhea_(self, table: ast.TableBlock) -> None:
         statements = table.statements
         fields = ("CaretOffset", "Ascender", "Descender", "LineGap")
         while self.next_token_ != "}" or self.cur_comments_:
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
+                assert self.cur_token_ is not None
                 statements.append(
                     self.ast.Comment(self.cur_token_, location=self.cur_token_location_)
                 )
@@ -1140,12 +1196,13 @@ class Parser(object):
                     self.cur_token_location_,
                 )
 
-    def parse_table_vhea_(self, table):
+    def parse_table_vhea_(self, table: ast.TableBlock) -> None:
         statements = table.statements
         fields = ("VertTypoAscender", "VertTypoDescender", "VertTypoLineGap")
         while self.next_token_ != "}" or self.cur_comments_:
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
+                assert self.cur_token_ is not None
                 statements.append(
                     self.ast.Comment(self.cur_token_, location=self.cur_token_location_)
                 )
@@ -1168,11 +1225,12 @@ class Parser(object):
                     self.cur_token_location_,
                 )
 
-    def parse_table_name_(self, table):
+    def parse_table_name_(self, table: ast.TableBlock) -> None:
         statements = table.statements
         while self.next_token_ != "}" or self.cur_comments_:
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
+                assert self.cur_token_ is not None
                 statements.append(
                     self.ast.Comment(self.cur_token_, location=self.cur_token_location_)
                 )
@@ -1185,7 +1243,7 @@ class Parser(object):
             else:
                 raise FeatureLibError("Expected nameid", self.cur_token_location_)
 
-    def parse_name_(self):
+    def parse_name_(self) -> Tuple[int, int, int, str]:
         """Parses a name record. See `section 9.e <https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#9.e>`_."""
         platEncID = None
         langID = None
@@ -1217,7 +1275,7 @@ class Parser(object):
         unescaped = self.unescape_string_(string, encoding)
         return platformID, platEncID, langID, unescaped
 
-    def parse_stat_name_(self):
+    def parse_stat_name_(self) -> Tuple[int, int, int, str]:
         platEncID = None
         langID = None
         if self.next_token_type_ in Lexer.NUMBERS:
@@ -1246,7 +1304,7 @@ class Parser(object):
         unescaped = self.unescape_string_(string, encoding)
         return platformID, platEncID, langID, unescaped
 
-    def parse_nameid_(self):
+    def parse_nameid_(self) -> ast.NameRecord:
         assert self.cur_token_ == "nameid", self.cur_token_
         location, nameID = self.cur_token_location_, self.expect_any_number_()
         if nameID > 32767:
@@ -1280,11 +1338,12 @@ class Parser(object):
         n = match.group(0)[1:]
         return bytechr(int(n, 16)).decode(encoding)
 
-    def parse_table_BASE_(self, table):
+    def parse_table_BASE_(self, table: ast.TableBlock) -> None:
         statements = table.statements
         while self.next_token_ != "}" or self.cur_comments_:
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
+                assert self.cur_token_ is not None
                 statements.append(
                     self.ast.Comment(self.cur_token_, location=self.cur_token_location_)
                 )
@@ -1316,6 +1375,7 @@ class Parser(object):
                 continue
 
     def parse_table_OS_2_(self, table):
+        # No type checking here as the type of "value" is nasty
         statements = table.statements
         numbers = (
             "FSType",
@@ -1335,6 +1395,7 @@ class Parser(object):
         while self.next_token_ != "}" or self.cur_comments_:
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
+                assert self.cur_token_ is not None
                 statements.append(
                     self.ast.Comment(self.cur_token_, location=self.cur_token_location_)
                 )
@@ -1359,7 +1420,7 @@ class Parser(object):
             elif self.cur_token_ == ";":
                 continue
 
-    def parse_STAT_ElidedFallbackName(self):
+    def parse_STAT_ElidedFallbackName(self) -> List[ast.STATNameStatement]:
         assert self.is_cur_keyword_("ElidedFallbackName")
         self.expect_symbol_("{")
         names = []
@@ -1603,12 +1664,12 @@ class Parser(object):
             or self.next_token_ == "("
         )
 
-    def parse_valuerecord_(self, vertical):
+    def parse_valuerecord_(self, vertical) -> ast.ValueRecord:
         if (
             self.next_token_type_ is Lexer.SYMBOL and self.next_token_ == "("
         ) or self.next_token_type_ is Lexer.NUMBER:
             number, location = (
-                self.expect_number_(variable=True),
+                self.expect_number_or_variable_(),
                 self.cur_token_location_,
             )
             if vertical:
@@ -1637,10 +1698,10 @@ class Parser(object):
             xAdvance, yAdvance = (value.xAdvance, value.yAdvance)
         else:
             xPlacement, yPlacement, xAdvance, yAdvance = (
-                self.expect_number_(variable=True),
-                self.expect_number_(variable=True),
-                self.expect_number_(variable=True),
-                self.expect_number_(variable=True),
+                self.expect_number_or_variable_(),
+                self.expect_number_or_variable_(),
+                self.expect_number_or_variable_(),
+                self.expect_number_or_variable_(),
             )
 
         if self.next_token_ == "<":
@@ -1902,12 +1963,12 @@ class Parser(object):
             if self.next_token_type_ is Lexer.FLOAT:
                 min_value = self.expect_float_()
             elif self.next_token_type_ is Lexer.NUMBER:
-                min_value = self.expect_number_(variable=False)
+                min_value = self.expect_number_()
 
             if self.next_token_type_ is Lexer.FLOAT:
                 max_value = self.expect_float_()
             elif self.next_token_type_ is Lexer.NUMBER:
-                max_value = self.expect_number_(variable=False)
+                max_value = self.expect_number_()
             self.expect_symbol_(";")
 
             conditions[axis] = (min_value, max_value)
@@ -1921,7 +1982,7 @@ class Parser(object):
 
     def parse_block_(
         self, block, vertical, stylisticset=None, size_feature=False, cv_feature=None
-    ):
+    ) -> None:
         self.expect_symbol_("{")
         for symtab in self.symbol_tables_:
             symtab.enter_scope()
@@ -1930,6 +1991,7 @@ class Parser(object):
         while self.next_token_ != "}" or self.cur_comments_:
             self.advance_lexer_(comments=True)
             if self.cur_token_type_ is Lexer.COMMENT:
+                assert self.cur_token_ is not None
                 statements.append(
                     self.ast.Comment(self.cur_token_, location=self.cur_token_location_)
                 )
@@ -2024,9 +2086,9 @@ class Parser(object):
                         statements.append(
                             self.ast.MultipleSubstStatement(
                                 s.prefix,
-                                glyph,
+                                self.ast.GlyphName(glyph),
                                 s.suffix,
-                                [replacements[i]],
+                                [self.ast.GlyphName(replacements[i])],
                                 s.forceChain,
                                 location=s.location,
                             )
@@ -2035,7 +2097,7 @@ class Parser(object):
                     statements.append(s)
             block.statements = statements
 
-    def is_cur_keyword_(self, k):
+    def is_cur_keyword_(self, k) -> bool:
         if self.cur_token_type_ is Lexer.NAME:
             if isinstance(k, type("")):  # basestring is gone in Python3
                 return self.cur_token_ == k
@@ -2043,27 +2105,30 @@ class Parser(object):
                 return self.cur_token_ in k
         return False
 
-    def expect_class_name_(self):
+    def expect_class_name_(self) -> str:
         self.advance_lexer_()
         if self.cur_token_type_ is not Lexer.GLYPHCLASS:
             raise FeatureLibError("Expected @NAME", self.cur_token_location_)
+        assert self.cur_token_ is not None
         return self.cur_token_
 
-    def expect_cid_(self):
+    def expect_cid_(self) -> int:
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.CID:
-            return self.cur_token_
+            return int(self.cur_token_)  # type: ignore
         raise FeatureLibError("Expected a CID", self.cur_token_location_)
 
-    def expect_filename_(self):
+    def expect_filename_(self) -> str:
         self.advance_lexer_()
         if self.cur_token_type_ is not Lexer.FILENAME:
             raise FeatureLibError("Expected file name", self.cur_token_location_)
+        assert self.cur_token_ is not None
         return self.cur_token_
 
-    def expect_glyph_(self):
+    def expect_glyph_(self) -> str:
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.NAME:
+            assert self.cur_token_ is not None
             self.cur_token_ = self.cur_token_.lstrip("\\")
             if len(self.cur_token_) > 63:
                 raise FeatureLibError(
@@ -2072,10 +2137,11 @@ class Parser(object):
                 )
             return self.cur_token_
         elif self.cur_token_type_ is Lexer.CID:
-            return "cid%05d" % self.cur_token_
+            assert self.cur_token_ is not None
+            return "cid%05d" % self.cur_token_  # type: ignore
         raise FeatureLibError("Expected a glyph name or CID", self.cur_token_location_)
 
-    def check_glyph_name_in_glyph_set(self, *names):
+    def check_glyph_name_in_glyph_set(self, *names) -> None:
         """Adds a glyph name (just `start`) or glyph names of a
         range (`start` and `end`) which are not in the glyph set
         to the "missing list" for future error reporting.
@@ -2089,7 +2155,7 @@ class Parser(object):
                 if name not in self.missing:
                     self.missing[name] = self.cur_token_location_
 
-    def expect_markClass_reference_(self):
+    def expect_markClass_reference_(self) -> ast.MarkClass:
         name = self.expect_class_name_()
         mc = self.glyphclasses_.resolve(name)
         if mc is None:
@@ -2102,17 +2168,18 @@ class Parser(object):
             )
         return mc
 
-    def expect_tag_(self):
+    def expect_tag_(self) -> str:
         self.advance_lexer_()
         if self.cur_token_type_ is not Lexer.NAME:
             raise FeatureLibError("Expected a tag", self.cur_token_location_)
+        assert self.cur_token_ is not None
         if len(self.cur_token_) > 4:
             raise FeatureLibError(
                 "Tags cannot be longer than 4 characters", self.cur_token_location_
             )
         return (self.cur_token_ + "    ")[:4]
 
-    def expect_script_tag_(self):
+    def expect_script_tag_(self) -> str:
         tag = self.expect_tag_()
         if tag == "dflt":
             raise FeatureLibError(
@@ -2121,7 +2188,7 @@ class Parser(object):
             )
         return tag
 
-    def expect_language_tag_(self):
+    def expect_language_tag_(self) -> str:
         tag = self.expect_tag_()
         if tag == "DFLT":
             raise FeatureLibError(
@@ -2130,33 +2197,41 @@ class Parser(object):
             )
         return tag
 
-    def expect_symbol_(self, symbol):
+    def expect_symbol_(self, symbol) -> str:
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.SYMBOL and self.cur_token_ == symbol:
             return symbol
         raise FeatureLibError("Expected '%s'" % symbol, self.cur_token_location_)
 
-    def expect_keyword_(self, keyword):
+    def expect_keyword_(self, keyword) -> str:
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.NAME and self.cur_token_ == keyword:
             return self.cur_token_
         raise FeatureLibError('Expected "%s"' % keyword, self.cur_token_location_)
 
-    def expect_name_(self):
+    def expect_name_(self) -> str:
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.NAME:
+            assert self.cur_token_ is not None
             return self.cur_token_
         raise FeatureLibError("Expected a name", self.cur_token_location_)
 
-    def expect_number_(self, variable=False):
+    def expect_number_or_variable_(self) -> Union[int, VariableScalar]:
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.NUMBER:
-            return self.cur_token_
-        if variable and self.cur_token_type_ is Lexer.SYMBOL and self.cur_token_ == "(":
+            assert self.cur_token_ is not None
+            return self.cur_token_  # type: ignore
+        if self.cur_token_type_ is Lexer.SYMBOL and self.cur_token_ == "(":
             return self.expect_variable_scalar_()
         raise FeatureLibError("Expected a number", self.cur_token_location_)
 
-    def expect_variable_scalar_(self):
+    def expect_number_(self) -> int:
+        self.advance_lexer_()
+        if self.cur_token_type_ is Lexer.NUMBER:
+            return self.cur_token_  # type: ignore
+        raise FeatureLibError("Expected a number", self.cur_token_location_)
+
+    def expect_variable_scalar_(self) -> VariableScalar:
         self.advance_lexer_()  # "("
         scalar = VariableScalar()
         while True:
@@ -2166,12 +2241,13 @@ class Parser(object):
             scalar.add_value(location, value)
         return scalar
 
-    def expect_master_(self):
+    def expect_master_(self) -> Tuple[Dict[str, int], int]:
         location = {}
         while True:
             if self.cur_token_type_ is not Lexer.NAME:
                 raise FeatureLibError("Expected an axis name", self.cur_token_location_)
             axis = self.cur_token_
+            assert axis is not None
             self.advance_lexer_()
             if not (self.cur_token_type_ is Lexer.SYMBOL and self.cur_token_ == "="):
                 raise FeatureLibError(
@@ -2179,6 +2255,11 @@ class Parser(object):
                 )
             value = self.expect_number_()
             location[axis] = value
+            if self.next_token_ is None:
+                raise FeatureLibError(
+                    "End of file while parsing a variable scalar",
+                    self.cur_token_location_,
+                )
             if self.next_token_type_ is Lexer.NAME and self.next_token_[0] == ":":
                 # Lexer has just read the value as a glyph name. We'll correct it later
                 break
@@ -2201,10 +2282,10 @@ class Parser(object):
             "Expected a decimal, hexadecimal or octal number", self.cur_token_location_
         )
 
-    def expect_float_(self):
+    def expect_float_(self) -> float:
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.FLOAT:
-            return self.cur_token_
+            return float(self.cur_token_)  # type: ignore
         raise FeatureLibError(
             "Expected a floating-point number", self.cur_token_location_
         )

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -148,7 +148,7 @@ class Parser(object):
         if self.next_token_ == "NULL":  # Format D
             self.expect_keyword_("NULL")
             self.expect_symbol_(">")
-            return None
+            return self.ast.NullAnchor
 
         if self.next_token_type_ == Lexer.NAME:  # Format E
             name = self.expect_name_()

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1243,7 +1243,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(glyphstr(pos.prefix), "[A a] [B b]")
         self.assertEqual(glyphstr(pos.glyphs), "I [N n] P")
         self.assertEqual(glyphstr(pos.suffix), "[Y y] [Z z]")
-        self.assertEqual(pos.lookups, [[lookup1], [lookup2], None])
+        self.assertEqual(pos.lookups, [[lookup1], [lookup2], []])
 
     def test_gpos_type_8_lookup_with_values(self):
         self.assertRaisesRegex(
@@ -1767,8 +1767,8 @@ class ParserTest(unittest.TestCase):
     def test_substitute_lookups(self):  # GSUB LookupType 6
         doc = Parser(self.getpath("spec5fi1.fea"), GLYPHNAMES).parse()
         [_, _, _, langsys, ligs, sub, feature] = doc.statements
-        self.assertEqual(feature.statements[0].lookups, [[ligs], None, [sub]])
-        self.assertEqual(feature.statements[1].lookups, [[ligs], None, [sub]])
+        self.assertEqual(feature.statements[0].lookups, [[ligs], [], [sub]])
+        self.assertEqual(feature.statements[1].lookups, [[ligs], [], [sub]])
 
     def test_substitute_missing_by(self):
         self.assertRaisesRegex(

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1608,22 +1608,22 @@ class ParserTest(unittest.TestCase):
         doc = self.parse("lookup Look {substitute f_f_i by f f i;} Look;")
         sub = doc.statements[0].statements[0]
         self.assertIsInstance(sub, ast.MultipleSubstStatement)
-        self.assertEqual(sub.glyph, "f_f_i")
-        self.assertEqual(sub.replacement, ("f", "f", "i"))
+        self.assertEqual(sub.glyph.asFea(), "f_f_i")
+        self.assertEqual([x.asFea() for x in sub.replacement], ["f", "f", "i"])
 
     def test_substitute_multiple_chained(self):  # chain to GSUB LookupType 2
         doc = self.parse("lookup L {sub [A-C] f_f_i' [X-Z] by f f i;} L;")
         sub = doc.statements[0].statements[0]
         self.assertIsInstance(sub, ast.MultipleSubstStatement)
-        self.assertEqual(sub.glyph, "f_f_i")
-        self.assertEqual(sub.replacement, ("f", "f", "i"))
+        self.assertEqual(sub.glyph.asFea(), "f_f_i")
+        self.assertEqual([x.asFea() for x in sub.replacement], ["f", "f", "i"])
 
     def test_substitute_multiple_force_chained(self):
         doc = self.parse("lookup L {sub f_f_i' by f f i;} L;")
         sub = doc.statements[0].statements[0]
         self.assertIsInstance(sub, ast.MultipleSubstStatement)
-        self.assertEqual(sub.glyph, "f_f_i")
-        self.assertEqual(sub.replacement, ("f", "f", "i"))
+        self.assertEqual(sub.glyph.asFea(), "f_f_i")
+        self.assertEqual([x.asFea() for x in sub.replacement], ["f", "f", "i"])
         self.assertEqual(sub.asFea(), "sub f_f_i' by f f i;")
 
     def test_substitute_multiple_by_mutliple(self):
@@ -1688,16 +1688,16 @@ class ParserTest(unittest.TestCase):
         statements = doc.statements[0].statements
         for sub in statements:
             self.assertIsInstance(sub, ast.MultipleSubstStatement)
-        self.assertEqual(statements[1].glyph, "f")
-        self.assertEqual(statements[1].replacement, ["f"])
-        self.assertEqual(statements[3].glyph, "a")
-        self.assertEqual(statements[3].replacement, ["a"])
-        self.assertEqual(statements[4].glyph, "a.sc")
-        self.assertEqual(statements[4].replacement, ["a"])
-        self.assertEqual(statements[5].glyph, "a")
-        self.assertEqual(statements[5].replacement, ["b"])
-        self.assertEqual(statements[6].glyph, "a.sc")
-        self.assertEqual(statements[6].replacement, ["b.sc"])
+        self.assertEqual(statements[1].glyph.asFea(), "f")
+        self.assertEqual([x.asFea() for x in statements[1].replacement], ["f"])
+        self.assertEqual(statements[3].glyph.asFea(), "a")
+        self.assertEqual([x.asFea() for x in statements[3].replacement], ["a"])
+        self.assertEqual(statements[4].glyph.asFea(), "a.sc")
+        self.assertEqual([x.asFea() for x in statements[4].replacement], ["a"])
+        self.assertEqual(statements[5].glyph.asFea(), "a")
+        self.assertEqual([x.asFea() for x in statements[5].replacement], ["b"])
+        self.assertEqual(statements[6].glyph.asFea(), "a.sc")
+        self.assertEqual([x.asFea() for x in statements[6].replacement], ["b.sc"])
 
     def test_substitute_from(self):  # GSUB LookupType 3
         doc = self.parse(

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -167,7 +167,7 @@ class ParserTest(unittest.TestCase):
             "} test;"
         )
         anchor = doc.statements[0].statements[0].exitAnchor
-        self.assertIsNone(anchor)
+        assert(anchor.isNull())
 
     def test_anchor_format_e(self):
         doc = self.parse(

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -2081,6 +2081,10 @@ class ParserTest(unittest.TestCase):
         doc = Parser(fea_path, includeDir=include_dir).parse()
         assert len(doc.statements) == 1 and doc.statements[0].text == "# Nothing"
 
+    def test_markclass_format_D(self):
+        flag = self.parse("markClass A <anchor NULL> @top;")
+        self.assertEqual(flag.asFea(), "markClass A <anchor NULL> @top;")
+
     def parse(self, text, glyphNames=GLYPHNAMES, followIncludes=True):
         featurefile = StringIO(text)
         p = Parser(featurefile, glyphNames, followIncludes=followIncludes)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 python_version = 3.7
-files = Lib/fontTools/misc/plistlib
+files = Lib/fontTools/misc/plistlib,Lib/fontTools/fealib
 follow_imports = silent
 ignore_missing_imports = True
 warn_redundant_casts = True
@@ -8,6 +8,19 @@ warn_unused_configs = True
 warn_unused_ignores = True
 
 [mypy-fontTools.misc.plistlib]
+check_untyped_defs = True
+disallow_any_generics = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_decorators = True
+disallow_untyped_calls = False
+disallow_untyped_defs = True
+no_implicit_optional = True
+no_implicit_reexport = True
+strict_equality = True
+warn_return_any = True
+
+[mypy-fontTools.fealib]
 check_untyped_defs = True
 disallow_any_generics = True
 disallow_incomplete_defs = True


### PR DESCRIPTION
This is a big and noisy change; sorry. It also changes some public-facing aspects of the feaLib API (particularly the constructor parameters of AST object).

But in a good way! We previously had several situations where the documentation specified certain types, and either the builder expected or the parser generated something different. This lead to horrible bugs like #2747. I also found a couple of typos which were hidden by the lack of typing.

I suggest that because of the API change, we send a courtesy ping to anyone we know who's using it. (I know SIL are, at least.)