### PR TITLE
[svgPathPen] Don't close path in endPath()

### DIFF
--- a/Lib/fontTools/pens/svgPathPen.py
+++ b/Lib/fontTools/pens/svgPathPen.py
@@ -195,9 +195,8 @@ class SVGPathPen(BasePen):
         >>> pen = SVGPathPen(None)
         >>> pen.endPath()
         >>> pen._commands
-        ['Z']
+        []
         """
-        self._closePath()
         self._lastCommand = None
         self._lastX = self._lastY = None
 


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/2089