### PR TITLE
[designspaceLib] Provide fallback for `elidedFallbackName`

### DIFF
--- a/Lib/fontTools/designspaceLib/statNames.py
+++ b/Lib/fontTools/designspaceLib/statNames.py
@@ -49,10 +49,13 @@ class StatNames:
 
 
 def getStatNames(
-    doc: DesignSpaceDocument, userLocation: SimpleLocationDict
+    doc: DesignSpaceDocument,
+    userLocation: SimpleLocationDict,
+    defaultElidedFallbackName: Dict[str, str] | None = None,
 ) -> StatNames:
     """Compute the family, style, PostScript names of the given ``userLocation``
-    using the document's STAT information.
+    using the document's STAT information, falling back to the names in
+    ``defaultElidedFallbackName`` if all names are elided.
 
     Also computes localizations.
 
@@ -66,6 +69,9 @@ def getStatNames(
 
     .. versionadded:: 5.0
     """
+    if defaultElidedFallbackName is None:
+        defaultElidedFallbackName = {"en": "Regular"}
+
     familyNames: Dict[str, str] = {}
     defaultSource: Optional[SourceDescriptor] = doc.findDefault()
     if defaultSource is None:
@@ -102,8 +108,13 @@ def getStatNames(
                     for label in labels
                     if not label.elidable
                 )
-                if not styleName and doc.elidedFallbackName is not None:
-                    styleName = doc.elidedFallbackName
+                if not styleName:
+                    if doc.elidedFallbackName is not None:
+                        styleName = doc.elidedFallbackName
+                    else:
+                        styleName = defaultElidedFallbackName.get(
+                            language, defaultElidedFallbackName["en"]
+                        )
                 styleNames[language] = styleName
 
     if "en" not in familyNames or "en" not in styleNames:
