### PR TITLE
[instancer] Don't prune stat.ElidedFallbackNameID

### DIFF
--- a/Lib/fontTools/varLib/instancer/names.py
+++ b/Lib/fontTools/varLib/instancer/names.py
@@ -37,6 +37,9 @@ def getVariationNameIDs(varfont):
             used.append(axis.AxisNameID)
         for value in stat.AxisValueArray.AxisValue if stat.AxisValueArray else ():
             used.append(value.ValueNameID)
+        elidedFallbackNameID = getattr(stat, "ElidedFallbackNameID", None)
+        if elidedFallbackNameID is not None:
+            used.append(stat.ElidedFallbackNameID)
     # nameIDs <= 255 are reserved by OT spec so we don't touch them
     return {nameID for nameID in used if nameID > 255}
 


### PR DESCRIPTION
Add stat.ElidedFallbackNameID to the set of used name IDs, to prevent it being pruned. Fixes #2822