### PR TITLE
[instancer-l4] expand singles/tuples to triples upfront and use triples throughout

### DIFF
--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -134,7 +134,7 @@ def NormalizedAxisRange(minimum, maximum):
     return NormalizedAxisTriple(minimum, None, maximum)
 
 
-@dataclasses.dataclass(frozen=True, order=True)
+@dataclasses.dataclass(frozen=True, order=True, repr=False)
 class AxisTriple(Sequence):
     """A triple of (min, default, max) axis values.
 
@@ -168,6 +168,11 @@ class AxisTriple(Sequence):
 
     def _replace(self, **kwargs):
         return dataclasses.replace(self, **kwargs)
+
+    def __repr__(self):
+        return (
+            f"({', '.join(format(v, 'g') if v is not None else 'None' for v in self)})"
+        )
 
     @classmethod
     def expand(
@@ -217,7 +222,7 @@ class AxisTriple(Sequence):
         return dataclasses.replace(self, default=default)
 
 
-@dataclasses.dataclass(frozen=True, order=True)
+@dataclasses.dataclass(frozen=True, order=True, repr=False)
 class NormalizedAxisTriple(AxisTriple):
     """A triple of (min, default, max) normalized axis values."""
 
@@ -247,6 +252,9 @@ class _BaseAxisLimits(Mapping[str, AxisTriple]):
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self._data!r})"
+
+    def __str__(self) -> str:
+        return str(self._data)
 
     def pinnedLocation(self) -> Dict[str, float]:
         """Return a location dict with only the pinned axes."""

--- a/Lib/fontTools/varLib/instancer/names.py
+++ b/Lib/fontTools/varLib/instancer/names.py
@@ -86,7 +86,7 @@ def updateNameTable(varfont, axisLimits):
 
     Example: Updating a partial variable font:
     | >>> ttFont = TTFont("OpenSans[wdth,wght].ttf")
-    | >>> updateNameTable(ttFont, {"wght": AxisRange(400, 900), "wdth": 75})
+    | >>> updateNameTable(ttFont, {"wght": (400, 900), "wdth": 75})
 
     The name table records will be updated in the following manner:
     NameID 1 familyName: "Open Sans" --> "Open Sans Condensed"
@@ -102,7 +102,7 @@ def updateNameTable(varfont, axisLimits):
     https://docs.microsoft.com/en-us/typography/opentype/spec/stat
     https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-ids
     """
-    from . import AxisRange, axisValuesFromAxisLimits
+    from . import AxisLimits, axisValuesFromAxisLimits
 
     if "STAT" not in varfont:
         raise ValueError("Cannot update name table since there is no STAT table.")
@@ -113,17 +113,15 @@ def updateNameTable(varfont, axisLimits):
 
     # The updated name table will reflect the new 'zero origin' of the font.
     # If we're instantiating a partial font, we will populate the unpinned
-    # axes with their default axis values.
+    # axes with their default axis values from fvar.
+    axisLimits = AxisLimits(axisLimits).populateDefaults(varfont)
+    partialDefaults = {k: v.default for k, v in axisLimits.items()}
     fvarDefaults = {a.axisTag: a.defaultValue for a in fvar.axes}
-    defaultAxisCoords = deepcopy(axisLimits)
-    for axisTag, val in fvarDefaults.items():
-        if axisTag not in defaultAxisCoords or isinstance(
-            defaultAxisCoords[axisTag], AxisRange
-        ):
-            defaultAxisCoords[axisTag] = val
+    defaultAxisCoords = AxisLimits({**fvarDefaults, **partialDefaults})
+    assert all(v.minimum == v.maximum for v in defaultAxisCoords.values())
 
     axisValueTables = axisValuesFromAxisLimits(stat, defaultAxisCoords)
