### PR TITLE
[varLib] Optimize gvar isComposite workaround hack

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -272,8 +272,10 @@ def _add_gvar(font, masterModel, master_ttfs, tolerance=0.5, optimize=True):
 		endPts = control.endPts
 
 		for i,(delta,support) in enumerate(zip(deltas[1:], supports[1:])):
+			# For Composite glyphs we want to write at least one entry.
 			if all(v == 0 for v in delta.array) and not isComposite:
 				continue
+			isComposite = False
 			var = TupleVariation(support, delta)
 			if optimize:
 				delta_opt = iup_delta_optimize(delta, origCoords, endPts, tolerance=tolerance)


### PR DESCRIPTION
In 9c3dde3 we made varLib write gvar variation entries for composite glyphs even if they are all-zero vectors.

This is overkill. The requirement from the bug it's trying to fix is that composite glyphs have some entry in gvar table. So we just need to write one variation entry per composite glyph, not for all masters. For fonts with many masters the empty entries add up.

Fixes https://github.com/fonttools/fonttools/issues/2831