### PR TITLE
[instancer] downgrade GSUB/GPOS version if there are no FeatureVariations after instancing (2)

### DIFF
--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -864,6 +864,8 @@ def _instantiateFeatureVariations(table, fvarAxes, axisLimits):
         table.FeatureVariations.FeatureVariationCount = len(newRecords)
     else:
         del table.FeatureVariations
+        # downgrade table version if there are no FeatureVariations left
+        table.Version = 0x00010000
 
 
 def _isValidAvarSegmentMap(axisTag, segmentMap):

--- a/Tests/varLib/instancer/instancer_test.py
+++ b/Tests/varLib/instancer/instancer_test.py
@@ -1638,11 +1638,14 @@ class InstantiateFeatureVariationsTest(object):
                 ),
             ]
         )
+        gsub = font["GSUB"].table
+        assert gsub.FeatureVariations
+        assert gsub.Version == 0x00010001
 
         instancer.instantiateFeatureVariations(font, location)
 
-        gsub = font["GSUB"].table
         assert not hasattr(gsub, "FeatureVariations")
+        assert gsub.Version == 0x00010000
 
         if appliedSubs:
             lookupIndices = gsub.FeatureList.FeatureRecord[0].Feature.LookupListIndex


### PR DESCRIPTION
same as https://github.com/fonttools/fonttools/pull/2811 but moved the logic to _instantiateFeatureVariations directly, instead of after it. Plus, added small test

/cc @qxliu76 