-    checkAxisValuesExist(stat, axisValueTables, defaultAxisCoords)
+    checkAxisValuesExist(stat, axisValueTables, defaultAxisCoords.pinnedLocation())
 
     # ignore "elidable" axis values, should be omitted in application font menus.
     axisValueTables = [
@@ -154,8 +152,8 @@ def checkAxisValuesExist(stat, axisValues, axisCoords):
 
     missingAxes = set(axisCoords) - seen
     if missingAxes:
-        missing = ", ".join(f"'{i}={axisCoords[i]}'" for i in missingAxes)
-        raise ValueError(f"Cannot find Axis Values [{missing}]")
+        missing = ", ".join(f"'{i}': {axisCoords[i]}" for i in missingAxes)
+        raise ValueError(f"Cannot find Axis Values {{{missing}}}")
 
 
 def _sortAxisValues(axisValues):

--- a/Tests/varLib/instancer/data/PartialInstancerTest-VF.ttx
+++ b/Tests/varLib/instancer/data/PartialInstancerTest-VF.ttx
@@ -728,7 +728,7 @@
         <AxisOrdering value="2"/>
       </Axis>
     </DesignAxisRecord>
-    <!-- AxisValueCount=5 -->
+    <!-- AxisValueCount=7 -->
     <AxisValueArray>
       <AxisValue index="0" Format="1">
         <AxisIndex value="0"/>
@@ -743,7 +743,13 @@
         <Value value="400.0"/>
         <LinkedValue value="700.0"/>
       </AxisValue>
-      <AxisValue index="2" Format="2">
+      <AxisValue index="2" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="262"/>  <!-- Medium -->
+        <Value value="500.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="2">
         <AxisIndex value="0"/>
         <Flags value="0"/>
         <ValueNameID value="266"/>  <!-- Black -->
@@ -751,7 +757,7 @@
         <RangeMinValue value="801.0"/>
         <RangeMaxValue value="900.0"/>
       </AxisValue>
-      <AxisValue index="3" Format="4">
+      <AxisValue index="4" Format="4">
         <!-- AxisCount=1 -->
         <Flags value="0"/>
         <ValueNameID value="279"/>  <!-- Condensed -->
@@ -760,14 +766,14 @@
           <Value value="79.0"/>
         </AxisValueRecord>
       </AxisValue>
-      <AxisValue index="4" Format="3">
+      <AxisValue index="5" Format="3">
         <AxisIndex value="2"/>
         <Flags value="2"/>
         <ValueNameID value="295"/>  <!-- Upright -->
         <Value value="0.0"/>
         <LinkedValue value="1.0"/>
       </AxisValue>
-      <AxisValue index="3" Format="4">
+      <AxisValue index="6" Format="4">
         <!-- AxisCount=1 -->
         <Flags value="2"/>
         <ValueNameID value="297"/>  <!-- Normal -->

--- a/Tests/varLib/instancer/instancer_test.py
+++ b/Tests/varLib/instancer/instancer_test.py
@@ -112,6 +112,8 @@ class InstantiateGvarTest(object):
         ],
     )
     def test_pin_and_drop_axis(self, varfont, glyph_name, location, expected, optimize):
+        location = instancer.NormalizedAxisLimits(location)
+
         instancer.instantiateGvar(varfont, location, optimize=optimize)
 
         assert _get_coordinates(varfont, glyph_name) == expected[glyph_name]
@@ -124,9 +126,9 @@ class InstantiateGvarTest(object):
         )
 
     def test_full_instance(self, varfont, optimize):
-        instancer.instantiateGvar(
-            varfont, {"wght": 0.0, "wdth": -0.5}, optimize=optimize
-        )
+        location = instancer.NormalizedAxisLimits(wght=0.0, wdth=-0.5)
+
+        instancer.instantiateGvar(varfont, location, optimize=optimize)
 
         assert _get_coordinates(varfont, "hyphen") == [
             (33.5, 229),
@@ -169,7 +171,7 @@ class InstantiateGvarTest(object):
         assert hmtx["minus"] == (422, 40)
         assert vmtx["minus"] == (536, 229)
 
-        location = {"wght": -1.0, "wdth": -1.0}
+        location = instancer.NormalizedAxisLimits(wght=-1.0, wdth=-1.0)
 
         instancer.instantiateGvar(varfont, location)
 
@@ -206,6 +208,8 @@ class InstantiateCvarTest(object):
         ],
     )
     def test_pin_and_drop_axis(self, varfont, location, expected):
