### PR TITLE
[varLib] Clean up __all__

### DIFF
--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -1,11 +1,6 @@
 """Variation fonts interpolation models."""
 
 __all__ = [
-    "nonNone",
-    "allNone",
-    "allEqual",
-    "allEqualTo",
-    "subList",
     "normalizeValue",
     "normalizeLocation",
     "supportScalar",


### PR DESCRIPTION
It's okay for our other modules to use these symbols, but they don't really belong in the API of varLib.