### PR TITLE
[instancer] update OS/2 class and post.italicAngle when default moved (L4)

### DIFF
--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -257,6 +257,10 @@ class _BaseAxisLimits(Mapping[str, AxisTriple]):
     def __str__(self) -> str:
         return str(self._data)
 
+    def defaultLocation(self) -> Dict[str, float]:
+        """Return a dict of default axis values."""
+        return {k: v.default for k, v in self.items()}
+
     def pinnedLocation(self) -> Dict[str, float]:
         """Return a location dict with only the pinned axes."""
         return {k: v.default for k, v in self.items() if v.minimum == v.maximum}
@@ -1167,7 +1171,9 @@ def instantiateVariableFont(
                     ignoreErrors=(overlap == OverlapMode.REMOVE_AND_IGNORE_ERRORS),
                 )
 
-    varLib.set_default_weight_width_slant(varfont, location=axisLimits.pinnedLocation())
+    varLib.set_default_weight_width_slant(
+        varfont, location=axisLimits.defaultLocation()
+    )
 
     if updateFontNames:
         # Set Regular/Italic/Bold/Bold Italic bits as appropriate, after the

--- a/Lib/fontTools/varLib/instancer/names.py
+++ b/Lib/fontTools/varLib/instancer/names.py
@@ -115,7 +115,7 @@ def updateNameTable(varfont, axisLimits):
     # If we're instantiating a partial font, we will populate the unpinned
     # axes with their default axis values from fvar.
     axisLimits = AxisLimits(axisLimits).populateDefaults(varfont)
-    partialDefaults = {k: v.default for k, v in axisLimits.items()}
+    partialDefaults = axisLimits.defaultLocation()
     fvarDefaults = {a.axisTag: a.defaultValue for a in fvar.axes}
     defaultAxisCoords = AxisLimits({**fvarDefaults, **partialDefaults})
     assert all(v.minimum == v.maximum for v in defaultAxisCoords.values())

--- a/Tests/varLib/instancer/instancer_test.py
+++ b/Tests/varLib/instancer/instancer_test.py
@@ -1502,6 +1502,18 @@ class InstantiateVariableFontTest(object):
 
         assert _dump_ttx(instance) == expected
 
+    def test_move_weight_width_axis_default(self, varfont2):
+        # https://github.com/fonttools/fonttools/issues/2885
+        assert varfont2["OS/2"].usWeightClass == 400
+        assert varfont2["OS/2"].usWidthClass == 5
+
+        varfont = instancer.instantiateVariableFont(
+            varfont2, {"wght": (100, 500, 900), "wdth": 87.5}
+        )
+
+        assert varfont["OS/2"].usWeightClass == 500
+        assert varfont["OS/2"].usWidthClass == 4
+
     @pytest.mark.parametrize(
         "overlap, wght",
         [


### PR DESCRIPTION
Previously we were only updating these when pinning wght/wdth/slnt axes. Now we do whenever any of these axes defaults are changed, whether or not the axes are pinned or kept

Fixes https://github.com/fonttools/fonttools/issues/2885