+        location = instancer.NormalizedAxisLimits(location)
+
         instancer.instantiateCvar(varfont, location)
 
         assert list(varfont["cvt "].values) == expected
@@ -217,7 +221,9 @@ class InstantiateCvarTest(object):
         )
 
     def test_full_instance(self, varfont):
-        instancer.instantiateCvar(varfont, {"wght": -0.5, "wdth": -0.5})
+        location = instancer.NormalizedAxisLimits(wght=-0.5, wdth=-0.5)
+
+        instancer.instantiateCvar(varfont, location)
 
         assert list(varfont["cvt "].values) == [500, -400, 165, 225]
 
@@ -272,6 +278,8 @@ class InstantiateMVARTest(object):
         assert mvar.VarStore.VarData[1].VarRegionCount == 1
         assert all(len(item) == 1 for item in mvar.VarStore.VarData[1].Item)
 
+        location = instancer.NormalizedAxisLimits(location)
+
         instancer.instantiateMVAR(varfont, location)
 
         for mvar_tag, expected_value in expected.items():
@@ -312,6 +320,8 @@ class InstantiateMVARTest(object):
         ],
     )
     def test_full_instance(self, varfont, location, expected):
+        location = instancer.NormalizedAxisLimits(location)
+
         instancer.instantiateMVAR(varfont, location)
 
         for mvar_tag, expected_value in expected.items():
@@ -344,6 +354,8 @@ class InstantiateHVARTest(object):
         ],
     )
     def test_partial_instance(self, varfont, location, expectedRegions, expectedDeltas):
+        location = instancer.NormalizedAxisLimits(location)
+
         instancer.instantiateHVAR(varfont, location)
 
         assert "HVAR" in varfont
@@ -376,7 +388,9 @@ class InstantiateHVARTest(object):
         assert varStore.VarData[varIdx >> 16].Item[varIdx & 0xFFFF] == expectedDeltas
 
     def test_full_instance(self, varfont):
-        instancer.instantiateHVAR(varfont, {"wght": 0, "wdth": 0})
+        location = instancer.NormalizedAxisLimits(wght=0, wdth=0)
+
+        instancer.instantiateHVAR(varfont, location)
 
         assert "HVAR" not in varfont
 
@@ -390,7 +404,9 @@ class InstantiateHVARTest(object):
         axis.axisTag = "TEST"
         fvar.axes.append(axis)
 
-        instancer.instantiateHVAR(varfont, {"wght": 0, "wdth": 0})
+        location = instancer.NormalizedAxisLimits(wght=0, wdth=0)
+
+        instancer.instantiateHVAR(varfont, location)
 
         assert "HVAR" in varfont
 
@@ -452,6 +468,8 @@ class InstantiateItemVariationStoreTest(object):
     def test_instantiate_default_deltas(
         self, varStore, fvarAxes, location, expected_deltas, num_regions
     ):
+        location = instancer.NormalizedAxisLimits(location)
+
         defaultDeltas = instancer.instantiateItemVariationStore(
             varStore, fvarAxes, location
         )
@@ -504,8 +522,9 @@ class TupleVarStoreAdapterTest(object):
         adapter = instancer._TupleVarStoreAdapter(
             regions, axisOrder, tupleVarData, itemCounts=[2, 2]
         )
+        location = instancer.NormalizedAxisLimits(wght=0.5)
 
-        defaultDeltaArray = adapter.instantiate({"wght": 0.5})
+        defaultDeltaArray = adapter.instantiate(location)
 
         assert defaultDeltaArray == [[15, 45], [0, 0]]
         assert adapter.regions == [{"wdth": (-1.0, -1.0, 0)}]
