### PR TITLE
set codecov to not fail_ci_if_error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
         file: coverage.xml
         flags: unittests
         name: codecov-umbrella
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         # see https://github.com/codecov/codecov-action/issues/557
         token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Codecov keeps failing to upload the coverage report seemingly at random, e.g.

https://github.com/fonttools/fonttools/actions/runs/3686952402/jobs/6240048994#step:8:40

I thought I had already fixed it by setting a CODECOV_TOKEN in the repo secrets with #2763 

but it still keeps pestering us so I think the only option left is to not have the PR checks fail with codecov errors.