### PR TITLE
Unify pen argument names

### DIFF
--- a/Lib/fontTools/cu2qu/ufo.py
+++ b/Lib/fontTools/cu2qu/ufo.py
@@ -24,6 +24,7 @@ the resulting splines are interpolation-compatible.
 """
 
 import logging
+from typing import Tuple
 from fontTools.pens.basePen import AbstractPen
 from fontTools.pens.pointPen import PointToSegmentPen
 from fontTools.pens.reverseContourPen import ReverseContourPen
@@ -91,7 +92,11 @@ class GetSegmentsPen(AbstractPen):
     def endPath(self):
         self._add_segment('end')
 
-    def addComponent(self, glyphName, transformation):
+    def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+	) -> None:
         pass
 
 

--- a/Lib/fontTools/cu2qu/ufo.py
+++ b/Lib/fontTools/cu2qu/ufo.py
@@ -65,38 +65,38 @@ class GetSegmentsPen(AbstractPen):
     duplicated between segments.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._last_pt = None
         self.segments = []
 
-    def _add_segment(self, tag, *args):
+    def _add_segment(self, tag, *args) -> None:
         if tag in ['move', 'line', 'qcurve', 'curve']:
             self._last_pt = args[-1]
         self.segments.append((tag, args))
 
-    def moveTo(self, pt):
+    def moveTo(self, pt) -> None:
         self._add_segment('move', pt)
 
-    def lineTo(self, pt):
+    def lineTo(self, pt) -> None:
         self._add_segment('line', pt)
 
-    def qCurveTo(self, *points):
+    def qCurveTo(self, *points) -> None:
         self._add_segment('qcurve', self._last_pt, *points)
 
-    def curveTo(self, *points):
+    def curveTo(self, *points) -> None:
         self._add_segment('curve', self._last_pt, *points)
 
-    def closePath(self):
+    def closePath(self) -> None:
         self._add_segment('close')
 
-    def endPath(self):
+    def endPath(self) -> None:
         self._add_segment('end')
 
     def addComponent(
-		self,
-		glyphName: str,
-		transformation: Tuple[float, float, float, float, float, float],
-	) -> None:
+        self,
+        glyphName: str,
+        transformation: Tuple[float, float, float, float, float, float],
+    ) -> None:
         pass
 
 

--- a/Lib/fontTools/pens/areaPen.py
+++ b/Lib/fontTools/pens/areaPen.py
@@ -39,10 +39,10 @@ class AreaPen(BasePen):
 		x2, y2 = p2[0] - x0, p2[1] - y0
 		x3, y3 = p3[0] - x0, p3[1] - y0
 		self.value -= (
-				x1 * (   -   y2 -   y3) +
-				x2 * (y1        - 2*y3) +
-				x3 * (y1 + 2*y2       )
-			      ) * 0.15
+			x1 * (   -   y2 -   y3) +
+			x2 * (y1        - 2*y3) +
+			x3 * (y1 + 2*y2       )
+		) * 0.15
 		self._lineTo(p3)
 		self._p0 = p3
 

--- a/Lib/fontTools/pens/areaPen.py
+++ b/Lib/fontTools/pens/areaPen.py
@@ -1,6 +1,6 @@
 """Calculate the area of a glyph."""
 
-from fontTools.pens.basePen import BasePen
+from fontTools.pens.basePen import BasePen, PenPoint
 
 
 __all__ = ["AreaPen"]
@@ -8,20 +8,20 @@ __all__ = ["AreaPen"]
 
 class AreaPen(BasePen):
 
-	def __init__(self, glyphset=None):
+	def __init__(self, glyphset=None) -> None:
 		BasePen.__init__(self, glyphset)
-		self.value = 0
+		self.value: float = 0
 
-	def _moveTo(self, p0):
+	def _moveTo(self, p0: PenPoint) -> None:
 		self._p0 = self._startPoint = p0
 
-	def _lineTo(self, p1):
+	def _lineTo(self, p1: PenPoint) -> None:
 		x0, y0 = self._p0
 		x1, y1 = p1
 		self.value -= (x1 - x0) * (y1 + y0) * .5
 		self._p0 = p1
 
-	def _qCurveToOne(self, p1, p2):
+	def _qCurveToOne(self, p1: PenPoint, p2: PenPoint) -> None:
 		# https://github.com/Pomax/bezierinfo/issues/44
 		p0 = self._p0
 		x0, y0 = p0[0], p0[1]
@@ -31,7 +31,7 @@ class AreaPen(BasePen):
 		self._lineTo(p2)
 		self._p0 = p2
 
-	def _curveToOne(self, p1, p2, p3):
+	def _curveToOne(self, p1: PenPoint, p2: PenPoint, p3: PenPoint) -> None:
 		# https://github.com/Pomax/bezierinfo/issues/44
 		p0 = self._p0
 		x0, y0 = p0[0], p0[1]
@@ -46,11 +46,11 @@ class AreaPen(BasePen):
 		self._lineTo(p3)
 		self._p0 = p3
 
-	def _closePath(self):
+	def _closePath(self) -> None:
 		self._lineTo(self._startPoint)
 		del self._p0, self._startPoint
 
-	def _endPath(self):
+	def _endPath(self) -> None:
 		if self._p0 != self._startPoint:
 			# Area is not defined for open contours.
 			raise NotImplementedError

--- a/Lib/fontTools/pens/areaPen.py
+++ b/Lib/fontTools/pens/areaPen.py
@@ -1,6 +1,7 @@
 """Calculate the area of a glyph."""
 
-from fontTools.pens.basePen import BasePen, PenPoint
+from typing import Any, Dict, Optional
+from fontTools.pens.basePen import BasePen, PenGlyphSet, PenPoint
 
 
 __all__ = ["AreaPen"]
@@ -8,7 +9,7 @@ __all__ = ["AreaPen"]
 
 class AreaPen(BasePen):
 
-	def __init__(self, glyphset=None) -> None:
+	def __init__(self, glyphset: PenGlyphSet = None) -> None:
 		BasePen.__init__(self, glyphset)
 		self.value: float = 0
 

--- a/Lib/fontTools/pens/basePen.py
+++ b/Lib/fontTools/pens/basePen.py
@@ -47,6 +47,7 @@ __all__ = [
 ]
 
 
+PenGlyphSet: TypeAlias = Optional[Dict[str, Any]]
 PenPoint: TypeAlias = Tuple[float, float]
 
 
@@ -190,7 +191,7 @@ class DecomposingPen(LoggingPen):
 
 	skipMissingComponents = True
 
-	def __init__(self, glyphSet: Optional[Dict[str, Any]] = None) -> None:
+	def __init__(self, glyphSet: PenGlyphSet = None) -> None:
 		""" Takes a single 'glyphSet' argument (dict), in which the glyphs
 		that are referenced as components are looked up by their name.
 		"""
@@ -227,7 +228,7 @@ class BasePen(DecomposingPen):
 	methods.
 	"""
 
-	def __init__(self, glyphSet: Optional[Dict[str, Any]] = None) -> None:
+	def __init__(self, glyphSet: PenGlyphSet = None) -> None:
 		super(BasePen, self).__init__(glyphSet)
 		self.__currentPoint: Optional[PenPoint] = None
 

--- a/Lib/fontTools/pens/basePen.py
+++ b/Lib/fontTools/pens/basePen.py
@@ -47,6 +47,7 @@ __all__ =  ["AbstractPen", "NullPen", "BasePen", "PenError",
 class PenError(Exception):
 	"""Represents an error during penning."""
 
+
 class OpenContourError(PenError):
 	pass
 

--- a/Lib/fontTools/pens/basePen.py
+++ b/Lib/fontTools/pens/basePen.py
@@ -36,7 +36,7 @@ Coordinates are usually expressed as (x, y) tuples, but generally any
 sequence of length 2 will do.
 """
 
-from typing import Tuple
+from typing import Any, Optional, Tuple
 
 from fontTools.misc.loggingTools import LogMixin
 
@@ -116,7 +116,7 @@ class AbstractPen:
 	def addComponent(
 		self,
 		glyphName: str,
-		transformation: Tuple[float, float, float, float, float, float]
+		transformation: Tuple[float, float, float, float, float, float],
 	) -> None:
 		"""Add a sub glyph. The 'transformation' argument must be a 6-tuple
 		containing an affine transformation, or a Transform object from the
@@ -149,7 +149,11 @@ class NullPen(AbstractPen):
 	def endPath(self):
 		pass
 
-	def addComponent(self, glyphName, transformation):
+	def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+	) -> None:
 		pass
 
 
