### PR TITLE
Avoid crash when handling unbounded conditions during designspace splitting

### DIFF
--- a/Lib/fontTools/designspaceLib/split.py
+++ b/Lib/fontTools/designspaceLib/split.py
@@ -352,7 +352,7 @@ def _extractSubSpace(
 def _conditionSetFrom(conditionSet: List[Dict[str, Any]]) -> ConditionSet:
     c: Dict[str, Range] = {}
     for condition in conditionSet:
-        minimum, maximum = condition["minimum"], condition["maximum"]
+        minimum, maximum = condition.get("minimum"), condition.get("maximum")
         c[condition["name"]] = Range(
             minimum if minimum is not None else -math.inf,
             maximum if maximum is not None else math.inf,

--- a/Lib/fontTools/designspaceLib/split.py
+++ b/Lib/fontTools/designspaceLib/split.py
@@ -352,9 +352,10 @@ def _extractSubSpace(
 def _conditionSetFrom(conditionSet: List[Dict[str, Any]]) -> ConditionSet:
     c: Dict[str, Range] = {}
     for condition in conditionSet:
+        minimum, maximum = condition["minimum"], condition["maximum"]
         c[condition["name"]] = Range(
-            condition.get("minimum", -math.inf),
-            condition.get("maximum", math.inf),
+            minimum if minimum is not None else -math.inf,
+            maximum if maximum is not None else math.inf,
         )
     return c
 

--- a/Tests/designspaceLib/split_test.py
+++ b/Tests/designspaceLib/split_test.py
@@ -160,13 +160,15 @@ def test_convert5to4(datadir, tmpdir, test_ds, expected_vfs):
 @pytest.mark.parametrize(
     ["unbounded_condition"],
     [
+        ({"name": "Weight", "minimum": 500},),
+        ({"name": "Weight", "maximum": 500},),
         ({"name": "Weight", "minimum": 500, "maximum": None},),
         ({"name": "Weight", "minimum": None, "maximum": 500},),
     ],
 )
 def test_optional_min_max(unbounded_condition):
     """Check that split functions can handle conditions that are partially
-    unbounded without tripping over the None values."""
+    unbounded without tripping over None values and missing keys."""
     doc = DesignSpaceDocument()
 
     doc.addAxisDescriptor(
@@ -185,6 +187,14 @@ def test_optional_min_max(unbounded_condition):
 @pytest.mark.parametrize(
     ["condition", "expected_set"],
     [
+        (
+            {"name": "axis", "minimum": 0.5},
+            {"axis": Range(minimum=0.5, maximum=math.inf)},
+        ),
+        (
+            {"name": "axis", "maximum": 0.5},
+            {"axis": Range(minimum=-math.inf, maximum=0.5)},
+        ),
         (
             {"name": "axis", "minimum": 0.5, "maximum": None},
             {"axis": Range(minimum=0.5, maximum=math.inf)},

--- a/Tests/designspaceLib/split_test.py
+++ b/Tests/designspaceLib/split_test.py
@@ -1,9 +1,16 @@
+import math
 import shutil
 from pathlib import Path
 
 import pytest
 from fontTools.designspaceLib import DesignSpaceDocument
-from fontTools.designspaceLib.split import splitInterpolable, splitVariableFonts, convert5to4
+from fontTools.designspaceLib.split import (
+    _conditionSetFrom,
+    convert5to4,
+    splitInterpolable,
+    splitVariableFonts,
+)
+from fontTools.designspaceLib.types import ConditionSet, Range
 
 from .fixtures import datadir
 
@@ -148,3 +155,47 @@ def test_convert5to4(datadir, tmpdir, test_ds, expected_vfs):
             assert data_out.read_text(encoding="utf-8") == temp_out.read_text(
                 encoding="utf-8"
             )
+
+
+@pytest.mark.parametrize(
+    ["unbounded_condition"],
+    [
+        ({"name": "Weight", "minimum": 500, "maximum": None},),
+        ({"name": "Weight", "minimum": None, "maximum": 500},),
+    ],
+)
+def test_optional_min_max(unbounded_condition):
+    """Check that split functions can handle conditions that are partially
+    unbounded without tripping over the None values."""
+    doc = DesignSpaceDocument()
+
+    doc.addAxisDescriptor(
+        name="Weight", tag="wght", minimum=400, maximum=1000, default=400
+    )
+
+    doc.addRuleDescriptor(
+        name="unbounded",
+        conditionSets=[[unbounded_condition]],
+    )
+
+    assert len(list(splitInterpolable(doc))) == 1
+    assert len(list(splitVariableFonts(doc))) == 1
+
+
+@pytest.mark.parametrize(
+    ["condition", "expected_set"],
+    [
+        (
+            {"name": "axis", "minimum": 0.5, "maximum": None},
+            {"axis": Range(minimum=0.5, maximum=math.inf)},
+        ),
+        (
+            {"name": "axis", "minimum": None, "maximum": 0.5},
+            {"axis": Range(minimum=-math.inf, maximum=0.5)},
+        ),
+    ],
+)
+def test_optional_min_max_internal(condition, expected_set: ConditionSet):
+    """Check that split's internal helper functions produce the correct output
+    for conditions that are partially unbounded."""
+    assert _conditionSetFrom([condition]) == expected_set


### PR DESCRIPTION
## Context

Designspace documents can contain unbounded conditions, which [omit one of "minimum" or "maximum"](https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#condition-element). In fontTools, the absence of either is represented with None, both when designspace files [are parsed](https://github.com/fonttools/fonttools/blob/1306a71/Lib/fontTools/designspaceLib/__init__.py#L1838-L1850), and when designspace objects [are processed in varLib](https://github.com/fonttools/fonttools/blob/bb6fd8d22e7aa20d8ae6553c15f5686fbaf7d862/Lib/fontTools/varLib/__init__.py#L670-L677).

## Problem

For unbounded conditions, the splitting functions expect "minimum" or "maximum" [to be absent](https://github.com/fonttools/fonttools/blob/1306a71db323556232b1f5ece1c2ab77476d0884/Lib/fontTools/designspaceLib/split.py#L356-L357), instead of present with a value of None. This means that the None values are never substituted by an appropriate value, and so propagate further until the program crashes.

ufo2ft [uses splitting](https://github.com/googlefonts/ufo2ft/blob/6d618f6/Lib/ufo2ft/__init__.py#L750) as part of its build pipeline, and so unbounded conditions break the build process downstream.

## Fix

This PR changes the splitting code to expect "minimum" and "maximum" to always be present, with potential values of None. This makes the behaviour consistent with the rest of the library, and fixes the crash.

In addition, a test has been added to check for regressions.

### Caveat

At least [one area of the existing code](https://github.com/fonttools/fonttools/blob/1306a71/Lib/fontTools/designspaceLib/__init__.py#L1422-L1430) accounts for the values being None AND the keys being absent. This is probably overkill, as the codebase is already heavily dependent on both keys always being present. For this reason, checking for both cases was avoided here.

## Future work

We could type the conditions in DesignSpaceDocument to avoid issues like this in the future. In addition, we could add tests downstream that compile projects with unbounded conditions, as this would have highlighted the issue sooner.