@@ -129,7 +140,10 @@ def getStatNames(
     for language in set(familyNames).union(styleNames.keys()):
         familyName = familyNames.get(language, familyNames["en"])
         styleName = styleNamesForStyleMap.get(language, styleNamesForStyleMap["en"])
-        styleMapFamilyNames[language] = (familyName + " " + styleName).strip()
+        if styleName.lower() in BOLD_ITALIC_TO_RIBBI_STYLE.values():
+            styleMapFamilyNames[language] = familyName.strip()
+        else:
+            styleMapFamilyNames[language] = f"{familyName} {styleName}".strip()
 
     return StatNames(
         familyNames=familyNames,

--- a/Tests/designspaceLib/data/convert5to4_output/AktivGroteskVF_Wght.designspace
+++ b/Tests/designspaceLib/data/convert5to4_output/AktivGroteskVF_Wght.designspace
@@ -57,7 +57,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance name="Aktiv Grotesk " familyname="Aktiv Grotesk" stylename="" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
+    <instance name="Aktiv Grotesk Regular" familyname="Aktiv Grotesk" stylename="Regular" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-Regular" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="84"/>
       </location>

--- a/Tests/designspaceLib/data/convert5to4_output/AktivGroteskVF_WghtWdth.designspace
+++ b/Tests/designspaceLib/data/convert5to4_output/AktivGroteskVF_WghtWdth.designspace
@@ -167,7 +167,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance name="Aktiv Grotesk " familyname="Aktiv Grotesk" stylename="" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
+    <instance name="Aktiv Grotesk Regular" familyname="Aktiv Grotesk" stylename="Regular" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-Regular" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="84"/>
         <dimension name="Width" xvalue="100"/>

--- a/Tests/designspaceLib/data/convert5to4_output/AktivGroteskVF_WghtWdthItal.designspace
+++ b/Tests/designspaceLib/data/convert5to4_output/AktivGroteskVF_WghtWdthItal.designspace
@@ -360,7 +360,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance name="Aktiv Grotesk " familyname="Aktiv Grotesk" stylename="" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
+    <instance name="Aktiv Grotesk Regular" familyname="Aktiv Grotesk" stylename="Regular" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-Regular" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="84"/>
         <dimension name="Width" xvalue="100"/>

--- a/Tests/designspaceLib/data/convert5to4_output/SourceSerif4Variable-Italic.designspace
+++ b/Tests/designspaceLib/data/convert5to4_output/SourceSerif4Variable-Italic.designspace
@@ -180,7 +180,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance name="Source Serif 4 Italic" familyname="Source Serif 4" stylename="Italic" filename="Source Serif 4-Italic.ttf" postscriptfontname="SourceSerif4Italic-Regular" stylemapfamilyname="Source Serif 4 Italic" stylemapstylename="regular">
+    <instance name="Source Serif 4 Italic" familyname="Source Serif 4" stylename="Italic" filename="Source Serif 4-Italic.ttf" postscriptfontname="SourceSerif4Italic-Regular" stylemapfamilyname="Source Serif 4" stylemapstylename="regular">
       <location>
         <dimension name="weight" xvalue="394"/>
         <dimension name="optical" xvalue="20"/>
@@ -196,7 +196,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance name="Source Serif 4 Bold Italic" familyname="Source Serif 4" stylename="Bold Italic" filename="Source Serif 4-Bold Italic.ttf" postscriptfontname="SourceSerif4Italic-Bold" stylemapfamilyname="Source Serif 4 Bold Italic" stylemapstylename="regular">
+    <instance name="Source Serif 4 Bold Italic" familyname="Source Serif 4" stylename="Bold Italic" filename="Source Serif 4-Bold Italic.ttf" postscriptfontname="SourceSerif4Italic-Bold" stylemapfamilyname="Source Serif 4" stylemapstylename="regular">
       <location>
         <dimension name="weight" xvalue="823"/>
         <dimension name="optical" xvalue="20"/>

--- a/Tests/designspaceLib/data/convert5to4_output/SourceSerif4Variable-Roman.designspace
+++ b/Tests/designspaceLib/data/convert5to4_output/SourceSerif4Variable-Roman.designspace
@@ -196,7 +196,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance name="Source Serif 4 Bold" familyname="Source Serif 4" stylename="Bold" filename="Source Serif 4-Bold.ttf" postscriptfontname="SourceSerif4Roman-Bold" stylemapfamilyname="Source Serif 4 Bold" stylemapstylename="regular">
+    <instance name="Source Serif 4 Bold" familyname="Source Serif 4" stylename="Bold" filename="Source Serif 4-Bold.ttf" postscriptfontname="SourceSerif4Roman-Bold" stylemapfamilyname="Source Serif 4" stylemapstylename="regular">
       <location>
         <dimension name="weight" xvalue="823"/>
         <dimension name="optical" xvalue="20"/>

--- a/Tests/designspaceLib/data/split_output/AktivGroteskVF_Wght.designspace
+++ b/Tests/designspaceLib/data/split_output/AktivGroteskVF_Wght.designspace
@@ -51,7 +51,7 @@
         <dimension name="Weight" xvalue="57"/>
       </location>
     </instance>
-    <instance name="Aktiv Grotesk " familyname="Aktiv Grotesk" stylename="" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
+    <instance name="Aktiv Grotesk Regular" familyname="Aktiv Grotesk" stylename="Regular" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-Regular" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="84"/>
       </location>

--- a/Tests/designspaceLib/data/split_output/AktivGroteskVF_WghtWdth.designspace
+++ b/Tests/designspaceLib/data/split_output/AktivGroteskVF_WghtWdth.designspace
@@ -147,7 +147,7 @@
         <dimension name="Width" xvalue="75"/>
       </location>
     </instance>
-    <instance name="Aktiv Grotesk " familyname="Aktiv Grotesk" stylename="" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
+    <instance name="Aktiv Grotesk Regular" familyname="Aktiv Grotesk" stylename="Regular" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-Regular" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="84"/>
         <dimension name="Width" xvalue="100"/>

--- a/Tests/designspaceLib/data/split_output/AktivGroteskVF_WghtWdthItal.designspace
+++ b/Tests/designspaceLib/data/split_output/AktivGroteskVF_WghtWdthItal.designspace
@@ -320,7 +320,7 @@
         <dimension name="Italic" xvalue="1"/>
       </location>
     </instance>
-    <instance name="Aktiv Grotesk " familyname="Aktiv Grotesk" stylename="" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
+    <instance name="Aktiv Grotesk Regular" familyname="Aktiv Grotesk" stylename="Regular" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-Regular" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="84"/>
         <dimension name="Width" xvalue="100"/>

--- a/Tests/designspaceLib/data/split_output/SourceSerif4Variable-Italic.designspace
+++ b/Tests/designspaceLib/data/split_output/SourceSerif4Variable-Italic.designspace
@@ -152,7 +152,7 @@
         <dimension name="optical" xvalue="20"/>
       </location>
     </instance>
-    <instance name="Source Serif 4 Italic" familyname="Source Serif 4" stylename="Italic" filename="Source Serif 4-Italic.ttf" postscriptfontname="SourceSerif4Italic-Regular" stylemapfamilyname="Source Serif 4 Italic" stylemapstylename="regular">
+    <instance name="Source Serif 4 Italic" familyname="Source Serif 4" stylename="Italic" filename="Source Serif 4-Italic.ttf" postscriptfontname="SourceSerif4Italic-Regular" stylemapfamilyname="Source Serif 4" stylemapstylename="regular">
       <location>
         <dimension name="weight" xvalue="394"/>
         <dimension name="optical" xvalue="20"/>
@@ -164,7 +164,7 @@
         <dimension name="optical" xvalue="20"/>
       </location>
     </instance>
-    <instance name="Source Serif 4 Bold Italic" familyname="Source Serif 4" stylename="Bold Italic" filename="Source Serif 4-Bold Italic.ttf" postscriptfontname="SourceSerif4Italic-Bold" stylemapfamilyname="Source Serif 4 Bold Italic" stylemapstylename="regular">
+    <instance name="Source Serif 4 Bold Italic" familyname="Source Serif 4" stylename="Bold Italic" filename="Source Serif 4-Bold Italic.ttf" postscriptfontname="SourceSerif4Italic-Bold" stylemapfamilyname="Source Serif 4" stylemapstylename="regular">
       <location>
         <dimension name="weight" xvalue="823"/>
         <dimension name="optical" xvalue="20"/>

--- a/Tests/designspaceLib/data/split_output/SourceSerif4Variable-Roman.designspace
+++ b/Tests/designspaceLib/data/split_output/SourceSerif4Variable-Roman.designspace
@@ -164,7 +164,7 @@
         <dimension name="optical" xvalue="20"/>
       </location>
     </instance>
-    <instance name="Source Serif 4 Bold" familyname="Source Serif 4" stylename="Bold" filename="Source Serif 4-Bold.ttf" postscriptfontname="SourceSerif4Roman-Bold" stylemapfamilyname="Source Serif 4 Bold" stylemapstylename="regular">
+    <instance name="Source Serif 4 Bold" familyname="Source Serif 4" stylename="Bold" filename="Source Serif 4-Bold.ttf" postscriptfontname="SourceSerif4Roman-Bold" stylemapfamilyname="Source Serif 4" stylemapstylename="regular">
       <location>
         <dimension name="weight" xvalue="823"/>
         <dimension name="optical" xvalue="20"/>

--- a/Tests/designspaceLib/data/split_output/test_v5_aktiv_.designspace
+++ b/Tests/designspaceLib/data/split_output/test_v5_aktiv_.designspace
@@ -353,7 +353,7 @@
         <dimension name="Italic" xvalue="1"/>
       </location>
     </instance>
-    <instance name="Aktiv Grotesk " familyname="Aktiv Grotesk" stylename="" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
+    <instance name="Aktiv Grotesk Regular" familyname="Aktiv Grotesk" stylename="Regular" filename="../instances/AktivGrotesk_Rg.ufo" postscriptfontname="AktivGrotesk-Regular" stylemapfamilyname="Aktiv Grotesk" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="84"/>
         <dimension name="Width" xvalue="100"/>

--- a/Tests/designspaceLib/data/split_output/test_v5_sourceserif_italic_0.0.designspace
+++ b/Tests/designspaceLib/data/split_output/test_v5_sourceserif_italic_0.0.designspace
@@ -194,7 +194,7 @@
         <dimension name="optical" xvalue="20"/>
       </location>
     </instance>
-    <instance name="Source Serif 4 Bold" familyname="Source Serif 4" stylename="Bold" filename="Source Serif 4-Bold.ttf" postscriptfontname="SourceSerif4Roman-Bold" stylemapfamilyname="Source Serif 4 Bold" stylemapstylename="regular">
+    <instance name="Source Serif 4 Bold" familyname="Source Serif 4" stylename="Bold" filename="Source Serif 4-Bold.ttf" postscriptfontname="SourceSerif4Roman-Bold" stylemapfamilyname="Source Serif 4" stylemapstylename="regular">
       <location>
         <dimension name="weight" xvalue="823"/>
         <dimension name="optical" xvalue="20"/>

--- a/Tests/designspaceLib/data/split_output/test_v5_sourceserif_italic_1.0.designspace
+++ b/Tests/designspaceLib/data/split_output/test_v5_sourceserif_italic_1.0.designspace
@@ -174,7 +174,7 @@
         <dimension name="optical" xvalue="20"/>
       </location>
     </instance>
-    <instance name="Source Serif 4 Italic" familyname="Source Serif 4" stylename="Italic" filename="Source Serif 4-Italic.ttf" postscriptfontname="SourceSerif4Italic-Regular" stylemapfamilyname="Source Serif 4 Italic" stylemapstylename="regular">
+    <instance name="Source Serif 4 Italic" familyname="Source Serif 4" stylename="Italic" filename="Source Serif 4-Italic.ttf" postscriptfontname="SourceSerif4Italic-Regular" stylemapfamilyname="Source Serif 4" stylemapstylename="regular">
       <location>
         <dimension name="weight" xvalue="394"/>
         <dimension name="optical" xvalue="20"/>
@@ -186,7 +186,7 @@
         <dimension name="optical" xvalue="20"/>
       </location>
     </instance>
-    <instance name="Source Serif 4 Bold Italic" familyname="Source Serif 4" stylename="Bold Italic" filename="Source Serif 4-Bold Italic.ttf" postscriptfontname="SourceSerif4Italic-Bold" stylemapfamilyname="Source Serif 4 Bold Italic" stylemapstylename="regular">
+    <instance name="Source Serif 4 Bold Italic" familyname="Source Serif 4" stylename="Bold Italic" filename="Source Serif 4-Bold Italic.ttf" postscriptfontname="SourceSerif4Italic-Bold" stylemapfamilyname="Source Serif 4" stylemapstylename="regular">
       <location>
         <dimension name="weight" xvalue="823"/>
         <dimension name="optical" xvalue="20"/>

--- a/Tests/designspaceLib/statNames_test.py
+++ b/Tests/designspaceLib/statNames_test.py
@@ -16,6 +16,19 @@ def test_instance_getStatNames(datadir):
     )
 
 
+def test_instance_getStatNames_no_style_links(datadir):
+    """Tests that without style linking in the DS, all styleMapStyleNames are
+    `regular`.
+
+    This is not necessarily a feature, just the code following orders.
+    """
+    doc = DesignSpaceDocument.fromfile(datadir / "test_v5_sourceserif.designspace")
+
+    for instance in doc.instances:
+        location = instance.getFullUserLocation(doc)
+        assert getStatNames(doc, location).styleMapStyleName == "regular"
+
+
 def test_not_all_ordering_specified_and_translations(datadir):
     doc = DesignSpaceDocument.fromfile(datadir / "test_v5.designspace")
 
@@ -44,12 +57,30 @@ def test_not_all_ordering_specified_and_translations(datadir):
 def test_detect_ribbi_aktiv(datadir):
     doc = DesignSpaceDocument.fromfile(datadir / "test_v5_aktiv.designspace")
 
+    # The default location has all names elided, so getStatNames must fall back
+    # to the fallback.
+    assert getStatNames(doc, doc.newDefaultLocation()) == StatNames(
+        familyNames={"en": "Aktiv Grotesk"},
+        styleNames={"en": "Regular"},
+        postScriptFontName="AktivGrotesk-Regular",
+        styleMapFamilyNames={"en": "Aktiv Grotesk"},
+        styleMapStyleName="regular",
+    )
+
     assert getStatNames(doc, {"Weight": 600, "Width": 125, "Italic": 1}) == StatNames(
         familyNames={"en": "Aktiv Grotesk"},
         styleNames={"en": "Ex SemiBold Italic"},
         postScriptFontName="AktivGrotesk-ExSemiBoldItalic",
         styleMapFamilyNames={"en": "Aktiv Grotesk Ex SemiBold"},
         styleMapStyleName="italic",
+    )
+
+    assert getStatNames(doc, {"Weight": 700, "Width": 100, "Italic": 0}) == StatNames(
+        familyNames={"en": "Aktiv Grotesk"},
+        styleNames={"en": "Bold"},
+        postScriptFontName="AktivGrotesk-Bold",
+        styleMapFamilyNames={"en": "Aktiv Grotesk"},
+        styleMapStyleName="bold",
     )
 
     assert getStatNames(doc, {"Weight": 700, "Width": 75, "Italic": 1}) == StatNames(


### PR DESCRIPTION
Provide a fallback for the DS-wide `elidedFallbackName`.

This is a bit unfortunate, because the `DesignSpaceDocument.elidedFallbackName` is a string, not a localization dict. However, if it is not set by the user, we just insert a generic English "Regular". Still better than having an empty style name.

This also fixes a bug where a RIBBI style would end up with a style mapping like `stylemapfamilyname="Source Serif 4 Bold Italic" stylemapstylename="regular"`. RIBBI styles should not be part of the style map family name.

Closes https://github.com/fonttools/fonttools/issues/2877.