@@ -186,7 +190,11 @@ class DecomposingPen(LoggingPen):
 		super(DecomposingPen, self).__init__()
 		self.glyphSet = glyphSet
 
-	def addComponent(self, glyphName, transformation):
+	def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+	) -> None:
 		""" Transform the points of the base glyph and draw it onto self.
 		"""
 		from fontTools.pens.transformPen import TransformPen

--- a/Lib/fontTools/pens/boundsPen.py
+++ b/Lib/fontTools/pens/boundsPen.py
@@ -27,8 +27,8 @@ class ControlBoundsPen(BasePen):
 		self.init()
 
 	def init(self):
-	    self.bounds = None
-	    self._start = None
+		self.bounds = None
+		self._start = None
 
 	def _moveTo(self, pt):
 		self._start = pt

--- a/Lib/fontTools/pens/cairoPen.py
+++ b/Lib/fontTools/pens/cairoPen.py
@@ -1,7 +1,7 @@
 """Pen to draw to a Cairo graphics library context."""
 
 from typing import Any, Dict, Optional
-from fontTools.pens.basePen import BasePen, PenError, PenPoint
+from fontTools.pens.basePen import BasePen, PenError, PenGlyphSet, PenPoint
 
 
 __all__ = ["CairoPen"]
@@ -10,7 +10,7 @@ __all__ = ["CairoPen"]
 class CairoPen(BasePen):
     """Pen to draw to a Cairo graphics library context."""
 
-    def __init__(self, glyphSet: Optional[Dict[str, Any]] = None, context: Optional[Any] = None) -> None:
+    def __init__(self, glyphSet: PenGlyphSet = None, context: Optional[Any] = None) -> None:
         BasePen.__init__(self, glyphSet)
         if context is None:
             raise PenError("Must supply a context")

--- a/Lib/fontTools/pens/cairoPen.py
+++ b/Lib/fontTools/pens/cairoPen.py
@@ -1,6 +1,7 @@
 """Pen to draw to a Cairo graphics library context."""
 
-from fontTools.pens.basePen import BasePen
+from typing import Any, Dict, Optional
+from fontTools.pens.basePen import BasePen, PenError, PenPoint
 
 
 __all__ = ["CairoPen"]
@@ -9,18 +10,20 @@ __all__ = ["CairoPen"]
 class CairoPen(BasePen):
     """Pen to draw to a Cairo graphics library context."""
 
-    def __init__(self, glyphSet, context):
+    def __init__(self, glyphSet: Optional[Dict[str, Any]] = None, context: Optional[Any] = None) -> None:
         BasePen.__init__(self, glyphSet)
+        if context is None:
+            raise PenError("Must supply a context")
         self.context = context
 
-    def _moveTo(self, p):
+    def _moveTo(self, p: PenPoint) -> None:
         self.context.move_to(*p)
 
-    def _lineTo(self, p):
+    def _lineTo(self, p: PenPoint) -> None:
         self.context.line_to(*p)
 
-    def _curveToOne(self, p1, p2, p3):
+    def _curveToOne(self, p1: PenPoint, p2: PenPoint, p3: PenPoint) -> None:
         self.context.curve_to(*p1, *p2, *p3)
 
-    def _closePath(self):
+    def _closePath(self) -> None:
         self.context.close_path()

--- a/Lib/fontTools/pens/cocoaPen.py
+++ b/Lib/fontTools/pens/cocoaPen.py
@@ -1,4 +1,4 @@
-from fontTools.pens.basePen import BasePen, PenPoint
+from fontTools.pens.basePen import BasePen, PenGlyphSet, PenPoint
 from typing import Any, Dict, Optional
 
 __all__ = ["CocoaPen"]
@@ -6,7 +6,7 @@ __all__ = ["CocoaPen"]
 
 class CocoaPen(BasePen):
 
-	def __init__(self, glyphSet: Optional[Dict[str, Any]], path: Optional[Any] = None) -> None:
+	def __init__(self, glyphSet: PenGlyphSet, path: Optional[Any] = None) -> None:
 		BasePen.__init__(self, glyphSet)
 		if path is None:
 			from AppKit import NSBezierPath

--- a/Lib/fontTools/pens/cocoaPen.py
+++ b/Lib/fontTools/pens/cocoaPen.py
@@ -1,26 +1,26 @@
-from fontTools.pens.basePen import BasePen
-
+from fontTools.pens.basePen import BasePen, PenPoint
+from typing import Any, Dict, Optional
 
 __all__ = ["CocoaPen"]
 
 
 class CocoaPen(BasePen):
 
-	def __init__(self, glyphSet, path=None):
+	def __init__(self, glyphSet: Optional[Dict[str, Any]], path: Optional[Any] = None) -> None:
 		BasePen.__init__(self, glyphSet)
 		if path is None:
 			from AppKit import NSBezierPath
 			path = NSBezierPath.bezierPath()
 		self.path = path
 
-	def _moveTo(self, p):
+	def _moveTo(self, p: PenPoint) -> None:
 		self.path.moveToPoint_(p)
 
-	def _lineTo(self, p):
+	def _lineTo(self, p: PenPoint) -> None:
 		self.path.lineToPoint_(p)
 
-	def _curveToOne(self, p1, p2, p3):
+	def _curveToOne(self, p1: PenPoint, p2: PenPoint, p3: PenPoint) -> None:
 		self.path.curveToPoint_controlPoint1_controlPoint2_(p3, p1, p2)
 
-	def _closePath(self):
+	def _closePath(self) -> None:
 		self.path.closePath()

--- a/Lib/fontTools/pens/cu2quPen.py
+++ b/Lib/fontTools/pens/cu2quPen.py
@@ -260,6 +260,12 @@ class Cu2QuPointPen(BasePointToSegmentPen):
             pen.addPoint(pt, None, smooth, name, **kwargs)
         pen.endPath()
 
-    def addComponent(self, baseGlyphName, transformation):
+    def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+		identifier: Optional[str] = None,
+		**kwargs: Any
+	) -> None:
         assert self.currentPath is None
-        self.pen.addComponent(baseGlyphName, transformation)
+        self.pen.addComponent(glyphName, transformation, identifier, **kwargs)

--- a/Lib/fontTools/pens/cu2quPen.py
+++ b/Lib/fontTools/pens/cu2quPen.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 from fontTools.cu2qu import curve_to_quadratic
-from fontTools.pens.basePen import AbstractPen, decomposeSuperBezierSegment
+from fontTools.pens.basePen import AbstractPen, decomposeSuperBezierSegment, PenPoint
 from fontTools.pens.reverseContourPen import ReverseContourPen
-from fontTools.pens.pointPen import BasePointToSegmentPen
+from fontTools.pens.pointPen import BasePointToSegmentPen, PointPenPathTuple
 from fontTools.pens.pointPen import ReverseContourPointPen
 
 
