### PR TITLE
[merge] Sort tags before processing

### DIFF
--- a/Lib/fontTools/merge/__init__.py
+++ b/Lib/fontTools/merge/__init__.py
@@ -106,7 +106,7 @@ class Merger(object):
         allTags = reduce(set.union, (list(font.keys()) for font in fonts), set())
         allTags.remove("GlyphOrder")
 
-        for tag in allTags:
+        for tag in sorted(allTags):
             if tag in self.options.drop_tables:
                 continue
 


### PR DESCRIPTION
Sort tags before processing; this makes merge behave more deterministically.

Due to the nature of Python sets, the unioning of the tag lists results in a fairly random tag order.

This causes surprising errors if multiple tables contain problems: you randomly get one or the other error.