### PR TITLE
Make NameRecord comparison not fail on encoding errors #3006

### DIFF
--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -72,14 +72,33 @@ class NameTableTest(unittest.TestCase):
         ]
         table.compile(None)
 
-    def test_names_sort_bytes_str_encoding_error(self):
+    def test_names_sort_attributes(self):
         table = table__n_a_m_e()
+        # Create an actual invalid NameRecord object
+        broken = makeName("Test", 25, 3, 1, 0x409)
+        delattr(broken, "platformID")
         table.names = [
-            makeName("Test寬", 25, 1, 0, 0),
-            makeName("Test鬆鬆", 25, 1, 0, 0),
+            makeName("Test", 25, 3, 1, 0x409),
+            broken,
         ]
+        # Sorting these two is impossible, expect an error to be raised
         with self.assertRaises(TypeError):
             table.names.sort()
+
+    def test_names_sort_encoding(self):
+        """
+        Confirm that encoding errors in name table strings do not prevent at
+        least sorting by other IDs
+        """
+        table = table__n_a_m_e()
+        table.names = [
+            makeName("Mac Unicode 寬 encodes ok", 25, 3, 0, 0x409),
+            makeName("Win Latin 寬 fails to encode", 25, 1, 0, 0),
+        ]
+        table.names.sort()
+        # Encoding errors or not, sort based on other IDs nonetheless
+        self.assertEqual(table.names[0].platformID, 1)
+        self.assertEqual(table.names[1].platformID, 3)
 
     def test_addName(self):
         table = table__n_a_m_e()


### PR DESCRIPTION
- Distinguish raised errors in comparing / sorting of `NameRecord`s to not fail sorting on encoding errors of the NameRecord, but retain behavior of failing on attribute errors or incomplete NameRecords
- Emit warning when encountering NameRecord encoding issues
- Added test for sorting incomplete NameRecords (the code comments in the comparison function mention such cases, but I don't think there was an actual test for it)
- Modified test for sorting NameRecords with encoding errors (previously failing test should now a) not fail, b) perform sorting based on available IDs)

I tested with `pytest` only; got `tox` to run some tests (lints okay), but coverage tests I could not manage to get running:

```
ERROR: Could not find a version that satisfies the requirement lxml==4.9.0 (from versions: none)
ERROR: No matching distribution found for lxml==4.9.0

py310-cov: exit 1 (0.59 seconds) /Users/johannes/Projects/fonttools> python -m pip install --only-binary=lxml 'coverage>=4.3' lxml==4.9.0 pytest pytest-randomly -r requirements.txt pid=73604
```