### PR TITLE
[gvar] be non lazy for TTFont.lazy=False, add ensureDecompiled

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -1,4 +1,4 @@
-from collections import UserDict
+from collections import UserDict, deque
 from functools import partial
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval
@@ -125,6 +125,15 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			glyphName = glyphs[gid]
 			variations[glyphName] = partial(decompileVarGlyph, glyphName, gid)
 		self.variations = _LazyDict(variations)
+
+		if ttFont.lazy is False: # Be lazy for None and True
+			self.ensureDecompiled()
+
+	def ensureDecompiled(self, recurse=False):
+		# The recurse argument is unused, but part of the signature of
+		# ensureDecompiled across the library.
+		# Use a zero-length deque to consume the lazy dict
+		deque(self.variations.values(), maxlen=0)
 
 	@staticmethod
 	def decompileOffsets_(data, tableFormat, glyphCount):

--- a/Tests/ttLib/tables/_g_v_a_r_test.py
+++ b/Tests/ttLib/tables/_g_v_a_r_test.py
@@ -174,9 +174,18 @@ class GVARTableTest(unittest.TestCase):
 		                 hexStr(GVAR_DATA_EMPTY_VARIATIONS))
 
 	def test_decompile(self):
-		font, gvar = self.makeFont({})
-		gvar.decompile(GVAR_DATA, font)
-		self.assertVariationsAlmostEqual(gvar.variations, GVAR_VARIATIONS)
+		for lazy in (True, False, None):
+			with self.subTest(lazy=lazy):
+				font, gvar = self.makeFont({})
+				font.lazy = lazy
+				gvar.decompile(GVAR_DATA, font)
+
+				self.assertEqual(
+					all(callable(v) for v in gvar.variations.data.values()),
+					lazy is not False,
+				)
+
+				self.assertVariationsAlmostEqual(gvar.variations, GVAR_VARIATIONS)
 
 	def test_decompile_noVariations(self):
 		font, gvar = self.makeFont({})


### PR DESCRIPTION
like cmap, or glyf or OTL tables, we need to respect lazy=False flag and decompile everything upfront, also we want to add an ensureDecompiled method (called by TTFont.ensureDecompiled) to allow loading everything in one go even when a font had been opened lazily.