@@ -747,6 +766,8 @@ class InstantiateOTLTest(object):
         vf = varfontGDEF
         assert "GDEF" in vf
 
+        location = instancer.NormalizedAxisLimits(location)
+
         instancer.instantiateOTL(vf, location)
 
         assert "GDEF" in vf
@@ -778,6 +799,8 @@ class InstantiateOTLTest(object):
         vf = varfontGDEF
         assert "GDEF" in vf
 
+        location = instancer.NormalizedAxisLimits(location)
+
         instancer.instantiateOTL(vf, location)
 
         assert "GDEF" in vf
@@ -805,6 +828,8 @@ class InstantiateOTLTest(object):
         vf = varfontGPOS
         assert "GDEF" in vf
         assert "GPOS" in vf
+
+        location = instancer.NormalizedAxisLimits(location)
 
         instancer.instantiateOTL(vf, location)
 
@@ -839,6 +864,8 @@ class InstantiateOTLTest(object):
         assert "GDEF" in vf
         assert "GPOS" in vf
 
+        location = instancer.NormalizedAxisLimits(location)
+
         instancer.instantiateOTL(vf, location)
 
         assert "GDEF" not in vf
@@ -869,6 +896,8 @@ class InstantiateOTLTest(object):
         vf = varfontGPOS2
         assert "GDEF" in vf
         assert "GPOS" in vf
+
+        location = instancer.NormalizedAxisLimits(location)
 
         instancer.instantiateOTL(vf, location)
 
@@ -915,6 +944,8 @@ class InstantiateOTLTest(object):
         assert "GDEF" in vf
         assert "GPOS" in vf
 
+        location = instancer.NormalizedAxisLimits(location)
+
         instancer.instantiateOTL(vf, location)
 
         v1, v2 = expected
@@ -955,7 +986,7 @@ class InstantiateOTLTest(object):
 
         # check that MutatorMerger for ValueRecord doesn't raise AttributeError
         # when XAdvDevice is present but there's no corresponding XAdvance.
-        instancer.instantiateOTL(vf, {"wght": 0.5})
+        instancer.instantiateOTL(vf, instancer.NormalizedAxisLimits(wght=0.5))
 
         pairPos = vf["GPOS"].table.LookupList.Lookup[0].SubTable[0]
         assert pairPos.ValueFormat1 == 0x4
@@ -967,12 +998,16 @@ class InstantiateOTLTest(object):
 class InstantiateAvarTest(object):
     @pytest.mark.parametrize("location", [{"wght": 0.0}, {"wdth": 0.0}])
     def test_pin_and_drop_axis(self, varfont, location):
+        location = instancer.AxisLimits(location)
+
         instancer.instantiateAvar(varfont, location)
 
         assert set(varfont["avar"].segments).isdisjoint(location)
 
     def test_full_instance(self, varfont):
-        instancer.instantiateAvar(varfont, {"wght": 0.0, "wdth": 0.0})
+        location = instancer.AxisLimits(wght=0.0, wdth=0.0)
+
+        instancer.instantiateAvar(varfont, location)
 
         assert "avar" not in varfont
 
@@ -1139,6 +1174,8 @@ class InstantiateAvarTest(object):
         ],
     )
     def test_limit_axes(self, varfont, axisLimits, expectedSegments):
+        axisLimits = instancer.AxisLimits(axisLimits)
+
         instancer.instantiateAvar(varfont, axisLimits)
 
         newSegments = varfont["avar"].segments
@@ -1162,8 +1199,10 @@ class InstantiateAvarTest(object):
     def test_drop_invalid_segment_map(self, varfont, invalidSegmentMap, caplog):
         varfont["avar"].segments["wght"] = invalidSegmentMap
 
+        axisLimits = instancer.AxisLimits(wght=(100, 400))
+
         with caplog.at_level(logging.WARNING, logger="fontTools.varLib.instancer"):
