### PR TITLE
subset: add --no-lazy option to load font eagerly as TTFont(lazy=False)

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2670,6 +2670,7 @@ class Options(object):
 		self.xml = False
 		self.font_number = -1
 		self.pretty_svg = False
+		self.lazy = True
 
 		self.set(**kwargs)
 
@@ -3188,7 +3189,8 @@ def main(args=None):
 		glyphs.append(g)
 
 	dontLoadGlyphNames = not options.glyph_names and not glyphs
-	font = load_font(fontfile, options, dontLoadGlyphNames=dontLoadGlyphNames)
+	lazy = options.lazy
+	font = load_font(fontfile, options, dontLoadGlyphNames=dontLoadGlyphNames, lazy=lazy)
 
 	if outfile is None:
 		outfile = makeOutputFileName(fontfile, overWrite=True, suffix=".subset")


### PR DESCRIPTION
may aid debugging lazy-loading issues like https://github.com/fonttools/fonttools/issues/2806