@@ -41,8 +41,8 @@ class Cu2QuPen(AbstractPen):
     but are handled separately as anchors.
     """
 
-    def __init__(self, other_pen, max_err, reverse_direction=False,
-                 stats=None, ignore_single_points=False):
+    def __init__(self, other_pen, max_err: float, reverse_direction=False,
+                 stats=None, ignore_single_points=False) -> None:
         if reverse_direction:
             self.pen = ReverseContourPen(other_pen)
         else:
@@ -55,39 +55,41 @@ class Cu2QuPen(AbstractPen):
                           "will be removed in future versions",
                           UserWarning, stacklevel=2)
         self.ignore_single_points = ignore_single_points
-        self.start_pt = None
-        self.current_pt = None
+        self.start_pt: Optional[PenPoint] = None
+        self.current_pt: Optional[PenPoint] = None
 
-    def _check_contour_is_open(self):
+    def _check_contour_is_open(self) -> None:
         if self.current_pt is None:
             raise AssertionError("moveTo is required")
 
-    def _check_contour_is_closed(self):
+    def _check_contour_is_closed(self) -> None:
         if self.current_pt is not None:
             raise AssertionError("closePath or endPath is required")
 
-    def _add_moveTo(self):
+    def _add_moveTo(self) -> None:
         if self.start_pt is not None:
             self.pen.moveTo(self.start_pt)
             self.start_pt = None
 
-    def moveTo(self, pt):
+    def moveTo(self, pt: PenPoint) -> None:
         self._check_contour_is_closed()
         self.start_pt = self.current_pt = pt
         if not self.ignore_single_points:
             self._add_moveTo()
 
-    def lineTo(self, pt):
+    def lineTo(self, pt: PenPoint) -> None:
         self._check_contour_is_open()
         self._add_moveTo()
         self.pen.lineTo(pt)
         self.current_pt = pt
 
-    def qCurveTo(self, *points):
+    def qCurveTo(self, *points: Optional[PenPoint]) -> None:
         self._check_contour_is_open()
         n = len(points)
         if n == 1:
-            self.lineTo(points[0])
+            pt0 = points[0]
+            assert pt0 is not None
+            self.lineTo(pt0)
         elif n > 1:
             self._add_moveTo()
             self.pen.qCurveTo(*points)
@@ -95,7 +97,7 @@ class Cu2QuPen(AbstractPen):
         else:
             raise AssertionError("illegal qcurve segment point count: %d" % n)
 
-    def _curve_to_quadratic(self, pt1, pt2, pt3):
+    def _curve_to_quadratic(self, pt1: PenPoint, pt2: PenPoint, pt3: PenPoint) -> None:
         curve = (self.current_pt, pt1, pt2, pt3)
         quadratic = curve_to_quadratic(curve, self.max_err)
         if self.stats is not None:
@@ -103,14 +105,14 @@ class Cu2QuPen(AbstractPen):
             self.stats[n] = self.stats.get(n, 0) + 1
         self.qCurveTo(*quadratic[1:])
 
-    def curveTo(self, *points):
+    def curveTo(self, *points: PenPoint) -> None:
         self._check_contour_is_open()
         n = len(points)
         if n == 3:
             # this is the most common case, so we special-case it
             self._curve_to_quadratic(*points)
         elif n > 3:
-            for segment in decomposeSuperBezierSegment(points):
+            for segment in decomposeSuperBezierSegment(list(points)):
                 self._curve_to_quadratic(*segment)
         elif n == 2:
             self.qCurveTo(*points)
@@ -119,14 +121,14 @@ class Cu2QuPen(AbstractPen):
         else:
             raise AssertionError("illegal curve segment point count: %d" % n)
 
-    def closePath(self):
+    def closePath(self) -> None:
         self._check_contour_is_open()
         if self.start_pt is None:
             # if 'start_pt' is _not_ None, we are ignoring single-point paths
             self.pen.closePath()
         self.current_pt = self.start_pt = None
 
-    def endPath(self):
+    def endPath(self) -> None:
         self._check_contour_is_open()
         if self.start_pt is None:
             self.pen.endPath()
@@ -140,6 +142,11 @@ class Cu2QuPen(AbstractPen):
         self._check_contour_is_closed()
         self.pen.addComponent(glyphName, transformation)
 
+
+from typing_extensions import TypeAlias
+
+FourTuplePoint: TypeAlias = Tuple[PenPoint, bool, Optional[str], Any]
+FourTupleSegment: TypeAlias = Tuple[str, List[FourTuplePoint]]
 
 class Cu2QuPointPen(BasePointToSegmentPen):
     """ A filter pen to convert cubic bezier curves to quadratic b-splines
@@ -155,7 +162,7 @@ class Cu2QuPointPen(BasePointToSegmentPen):
     """
 
     def __init__(self, other_point_pen, max_err, reverse_direction=False,
-                 stats=None):
+                 stats=None) -> None:
         BasePointToSegmentPen.__init__(self)
         if reverse_direction:
             self.pen = ReverseContourPointPen(other_point_pen)
@@ -164,10 +171,10 @@ class Cu2QuPointPen(BasePointToSegmentPen):
         self.max_err = max_err
         self.stats = stats
 
-    def _flushContour(self, segments):
+    def _flushContour(self, segments: List[FourTupleSegment]) -> None:
         assert len(segments) >= 1
         closed = segments[0][0] != "move"
-        new_segments = []
+        new_segments: List[FourTupleSegment] = []
         prev_points = segments[-1][1]
         prev_on_curve = prev_points[-1][0]
         for segment_type, points in segments:
@@ -180,12 +187,14 @@ class Cu2QuPointPen(BasePointToSegmentPen):
                     if self.stats is not None:
                         n = str(len(quad) - 2)
                         self.stats[n] = self.stats.get(n, 0) + 1
-                    new_points = [(pt, False, None, {}) for pt in quad[1:-1]]
+                    new_points: List[FourTuplePoint] = [
+                        (pt, False, None, {}) for pt in quad[1:-1]
+                    ]
                     new_points.append((on_curve, smooth, name, kwargs))
-                    new_segments.append(["qcurve", new_points])
+                    new_segments.append(("qcurve", new_points))
                     prev_on_curve = sub_points[-1][0]
             else:
-                new_segments.append([segment_type, points])
+                new_segments.append((segment_type, points))
                 prev_on_curve = points[-1][0]
         if closed:
             # the BasePointToSegmentPen.endPath method that calls _flushContour
@@ -194,8 +203,8 @@ class Cu2QuPointPen(BasePointToSegmentPen):
             new_segments = new_segments[-1:] + new_segments[:-1]
         self._drawPoints(new_segments)
 
-    def _split_super_bezier_segments(self, points):
-        sub_segments = []
+    def _split_super_bezier_segments(self, points: List[FourTuplePoint]) -> List[List[FourTuplePoint]]:
+        sub_segments: List[List[FourTuplePoint]] = []
         # n is the number of control points
         n = len(points) - 1
         if n == 2:
@@ -207,7 +216,7 @@ class Cu2QuPointPen(BasePointToSegmentPen):
             num_sub_segments = n - 1
             for i, sub_points in enumerate(decomposeSuperBezierSegment([
                     pt for pt, _, _, _ in points])):
-                new_segment = []
+                new_segment: List[FourTuplePoint] = []
                 for point in sub_points[:-1]:
                     new_segment.append((point, False, None, {}))
                 if i == (num_sub_segments - 1):
@@ -222,7 +231,7 @@ class Cu2QuPointPen(BasePointToSegmentPen):
                 "expected 2 control points, found: %d" % n)
         return sub_segments
 
-    def _drawPoints(self, segments):
+    def _drawPoints(self, segments: List[FourTupleSegment]) -> None:
         pen = self.pen
         pen.beginPath()
         last_offcurves = []

--- a/Lib/fontTools/pens/cu2quPen.py
+++ b/Lib/fontTools/pens/cu2quPen.py
@@ -133,10 +133,10 @@ class Cu2QuPen(AbstractPen):
         self.current_pt = self.start_pt = None
 
     def addComponent(
-		self,
-		glyphName: str,
-		transformation: Tuple[float, float, float, float, float, float],
-	) -> None:
+        self,
+        glyphName: str,
+        transformation: Tuple[float, float, float, float, float, float],
+    ) -> None:
         self._check_contour_is_closed()
         self.pen.addComponent(glyphName, transformation)
 
@@ -261,11 +261,11 @@ class Cu2QuPointPen(BasePointToSegmentPen):
         pen.endPath()
 
     def addComponent(
-		self,
-		glyphName: str,
-		transformation: Tuple[float, float, float, float, float, float],
-		identifier: Optional[str] = None,
-		**kwargs: Any
-	) -> None:
+        self,
+        glyphName: str,
+        transformation: Tuple[float, float, float, float, float, float],
+        identifier: Optional[str] = None,
+        **kwargs: Any
+    ) -> None:
         assert self.currentPath is None
         self.pen.addComponent(glyphName, transformation, identifier, **kwargs)

--- a/Lib/fontTools/pens/cu2quPen.py
+++ b/Lib/fontTools/pens/cu2quPen.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Optional, Tuple
 from fontTools.cu2qu import curve_to_quadratic
 from fontTools.pens.basePen import AbstractPen, decomposeSuperBezierSegment
 from fontTools.pens.reverseContourPen import ReverseContourPen
@@ -131,7 +132,11 @@ class Cu2QuPen(AbstractPen):
             self.pen.endPath()
         self.current_pt = self.start_pt = None
 
-    def addComponent(self, glyphName, transformation):
+    def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+	) -> None:
         self._check_contour_is_closed()
         self.pen.addComponent(glyphName, transformation)
 

--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -1,5 +1,5 @@
-from typing import Any, Optional, Tuple
-from fontTools.pens.basePen import AbstractPen
+from typing import Any, List, Optional, Tuple
+from fontTools.pens.basePen import AbstractPen, PenPoint
 from fontTools.pens.pointPen import AbstractPointPen
 from fontTools.pens.recordingPen import RecordingPen
 
@@ -72,25 +72,25 @@ class FilterPen(_PassThruComponentsMixin, AbstractPen):
     ('addComponent', ('foo', (1, 0, 0, 1, 0, 0)))
     """
 
