### PR TITLE
[varLib.models] Attempt to fix #2843 by computing the axis ranges

### DIFF
--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -244,8 +244,7 @@ class VariationModel(object):
         self.origLocations = locations
         self.axisOrder = axisOrder if axisOrder is not None else []
         self.extrapolate = extrapolate
-        if extrapolate:
-            self.axisRanges = self.computeAxisRanges(locations)
+        self.axisRanges = self.computeAxisRanges(locations) if extrapolate else None
 
         locations = [{k: v for k, v in loc.items() if v != 0.0} for loc in locations]
         keyFunc = self.getMasterLocationsSortKeyFunc(

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -121,6 +121,9 @@ def supportScalar(location, support, ot=True, extrapolate=False, axisRanges=None
     for support of an axis means "axis does not participate".  That
     is how OpenType Variation Font technology works.
 
+    If extrapolate is True, axisRanges must be a dict that maps axis
+    names to (axisMin, axisMax) tuples.
+
       >>> supportScalar({}, {})
       1.0
       >>> supportScalar({'wght':.2}, {})
@@ -137,10 +140,14 @@ def supportScalar(location, support, ot=True, extrapolate=False, axisRanges=None
       0.75
       >>> supportScalar({'wght':2.5, 'wdth':.5}, {'wght':(0,2,4), 'wdth':(-1,0,+1)})
       0.75
-      >>> supportScalar({'wght':4}, {'wght':(0,2,3)}, extrapolate=True)
-      2.0
-      >>> supportScalar({'wght':4}, {'wght':(0,2,2)}, extrapolate=True)
-      2.0
+      >>> supportScalar({'wght':3}, {'wght':(0,1,2)}, extrapolate=True, axisRanges={'wght':(0, 2)})
+      -1.0
+      >>> supportScalar({'wght':-1}, {'wght':(0,1,2)}, extrapolate=True, axisRanges={'wght':(0, 2)})
+      -1.0
+      >>> supportScalar({'wght':3}, {'wght':(0,2,2)}, extrapolate=True, axisRanges={'wght':(0, 2)})
+      1.5
+      >>> supportScalar({'wght':-1}, {'wght':(0,2,2)}, extrapolate=True, axisRanges={'wght':(0, 2)})
+      -0.5
     """
     if extrapolate and axisRanges is None:
         axisRanges = {}
@@ -192,9 +199,8 @@ def supportScalar(location, support, ot=True, extrapolate=False, axisRanges=None
 class VariationModel(object):
     """Locations must have the base master at the origin (ie. 0).
 
-    If the extrapolate argument is set to True, then location values are
-    interpretted in the normalized space, ie. in the [-1,+1] range, and
-    values are extrapolated outside this range.
+    If the extrapolate argument is set to True, then values are extrapolated
+    outside the axis range.
 
       >>> from pprint import pprint
       >>> locations = [ \

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -282,7 +282,7 @@ class VariationModel(object):
         for loc in locations:
             for axis in allAxes:
                 value = loc.get(axis, 0)
-                axisMin, axisMax = axisRanges.get(axis, (0, 0))
+                axisMin, axisMax = axisRanges.get(axis, (value, value))
                 axisRanges[axis] = min(value, axisMin), max(value, axisMax)
         return axisRanges
 

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -169,7 +169,7 @@ def supportScalar(location, support, ot=True, extrapolate=False, axisRanges=None
             continue
 
         if extrapolate:
-            axisMin, axisMax = axisRanges.get(axis, (-1, +1))
+            axisMin, axisMax = axisRanges[axis]
             if v < axisMin and lower <= axisMin:
                 if peak <= axisMin and peak < upper:
                     scalar *= (v - upper) / (peak - upper)

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -274,7 +274,7 @@ class VariationModel(object):
         axisRanges = {}
         for loc in locations:
             for axis, value in loc.items():
-                axisMin, axisMax = axisRanges.get(axis, (0, 0))
+                axisMin, axisMax = axisRanges.get(axis, (value, value))
                 axisRanges[axis] = min(value, axisMin), max(value, axisMax)
         return axisRanges
 

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -278,9 +278,11 @@ class VariationModel(object):
     @staticmethod
     def computeAxisRanges(locations):
         axisRanges = {}
+        allAxes = {axis for loc in locations for axis in loc.keys()}
         for loc in locations:
-            for axis, value in loc.items():
-                axisMin, axisMax = axisRanges.get(axis, (value, value))
+            for axis in allAxes:
+                value = loc.get(axis, 0)
+                axisMin, axisMax = axisRanges.get(axis, (0, 0))
                 axisRanges[axis] = min(value, axisMin), max(value, axisMax)
         return axisRanges
 

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -150,7 +150,7 @@ def supportScalar(location, support, ot=True, extrapolate=False, axisRanges=None
       -0.5
     """
     if extrapolate and axisRanges is None:
-        axisRanges = {}
+        raise TypeError("axisRanges must be passed when extrapolate is True")
     scalar = 1.0
     for axis, (lower, peak, upper) in support.items():
         if ot:

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -452,8 +452,12 @@ class VariationModel(object):
         return model.getDeltas(items, round=round), model.supports
 
     def getScalars(self, loc):
-        return [supportScalar(loc, support, extrapolate=self.extrapolate, axisRanges=self.axisRanges)
-                for support in self.supports]
+        return [
+            supportScalar(
+                loc, support, extrapolate=self.extrapolate, axisRanges=self.axisRanges
+            )
+            for support in self.supports
+        ]
 
     @staticmethod
     def interpolateFromDeltasAndScalars(deltas, scalars):

--- a/Tests/varLib/models_test.py
+++ b/Tests/varLib/models_test.py
@@ -36,10 +36,12 @@ def test_supportScalar():
     assert supportScalar({"wght": 0.2}, {}) == 1.0
     assert supportScalar({"wght": 0.2}, {"wght": (0, 2, 3)}) == 0.1
     assert supportScalar({"wght": 2.5}, {"wght": (0, 2, 4)}) == 0.75
-    assert supportScalar({"wght": 4}, {"wght": (0, 2, 2)}) == 0.0
-    assert supportScalar({"wght": 4}, {"wght": (0, 2, 2)}, extrapolate=True) == 2.0
-    assert supportScalar({"wght": 4}, {"wght": (0, 2, 3)}, extrapolate=True) == 2.0
-    assert supportScalar({"wght": 2}, {"wght": (0, 0.75, 1)}, extrapolate=True) == -4.0
+    assert supportScalar({"wght": 3}, {"wght": (0, 2, 2)}) == 0.0
+    assert supportScalar({"wght": 3}, {"wght": (0, 2, 2)}, extrapolate=True, axisRanges={"wght": (0, 2)}) == 1.5
+    assert supportScalar({"wght": -1}, {"wght": (0, 2, 2)}, extrapolate=True, axisRanges={"wght": (0, 2)}) == -0.5
+    assert supportScalar({"wght": 3}, {"wght": (0, 1, 2)}, extrapolate=True, axisRanges={"wght": (0, 2)}) == -1.0
+    assert supportScalar({"wght": -1}, {"wght": (0, 1, 2)}, extrapolate=True, axisRanges={"wght": (0, 2)}) == -1.0
+    assert supportScalar({"wght": 2}, {"wght": (0, 0.75, 1)}, extrapolate=True, axisRanges={"wght": (0, 1)}) == -4.0
 
 
 @pytest.mark.parametrize(

--- a/Tests/varLib/models_test.py
+++ b/Tests/varLib/models_test.py
@@ -46,6 +46,34 @@ def test_supportScalar():
         supportScalar({"wght": 2}, {"wght": (0, 0.75, 1)}, extrapolate=True, axisRanges=None)
 
 
+def test_model_extrapolate():
+    locations = [{}, {"a": 1}, {"b": 1}, {"a": 1, "b": 1}]
+    model = VariationModel(locations, extrapolate=True)
+    masterValues = [
+     100, 200,
+     300, 400]
+    testLocsAndValues = [
+        ({"a": -1, "b": -1}, -200),
+        ({"a": -1, "b": 0}, 0),
+        ({"a": -1, "b": 1}, 200),
+        ({"a": -1, "b": 2}, 400),
+        ({"a": 0, "b": -1}, -100),
+        ({"a": 0, "b": 0}, 100),
+        ({"a": 0, "b": 1}, 300),
+        ({"a": 0, "b": 2}, 500),
+        ({"a": 1, "b": -1}, 0),
+        ({"a": 1, "b": 0}, 200),
+        ({"a": 1, "b": 1}, 400),
+        ({"a": 1, "b": 2}, 600),
+        ({"a": 2, "b": -1}, 100),
+        ({"a": 2, "b": 0}, 300),
+        ({"a": 2, "b": 1}, 500),
+        ({"a": 2, "b": 2}, 700),
+    ]
+    for loc, expectedValue in testLocsAndValues:
+        assert expectedValue == model.interpolateFromMasters(loc, masterValues)
+
+
 @pytest.mark.parametrize(
     "numLocations, numSamples",
     [

--- a/Tests/varLib/models_test.py
+++ b/Tests/varLib/models_test.py
@@ -49,9 +49,7 @@ def test_supportScalar():
 def test_model_extrapolate():
     locations = [{}, {"a": 1}, {"b": 1}, {"a": 1, "b": 1}]
     model = VariationModel(locations, extrapolate=True)
-    masterValues = [
-     100, 200,
-     300, 400]
+    masterValues = [100, 200, 300, 400]
     testLocsAndValues = [
         ({"a": -1, "b": -1}, -200),
         ({"a": -1, "b": 0}, 0),

--- a/Tests/varLib/models_test.py
+++ b/Tests/varLib/models_test.py
@@ -42,6 +42,8 @@ def test_supportScalar():
     assert supportScalar({"wght": 3}, {"wght": (0, 1, 2)}, extrapolate=True, axisRanges={"wght": (0, 2)}) == -1.0
     assert supportScalar({"wght": -1}, {"wght": (0, 1, 2)}, extrapolate=True, axisRanges={"wght": (0, 2)}) == -1.0
     assert supportScalar({"wght": 2}, {"wght": (0, 0.75, 1)}, extrapolate=True, axisRanges={"wght": (0, 1)}) == -4.0
+    with pytest.raises(TypeError):
+        supportScalar({"wght": 2}, {"wght": (0, 0.75, 1)}, extrapolate=True, axisRanges=None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The problem @LettError pointed out in #2843 could be resolved if `supportScalar()` uses the axis min/max values, instead of hard-coding them to -1 and +1.

With this change, the snippet below shows extrapolations as expected:
```python
from fontTools.varLib.models import VariationModel


def formatRow(row, cellWidth=8):
    fmt = f"{{v:>{cellWidth}}}"
    return "".join(fmt.format(v=v) for v in row)


locations = [{}, {"x": 1}, {"y": 1}, {"x": 1, "y": 1}]

model = VariationModel(locations, extrapolate=True)

values = [100, 200, 300, 400]

rng = [-1, 0, 1, 2]

print(formatRow([""] + rng))
for x in rng:
    row = [x]
    for y in rng:
        v = model.interpolateFromMasters({"x": x, "y": y}, values)
        row.append(v)
    print(formatRow(row))
```

Output:
```
              -1       0       1       2
      -1  -200.0     0.0   200.0   400.0
       0  -100.0   100.0   300.0   500.0
       1     0.0   200.0   400.0   600.0
       2   100.0   300.0   500.0   700.0
```

I think this keeps the original functionality as intended by @behdad, it just assumes less of the input design space.

I also believe this lifts the requirement for the locations to be normalized when extrapolating.