### PR TITLE
Fix ZeroDivisionErrors with normalizeLocation(extrapolate=True)

### DIFF
--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -61,13 +61,16 @@ def normalizeValue(v, triple, extrapolate=False):
         )
     if not extrapolate:
         v = max(min(v, upper), lower)
-    if v == default:
-        v = 0.0
-    elif v < default:
-        v = (v - default) / (default - lower)
-    else:
-        v = (v - default) / (upper - default)
-    return v
+
+    if v == default or lower == upper:
+        return 0.0
+
+    if (v < default and lower != default) or (v > default and upper == default):
+        return (v - default) / (default - lower)
+    elif (v > default and upper != default) or (v < default and lower == default):
+        return (v - default) / (upper - default)
+
+    raise AssertionError("that's not possible")
 
 
 def normalizeLocation(location, axes, extrapolate=False):

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -67,10 +67,11 @@ def normalizeValue(v, triple, extrapolate=False):
 
     if (v < default and lower != default) or (v > default and upper == default):
         return (v - default) / (default - lower)
-    elif (v > default and upper != default) or (v < default and lower == default):
+    else:
+        assert (v > default and upper != default) or (
+            v < default and lower == default
+        ), f"Ooops... v={v}, triple=({lower}, {default}, {upper})"
         return (v - default) / (upper - default)
-
-    raise AssertionError("that's not possible")
 
 
 def normalizeLocation(location, axes, extrapolate=False):


### PR DESCRIPTION
https://github.com/fonttools/fonttools/pull/2847 is incomplete, because it fails with ZeroDivisionError for things like:

```
normalizeLocation({"wght": 100}, {"wght": (400, 400, 700)}, extrapolate=True)
normalizeLocation({"wght": 1000}, {"wght": (400, 700, 700)}, extrapolate=True)
```

tests fails at the moment, fix in follow-up commit.