### PR TITLE
chore(deps): upgrade `zopfli` to 0.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ unicodedata2==15.0.0; python_version <= '3.11'
 scipy==1.7.3; platform_python_implementation != "PyPy" and python_version <= '3.7'  # pyup: ignore
 scipy==1.9.3; platform_python_implementation != "PyPy" and python_version > '3.7'
 munkres==1.1.4; platform_python_implementation == "PyPy"
-zopfli==0.2.1
+zopfli==0.2.2
 fs==2.4.16
 skia-pathops==0.7.3; platform_python_implementation != "PyPy"
 # this is only required to run Tests/cu2qu/{ufo,cli}_test.py


### PR DESCRIPTION
## Description
This PR upgrades `zopfli` to the latest version.
Changelog: https://github.com/fonttools/py-zopfli/releases/tag/v0.2.2