### PR TITLE
Replace `master` word in designspace document files

### DIFF
--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -48,8 +48,8 @@ templates_path = ["_templates"]
 # source_suffix = ['.rst', '.md']
 source_suffix = ".rst"
 
-# The master toctree document.
-master_doc = "index"
+# The root toctree document.
+root_doc = "index"
 
 # General information about the project.
 project = u"fontTools"
@@ -140,7 +140,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (
-        master_doc,
+        root_doc,
         "fontTools.tex",
         u"fontTools Documentation",
         u"Just van Rossum, Behdad Esfahbod et al.",
@@ -153,7 +153,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "fonttools", u"fontTools Documentation", [author], 1)]
+man_pages = [(root_doc, "fonttools", u"fontTools Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -163,7 +163,7 @@ man_pages = [(master_doc, "fonttools", u"fontTools Documentation", [author], 1)]
 #  dir menu entry, description, category)
 texinfo_documents = [
     (
-        master_doc,
+        root_doc,
         "fontTools",
         u"fontTools Documentation",
         author,

--- a/Doc/source/designspaceLib/scripting.rst
+++ b/Doc/source/designspaceLib/scripting.rst
@@ -59,7 +59,7 @@ Make a descriptor object and add it to the document.
 -  The ``tag`` attribute is the one of the registered `OpenType
    Variation Axis
    Tags <https://www.microsoft.com/typography/otspec/fvar.htm#VAT>`__
--  The default master is expected at the intersection of all
+-  The default source is expected at the intersection of all
    default values of all axes.
 
 Option: add label names
@@ -101,14 +101,14 @@ outline geometry, kerning and font.info that we want to work with.
 
     s0 = SourceDescriptor()
     s0.path = "my/path/to/thin.ufo"
-    s0.name = "master.thin"
+    s0.name = "source.thin"
     s0.location = dict(weight=0)
     doc.addSource(s0)
 
 -  You'll need to have at least 2 sources in your document, so go ahead
    and add another one.
 -  The **location** attribute is a dictionary with the designspace
-   location for this master.
+   location for this source.
 -  The axis names in the location have to match one of the ``axis.name``
    values you defined before.
 -  The **path** attribute is the absolute path to an existing UFO.
@@ -116,13 +116,13 @@ outline geometry, kerning and font.info that we want to work with.
    track it.
 -  The **layerName** attribute is the name of the UFO3 layer. Default None for ``foreground``.
 
-So go ahead and add another master:
+So go ahead and add another source:
 
 .. code:: python
 
     s1 = SourceDescriptor()
     s1.path = "my/path/to/bold.ufo"
-    s1.name = "master.bold"
+    s1.name = "source.bold"
     s1.location = dict(weight=1000)
     doc.addSource(s1)
 
@@ -177,7 +177,7 @@ and a stylemap styleName.
     i0.styleMapFamilyName = "MyVarProtoMedium"
     i0.styleMapStyleName = "regular"
 
-Option: add glyph specific masters
+Option: add glyph specific sources
 ----------------------------------
 
 This bit is not supported by OpenType variable fonts, but it is needed
@@ -195,16 +195,16 @@ this into something clever.
     # you can specify a different location for a glyph
     glyphData['instanceLocation'] = dict(weight=500)
 
-    # You can specify different masters
+    # You can specify different sources
     # for this specific glyph.
-    # You can also give those masters new
+    # You can also give those sources new
     # locations. It's a miniature designspace.
     # Remember the "name" attribute we assigned to the sources?
-    glyphData['masters'] = [
-        dict(font="master.thin",
+    glyphData['sources'] = [
+        dict(font="source.thin",
             glyphName="dollar.nostroke",
             location=dict(weight=0)),
-        dict(font="master.bold",
+        dict(font="source.bold",
             glyphName="dollar.nostroke",
             location=dict(weight=1000)),
         ]
@@ -232,7 +232,7 @@ You can generate the UFOs with MutatorMath:
     from mutatorMath.ufo import build
     build("whatevs/myprototype.designspace")
 
--  Assuming the outline data in the masters is compatible.
+-  Assuming the outline data in the sources is compatible.
 
 Or you can use the file in making a **variable font** with varlib.
 

--- a/Doc/source/designspaceLib/xml.rst
+++ b/Doc/source/designspaceLib/xml.rst
@@ -31,7 +31,7 @@ Overview
             <label... />
         </labels>
         <sources>
-            <!-- define masters here -->
+            <!-- define sources here -->
             <source... />
         </sources>
         <variable-fonts>
@@ -603,7 +603,7 @@ Defines the coordinates of this source in the design space.
 .. rubric:: Attributes
 
 -  ``mute``: optional attribute, number 1 or 0. Indicate if this glyph
-   should be ignored as a master.
+   should be ignored as a source.
 
 .. note::
 
@@ -633,7 +633,7 @@ Defines the coordinates of this source in the design space.
 
 .. code:: xml
 
-    <source familyname="MasterFamilyName" filename="masters/masterTest1.ufo" name="master.ufo1" stylename="MasterStyleNameOne">
+    <source familyname="SourceFamilyName" filename="sources/sourceTest1.ufo" name="source.ufo1" stylename="SourceStyleNameOne">
         <location>
             <dimension name="width" xvalue="0.000000" />
             <dimension name="weight" xvalue="0.000000" />
@@ -807,7 +807,7 @@ The ``<instances>`` element contains one or more ``<instance>`` elements.
 -  For use in Varlib the instance element really only needs the names
    and the location. The ``<glyphs>`` element is not required.
 -  MutatorMath uses the ``<glyphs>`` element to describe how certain
-   glyphs need different masters, mainly to describe the effects of
+   glyphs need different sources, mainly to describe the effects of
    conditional rules in Superpolator.
 -  Location in designspace coordinates.
 
@@ -937,7 +937,7 @@ Example for varlib
 ,,,,,,,,,,,,,,,,,,,,,
 
 -  Container for ``<master>`` elements
--  These ``<master>`` elements define an alternative set of glyph masters
+-  These ``<master>`` elements define an alternative set of glyph sources
    for this glyph.
 
 .. deprecated:: 5.0
@@ -946,13 +946,13 @@ Example for varlib
 ``<master>`` element
 ++++++++++++++++++++
 
--  Defines a single alternative master for this glyph.
+-  Defines a single alternative source for this glyph.
 
 .. deprecated:: 5.0
 
 .. rubric:: Attributes
 
--  ``glyphname``: the name of the alternate master glyph.
+-  ``glyphname``: the name of the alternate source glyph.
 -  ``source``: the identifier name of the source this master glyph needs
    to be loaded from
 
@@ -976,7 +976,7 @@ Example for MutatorMath
         </location>
         <note>A note about this glyph</note>
         <masters>
-            <master glyphname="BB" source="master.ufo1">
+            <master glyphname="BB" source="source.ufo1">
             <location>
                 <dimension name="width" xvalue="20" />
                 <dimension name="weight" xvalue="20" />


### PR DESCRIPTION
This PR is an attempt to fix some `master` word entries in `fonttools/Doc/source/` directory files.
Please review this PR and do suggest if needed any changes.

This PR is created to fix issue #2896