### PR TITLE
Ensure sbix's Glyph.referenceGlyphName is set

### DIFF
--- a/Lib/fontTools/ttLib/tables/sbixGlyph.py
+++ b/Lib/fontTools/ttLib/tables/sbixGlyph.py
@@ -133,9 +133,9 @@ class Glyph(object):
             # glyph is a "dupe", i.e. a reference to another glyph's image data.
             # in this case imageData contains the glyph id of the reference glyph
             # get glyph id from glyphname
-            self.imageData = struct.pack(
-                ">H", ttFont.getGlyphID(safeEval("'''" + attrs["glyphname"] + "'''"))
-            )
+            glyphname = safeEval("'''" + attrs["glyphname"] + "'''")
+            self.imageData = struct.pack(">H", ttFont.getGlyphID(glyphname))
+            self.referenceGlyphName = glyphname
         elif name == "hexdata":
             self.imageData = readHex(content)
         else:


### PR DESCRIPTION
Minimal example is when you extract TTX files (including sbix, with one or more glyphs using `ref`) and rebuild the TTF via `ttx` command.

```
...
  File "/opt/homebrew/lib/python3.10/site-packages/fontTools/misc/xmlReader.py", line 155, in _endElementHandler
    self.currentTable.fromXML(name, attrs, content, self.ttFont)
  File "/opt/homebrew/lib/python3.10/site-packages/fontTools/ttLib/tables/_s_b_i_x.py", line 105, in fromXML
    current_strike.fromXML(name, attrs, content, ttFont)
  File "/opt/homebrew/lib/python3.10/site-packages/fontTools/ttLib/tables/sbixStrike.py", line 144, in fromXML
    current_glyph.compile(ttFont)
  File "/opt/homebrew/lib/python3.10/site-packages/fontTools/ttLib/tables/sbixGlyph.py", line 80, in compile
    rawdata += struct.pack(">H", ttFont.getGlyphID(self.referenceGlyphName))
  File "/opt/homebrew/lib/python3.10/site-packages/fontTools/ttLib/ttFont.py", line 617, in getGlyphID
    if glyphName[:5] == "glyph":
TypeError: 'NoneType' object is not subscriptable
```

So looking at the code:

<img width="1340" alt="image" src="https://user-images.githubusercontent.com/3608783/216998970-0eba4934-f697-4343-856d-7235d522a239.png">

`compile()` function expects `self.referenceGlyphName` to be defined but it was not. I simply had to assign the correct value to it when we read from XML content (line 143, right pane) as shown in the PR.