### PR TITLE
[woff2] Support encoding/decoding OVERLAP_SIMPLE glyf flags

### DIFF
--- a/Tests/ttLib/woff2_test.py
+++ b/Tests/ttLib/woff2_test.py
@@ -1239,7 +1239,10 @@ class WOFF2RoundtripTest(object):
 
 		_, ttFont2 = self.roundtrip(tmp)
 		assert ttFont2.flavor == "woff2"
-		assert ttFont2["glyf"]["A"].flags[0] == 0
+		# check that the off-curve point is still there
+		assert ttFont2["glyf"]["A"].flags[0] & _g_l_y_f.flagOnCurve == 0
+		# check that the overlap bit is still there
+		assert ttFont2["glyf"]["A"].flags[0] & _g_l_y_f.flagOverlapSimple != 0
 
 class MainTest(object):
 


### PR DESCRIPTION
Fixes #2576

This updates our `fontTools.ttLib.woff2` encoder/decoder to support retaining the `OVERLAP_SIMPLE` glyf flag, following the updated [WOFF 2.0 specification](https://www.w3.org/TR/WOFF2/#glyf_table_format) and official google/woff2 implementation.

