### PR TITLE
[feaLib] Sort name table entries in builder

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -446,6 +446,7 @@ class Builder(object):
                         assert self.cv_parameters_ids_[tag] is not None
                     nameID = self.cv_parameters_ids_[tag]
             table.setName(string, nameID, platformID, platEncID, langID)
+        table.names.sort()
 
     def build_OS_2(self):
         if not self.os2_:

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ Famira, Sam Fishman, Matt Fontaine, Takaaki Fuji, Yannis Haralambous, Greg
 Hitchcock, Jeremie Hornus, Khaled Hosny, John Hudson, Denis Moyogo Jacquerye,
 Jack Jansen, Tom Kacvinsky, Jens Kutilek, Antoine Leca, Werner Lemberg, Tal
 Leming, Peter Lofting, Cosimo Lupo, Olli Meier, Masaya Nakamura, Dave Opstad,
-Laurence Penney, Roozbeh Pournader, Garret Rieger, Read Roberts, Guido
-van Rossum, Just van Rossum, Andreas Seidel, Georg Seifert, Chris
+Laurence Penney, Roozbeh Pournader, Garret Rieger, Read Roberts, Colin Rofls,
+Guido van Rossum, Just van Rossum, Andreas Seidel, Georg Seifert, Chris
 Simpkins, Miguel Sousa, Adam Twardoch, Adrien Tétar, Vitaly Volkov,
 Paul Wise.
 

--- a/Tests/feaLib/data/name.ttx
+++ b/Tests/feaLib/data/name.ttx
@@ -2,6 +2,15 @@
 <ttFont>
 
   <name>
+    <namerecord nameID="8" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Test8
+    </namerecord>
+    <namerecord nameID="10" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Test10
+    </namerecord>
+    <namerecord nameID="11" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Test11
+    </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
       Test1
     </namerecord>
@@ -23,17 +32,8 @@
     <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
       Test7
     </namerecord>
-    <namerecord nameID="8" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Test8
-    </namerecord>
     <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
       Test9
-    </namerecord>
-    <namerecord nameID="10" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Test10
-    </namerecord>
-    <namerecord nameID="11" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      Test11
     </namerecord>
   </name>
 

--- a/Tests/feaLib/data/spec8b.ttx
+++ b/Tests/feaLib/data/spec8b.ttx
@@ -2,14 +2,14 @@
 <ttFont>
 
   <name>
-    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
-      Win MinionPro Size Name
-    </namerecord>
     <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Mac MinionPro Size Name
     </namerecord>
     <namerecord nameID="256" platformID="1" platEncID="0" langID="0x5" unicode="True">
       Mac MinionPro Size Name
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Win MinionPro Size Name
     </namerecord>
   </name>
 
@@ -37,7 +37,7 @@
           <FeatureParamsSize>
             <DesignSize value="10.0"/>
             <SubfamilyID value="3"/>
-            <SubfamilyNameID value="256"/>  <!-- Win MinionPro Size Name -->
+            <SubfamilyNameID value="256"/>  <!-- Mac MinionPro Size Name -->
             <RangeStart value="8.0"/>
             <RangeEnd value="13.9"/>
           </FeatureParamsSize>

--- a/Tests/feaLib/data/spec8c.ttx
+++ b/Tests/feaLib/data/spec8c.ttx
@@ -2,17 +2,17 @@
 <ttFont>
 
   <name>
-    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
-      Feature description for MS Platform, script Unicode, language English
-    </namerecord>
-    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x411">
-      Feature description for MS Platform, script Unicode, language Japanese
-    </namerecord>
     <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Feature description for Apple Platform, script Roman, language unspecified
     </namerecord>
     <namerecord nameID="256" platformID="1" platEncID="1" langID="0xc" unicode="True">
       Feature description for Apple Platform, script Japanese, language Japanese
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Feature description for MS Platform, script Unicode, language English
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x411">
+      Feature description for MS Platform, script Unicode, language Japanese
     </namerecord>
   </name>
 
@@ -39,7 +39,7 @@
         <Feature>
           <FeatureParamsStylisticSet>
             <Version value="0"/>
-            <UINameID value="256"/>  <!-- Feature description for MS Platform, script Unicode, language English -->
+            <UINameID value="256"/>  <!-- Feature description for Apple Platform, script Roman, language unspecified -->
           </FeatureParamsStylisticSet>
           <!-- LookupCount=1 -->
           <LookupListIndex index="0" value="0"/>

--- a/Tests/feaLib/data/spec8d.ttx
+++ b/Tests/feaLib/data/spec8d.ttx
@@ -2,34 +2,34 @@
 <ttFont>
 
   <name>
-    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
       uilabel simple a
     </namerecord>
-    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      tool tip simple a
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      sample text simple a
+    </namerecord>
+    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      param1 text simple a
+    </namerecord>
+    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      param2 text simple a
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
       uilabel simple a
     </namerecord>
     <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
       tool tip simple a
     </namerecord>
-    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      tool tip simple a
-    </namerecord>
     <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
-      sample text simple a
-    </namerecord>
-    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
       sample text simple a
     </namerecord>
     <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
       param1 text simple a
     </namerecord>
-    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      param1 text simple a
-    </namerecord>
     <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
-      param2 text simple a
-    </namerecord>
-    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
       param2 text simple a
     </namerecord>
   </name>

--- a/Tests/feaLib/data/spec9e.ttx
+++ b/Tests/feaLib/data/spec9e.ttx
@@ -2,10 +2,10 @@
 <ttFont>
 
   <name>
-    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="9" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Joachim Müller-Lancé
     </namerecord>
-    <namerecord nameID="9" platformID="1" platEncID="0" langID="0x0" unicode="True">
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
       Joachim Müller-Lancé
     </namerecord>
   </name>


### PR DESCRIPTION
This patch ensures that feaLib always produces a name table with entries sorted in the order proscribed by the spec: platform id, encoding id, language id, name id.

This breaks some tests, and so I have manually updated the test data to match the new outputs.


---

I'm not very familiar with this project, so very possible i have overlooked or omitted something, please let me know! There was one question I had, will point it out in the diff.

closes #2909