### PR TITLE
Allow extrapolation in normalization

### DIFF
--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -43,7 +43,7 @@ def subList(truth, lst):
     return [l for l, t in zip(lst, truth) if t]
 
 
-def normalizeValue(v, triple):
+def normalizeValue(v, triple, extrapolate=False):
     """Normalizes value based on a min/default/max triple.
 
       >>> normalizeValue(400, (100, 400, 900))
@@ -59,7 +59,8 @@ def normalizeValue(v, triple):
             f"Invalid axis values, must be minimum, default, maximum: "
             f"{lower:3.3f}, {default:3.3f}, {upper:3.3f}"
         )
-    v = max(min(v, upper), lower)
+    if not extrapolate:
+        v = max(min(v, upper), lower)
     if v == default:
         v = 0.0
     elif v < default:
@@ -69,7 +70,7 @@ def normalizeValue(v, triple):
     return v
 
 
-def normalizeLocation(location, axes):
+def normalizeLocation(location, axes, extrapolate=False):
     """Normalizes location based on axis min/default/max values from axes.
 
       >>> axes = {"wght": (100, 400, 900)}
@@ -111,7 +112,7 @@ def normalizeLocation(location, axes):
     out = {}
     for tag, triple in axes.items():
         v = location.get(tag, triple[1])
-        out[tag] = normalizeValue(v, triple)
+        out[tag] = normalizeValue(v, triple, extrapolate=extrapolate)
     return out
 
 


### PR DESCRIPTION
We are allowing extrapolation in the variation model, but when we normalise values, these are still clamped to the axis min/max (-1.0<=>1.0). This allows normalized values to extend beyond that range.

This may not be the right approach, because it looks like the extrapolation option of the variation model allows for values which aren't normalised but which just have a min/max range. But I don't understand that well enough to know how it handles defaults.