### PR TITLE
[varLib_instancer - updateNameRecords] Allow NameRecord that do not exist for an platform

### DIFF
--- a/Lib/fontTools/varLib/instancer/names.py
+++ b/Lib/fontTools/varLib/instancer/names.py
@@ -209,13 +209,20 @@ def _updateNameRecords(varfont, axisValues):
             # we cannot update this set of name Records.
             continue
 
-        subFamilyName = " ".join(
-            getName(n, *platform).toUnicode() for n in ribbiNameIDs
-        )
-        if nonRibbiNameIDs:
-            typoSubFamilyName = " ".join(
-                getName(n, *platform).toUnicode() for n in axisValueNameIDs
+        try:
+            subFamilyName = " ".join(
+                getName(n, *platform).toUnicode() for n in ribbiNameIDs
             )
+        except AttributeError:
+            subFamilyName = None
+
+        if nonRibbiNameIDs:
+            try:
+                typoSubFamilyName = " ".join(
+                    getName(n, *platform).toUnicode() for n in axisValueNameIDs
+                )
+            except AttributeError:
+                typoSubFamilyName = None
         else:
             typoSubFamilyName = None
 
@@ -226,10 +233,12 @@ def _updateNameRecords(varfont, axisValues):
                 subFamilyName = getName(elidedNameID, *platform).toUnicode()
             else:
                 typoSubFamilyName = getName(elidedNameID, *platform).toUnicode()
-
-        familyNameSuffix = " ".join(
-            getName(n, *platform).toUnicode() for n in nonRibbiNameIDs
-        )
+        try:
+            familyNameSuffix = " ".join(
+                getName(n, *platform).toUnicode() for n in nonRibbiNameIDs
+            )
+        except AttributeError:
+            familyNameSuffix = None
 
         _updateNameTableStyleRecords(
             varfont,


### PR DESCRIPTION
### Problem that this PR solve
When updating namerecord, allow an NameRecord that do not exist for an platform.

### Example of an case where this PR is usefull
When trying to instantiateVariableFont with the font [Bahnschrift](https://www.dafontfree.io/download/bahnschrift/), an exception is raised.

```py
from fontTools import ttLib
from fontTools.ttLib.tables._f_v_a_r import NamedInstance
from fontTools.varLib import instancer
from typing import List

fontCollection = ttLib.TTCollection()
font = ttLib.TTFont("BAHNSCHRIFT.TTF")
instances: List[NamedInstance] = font["fvar"].instances

for instance in instances:
    generatedFont = instancer.instantiateVariableFont(font, instance.coordinates,  updateFontNames=True)
    fontCollection.fonts.append(generatedFont)

savePath = "BAHNSCHRIFT.ttc"
fontCollection.save(savePath)
```

It append because the platform 1 doesn't have the nameID that the stat table use.
So, when it try to getName, it return None which raise an exception.

In order not to raise the exception, we catch it and set the variable to None. Like that, we can instantiate our variable font without problem.