-    def __init__(self, outPen):
+    def __init__(self, outPen) -> None:
         self._outPen = outPen
 
-    def moveTo(self, pt):
+    def moveTo(self, pt: PenPoint) -> None:
         self._outPen.moveTo(pt)
 
-    def lineTo(self, pt):
+    def lineTo(self, pt: PenPoint) -> None:
         self._outPen.lineTo(pt)
 
-    def curveTo(self, *points):
+    def curveTo(self, *points: PenPoint) -> None:
         self._outPen.curveTo(*points)
 
-    def qCurveTo(self, *points):
+    def qCurveTo(self, *points: Optional[PenPoint]) -> None:
         self._outPen.qCurveTo(*points)
 
-    def closePath(self):
+    def closePath(self) -> None:
         self._outPen.closePath()
 
-    def endPath(self):
+    def endPath(self) -> None:
         self._outPen.endPath()
 
 
@@ -102,26 +102,26 @@ class ContourFilterPen(_PassThruComponentsMixin, RecordingPen):
     Components are passed through unchanged.
     """
 
-    def __init__(self, outPen):
+    def __init__(self, outPen) -> None:
         super(ContourFilterPen, self).__init__()
         self._outPen = outPen
 
-    def closePath(self):
+    def closePath(self) -> None:
         super(ContourFilterPen, self).closePath()
         self._flushContour()
 
-    def endPath(self):
+    def endPath(self) -> None:
         super(ContourFilterPen, self).endPath()
         self._flushContour()
 
-    def _flushContour(self):
+    def _flushContour(self) -> None:
         result = self.filterContour(self.value)
         if result is not None:
             self.value = result
         self.replay(self._outPen)
         self.value = []
 
-    def filterContour(self, contour):
+    def filterContour(self, contour: List[Tuple[str, Any]]) -> Optional[List[Tuple[str, Any]]]:
         """Subclasses must override this to perform the filtering.
 
         The contour is a list of pen (operator, operands) tuples.
@@ -134,7 +134,7 @@ class ContourFilterPen(_PassThruComponentsMixin, RecordingPen):
         assumed that the argument was modified in-place.
         Otherwise, the return value is drawn with the output pen.
         """
-        return  # or return contour
+        return None # or return contour
 
 
 class FilterPointPen(_PassThruComponentsPointPenMixin, AbstractPointPen):
@@ -162,18 +162,18 @@ class FilterPointPen(_PassThruComponentsPointPenMixin, AbstractPointPen):
     ('endPath', (), {})
     """
 
-    def __init__(self, outPointPen):
+    def __init__(self, outPointPen) -> None:
         self._outPen = outPointPen
 
-    def beginPath(self, **kwargs):
+    def beginPath(self, identifier: Optional[str] = None, **kwargs: Any) -> None:
         self._outPen.beginPath(**kwargs)
 
-    def endPath(self):
+    def endPath(self) -> None:
         self._outPen.endPath()
 
     def addPoint(
         self,
-        pt: Tuple[float, float],
+        pt: PenPoint,
         segmentType: Optional[str] = None,
         smooth: bool = False,
         name: Optional[str] = None,

--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -1,3 +1,4 @@
+from typing import Any, Optional, Tuple
 from fontTools.pens.basePen import AbstractPen
 from fontTools.pens.pointPen import AbstractPointPen
 from fontTools.pens.recordingPen import RecordingPen
@@ -5,8 +6,12 @@ from fontTools.pens.recordingPen import RecordingPen
 
 class _PassThruComponentsMixin(object):
 
-    def addComponent(self, glyphName, transformation, **kwargs):
-        self._outPen.addComponent(glyphName, transformation, **kwargs)
+    def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+	) -> None:
+        self._outPen.addComponent(glyphName, transformation)
 
 
 class FilterPen(_PassThruComponentsMixin, AbstractPen):

--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -7,22 +7,22 @@ from fontTools.pens.recordingPen import RecordingPen
 class _PassThruComponentsMixin(object):
 
     def addComponent(
-		self,
-		glyphName: str,
-		transformation: Tuple[float, float, float, float, float, float],
-	) -> None:
+        self,
+        glyphName: str,
+        transformation: Tuple[float, float, float, float, float, float],
+    ) -> None:
         self._outPen.addComponent(glyphName, transformation)
 
 
 class _PassThruComponentsPointPenMixin(object):
 
     def addComponent(
-		self,
-		glyphName: str,
-		transformation: Tuple[float, float, float, float, float, float],
-		identifier: Optional[str] = None,
-		**kwargs: Any
-	) -> None:
+        self,
+        glyphName: str,
+        transformation: Tuple[float, float, float, float, float, float],
+        identifier: Optional[str] = None,
+        **kwargs: Any
+    ) -> None:
         self._outPen.addComponent(glyphName, transformation, identifier, **kwargs)
 
 

--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -171,5 +171,13 @@ class FilterPointPen(_PassThruComponentsPointPenMixin, AbstractPointPen):
     def endPath(self):
         self._outPen.endPath()
 
-    def addPoint(self, pt, segmentType=None, smooth=False, name=None, **kwargs):
+    def addPoint(
+        self,
+        pt: Tuple[float, float],
+        segmentType: Optional[str] = None,
+        smooth: bool = False,
+        name: Optional[str] = None,
+        identifier: Optional[str] = None,
+        **kwargs,
+    ) -> None:
         self._outPen.addPoint(pt, segmentType, smooth, name, **kwargs)

--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -166,6 +166,8 @@ class FilterPointPen(_PassThruComponentsPointPenMixin, AbstractPointPen):
         self._outPen = outPointPen
 
     def beginPath(self, identifier: Optional[str] = None, **kwargs: Any) -> None:
+        if identifier is not None:
+            kwargs["identifier"] = identifier
         self._outPen.beginPath(**kwargs)
 
     def endPath(self) -> None:
@@ -180,4 +182,6 @@ class FilterPointPen(_PassThruComponentsPointPenMixin, AbstractPointPen):
         identifier: Optional[str] = None,
         **kwargs,
     ) -> None:
+        if identifier is not None:
+            kwargs["identifier"] = identifier
         self._outPen.addPoint(pt, segmentType, smooth, name, **kwargs)

--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -14,6 +14,18 @@ class _PassThruComponentsMixin(object):
         self._outPen.addComponent(glyphName, transformation)
 
 
