### PR TITLE
Handle glyphs with dupe graphic type on compile correctly

### DIFF
--- a/Lib/fontTools/ttLib/tables/sbixGlyph.py
+++ b/Lib/fontTools/ttLib/tables/sbixGlyph.py
@@ -94,11 +94,11 @@ class Glyph(object):
             self.rawdata = b""
         else:
             rawdata = sstruct.pack(sbixGlyphHeaderFormat, self)
-	    if self.graphicType == 'dupe':
-	        rawdata += struct.pack(">H", ttFont.getGlyphID(self.referenceGlyphName))
-	    else:
-	        rawdata += self.imageData
-	    self.rawdata = rawdata
+        if self.graphicType == 'dupe':
+            rawdata += struct.pack(">H", ttFont.getGlyphID(self.referenceGlyphName))
+        else:
+            rawdata += self.imageData
+        self.rawdata = rawdata
 
     def toXML(self, xmlWriter, ttFont):
         if self.graphicType == None:

--- a/Lib/fontTools/ttLib/tables/sbixGlyph.py
+++ b/Lib/fontTools/ttLib/tables/sbixGlyph.py
@@ -94,7 +94,7 @@ class Glyph(object):
             self.rawdata = b""
         else:
             rawdata = sstruct.pack(sbixGlyphHeaderFormat, self)
-        if self.graphicType == 'dupe':
+        if self.graphicType == "dupe":
             rawdata += struct.pack(">H", ttFont.getGlyphID(self.referenceGlyphName))
         else:
             rawdata += self.imageData

--- a/Lib/fontTools/ttLib/tables/sbixGlyph.py
+++ b/Lib/fontTools/ttLib/tables/sbixGlyph.py
@@ -93,7 +93,12 @@ class Glyph(object):
         if self.graphicType is None:
             self.rawdata = b""
         else:
-            self.rawdata = sstruct.pack(sbixGlyphHeaderFormat, self) + self.imageData
+            rawdata = sstruct.pack(sbixGlyphHeaderFormat, self)
+	    if self.graphicType == 'dupe':
+	        rawdata += struct.pack(">H", ttFont.getGlyphID(self.referenceGlyphName))
+	    else:
+	        rawdata += self.imageData
+	    self.rawdata = rawdata
 
     def toXML(self, xmlWriter, ttFont):
         if self.graphicType == None:


### PR DESCRIPTION
Instead of appending glyph raw data with `imageData` for `graphicType=dupe` which will always be `NoneType`, append with the reference glyph ID.

Closes https://github.com/fonttools/fonttools/issues/2962