### PR TITLE
copy OTTableReader before copying/pickling lazily loaded table

### DIFF
--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -896,6 +896,15 @@ class BaseTable(object):
             for subtable in self.iterSubTables():
                 subtable.value.ensureDecompiled(recurse)
 
+    def __getstate__(self):
+        # before copying/pickling 'lazy' objects, make a shallow copy of OTTableReader
+        # https://github.com/fonttools/fonttools/issues/2965
+        if "reader" in self.__dict__:
+            state = self.__dict__.copy()
+            state["reader"] = self.__dict__["reader"].copy()
+            return state
+        return self.__dict__
+
     @classmethod
     def getRecordSize(cls, reader):
         totalSize = 0

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -1388,8 +1388,8 @@ def colrv1_path(tmp_path):
         clipBoxes={
             "uniE000": (0, 0, 200, 300),
             "uniE001": (0, 0, 500, 500),
-            "uniE002": (100, 100, 400, 400),
-            "uniE003": (-50, -50, 350, 350),
+            "uniE002": (-50, -50, 400, 400),
+            "uniE003": (-50, -50, 400, 400),
         },
     )
     fb.setupCPAL(
@@ -1520,6 +1520,7 @@ def test_subset_COLRv1_and_CPAL(colrv1_path):
 
     clipBoxes = colr.ClipList.clips
     assert {"uniE001", "uniE002", "uniE003"} == set(clipBoxes)
+    assert clipBoxes["uniE002"] == clipBoxes["uniE003"]
 
     assert "CPAL" in subset_font
     cpal = subset_font["CPAL"]


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/2965

In otTables.py we have a custom implementation of ClipList.postRead where we build a `clips` dictionary of ClipBox records keyed by glyph name, ensuring each value is a distinct object (they may be shared for ranges of glyph IDs in the binary table):

https://github.com/fonttools/fonttools/blob/f73220816264fc383b8a75f2146e8d69e455d398/Lib/fontTools/ttLib/tables/otTables.py#L1325-L1332

We call `copy.copy(rec.ClipBox)`. If the TTFont was loaded lazily like the subsetter does by default (unless one passes --no-lazy), then the ClipBox record is only decompiled when any of its attribute is accessed (thanks to our magic `BaseTable.__getattr__`).

In python <= 3.10 we didn't need to do anything special and calling copy.copy on a lazy object would automatically decompile it (I don't know exactly how, something again about our magic `__getattr__`).

Whereas since python3.11, calling `copy.copy(rec.ClipBox)` does _not_ automatically decompile our lazy objects.

So we should define a custom `__getstate__` as explained in the [python docs](https://docs.python.org/3/library/copy.html) to control how an object state gets copied/pickled.

In the case of lazy objects we could either call `ensureDecompiled` before returing `self.__dict__`, or better keep the object in lazy mode make a shallow copy of its OTTableReader. This way each distinct copy owns a different reader and can be un-lazified independently instead of stepping on each other's toes.

I hope that makes sense. It does fix the bug @RoelN found out in #2956, now I need to figure out how to test this..