-            instancer.instantiateAvar(varfont, {"wght": (100, 400)})
+            instancer.instantiateAvar(varfont, axisLimits)
 
         assert "Invalid avar" in caplog.text
         assert "wght" not in varfont["avar"].segments
@@ -1210,6 +1249,8 @@ class InstantiateFvarTest(object):
         ],
     )
     def test_pin_and_drop_axis(self, varfont, location, instancesLeft):
+        location = instancer.AxisLimits(location)
+
         instancer.instantiateFvar(varfont, location)
 
         fvar = varfont["fvar"]
@@ -1224,7 +1265,9 @@ class InstantiateFvarTest(object):
         ] == instancesLeft
 
     def test_full_instance(self, varfont):
-        instancer.instantiateFvar(varfont, {"wght": 0.0, "wdth": 0.0})
+        location = instancer.AxisLimits({"wght": 0.0, "wdth": 0.0})
+
+        instancer.instantiateFvar(varfont, location)
 
         assert "fvar" not in varfont
 
@@ -1234,10 +1277,15 @@ class InstantiateSTATTest(object):
         "location, expected",
         [
             ({"wght": 400}, ["Regular", "Condensed", "Upright", "Normal"]),
-            ({"wdth": 100}, ["Thin", "Regular", "Black", "Upright", "Normal"]),
+            (
+                {"wdth": 100},
+                ["Thin", "Regular", "Medium", "Black", "Upright", "Normal"],
+            ),
         ],
     )
     def test_pin_and_drop_axis(self, varfont, location, expected):
+        location = instancer.AxisLimits(location)
+
         instancer.instantiateSTAT(varfont, location)
 
         stat = varfont["STAT"].table
@@ -1256,7 +1304,7 @@ class InstantiateSTATTest(object):
     def test_skip_table_no_axis_value_array(self, varfont):
         varfont["STAT"].table.AxisValueArray = None
 
-        instancer.instantiateSTAT(varfont, {"wght": 100})
+        instancer.instantiateSTAT(varfont, instancer.AxisLimits(wght=100))
 
         assert len(varfont["STAT"].table.DesignAxisRecord.Axis) == 3
         assert varfont["STAT"].table.AxisValueArray is None
@@ -1318,7 +1366,9 @@ class InstantiateSTATTest(object):
         return result
 
     def test_limit_axes(self, varfont2):
