### PR TITLE
Cythonize lexer

### DIFF
--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -3,6 +3,12 @@ from fontTools.feaLib.location import FeatureLibLocation
 import re
 import os
 
+try:
+    import cython
+except ImportError:
+    # if cython not installed, use mock module with no-op decorators and types
+    from fontTools.misc import cython
+
 
 class Lexer(object):
     NUMBER = "NUMBER"

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,9 @@ if with_cython is True or (with_cython is None and has_cython):
 	ext_modules.append(
 		Extension("fontTools.varLib.iup", ["Lib/fontTools/varLib/iup.py"]),
 	)
+	ext_modules.append(
+		Extension("fontTools.feaLib.lexer", ["Lib/fontTools/feaLib/lexer.py"]),
+	)
 
 extras_require = {
 	# for fontTools.ufoLib: to read/write UFO fonts


### PR DESCRIPTION
This adds unoptimized cython magic to the feaLib.lexer class. On a large feature file, it reduced parsing time from 27s to 18s. (I tried doing the same to feaLib.parser but it didn't gain much.)