+class _PassThruComponentsPointPenMixin(object):
+
+    def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+		identifier: Optional[str] = None,
+		**kwargs: Any
+	) -> None:
+        self._outPen.addComponent(glyphName, transformation, identifier, **kwargs)
+
+
 class FilterPen(_PassThruComponentsMixin, AbstractPen):
 
     """ Base class for pens that apply some transformation to the coordinates
@@ -125,7 +137,7 @@ class ContourFilterPen(_PassThruComponentsMixin, RecordingPen):
         return  # or return contour
 
 
-class FilterPointPen(_PassThruComponentsMixin, AbstractPointPen):
+class FilterPointPen(_PassThruComponentsPointPenMixin, AbstractPointPen):
     """ Baseclass for point pens that apply some transformation to the
     coordinates they receive and pass them to another point pen.
 

--- a/Lib/fontTools/pens/hashPointPen.py
+++ b/Lib/fontTools/pens/hashPointPen.py
@@ -1,7 +1,7 @@
 # Modified from https://github.com/adobe-type-tools/psautohint/blob/08b346865710ed3c172f1eb581d6ef243b203f99/python/psautohint/ufoFont.py#L800-L838
 import hashlib
 
-from typing import Any, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 from fontTools.pens.basePen import MissingComponentError
 from fontTools.pens.pointPen import AbstractPointPen
 
