### PR TITLE
Revert #2963

### DIFF
--- a/Lib/fontTools/ttLib/tables/sbixGlyph.py
+++ b/Lib/fontTools/ttLib/tables/sbixGlyph.py
@@ -93,12 +93,7 @@ class Glyph(object):
         if self.graphicType is None:
             self.rawdata = b""
         else:
-            rawdata = sstruct.pack(sbixGlyphHeaderFormat, self)
-        if self.graphicType == "dupe":
-            rawdata += struct.pack(">H", ttFont.getGlyphID(self.referenceGlyphName))
-        else:
-            rawdata += self.imageData
-        self.rawdata = rawdata
+            self.rawdata = sstruct.pack(sbixGlyphHeaderFormat, self) + self.imageData
 
     def toXML(self, xmlWriter, ttFont):
         if self.graphicType == None:


### PR DESCRIPTION
I didn't realize this line of code https://github.com/PoomSmart/fonttools/blob/main/Lib/fontTools/ttLib/tables/sbixGlyph.py#L131 already handles ref glyph type. The reference glyph ID is already assigned to `self.imageData`. Hence, no need for the workaround.

I still do no understand why it did not work and I had to use the workaround before...