### PR TITLE
reverseContourPen_test: check outputImpliedClosingLine works as expected

### DIFF
--- a/Lib/fontTools/pens/reverseContourPen.py
+++ b/Lib/fontTools/pens/reverseContourPen.py
@@ -62,7 +62,7 @@ def reversedContour(contour, outputImpliedClosingLine=False):
         if closed:
             # for closed paths, we keep the starting point
             yield firstType, firstPts
-            if outputImpliedClosingLine or firstOnCurve != lastOnCurve:
+            if firstOnCurve != lastOnCurve:
                 # emit an implied line between the last and first points
                 yield "lineTo", (lastOnCurve,)
                 contour[-1] = (lastType, tuple(lastPts[:-1]) + (firstOnCurve,))

--- a/Tests/pens/reverseContourPen_test.py
+++ b/Tests/pens/reverseContourPen_test.py
@@ -288,7 +288,13 @@ def test_reverse_pen_outputImpliedClosingLine():
     revpen.lineTo((0, 10))
     revpen.lineTo((0, 0))
     revpen.closePath()
-    assert len(recpen.value) == 4
+    assert recpen.value == [
+        ("moveTo", ((0, 0),)),
+        ("lineTo", ((0, 10),)),
+        ("lineTo", ((10, 0),)),
+        # ("lineTo", ((0, 0),)),  # implied
+        ("closePath", ()),
+    ]
 
     recpen = RecordingPen()
     revpen = ReverseContourPen(recpen, outputImpliedClosingLine=True)
@@ -297,7 +303,13 @@ def test_reverse_pen_outputImpliedClosingLine():
     revpen.lineTo((0, 10))
     revpen.lineTo((0, 0))
     revpen.closePath()
-    assert len(recpen.value) == 6
+    assert recpen.value == [
+        ("moveTo", ((0, 0),)),
+        ("lineTo", ((0, 10),)),
+        ("lineTo", ((10, 0),)),
+        ("lineTo", ((0, 0),)),  # not implied
+        ("closePath", ()),
+    ]
 
 
 @pytest.mark.parametrize("contour, expected", TEST_DATA)

--- a/Tests/pens/reverseContourPen_test.py
+++ b/Tests/pens/reverseContourPen_test.py
@@ -12,6 +12,7 @@ TEST_DATA = [
             ("lineTo", ((3, 3),)),  # last not on move, line is implied
             ("closePath", ()),
         ],
+        False,  # outputImpliedClosingLine
         [
             ("moveTo", ((0, 0),)),
             ("lineTo", ((3, 3),)),
@@ -28,6 +29,7 @@ TEST_DATA = [
             ("lineTo", ((0, 0),)),  # last on move, no implied line
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 0),)),
             ("lineTo", ((2, 2),)),
@@ -43,6 +45,7 @@ TEST_DATA = [
             ("lineTo", ((2, 2),)),
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 0),)),
             ("lineTo", ((2, 2),)),
@@ -58,6 +61,7 @@ TEST_DATA = [
             ("lineTo", ((1, 1),)),
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 0),)),
             ("lineTo", ((1, 1),)),
@@ -71,6 +75,7 @@ TEST_DATA = [
             ("curveTo", ((4, 4), (5, 5), (0, 0))),
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 0),)),
             ("curveTo", ((5, 5), (4, 4), (3, 3))),
@@ -85,6 +90,7 @@ TEST_DATA = [
             ("curveTo", ((4, 4), (5, 5), (6, 6))),
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 0),)),
             ("lineTo", ((6, 6),)),  # implied line
@@ -101,6 +107,7 @@ TEST_DATA = [
             ("curveTo", ((5, 5), (6, 6), (7, 7))),
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 0),)),
             ("lineTo", ((7, 7),)),
@@ -116,6 +123,7 @@ TEST_DATA = [
             ("qCurveTo", ((3, 3), (0, 0))),
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 0),)),
             ("qCurveTo", ((3, 3), (2, 2))),
@@ -130,6 +138,7 @@ TEST_DATA = [
             ("qCurveTo", ((3, 3), (4, 4))),
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 0),)),
             ("lineTo", ((4, 4),)),
@@ -145,6 +154,7 @@ TEST_DATA = [
             ("qCurveTo", ((2, 2), (3, 3))),
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 0),)),
             ("lineTo", ((3, 3),)),
@@ -154,14 +164,16 @@ TEST_DATA = [
     ),
     (
         [("addComponent", ("a", (1, 0, 0, 1, 0, 0)))],
+        False,
         [("addComponent", ("a", (1, 0, 0, 1, 0, 0)))],
     ),