@@ -34,21 +34,25 @@ class HashPointPen(AbstractPointPen):
     >    pass
     """
 
-    def __init__(self, glyphWidth=0, glyphSet=None):
+    def __init__(
+        self, glyphWidth: float = 0, glyphSet: Optional[Dict[str, Any]] = None
+    ) -> None:
         self.glyphset = glyphSet
         self.data = ["w%s" % round(glyphWidth, 9)]
 
     @property
-    def hash(self):
+    def hash(self) -> str:
         data = "".join(self.data)
         if len(data) >= 128:
             data = hashlib.sha512(data.encode("ascii")).hexdigest()
         return data
 
-    def beginPath(self, identifier=None, **kwargs):
+    def beginPath(
+        self, identifier: Optional[str] = None, **kwargs: Any
+    ) -> None:
         pass
 
-    def endPath(self):
+    def endPath(self) -> None:
         self.data.append("|")
 
     def addPoint(
@@ -58,7 +62,7 @@ class HashPointPen(AbstractPointPen):
         smooth: bool = False,
         name: Optional[str] = None,
         identifier: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         if segmentType is None:
             pt_type = "o"  # offcurve
@@ -67,12 +71,12 @@ class HashPointPen(AbstractPointPen):
         self.data.append(f"{pt_type}{pt[0]:g}{pt[1]:+g}")
 
     def addComponent(
-		self,
-		glyphName: str,
-		transformation: Tuple[float, float, float, float, float, float],
-		identifier: Optional[str] = None,
-		**kwargs: Any
-	) -> None:
+        self,
+        glyphName: str,
+        transformation: Tuple[float, float, float, float, float, float],
+        identifier: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
         tr = "".join([f"{t:+}" for t in transformation])
         self.data.append("[")
         try:

--- a/Lib/fontTools/pens/hashPointPen.py
+++ b/Lib/fontTools/pens/hashPointPen.py
@@ -1,6 +1,7 @@
 # Modified from https://github.com/adobe-type-tools/psautohint/blob/08b346865710ed3c172f1eb581d6ef243b203f99/python/psautohint/ufoFont.py#L800-L838
 import hashlib
 
+from typing import Any, Optional, Tuple
 from fontTools.pens.basePen import MissingComponentError
 from fontTools.pens.pointPen import AbstractPointPen
 
@@ -66,12 +67,16 @@ class HashPointPen(AbstractPointPen):
         self.data.append(f"{pt_type}{pt[0]:g}{pt[1]:+g}")
 
     def addComponent(
-        self, baseGlyphName, transformation, identifier=None, **kwargs
-    ):
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+		identifier: Optional[str] = None,
+		**kwargs: Any
+	) -> None:
         tr = "".join([f"{t:+}" for t in transformation])
         self.data.append("[")
         try:
-            self.glyphset[baseGlyphName].drawPoints(self)
+            self.glyphset[glyphName].drawPoints(self)
         except KeyError:
-            raise MissingComponentError(baseGlyphName)
+            raise MissingComponentError(glyphName)
         self.data.append(f"({tr})]")

--- a/Lib/fontTools/pens/hashPointPen.py
+++ b/Lib/fontTools/pens/hashPointPen.py
@@ -53,13 +53,13 @@ class HashPointPen(AbstractPointPen):
 
     def addPoint(
         self,
-        pt,
-        segmentType=None,
-        smooth=False,
-        name=None,
-        identifier=None,
+        pt: Tuple[float, float],
+        segmentType: Optional[str] = None,
+        smooth: bool = False,
+        name: Optional[str] = None,
+        identifier: Optional[str] = None,
         **kwargs,
-    ):
+    ) -> None:
         if segmentType is None:
             pt_type = "o"  # offcurve
         else:

--- a/Lib/fontTools/pens/pointPen.py
+++ b/Lib/fontTools/pens/pointPen.py
@@ -52,7 +52,7 @@ class AbstractPointPen:
 
 	def addComponent(
 		self,
-		baseGlyphName: str,
+		glyphName: str,
 		transformation: Tuple[float, float, float, float, float, float],
 		identifier: Optional[str] = None,
 		**kwargs: Any
@@ -240,10 +240,16 @@ class PointToSegmentPen(BasePointToSegmentPen):
 		else:
 			pen.endPath()
 
-	def addComponent(self, glyphName, transform, identifier=None, **kwargs):
+	def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+		identifier: Optional[str] = None,
+		**kwargs: Any
+	) -> None:
 		del identifier  # unused
 		del kwargs  # unused
-		self.pen.addComponent(glyphName, transform)
+		self.pen.addComponent(glyphName, transformation)
 
 
 class SegmentToPointPen(AbstractPen):
@@ -318,10 +324,14 @@ class SegmentToPointPen(AbstractPen):
 		self._flushContour()
 		self.contour = None
 
-	def addComponent(self, glyphName, transform):
+	def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+	) -> None:
 		if self.contour is not None:
 			raise PenError("Components must be added before or after contours")
-		self.pen.addComponent(glyphName, transform)
+		self.pen.addComponent(glyphName, transformation)
 
 
 class GuessSmoothPointPen(AbstractPointPen):
@@ -396,7 +406,13 @@ class GuessSmoothPointPen(AbstractPointPen):
 			kwargs["identifier"] = identifier
 		self._points.append((pt, segmentType, False, name, kwargs))
 
-	def addComponent(self, glyphName, transformation, identifier=None, **kwargs):
+	def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+		identifier: Optional[str] = None,
+		**kwargs: Any
+	) -> None:
 		if self._points is not None:
 			raise PenError("Components must be added before or after contours")
 		if identifier is not None:
@@ -487,7 +503,13 @@ class ReverseContourPointPen(AbstractPointPen):
 			kwargs["identifier"] = identifier
 		self.currentContour.append((pt, segmentType, smooth, name, kwargs))
 
-	def addComponent(self, glyphName, transform, identifier=None, **kwargs):
+	def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+		identifier: Optional[str] = None,
+		**kwargs: Any
+	) -> None:
 		if self.currentContour is not None:
 			raise PenError("Components must be added before or after contours")
-		self.pen.addComponent(glyphName, transform, identifier=identifier, **kwargs)
+		self.pen.addComponent(glyphName, transformation, identifier, **kwargs)

--- a/Lib/fontTools/pens/pointPen.py
+++ b/Lib/fontTools/pens/pointPen.py
@@ -154,8 +154,15 @@ class BasePointToSegmentPen(AbstractPointPen):
 
 		self._flushContour(segments)
 
-	def addPoint(self, pt, segmentType=None, smooth=False, name=None,
-				 identifier=None, **kwargs):
+	def addPoint(
+        self,
+        pt: Tuple[float, float],
+        segmentType: Optional[str] = None,
+        smooth: bool = False,
+        name: Optional[str] = None,
+        identifier: Optional[str] = None,
+        **kwargs,
+    ) -> None:
 		if self.currentPath is None:
 			raise PenError("Path not begun")
 		self.currentPath.append((pt, segmentType, smooth, name, kwargs))
@@ -398,8 +405,15 @@ class GuessSmoothPointPen(AbstractPointPen):
 		self._outPen.endPath()
 		self._points = None
 
-	def addPoint(self, pt, segmentType=None, smooth=False, name=None,
-				 identifier=None, **kwargs):
+	def addPoint(
+        self,
+        pt: Tuple[float, float],
+        segmentType: Optional[str] = None,
+        smooth: bool = False,
+        name: Optional[str] = None,
+        identifier: Optional[str] = None,
+        **kwargs,
+    ) -> None:
 		if self._points is None:
 			raise PenError("Path not begun")
 		if identifier is not None:
@@ -496,7 +510,15 @@ class ReverseContourPointPen(AbstractPointPen):
 		self._flushContour()
 		self.currentContour = None
 
-	def addPoint(self, pt, segmentType=None, smooth=False, name=None, identifier=None, **kwargs):
+	def addPoint(
+        self,
+        pt: Tuple[float, float],
+        segmentType: Optional[str] = None,
+        smooth: bool = False,
+        name: Optional[str] = None,
+        identifier: Optional[str] = None,
+        **kwargs,
+    ) -> None:
 		if self.currentContour is None:
 			raise PenError("Path not begun")
 		if identifier is not None:

--- a/Lib/fontTools/pens/pointPen.py
+++ b/Lib/fontTools/pens/pointPen.py
@@ -155,14 +155,14 @@ class BasePointToSegmentPen(AbstractPointPen):
 		self._flushContour(segments)
 
 	def addPoint(
-        self,
-        pt: Tuple[float, float],
-        segmentType: Optional[str] = None,
-        smooth: bool = False,
-        name: Optional[str] = None,
-        identifier: Optional[str] = None,
-        **kwargs,
-    ) -> None:
+		self,
+		pt: Tuple[float, float],
+		segmentType: Optional[str] = None,
+		smooth: bool = False,
+		name: Optional[str] = None,
+		identifier: Optional[str] = None,
+		**kwargs,
+	) -> None:
 		if self.currentPath is None:
 			raise PenError("Path not begun")
 		self.currentPath.append((pt, segmentType, smooth, name, kwargs))
@@ -406,14 +406,14 @@ class GuessSmoothPointPen(AbstractPointPen):
 		self._points = None
 
 	def addPoint(
-        self,
-        pt: Tuple[float, float],
-        segmentType: Optional[str] = None,
-        smooth: bool = False,
-        name: Optional[str] = None,
-        identifier: Optional[str] = None,
-        **kwargs,
-    ) -> None:
+		self,
+		pt: Tuple[float, float],
+		segmentType: Optional[str] = None,
+		smooth: bool = False,
+		name: Optional[str] = None,
+		identifier: Optional[str] = None,
+		**kwargs,
+	) -> None:
 		if self._points is None:
 			raise PenError("Path not begun")
 		if identifier is not None:
@@ -511,14 +511,14 @@ class ReverseContourPointPen(AbstractPointPen):
 		self.currentContour = None
 
 	def addPoint(
-        self,
-        pt: Tuple[float, float],
-        segmentType: Optional[str] = None,
-        smooth: bool = False,
-        name: Optional[str] = None,
-        identifier: Optional[str] = None,
-        **kwargs,
-    ) -> None:
+		self,
+		pt: Tuple[float, float],
+		segmentType: Optional[str] = None,
+		smooth: bool = False,
+		name: Optional[str] = None,
+		identifier: Optional[str] = None,
+		**kwargs,
+	) -> None:
 		if self.currentContour is None:
 			raise PenError("Path not begun")
 		if identifier is not None:

--- a/Lib/fontTools/pens/recordingPen.py
+++ b/Lib/fontTools/pens/recordingPen.py
@@ -1,4 +1,5 @@
 """Pen recording operations that can be accessed or replayed."""
+from typing import Any, Optional, Tuple
 from fontTools.pens.basePen import AbstractPen, DecomposingPen
 from fontTools.pens.pointPen import AbstractPointPen
 
@@ -135,10 +136,16 @@ class RecordingPointPen(AbstractPointPen):
 			kwargs["identifier"] = identifier
 		self.value.append(("addPoint", (pt, segmentType, smooth, name), kwargs))
 
-	def addComponent(self, baseGlyphName, transformation, identifier=None, **kwargs):
+	def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+		identifier: Optional[str] = None,
+		**kwargs: Any
+	) -> None:
 		if identifier is not None:
 			kwargs["identifier"] = identifier
-		self.value.append(("addComponent", (baseGlyphName, transformation), kwargs))
+		self.value.append(("addComponent", (glyphName, transformation), kwargs))
 
 	def replay(self, pointPen):
 		for operator, args, kwargs in self.value:

--- a/Lib/fontTools/pens/recordingPen.py
+++ b/Lib/fontTools/pens/recordingPen.py
@@ -132,14 +132,14 @@ class RecordingPointPen(AbstractPointPen):
 		self.value.append(("endPath", (), {}))
 
 	def addPoint(
-        self,
-        pt: Tuple[float, float],
-        segmentType: Optional[str] = None,
-        smooth: bool = False,
-        name: Optional[str] = None,
-        identifier: Optional[str] = None,
-        **kwargs,
-    ) -> None:
+		self,
+		pt: Tuple[float, float],
+		segmentType: Optional[str] = None,
+		smooth: bool = False,
+		name: Optional[str] = None,
+		identifier: Optional[str] = None,
+		**kwargs,
+	) -> None:
 		if identifier is not None:
 			kwargs["identifier"] = identifier
 		self.value.append(("addPoint", (pt, segmentType, smooth, name), kwargs))

--- a/Lib/fontTools/pens/recordingPen.py
+++ b/Lib/fontTools/pens/recordingPen.py
@@ -131,7 +131,15 @@ class RecordingPointPen(AbstractPointPen):
 	def endPath(self):
 		self.value.append(("endPath", (), {}))
 
-	def addPoint(self, pt, segmentType=None, smooth=False, name=None, identifier=None, **kwargs):
+	def addPoint(
+        self,
+        pt: Tuple[float, float],
+        segmentType: Optional[str] = None,
+        smooth: bool = False,
+        name: Optional[str] = None,
+        identifier: Optional[str] = None,
+        **kwargs,
+    ) -> None:
 		if identifier is not None:
 			kwargs["identifier"] = identifier
 		self.value.append(("addPoint", (pt, segmentType, smooth, name), kwargs))

--- a/Lib/fontTools/pens/roundingPen.py
+++ b/Lib/fontTools/pens/roundingPen.py
@@ -1,3 +1,4 @@
+from typing import Any, Optional, Tuple
 from fontTools.misc.roundTools import otRound
 from fontTools.misc.transform import Transform
 from fontTools.pens.filterPen import FilterPen, FilterPointPen
@@ -48,7 +49,11 @@ class RoundingPen(FilterPen):
             *((self.roundFunc(x), self.roundFunc(y)) for x, y in points)
         )
 
-    def addComponent(self, glyphName, transformation):
+    def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+	) -> None:
         self._outPen.addComponent(
             glyphName,
             Transform(

--- a/Lib/fontTools/pens/roundingPen.py
+++ b/Lib/fontTools/pens/roundingPen.py
@@ -110,6 +110,7 @@ class RoundingPointPen(FilterPointPen):
             segmentType=segmentType,
             smooth=smooth,
             name=name,
+            identifier=identifier,
             **kwargs,
         )
 

--- a/Lib/fontTools/pens/roundingPen.py
+++ b/Lib/fontTools/pens/roundingPen.py
@@ -96,7 +96,15 @@ class RoundingPointPen(FilterPointPen):
         super().__init__(outPen)
         self.roundFunc = roundFunc
 
-    def addPoint(self, pt, segmentType=None, smooth=False, name=None, **kwargs):
+    def addPoint(
+        self,
+        pt: Tuple[float, float],
+        segmentType: Optional[str] = None,
+        smooth: bool = False,
+        name: Optional[str] = None,
+        identifier: Optional[str] = None,
+        **kwargs,
+    ) -> None:
         self._outPen.addPoint(
             (self.roundFunc(pt[0]), self.roundFunc(pt[1])),
             segmentType=segmentType,

--- a/Lib/fontTools/pens/roundingPen.py
+++ b/Lib/fontTools/pens/roundingPen.py
@@ -50,10 +50,10 @@ class RoundingPen(FilterPen):
         )
 
     def addComponent(
-		self,
-		glyphName: str,
-		transformation: Tuple[float, float, float, float, float, float],
-	) -> None:
+        self,
+        glyphName: str,
+        transformation: Tuple[float, float, float, float, float, float],
+    ) -> None:
         self._outPen.addComponent(
             glyphName,
             Transform(
@@ -114,12 +114,12 @@ class RoundingPointPen(FilterPointPen):
         )
 
     def addComponent(
-		self,
-		glyphName: str,
-		transformation: Tuple[float, float, float, float, float, float],
-		identifier: Optional[str] = None,
-		**kwargs: Any
-	) -> None:
+        self,
+        glyphName: str,
+        transformation: Tuple[float, float, float, float, float, float],
+        identifier: Optional[str] = None,
+        **kwargs: Any
+    ) -> None:
         self._outPen.addComponent(
             glyphName,
             Transform(

--- a/Lib/fontTools/pens/roundingPen.py
+++ b/Lib/fontTools/pens/roundingPen.py
@@ -105,9 +105,15 @@ class RoundingPointPen(FilterPointPen):
             **kwargs,
         )
 
-    def addComponent(self, baseGlyphName, transformation, **kwargs):
+    def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+		identifier: Optional[str] = None,
+		**kwargs: Any
+	) -> None:
         self._outPen.addComponent(
-            baseGlyphName,
+            glyphName,
             Transform(
                 *transformation[:4],
                 self.roundFunc(transformation[4]),

--- a/Lib/fontTools/pens/svgPathPen.py
+++ b/Lib/fontTools/pens/svgPathPen.py
@@ -1,5 +1,5 @@
 from typing import Callable
-from fontTools.pens.basePen import BasePen
+from fontTools.pens.basePen import BasePen, PenGlyphSet
 
 
 def pointToString(pt, ntos=str):
@@ -36,7 +36,7 @@ class SVGPathPen(BasePen):
             glyphset[glyphname].draw(pen)
             print(tpen.getCommands())
     """