-        instancer.instantiateSTAT(varfont2, {"wght": (400, 500), "wdth": (75, 100)})
+        axisLimits = instancer.AxisLimits({"wght": (400, 500), "wdth": (75, 100)})
+
+        instancer.instantiateSTAT(varfont2, axisLimits)
 
         assert len(varfont2["STAT"].table.AxisValueArray.AxisValue) == 5
         assert self.get_STAT_axis_values(varfont2["STAT"].table) == [
@@ -1344,11 +1394,11 @@ class InstantiateSTATTest(object):
             axisValue.AxisValueRecord.append(rec)
         stat.AxisValueArray.AxisValue.append(axisValue)
 
-        instancer.instantiateSTAT(varfont2, {"wght": (100, 600)})
+        instancer.instantiateSTAT(varfont2, instancer.AxisLimits(wght=(100, 600)))
 
         assert axisValue in varfont2["STAT"].table.AxisValueArray.AxisValue
 
-        instancer.instantiateSTAT(varfont2, {"wdth": (62.5, 87.5)})
+        instancer.instantiateSTAT(varfont2, instancer.AxisLimits(wdth=(62.5, 87.5)))
 
         assert axisValue not in varfont2["STAT"].table.AxisValueArray.AxisValue
 
@@ -1359,7 +1409,7 @@ class InstantiateSTATTest(object):
         stat.AxisValueArray.AxisValue.append(axisValue)
 
         with caplog.at_level(logging.WARNING, logger="fontTools.varLib.instancer"):
-            instancer.instantiateSTAT(varfont2, {"wght": 400})
+            instancer.instantiateSTAT(varfont2, instancer.AxisLimits(wght=400))
 
         assert "Unknown AxisValue table format (5)" in caplog.text
         assert axisValue in varfont2["STAT"].table.AxisValueArray.AxisValue
@@ -1482,15 +1532,13 @@ class InstantiateVariableFontTest(object):
         location = {"wght": 280, "opsz": 18}
 
         instance = instancer.instantiateVariableFont(
-            varfont, location,
+            varfont,
+            location,
         )
 
-        expected = _get_expected_instance_ttx(
-            "SinglePos", *location.values()
-        )
+        expected = _get_expected_instance_ttx("SinglePos", *location.values())
 
         assert _dump_ttx(instance) == expected
-
 
 
 def _conditionSetAsDict(conditionSet, axisOrder):
@@ -1577,15 +1625,15 @@ class InstantiateFeatureVariationsTest(object):
                 ],
             ),
             (
-                {"cntr": (-.5, 0, 1.0)},
+                {"cntr": (-0.5, 0, 1.0)},
                 {},
                 [
                     (
-                        {"wght": (0.20886, 1.0), "cntr": (.75, 1)},
+                        {"wght": (0.20886, 1.0), "cntr": (0.75, 1)},
                         {"uni0024": "uni0024.nostroke", "uni0041": "uni0061"},
                     ),
                     (
-                        {"wght": (-1.0, -0.45654), "cntr": (0, .25)},
+                        {"wght": (-1.0, -0.45654), "cntr": (0, 0.25)},
                         {"uni0061": "uni0041"},
                     ),
                     (
@@ -1599,7 +1647,7 @@ class InstantiateFeatureVariationsTest(object):
                 ],
             ),
             (
-                {"cntr": (.8, .9, 1.0)},
+                {"cntr": (0.8, 0.9, 1.0)},
                 {"uni0041": "uni0061"},
                 [
                     (
@@ -1626,8 +1674,7 @@ class InstantiateFeatureVariationsTest(object):
             ]
         )
 
-        limits = {tag:instancer.NormalizedAxisTent(l, l, l) if not isinstance(l, tuple) else instancer.NormalizedAxisTent(*l)
-                  for tag,l in location.items()}
+        limits = instancer.NormalizedAxisLimits(location)
         instancer.instantiateFeatureVariations(font, limits)
 
         gsub = font["GSUB"].table
@@ -1635,7 +1682,11 @@ class InstantiateFeatureVariationsTest(object):
 
         assert featureVariations.FeatureVariationCount == len(expectedRecords)
 
-        axisOrder = [a.axisTag for a in font["fvar"].axes if a.axisTag not in location or isinstance(location[a.axisTag], tuple)]
+        axisOrder = [
+            a.axisTag
+            for a in font["fvar"].axes
+            if a.axisTag not in location or isinstance(location[a.axisTag], tuple)
+        ]
         for i, (expectedConditionSet, expectedSubs) in enumerate(expectedRecords):
             rec = featureVariations.FeatureVariationRecord[i]
             conditionSet = _conditionSetAsDict(rec.ConditionSet, axisOrder)
@@ -1681,6 +1732,8 @@ class InstantiateFeatureVariationsTest(object):
         assert gsub.FeatureVariations
         assert gsub.Version == 0x00010001
 
+        location = instancer.NormalizedAxisLimits(location)
+
         instancer.instantiateFeatureVariations(font, location)
 
         assert not hasattr(gsub, "FeatureVariations")
@@ -1707,7 +1760,9 @@ class InstantiateFeatureVariationsTest(object):
         rec1.ConditionSet.ConditionTable[0].Format = 2
 
         with caplog.at_level(logging.WARNING, logger="fontTools.varLib.instancer"):
-            instancer.instantiateFeatureVariations(font, {"wdth": instancer.NormalizedAxisTent(0,0,0)})
+            instancer.instantiateFeatureVariations(
+                font, instancer.NormalizedAxisLimits(wdth=0)
+            )
 
         assert (
             "Condition table 0 of FeatureVariationRecord 0 "
@@ -1819,7 +1874,7 @@ class LimitTupleVariationAxisRangesTest:
         ],
     )
     def test_positive_var(self, var, axisTag, newMax, expected):
-        axisRange = instancer.NormalizedAxisRange(0, newMax)
+        axisRange = instancer.NormalizedAxisTriple(0, 0, newMax)
         self.check_limit_single_var_axis_range(var, axisTag, axisRange, expected)
 
     @pytest.mark.parametrize(
@@ -1898,7 +1953,7 @@ class LimitTupleVariationAxisRangesTest:
         ],
     )
     def test_negative_var(self, var, axisTag, newMin, expected):