-    ([], []),
+    ([], False, []),
     (
         [
             ("moveTo", ((0, 0),)),
             ("endPath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 0),)),
             ("endPath", ()),
@@ -172,6 +184,7 @@ TEST_DATA = [
             ("moveTo", ((0, 0),)),
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 0),)),
             ("endPath", ()),  # single-point paths is always open
@@ -179,10 +192,12 @@ TEST_DATA = [
     ),
     (
         [("moveTo", ((0, 0),)), ("lineTo", ((1, 1),)), ("endPath", ())],
+        False,
         [("moveTo", ((1, 1),)), ("lineTo", ((0, 0),)), ("endPath", ())],
     ),
     (
         [("moveTo", ((0, 0),)), ("curveTo", ((1, 1), (2, 2), (3, 3))), ("endPath", ())],
+        False,
         [("moveTo", ((3, 3),)), ("curveTo", ((2, 2), (1, 1), (0, 0))), ("endPath", ())],
     ),
     (
@@ -192,6 +207,7 @@ TEST_DATA = [
             ("lineTo", ((4, 4),)),
             ("endPath", ()),
         ],
+        False,
         [
             ("moveTo", ((4, 4),)),
             ("lineTo", ((3, 3),)),
@@ -206,6 +222,7 @@ TEST_DATA = [
             ("curveTo", ((2, 2), (3, 3), (4, 4))),
             ("endPath", ()),
         ],
+        False,
         [
             ("moveTo", ((4, 4),)),
             ("curveTo", ((3, 3), (2, 2), (1, 1))),
@@ -215,10 +232,12 @@ TEST_DATA = [
     ),
     (
         [("qCurveTo", ((0, 0), (1, 1), (2, 2), None)), ("closePath", ())],
+        False,
         [("qCurveTo", ((0, 0), (2, 2), (1, 1), None)), ("closePath", ())],
     ),
     (
         [("qCurveTo", ((0, 0), (1, 1), (2, 2), None)), ("endPath", ())],
+        False,
         [
             ("qCurveTo", ((0, 0), (2, 2), (1, 1), None)),
             ("closePath", ()),  # this is always "closed"
@@ -237,6 +256,7 @@ TEST_DATA = [
             ("qCurveTo", ((449, -3), (649, -3), (848, 171), (848, 348))),
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((848, 348),)),
             ("qCurveTo", ((848, 171), (649, -3), (449, -3), (449, -3))),
@@ -260,6 +280,7 @@ TEST_DATA = [
             ("lineTo", ((0, 651),)),
             ("closePath", ()),
         ],
+        False,
         [
             ("moveTo", ((0, 651),)),
             ("lineTo", ((0, 651),)),
@@ -271,10 +292,10 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize("contour, expected", TEST_DATA)
-def test_reverse_pen(contour, expected):
+@pytest.mark.parametrize("contour, outputImpliedClosingLine, expected", TEST_DATA)
+def test_reverse_pen(contour, outputImpliedClosingLine, expected):
     recpen = RecordingPen()
-    revpen = ReverseContourPen(recpen)
+    revpen = ReverseContourPen(recpen, outputImpliedClosingLine)
     for operator, operands in contour:
         getattr(revpen, operator)(*operands)
     assert recpen.value == expected
@@ -312,7 +333,7 @@ def test_reverse_pen_outputImpliedClosingLine():
     ]
 
 
-@pytest.mark.parametrize("contour, expected", TEST_DATA)
+@pytest.mark.parametrize("contour, expected", [(c, e) for c, _, e in TEST_DATA])
 def test_reverse_point_pen(contour, expected):
     from fontTools.ufoLib.pointPen import (
         ReverseContourPointPen,


### PR DESCRIPTION
In https://github.com/fonttools/fonttools/pull/2922, @behdad added an `outputImpliedClosingLine` parameter to the `ReverseContourPen`, plus a test that only expected a certain number of segments. 

I was looking at this again today, and got a little suspicious as I noticed the number of pen commands increases from _4_ in the default `outputImpliedClosingLine=False` case, to _6_ in the `outputImpliedClosingLine=True` case, whereas I would only expect it to increase only by +1, i.e. to _5_, in the latter case, given it no longer omits the closePath's closing line.

It turns out, with `outputImpliedClosingLine=True`, not only the implied closing line is emitted, but also an additional, duplicate lineTo right after moveTo is emitted, which I belive is incorrect.

Here I first push the failing test that exemplifies the issue, without changing the code. I'll follow up with the fix.