-    def __init__(self, glyphSet, ntos: Callable[[float], str] = str):
+    def __init__(self, glyphSet: PenGlyphSet, ntos: Callable[[float], str] = str):
         BasePen.__init__(self, glyphSet)
         self._commands = []
         self._lastCommand = None

--- a/Lib/fontTools/pens/teePen.py
+++ b/Lib/fontTools/pens/teePen.py
@@ -15,24 +15,31 @@ class TeePen(AbstractPen):
 		if len(pens) == 1:
 			pens = pens[0]
 		self.pens = pens
+
 	def moveTo(self, p0: PenPoint) -> None:
 		for pen in self.pens:
 			pen.moveTo(p0)
+
 	def lineTo(self, p1: PenPoint) -> None:
 		for pen in self.pens:
 			pen.lineTo(p1)
+
 	def qCurveTo(self, *points: Optional[PenPoint]) -> None:
 		for pen in self.pens:
 			pen.qCurveTo(*points)
+
 	def curveTo(self, *points: PenPoint) -> None:
 		for pen in self.pens:
 			pen.curveTo(*points)
+
 	def closePath(self) -> None:
 		for pen in self.pens:
 			pen.closePath()
+
 	def endPath(self) -> None:
 		for pen in self.pens:
 			pen.endPath()
