### PR TITLE
[ttLib] make glyphset[gn].drawPoints(pointPen) work for CFF

### DIFF
--- a/Lib/fontTools/ttLib/ttGlyphSet.py
+++ b/Lib/fontTools/ttLib/ttGlyphSet.py
@@ -79,8 +79,8 @@ class _TTGlyph(object):
 		self._glyph.draw(pen)
 
 	def drawPoints(self, pen):
-		# drawPoints is only implemented for _TTGlyphGlyf at this time.
-		raise NotImplementedError()
+		from fontTools.pens.pointPen import SegmentToPointPen
+		self.draw(SegmentToPointPen(pen))
 
 class _TTGlyphCFF(_TTGlyph):
 	pass


### PR DESCRIPTION
A trivial fix to make glyph.drawPoints(pen) work for CFF glyphs.