### PR TITLE
Skip scaling of vsindex in scaleUpem.py

### DIFF
--- a/Lib/fontTools/ttLib/scaleUpem.py
+++ b/Lib/fontTools/ttLib/scaleUpem.py
@@ -178,6 +178,8 @@ def visit(visitor, obj, attr, cff):
                 c.program, getNumRegions=getNumRegions
             )
             for op, args in commands:
+                if op == "vsindex":
+                    continue
                 _cff_scale(visitor, args)
             c.program[:] = cffSpecializer.commandsToProgram(commands)
 


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/2893