### PR TITLE
[glyf] Return component transform as part of control data

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -377,7 +377,7 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 				numberOfContours=glyph.numberOfContours,
 				endPts=list(range(len(glyph.components))),
 				flags=None,
-				components=[c.glyphName for c in glyph.components],
+				components=[(c.glyphName, getattr(c, 'transform', None)) for c in glyph.components],
 			)
 		else:
 			coords, endPts, flags = glyph.getCoordinates(self)


### PR DESCRIPTION
This makes sure that when we are building variable fonts, we check that all masters have the same component transform in composite glyphs.  We were not checking for this before.