### PR TITLE
prevent cython.compiled raise AttributeError if cython not properly installed

### DIFF
--- a/Lib/fontTools/cu2qu/cu2qu.py
+++ b/Lib/fontTools/cu2qu/cu2qu.py
@@ -17,9 +17,13 @@
 
 try:
     import cython
-except ImportError:
+
+    COMPILED = cython.compiled
+except (AttributeError, ImportError):
     # if cython not installed, use mock module with no-op decorators and types
     from fontTools.misc import cython
+
+    COMPILED = False
 
 import math
 
@@ -31,14 +35,6 @@ __all__ = ["curve_to_quadratic", "curves_to_quadratic"]
 MAX_N = 100
 
 NAN = float("NaN")
-
-
-if cython.compiled:
-    # Yep, I'm compiled.
-    COMPILED = True
-else:
-    # Just a lowly interpreted script.
-    COMPILED = False
 
 
 @cython.cfunc

--- a/Lib/fontTools/misc/bezierTools.py
+++ b/Lib/fontTools/misc/bezierTools.py
@@ -9,9 +9,13 @@ from collections import namedtuple
 
 try:
     import cython
-except ImportError:
+
+    COMPILED = cython.compiled
+except (AttributeError, ImportError):
     # if cython not installed, use mock module with no-op decorators and types
     from fontTools.misc import cython
+
+    COMPILED = False
 
 
 Intersection = namedtuple("Intersection", ["pt", "t1", "t2"])
@@ -47,13 +51,6 @@ __all__ = [
     "curveCurveIntersections",
     "segmentSegmentIntersections",
 ]
-
-if cython.compiled:
-    # Yep, I'm compiled.
-    COMPILED = True
-else:
-    # Just a lowly interpreted script.
-    COMPILED = False
 
 
 def calcCubicArcLength(pt1, pt2, pt3, pt4, tolerance=0.005):

--- a/Lib/fontTools/misc/symfont.py
+++ b/Lib/fontTools/misc/symfont.py
@@ -123,15 +123,12 @@ def printGreenPen(penName, funcs, file=sys.stdout, docstring=None):
         """from fontTools.pens.basePen import BasePen, OpenContourError
 try:
 	import cython
-except ImportError:
+
+	COMPILED = cython.compiled
+except (AttributeError, ImportError):
 	# if cython not installed, use mock module with no-op decorators and types
 	from fontTools.misc import cython
 
-if cython.compiled:
-	# Yep, I'm compiled.
-	COMPILED = True
-else:
-	# Just a lowly interpreted script.
 	COMPILED = False
 
 

--- a/Lib/fontTools/pens/momentsPen.py
+++ b/Lib/fontTools/pens/momentsPen.py
@@ -2,15 +2,12 @@ from fontTools.pens.basePen import BasePen, OpenContourError
 
 try:
     import cython
-except ImportError:
+
+    COMPILED = cython.compiled
+except (AttributeError, ImportError):
     # if cython not installed, use mock module with no-op decorators and types
     from fontTools.misc import cython
 
-if cython.compiled:
-    # Yep, I'm compiled.
-    COMPILED = True
-else:
-    # Just a lowly interpreted script.
     COMPILED = False
 
 

--- a/Lib/fontTools/qu2cu/qu2cu.py
+++ b/Lib/fontTools/qu2cu/qu2cu.py
@@ -18,9 +18,13 @@
 
 try:
     import cython
-except ImportError:
+
+    COMPILED = cython.compiled
+except (AttributeError, ImportError):
     # if cython not installed, use mock module with no-op decorators and types
     from fontTools.misc import cython
+
+    COMPILED = False
 
 from fontTools.misc.bezierTools import splitCubicAtTC
 from collections import namedtuple
@@ -33,14 +37,6 @@ from typing import (
 
 
 __all__ = ["quadratic_to_curves"]
-
-
-if cython.compiled:
-    # Yep, I'm compiled.
-    COMPILED = True
-else:
-    # Just a lowly interpreted script.
-    COMPILED = False
 
 
 # Copied from cu2qu

--- a/Lib/fontTools/varLib/iup.py
+++ b/Lib/fontTools/varLib/iup.py
@@ -7,15 +7,12 @@ from numbers import Integral, Real
 
 try:
     import cython
-except ImportError:
+
+    COMPILED = cython.compiled
+except (AttributeError, ImportError):
     # if cython not installed, use mock module with no-op decorators and types
     from fontTools.misc import cython
 
-if cython.compiled:
-    # Yep, I'm compiled.
-    COMPILED = True
-else:
-    # Just a lowly interpreted script.
     COMPILED = False
 
 


### PR DESCRIPTION
It's possible sometimes that `import cython` does _not_ fail but then attempting to get `cython.compiled` raises `AttributeError` exception. It actually happened in our internal production environment... (still unclear as to the root cause).
So here in this PR, to check that the cython library is correctly installed I also catch AttributeError raised when the `compiled` variable is not there (even though it _must_ be there for the 'real' cython, but sometimes a 'pretend' one sneaks in, probably because sys.path has been messed with).

somewhat similar issue to https://github.com/pydantic/pydantic/pull/573 and https://github.com/ipython/ipython/issues/13294