### PR TITLE
[ttLib] VarGlyphSet: implement drawPoints natively

### DIFF
--- a/Lib/fontTools/ttLib/ttGlyphSet.py
+++ b/Lib/fontTools/ttLib/ttGlyphSet.py
@@ -189,6 +189,12 @@ class _TTVarGlyph(_TTGlyph):
 class _TTVarGlyphGlyf(_TTVarGlyph):
 
 	def draw(self, pen):
+		self._drawWithPen(pen, False)
+
+	def drawPoints(self, pen):
+		self._drawWithPen(pen, True)
+
+	def _drawWithPen(self, pen, isPointPen):
 		from fontTools.varLib.iup import iup_delta
 		from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
 		from fontTools.varLib.models import supportScalar
@@ -219,4 +225,7 @@ class _TTVarGlyphGlyf(_TTVarGlyph):
 		self.height = height
 		self.tsb = tsb
 		offset = lsb - glyph.xMin if hasattr(glyph, "xMin") else 0
-		glyph.draw(pen, glyf, offset)
+		if isPointPen:
+			glyph.drawPoints(pen, glyf, offset)
+		else:
+			glyph.draw(pen, glyf, offset)

--- a/Lib/fontTools/ttLib/ttGlyphSet.py
+++ b/Lib/fontTools/ttLib/ttGlyphSet.py
@@ -189,10 +189,10 @@ class _TTVarGlyph(_TTGlyph):
 class _TTVarGlyphGlyf(_TTVarGlyph):
 
 	def draw(self, pen):
-		self._drawWithPen(pen, False)
+		self._drawWithPen(pen, isPointPen=False)
 
 	def drawPoints(self, pen):
-		self._drawWithPen(pen, True)
+		self._drawWithPen(pen, isPointPen=True)
 
 	def _drawWithPen(self, pen, isPointPen):
 		from fontTools.varLib.iup import iup_delta


### PR DESCRIPTION
This avoids going through SegmentToPointPen, which will arbitrarily delete an endpoint if happens to coincide with the start point. Which is not good for interpolation.