### PR TITLE
[subset] Compute xAvgCharWidth even when --no-prune-unicode-ranges is given

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -3081,7 +3081,6 @@ class Options(object):
     )
 
     def __init__(self, **kwargs):
-
         self.drop_tables = self._drop_tables_default[:]
         self.no_subset_tables = self._no_subset_tables_default[:]
         self.passthrough_tables = False  # keep/drop tables we can't subset
@@ -3226,7 +3225,6 @@ class Subsetter(object):
         pass
 
     def __init__(self, options=None):
-
         if not options:
             options = Options()
 
@@ -3275,7 +3273,6 @@ class Subsetter(object):
                     log.info("%s pruned", tag)
 
     def _closure_glyphs(self, font):
-
         realGlyphs = set(font.getGlyphOrder())
         self.orig_glyph_order = glyph_order = font.getGlyphOrder()
 
@@ -3465,11 +3462,14 @@ class Subsetter(object):
         for tag in font.keys():
             if tag == "GlyphOrder":
                 continue
-            if tag == "OS/2" and self.options.prune_unicode_ranges:
-                old_uniranges = font[tag].getUnicodeRanges()
-                new_uniranges = font[tag].recalcUnicodeRanges(font, pruneOnly=True)
-                if old_uniranges != new_uniranges:
-                    log.info("%s Unicode ranges pruned: %s", tag, sorted(new_uniranges))
+            if tag == "OS/2":
+                if self.options.prune_unicode_ranges:
+                    old_uniranges = font[tag].getUnicodeRanges()
+                    new_uniranges = font[tag].recalcUnicodeRanges(font, pruneOnly=True)
+                    if old_uniranges != new_uniranges:
+                        log.info(
+                            "%s Unicode ranges pruned: %s", tag, sorted(new_uniranges)
+                        )
                 if self.options.recalc_average_width:
                     old_avg_width = font[tag].xAvgCharWidth
                     new_avg_width = font[tag].recalcAvgCharWidth(font)
@@ -3506,7 +3506,6 @@ class Subsetter(object):
 
 @timer("load font")
 def load_font(fontFile, options, checkChecksums=0, dontLoadGlyphNames=False, lazy=True):
-
     font = ttLib.TTFont(
         fontFile,
         checkChecksums=checkChecksums,

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -1859,5 +1859,33 @@ def test_subset_COLR_glyph_closure(tmp_path):
     assert "grave" not in color_layers
 
 
+def test_subset_recalc_xAvgCharWidth(ttf_path):
+    # Note that the font in in the *ttLib*/data/TestTTF-Regular.ttx file,
+    # not this subset/data folder.
+    font = TTFont(ttf_path)
+    xAvgCharWidth_before = font["OS/2"].xAvgCharWidth
+
+    subset_path = ttf_path.with_suffix(".subset.ttf")
+    subset.main(
+        [
+            str(ttf_path),
+            f"--output-file={subset_path}",
+            # Keep only the ellipsis, which is very wide, that ought to bump up the average
+            "--glyphs=ellipsis",
+            "--recalc-average-width",
+            "--no-prune-unicode-ranges",
+        ]
+    )
+    subset_font = TTFont(subset_path)
+    xAvgCharWidth_after = subset_font["OS/2"].xAvgCharWidth
+
+    # Check that the value gets updated
+    assert xAvgCharWidth_after != xAvgCharWidth_before
+
+    # Check that the value gets updated to the actual new value
+    subset_font["OS/2"].recalcAvgCharWidth(subset_font)
+    assert xAvgCharWidth_after == subset_font["OS/2"].xAvgCharWidth
+
+
 if __name__ == "__main__":
     sys.exit(unittest.main())


### PR DESCRIPTION
The conditions in the subsetter were so that re-computing the xAvgCharWidth would only happen when also pruning Unicode ranges, while the two are not connected. This makes the two options independent from one another.