-        axisRange = instancer.NormalizedAxisRange(newMin, 0)
+        axisRange = instancer.NormalizedAxisTriple(newMin, 0, 0)
         self.check_limit_single_var_axis_range(var, axisTag, axisRange, expected)
 
 
@@ -1921,7 +1976,7 @@ def test_limitFeatureVariationConditionRange(oldRange, newLimit, expected):
     condition = featureVars.buildConditionTable(0, *oldRange)
 
     result = instancer._limitFeatureVariationConditionRange(
-        condition, instancer.NormalizedAxisTent(*newLimit)
+        condition, instancer.NormalizedAxisTriple(*newLimit)
     )
 
     assert result == expected
@@ -1933,12 +1988,23 @@ def test_limitFeatureVariationConditionRange(oldRange, newLimit, expected):
         (["wght=400", "wdth=100"], {"wght": 400, "wdth": 100}),
         (["wght=400:900"], {"wght": (400, 900)}),
         (["wght=400:700:900"], {"wght": (400, 700, 900)}),
-        (["slnt=11.4"], {"slnt": pytest.approx(11.399994)}),
+        (["slnt=11.4"], {"slnt": 11.399994}),
         (["ABCD=drop"], {"ABCD": None}),
     ],
 )
 def test_parseLimits(limits, expected):
