### PR TITLE
[gvar] Don't expand glyph for unused pointCount

### DIFF
--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -632,6 +632,8 @@ def compileSharedTuples(axisTags, variations,
 def compileTupleVariationStore(variations, pointCount,
                                axisTags, sharedTupleIndices,
                                useSharedPoints=True):
+	# pointCount is actually unused. Keeping for API compat.
+	del pointCount
 	newVariations = []
 	pointDatas = []
 	# Compile all points and figure out sharing if desired

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -99,9 +99,8 @@ class table__g_v_a_r(DefaultTable.DefaultTable):
 			if not variations:
 				result.append(b"")
 				continue
-			glyph = glyf[glyphName]
-			pointCount = self.getNumPoints_(glyph)
-			result.append(compileGlyph_(variations, pointCount,
+			pointCountUnused = 0 # pointCount is actually unused by compileGlyph
+			result.append(compileGlyph_(variations, pointCountUnused,
 			                            axisTags, sharedCoordIndices))
 		return result
 


### PR DESCRIPTION
Keep it in the API though.

The compile code doesn't use the pointCount. This avoids expanding the glyph unnecessarily (and makes my smarties code work as well, since it builds glyphs that cannot be expanded by current fonttools).