### PR TITLE
[subset] keep and don't prune CPAL if OT-SVG table is present

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2207,6 +2207,14 @@ def subset_glyphs(self, s):
 
 @_add_method(ttLib.getTableClass('CPAL'))
 def prune_post_subset(self, font, options):
+	# Keep whole "CPAL" if "SVG " is present as it may be referenced by the latter
+	# via 'var(--color{palette_entry_index}, ...)' CSS color variables.
+	# For now we just assume this is the case by the mere presence of "SVG " table,
+	# for parsing SVG to collect all the used indices is too much work...
+	# TODO(anthrotype): Do The Right Thing (TM).
+	if "SVG " in font:
+		return True
+
 	colr = font.get("COLR")
 	if not colr:  # drop CPAL if COLR was subsetted to empty
 		return False


### PR DESCRIPTION
Fixes #2814

or at least is a workaround until a proper 'fix'