-    assert instancer.parseLimits(limits) == expected
+    limits = instancer.parseLimits(limits)
+    expected = instancer.AxisLimits(expected)
+
+    assert limits.keys() == expected.keys()
+    for axis, triple in limits.items():
+        expected_triple = expected[axis]
+        if expected_triple is None:
+            assert triple is None
+        else:
+            assert isinstance(triple, instancer.AxisTriple)
+            assert isinstance(expected_triple, instancer.AxisTriple)
+            assert triple == pytest.approx(expected_triple)
 
 
 @pytest.mark.parametrize(
@@ -1949,22 +2015,34 @@ def test_parseLimits_invalid(limits):
         instancer.parseLimits(limits)
 
 
-def test_normalizeAxisLimits_tuple(varfont):
-    normalized = instancer.normalizeAxisLimits(varfont, {"wght": (100, 400)})
-    assert normalized == {"wght": (-1.0, 0, 0)}
+@pytest.mark.parametrize(
+    "limits, expected",
+    [
+        ({"wght": (100, 400)}, {"wght": (-1.0, 0, 0)}),
+        ({"wght": (100, 400, 400)}, {"wght": (-1.0, 0, 0)}),
+        ({"wght": (100, 300, 400)}, {"wght": (-1.0, -0.5, 0)}),
+    ],
+)
+def test_normalizeAxisLimits(varfont, limits, expected):
+    limits = instancer.AxisLimits(limits)
+
+    normalized = limits.normalize(varfont)
+
+    assert normalized == instancer.NormalizedAxisLimits(expected)
 
 
 def test_normalizeAxisLimits_no_avar(varfont):
     del varfont["avar"]
 
-    normalized = instancer.normalizeAxisLimits(varfont, {"wght": (400, 500)})
+    limits = instancer.AxisLimits(wght=(400, 400, 500))
+    normalized = limits.normalize(varfont)
 
     assert normalized["wght"] == pytest.approx((0, 0, 0.2), 1e-4)
 
 
 def test_normalizeAxisLimits_missing_from_fvar(varfont):
     with pytest.raises(ValueError, match="not present in fvar"):
-        instancer.normalizeAxisLimits(varfont, {"ZZZZ": 1000})
+        instancer.AxisLimits({"ZZZZ": 1000}).normalize(varfont)
 
 
 def test_sanityCheckVariableTables(varfont):

--- a/Tests/varLib/instancer/names_test.py
+++ b/Tests/varLib/instancer/names_test.py
@@ -115,7 +115,7 @@ def _test_name_records(varfont, expected, isNonRIBBI, platforms=[0x409]):
         ),
         # Condensed with unpinned weights
         (
-            {"wdth": 79, "wght": instancer.AxisRange(400, 900)},
+            {"wdth": 79, "wght": (400, 900)},
             {
                 (1, 3, 1, 0x409): "Test Variable Font Condensed",
                 (2, 3, 1, 0x409): "Regular",
@@ -123,6 +123,19 @@ def _test_name_records(varfont, expected, isNonRIBBI, platforms=[0x409]):
                 (6, 3, 1, 0x409): "TestVariableFont-Condensed",
                 (16, 3, 1, 0x409): "Test Variable Font",
                 (17, 3, 1, 0x409): "Condensed",
+            },
+            True,
+        ),
+        # Restrict weight and move default, new minimum (500) > old default (400)
+        (
+            {"wght": (500, 900)},
+            {
+                (1, 3, 1, 0x409): "Test Variable Font Medium",
+                (2, 3, 1, 0x409): "Regular",
+                (3, 3, 1, 0x409): "2.001;GOOG;TestVariableFont-Medium",
+                (6, 3, 1, 0x409): "TestVariableFont-Medium",
+                (16, 3, 1, 0x409): "Test Variable Font",
+                (17, 3, 1, 0x409): "Medium",
             },
             True,
         ),
@@ -215,7 +228,7 @@ def test_updateNameTable_with_multilingual_names(varfont, limits, expected, isNo
 
 
 def test_updateNameTable_missing_axisValues(varfont):
-    with pytest.raises(ValueError, match="Cannot find Axis Values \['wght=200'\]"):
+    with pytest.raises(ValueError, match="Cannot find Axis Values {'wght': 200}"):
         instancer.names.updateNameTable(varfont, {"wght": 200})
 
 
@@ -257,7 +270,7 @@ def test_updateNameTable_missing_stat(varfont):
 def test_updateNameTable_vf_with_italic_attribute(
     varfont, limits, expected, isNonRIBBI
 ):
-    font_link_axisValue = varfont["STAT"].table.AxisValueArray.AxisValue[4]
+    font_link_axisValue = varfont["STAT"].table.AxisValueArray.AxisValue[5]
     # Unset ELIDABLE_AXIS_VALUE_NAME flag
     font_link_axisValue.Flags &= ~instancer.names.ELIDABLE_AXIS_VALUE_NAME
     font_link_axisValue.ValueNameID = 294  # Roman --> Italic


### PR DESCRIPTION
Also renamed AxisTent => AxisTriple because I think "tent" is more appropriate to visualize master supports (i.e. a triangle with a peak in the middle), here it's simply the new desired min, default, max values of an axis, aka the axis limits.
I could have named the triple AxisLimit(s) but the latter name was already used to mean a map from axis tags to axis values so I decided to keep the term "AxisLimits" to mean exactly that; I even made a custom mapping that automatically expands singles/tuples so the rest of the code internally can expect triples.
The public facing `instantiateVariableFont` of course continues to accept a hybrid map of axis tags to single values or 2- (and now also 3-) tuples, which are normalized to this AxisLimits.
A lot of words for nothing.