### PR TITLE
[feaLib] Remove rogue whitespace in GPOS_1_zero.ttx

### DIFF
--- a/Tests/feaLib/data/GPOS_1_zero.ttx
+++ b/Tests/feaLib/data/GPOS_1_zero.ttx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont>
- 
+
   <GPOS>
     <Version value="0x00010000"/>
     <ScriptList>


### PR DESCRIPTION
In what I presume was error, this test case included a space on the line immediately following the `<ttFont>` element; this space is not present in any other ttx files.

For reasons that are unclear to me, and likely not worth investigating, the presence (or absence) of this space does not influence the passing or failure of this test case; however it *does* cause a failure in my feature compiler, which is reusing this test suite, and so I would like to fix it here, and simplify my own life somewhat.