+
 	def addComponent(
 		self,
 		glyphName: str,

--- a/Lib/fontTools/pens/teePen.py
+++ b/Lib/fontTools/pens/teePen.py
@@ -1,6 +1,6 @@
 """Pen multiplexing drawing to one or more pens."""
-from typing import Tuple
-from fontTools.pens.basePen import AbstractPen
+from typing import Optional, Tuple
+from fontTools.pens.basePen import AbstractPen, PenPoint
 
 
 __all__ = ["TeePen"]
@@ -11,26 +11,26 @@ class TeePen(AbstractPen):
 
 	Use either as TeePen(pen1, pen2, ...) or TeePen(iterableOfPens)."""
 
-	def __init__(self, *pens):
+	def __init__(self, *pens) -> None:
 		if len(pens) == 1:
 			pens = pens[0]
 		self.pens = pens
-	def moveTo(self, p0):
+	def moveTo(self, p0: PenPoint) -> None:
 		for pen in self.pens:
 			pen.moveTo(p0)
-	def lineTo(self, p1):
+	def lineTo(self, p1: PenPoint) -> None:
 		for pen in self.pens:
 			pen.lineTo(p1)
-	def qCurveTo(self, *points):
+	def qCurveTo(self, *points: Optional[PenPoint]) -> None:
 		for pen in self.pens:
 			pen.qCurveTo(*points)
-	def curveTo(self, *points):
+	def curveTo(self, *points: PenPoint) -> None:
 		for pen in self.pens:
 			pen.curveTo(*points)
-	def closePath(self):
+	def closePath(self) -> None:
 		for pen in self.pens:
 			pen.closePath()
-	def endPath(self):
+	def endPath(self) -> None:
 		for pen in self.pens:
 			pen.endPath()
 	def addComponent(

--- a/Lib/fontTools/pens/teePen.py
+++ b/Lib/fontTools/pens/teePen.py
@@ -1,4 +1,5 @@
 """Pen multiplexing drawing to one or more pens."""
+from typing import Tuple
 from fontTools.pens.basePen import AbstractPen
 
 
@@ -32,7 +33,11 @@ class TeePen(AbstractPen):
 	def endPath(self):
 		for pen in self.pens:
 			pen.endPath()
-	def addComponent(self, glyphName, transformation):
+	def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+	) -> None:
 		for pen in self.pens:
 			pen.addComponent(glyphName, transformation)
 

--- a/Lib/fontTools/pens/transformPen.py
+++ b/Lib/fontTools/pens/transformPen.py
@@ -1,6 +1,4 @@
-from typing import Any, List, Optional, Sequence, Tuple, Union
 from fontTools.misc.transform import Transform
-from fontTools.pens.basePen import PenPoint
 from fontTools.pens.filterPen import FilterPen, FilterPointPen
 
 
@@ -13,7 +11,7 @@ class TransformPen(FilterPen):
 	and passes them to another pen.
 	"""
 
-	def __init__(self, outPen, transformation: Union[Transform, Tuple[float, float, float, float, float, float]]) -> None:
+	def __init__(self, outPen, transformation):
 		"""The 'outPen' argument is another pen object. It will receive the
 		transformed coordinates. The 'transformation' argument can either
 		be a six-tuple, or a fontTools.misc.transform.Transform object.
@@ -25,18 +23,18 @@ class TransformPen(FilterPen):
 			transform = Transform(*transformation)
 		self._transformation = transform
 		self._transformPoint = transform.transformPoint
-		self._stack: List[Any] = []
+		self._stack = []
 
-	def moveTo(self, pt: PenPoint) -> None:
+	def moveTo(self, pt):
 		self._outPen.moveTo(self._transformPoint(pt))
 
-	def lineTo(self, pt: PenPoint) -> None:
+	def lineTo(self, pt):
 		self._outPen.lineTo(self._transformPoint(pt))
 
-	def curveTo(self, *points: PenPoint) -> None:
-		self._outPen.curveTo(*self._transformPoints(list(points)))
+	def curveTo(self, *points):
+		self._outPen.curveTo(*self._transformPoints(points))
 
-	def qCurveTo(self, *points: Optional[PenPoint]) -> None:
+	def qCurveTo(self, *points):
 		pt = points[-1]
 		if pt is None:
 			tpoints = self._transformPoints(points[:-1]) + [None]
@@ -44,21 +42,17 @@ class TransformPen(FilterPen):
 			tpoints = self._transformPoints(points)
 		self._outPen.qCurveTo(*tpoints)
 
-	def _transformPoints(self, points: Sequence[PenPoint]) -> List[PenPoint]:
+	def _transformPoints(self, points):
 		transformPoint = self._transformPoint
 		return [transformPoint(pt) for pt in points]
 
-	def closePath(self) -> None:
+	def closePath(self):
 		self._outPen.closePath()
 
-	def endPath(self) -> None:
+	def endPath(self):
 		self._outPen.endPath()
 
-	def addComponent(
-		self,
-		glyphName: str,
-		transformation: Tuple[float, float, float, float, float, float],
-	) -> None:
+	def addComponent(self, glyphName: str, transformation):
 		transformation = self._transformation.transform(transformation)
 		self._outPen.addComponent(glyphName, transformation)
 
@@ -98,26 +92,12 @@ class TransformPointPen(FilterPointPen):
 		self._transformation = transformation
 		self._transformPoint = transformation.transformPoint
 
-	def addPoint(
-		self,
-		pt: PenPoint,
-		segmentType: Optional[str] = None,
-		smooth: bool = False,
-		name: Optional[str] = None,
-		identifier: Optional[str] = None,
-		**kwargs: Any
-	) -> None:
+	def addPoint(self, pt, segmentType=None, smooth=False, name=None, identifier=None, **kwargs):
 		self._outPen.addPoint(
 			self._transformPoint(pt), segmentType, smooth, name, identifier, **kwargs
 		)
 
-	def addComponent(
-		self,
-		glyphName: str,
-		transformation: Tuple[float, float, float, float, float, float],
-		identifier: Optional[str] = None,
-		**kwargs: Any
-	) -> None:
+	def addComponent(self, glyphName, transformation, identifier=None, **kwargs):
 		transformation = self._transformation.transform(transformation)
 		self._outPen.addComponent(glyphName, transformation, identifier, **kwargs)
 

--- a/Lib/fontTools/pens/transformPen.py
+++ b/Lib/fontTools/pens/transformPen.py
@@ -99,9 +99,15 @@ class TransformPointPen(FilterPointPen):
 			self._transformPoint(pt), segmentType, smooth, name, **kwargs
 		)
 
-	def addComponent(self, baseGlyphName, transformation, **kwargs):
+	def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+		identifier: Optional[str] = None,
+		**kwargs: Any
+	) -> None:
 		transformation = self._transformation.transform(transformation)
-		self._outPen.addComponent(baseGlyphName, transformation, **kwargs)
+		self._outPen.addComponent(glyphName, transformation, identifier, **kwargs)
 
 
 if __name__ == "__main__":

--- a/Lib/fontTools/pens/transformPen.py
+++ b/Lib/fontTools/pens/transformPen.py
@@ -1,3 +1,4 @@
+from typing import Any, Optional, Tuple
 from fontTools.pens.filterPen import FilterPen, FilterPointPen
 
 
@@ -49,7 +50,11 @@ class TransformPen(FilterPen):
 	def endPath(self):
 		self._outPen.endPath()
 
-	def addComponent(self, glyphName, transformation):
+	def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+	) -> None:
 		transformation = self._transformation.transform(transformation)
 		self._outPen.addComponent(glyphName, transformation)
 

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import enum
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 from warnings import warn
 from collections import OrderedDict
 import fs
@@ -1744,7 +1745,15 @@ class GLIFPointPen(AbstractPointPen):
 		self.prevOffCurveCount = 0
 		self.prevPointTypes = []
 
-	def addPoint(self, pt, segmentType=None, smooth=None, name=None, identifier=None, **kwargs):
+	def addPoint(
+		self,
+		pt: Tuple[float, float],
+		segmentType: Optional[str] = None,
+		smooth: bool = False,
+		name: Optional[str] = None,
+		identifier: Optional[str] = None,
+		**kwargs: Any
+	) -> None:
 		attrs = OrderedDict()
 		# coordinates
 		if pt is not None:

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -1792,7 +1792,13 @@ class GLIFPointPen(AbstractPointPen):
 			self.identifiers.add(identifier)
 		etree.SubElement(self.contour, "point", attrs)
 
-	def addComponent(self, glyphName, transformation, identifier=None, **kwargs):
+	def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+		identifier: Optional[str] = None,
+		**kwargs: Any,
+	) -> None:
 		attrs = OrderedDict([("base", glyphName)])
 		for (attr, default), value in zip(_transformationInfo, transformation):
 			if self.validate and not isinstance(value, numberTypes):

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -7,7 +7,7 @@ $ fonttools varLib.interpolatable font1 font2 ...
 """
 
 from fontTools.pens.basePen import AbstractPen, BasePen
-from typing import Tuple
+from typing import Optional, Tuple
 from fontTools.pens.pointPen import SegmentToPointPen
 from fontTools.pens.recordingPen import RecordingPen
 from fontTools.pens.statisticsPen import StatisticsPen
@@ -80,7 +80,15 @@ class RecordingPointPen(BasePen):
     def endPath(self) -> None:
         pass
 
-    def addPoint(self, pt, segmentType=None):
+    def addPoint(
+        self,
+        pt: Tuple[float, float],
+        segmentType: Optional[str] = None,
+        smooth: bool = False,
+        name: Optional[str] = None,
+        identifier: Optional[str] = None,
+        **kwargs,
+    ) -> None:
         self.value.append((pt, False if segmentType is None else True))
 
 

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -7,6 +7,7 @@ $ fonttools varLib.interpolatable font1 font2 ...
 """
 
 from fontTools.pens.basePen import AbstractPen, BasePen
+from typing import Tuple
 from fontTools.pens.pointPen import SegmentToPointPen
 from fontTools.pens.recordingPen import RecordingPen
 from fontTools.pens.statisticsPen import StatisticsPen
@@ -59,7 +60,11 @@ class PerContourPen(BasePen):
 
 
 class PerContourOrComponentPen(PerContourPen):
-    def addComponent(self, glyphName, transformation):
+    def addComponent(
+		self,
+		glyphName: str,
+		transformation: Tuple[float, float, float, float, float, float],
+	) -> None:
         self._newItem()
         self.value[-1].addComponent(glyphName, transformation)
 

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -6,8 +6,8 @@ Call as:
 $ fonttools varLib.interpolatable font1 font2 ...
 """
 
-from fontTools.pens.basePen import AbstractPen, BasePen
 from typing import Optional, Tuple
+from fontTools.pens.basePen import BasePen
 from fontTools.pens.pointPen import SegmentToPointPen
 from fontTools.pens.recordingPen import RecordingPen
 from fontTools.pens.statisticsPen import StatisticsPen

--- a/Tests/pens/utils.py
+++ b/Tests/pens/utils.py
@@ -28,7 +28,7 @@ class BaseDummyPen(object):
         """Return the pen commands as a string of python code."""
         return _repr_pen_commands(self.commands)
 
-    def addComponent(self, glyphName, transformation, **kwargs):
+    def addComponent(self, glyphName, transformation, identifier=None, **kwargs):
         self.commands.append(('addComponent', (glyphName, transformation), kwargs))
 
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ tox>=2.5
 bump2version>=0.5.6
 sphinx>=1.5.5
 mypy>=0.782
+typing_extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ufoLib2==0.14.0
 pyobjc==9.0; sys_platform == "darwin"
 freetype-py==2.3.0
 uharfbuzz==0.32.0
+typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def doraise_py_compile(file, cfile=None, dfile=None, doraise=False):
 
 py_compile.compile = doraise_py_compile
 
-setup_requires = []
+setup_requires = ["typing_extensions"]
 
 if {'bdist_wheel'}.intersection(sys.argv):
 	setup_requires.append('wheel')


### PR DESCRIPTION
Some pens used `baseGlyphName` and `transform` as argument names, others used `glyphName` and `transformation`. This PR unifies the argument names and adds some type annotations.