### PR TITLE
[mtiLib] Add debug info

### DIFF
--- a/Lib/fontTools/mtiLib/__init__.py
+++ b/Lib/fontTools/mtiLib/__init__.py
@@ -12,6 +12,8 @@ from fontTools.ttLib.tables import otTables as ot
 from fontTools.ttLib.tables.otBase import ValueRecord, valueRecordFormatDict
 from fontTools.otlLib import builder as otl
 from contextlib import contextmanager
+from fontTools.ttLib import newTable
+from fontTools.feaLib.lookupDebugInfo import LOOKUP_DEBUG_INFO_KEY
 from operator import setitem
 import logging
 
@@ -1036,7 +1038,13 @@ def parseGSUBGPOS(lines, font, tableTag):
         self.LookupList.LookupCount = len(self.LookupList.Lookup)
     if lookupMap is not None:
         lookupMap.applyDeferredMappings()
-    if featureMap is not None:
+        if "Debg" not in font:
+            font["Debg"] = newTable("Debg")
+            font["Debg"].data = {}
+        debug = font["Debg"].data.setdefault(LOOKUP_DEBUG_INFO_KEY, {}).setdefault(tableTag, {})
+        for name, lookup in lookupMap.items():
+            debug[str(lookup)] = ["", name, ""]
+
         featureMap.applyDeferredMappings()
     container.table = self
     return container

--- a/Lib/fontTools/mtiLib/__init__.py
+++ b/Lib/fontTools/mtiLib/__init__.py
@@ -1041,7 +1041,11 @@ def parseGSUBGPOS(lines, font, tableTag):
         if "Debg" not in font:
             font["Debg"] = newTable("Debg")
             font["Debg"].data = {}
-        debug = font["Debg"].data.setdefault(LOOKUP_DEBUG_INFO_KEY, {}).setdefault(tableTag, {})
+        debug = (
+            font["Debg"]
+            .data.setdefault(LOOKUP_DEBUG_INFO_KEY, {})
+            .setdefault(tableTag, {})
+        )
         for name, lookup in lookupMap.items():
             debug[str(lookup)] = ["", name, ""]
 

--- a/Tests/mtiLib/data/featurename-backward.ttx.GSUB
+++ b/Tests/mtiLib/data/featurename-backward.ttx.GSUB
@@ -47,6 +47,7 @@
   </FeatureList>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- l1:  -->
     <Lookup index="0">
       <LookupType value="1"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/featurename-forward.ttx.GSUB
+++ b/Tests/mtiLib/data/featurename-forward.ttx.GSUB
@@ -47,6 +47,7 @@
   </FeatureList>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- l1:  -->
     <Lookup index="0">
       <LookupType value="1"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/lookupnames-backward.ttx.GSUB
+++ b/Tests/mtiLib/data/lookupnames-backward.ttx.GSUB
@@ -35,6 +35,7 @@
   </FeatureList>
   <LookupList>
     <!-- LookupCount=2 -->
+    <!-- l1:  -->
     <Lookup index="0">
       <LookupType value="1"/>
       <LookupFlag value="0"/>
@@ -44,6 +45,7 @@
         <Substitution in="uvowelsignkannada" out="uvowelsignaltkannada"/>
       </SingleSubst>
     </Lookup>
+    <!-- l0:  -->
     <Lookup index="1">
       <LookupType value="6"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/lookupnames-forward.ttx.GSUB
+++ b/Tests/mtiLib/data/lookupnames-forward.ttx.GSUB
@@ -35,6 +35,7 @@
   </FeatureList>
   <LookupList>
     <!-- LookupCount=2 -->
+    <!-- l0:  -->
     <Lookup index="0">
       <LookupType value="6"/>
       <LookupFlag value="0"/>
@@ -74,6 +75,7 @@
         </ChainSubClassSet>
       </ChainContextSubst>
     </Lookup>
+    <!-- l1:  -->
     <Lookup index="1">
       <LookupType value="1"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mixed-toplevels.ttx.GSUB
+++ b/Tests/mtiLib/data/mixed-toplevels.ttx.GSUB
@@ -35,6 +35,7 @@
   </FeatureList>
   <LookupList>
     <!-- LookupCount=2 -->
+    <!-- 0:  -->
     <Lookup index="0">
       <LookupType value="6"/>
       <LookupFlag value="0"/>
@@ -74,6 +75,7 @@
         </ChainSubClassSet>
       </ChainContextSubst>
     </Lookup>
+    <!-- 1:  -->
     <Lookup index="1">
       <LookupType value="1"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/chained-glyph.ttx.GPOS
+++ b/Tests/mtiLib/data/mti/chained-glyph.ttx.GPOS
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=2 -->
+    <!-- raucontext-sinh:  -->
     <Lookup index="0">
       <LookupType value="8"/>
       <LookupFlag value="512"/><!-- markAttachmentType[2] -->
@@ -43,6 +44,7 @@
         </ChainPosRuleSet>
       </ChainContextPos>
     </Lookup>
+    <!-- u2aelow-sinh:  -->
     <Lookup index="1" empty="1"/>
   </LookupList>
 </GPOS>

--- a/Tests/mtiLib/data/mti/chained-glyph.ttx.GSUB
+++ b/Tests/mtiLib/data/mti/chained-glyph.ttx.GSUB
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=2 -->
+    <!-- raucontext-sinh:  -->
     <Lookup index="0">
       <LookupType value="6"/>
       <LookupFlag value="512"/><!-- markAttachmentType[2] -->
@@ -43,6 +44,7 @@
         </ChainSubRuleSet>
       </ChainContextSubst>
     </Lookup>
+    <!-- u2aelow-sinh:  -->
     <Lookup index="1" empty="1"/>
   </LookupList>
 </GSUB>

--- a/Tests/mtiLib/data/mti/chainedclass.ttx.GSUB
+++ b/Tests/mtiLib/data/mti/chainedclass.ttx.GSUB
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=2 -->
+    <!-- swashes-knda:  -->
     <Lookup index="0">
       <LookupType value="6"/>
       <LookupFlag value="0"/>
@@ -42,6 +43,7 @@
         </ChainSubClassSet>
       </ChainContextSubst>
     </Lookup>
+    <!-- u-swash-knda:  -->
     <Lookup index="1">
       <LookupType value="1"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/chainedcoverage.ttx.GSUB
+++ b/Tests/mtiLib/data/mti/chainedcoverage.ttx.GSUB
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=2 -->
+    <!-- slashcontext:  -->
     <Lookup index="0">
       <LookupType value="6"/>
       <LookupFlag value="0"/>
@@ -45,6 +46,7 @@
         </SubstLookupRecord>
       </ChainContextSubst>
     </Lookup>
+    <!-- slashTofraction:  -->
     <Lookup index="1">
       <LookupType value="1"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/gposcursive.ttx.GPOS
+++ b/Tests/mtiLib/data/mti/gposcursive.ttx.GPOS
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- kernpairs:  -->
     <Lookup index="0">
       <LookupType value="3"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/gposkernset.ttx.GPOS
+++ b/Tests/mtiLib/data/mti/gposkernset.ttx.GPOS
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- 0:  -->
     <Lookup index="0">
       <LookupType value="2"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/gposmarktobase.ttx.GPOS
+++ b/Tests/mtiLib/data/mti/gposmarktobase.ttx.GPOS
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- topmarktobase-guru:  -->
     <Lookup index="0">
       <LookupType value="4"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/gpospairclass.ttx.GPOS
+++ b/Tests/mtiLib/data/mti/gpospairclass.ttx.GPOS
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- 0:  -->
     <Lookup index="0">
       <LookupType value="2"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/gpospairglyph.ttx.GPOS
+++ b/Tests/mtiLib/data/mti/gpospairglyph.ttx.GPOS
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- 0:  -->
     <Lookup index="0">
       <LookupType value="2"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/gpossingle.ttx.GPOS
+++ b/Tests/mtiLib/data/mti/gpossingle.ttx.GPOS
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- supsToInferiors:  -->
     <Lookup index="0">
       <LookupType value="1"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/gsubalternate.ttx.GSUB
+++ b/Tests/mtiLib/data/mti/gsubalternate.ttx.GSUB
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- 27:  -->
     <Lookup index="0">
       <LookupType value="3"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/gsubligature.ttx.GSUB
+++ b/Tests/mtiLib/data/mti/gsubligature.ttx.GSUB
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- latinLigatures:  -->
     <Lookup index="0">
       <LookupType value="4"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/gsubmultiple.ttx.GSUB
+++ b/Tests/mtiLib/data/mti/gsubmultiple.ttx.GSUB
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- replace-akhand-telugu:  -->
     <Lookup index="0">
       <LookupType value="2"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/gsubreversechanined.ttx.GSUB
+++ b/Tests/mtiLib/data/mti/gsubreversechanined.ttx.GSUB
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- arabicReverse:  -->
     <Lookup index="0">
       <LookupType value="8"/>
       <LookupFlag value="9"/><!-- rightToLeft ignoreMarks -->

--- a/Tests/mtiLib/data/mti/gsubsingle.ttx.GSUB
+++ b/Tests/mtiLib/data/mti/gsubsingle.ttx.GSUB
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- alt-fractions:  -->
     <Lookup index="0">
       <LookupType value="1"/>
       <LookupFlag value="0"/>

--- a/Tests/mtiLib/data/mti/mark-to-ligature.ttx.GPOS
+++ b/Tests/mtiLib/data/mti/mark-to-ligature.ttx.GPOS
@@ -3,6 +3,7 @@
   <Version value="0x00010000"/>
   <LookupList>
     <!-- LookupCount=1 -->
+    <!-- LigMk0:  -->
     <Lookup index="0">
       <LookupType value="5"/>
       <LookupFlag value="0"/>


### PR DESCRIPTION
This stores the original lookup name in the `Debg` table when building MTI feature files. This allows the fonts to be debugged used Crowbar or other debuggers, and more sensibly decompiled to FEA:

Before:

```
lookup ChainedContextualGSUB7 {
    lookupflag 0;
    ;
    # Original source: 6
    sub [katelu gatelu tthatelu ratelu shatelu] tasubscripttelu' lookup SingleSubstitution8;
    sub @class2 tasubscripttelu' lookup SingleSubstitution9;
    sub ssatelu tasubscripttelu' lookup SingleSubstitution19;
    sub [katelu gatelu tthatelu ratelu shatelu] @class3 tasubscripttelu' lookup SingleSubstitution8;
    sub @class2 @class3 tasubscripttelu' lookup SingleSubstitution9;
    sub ssatelu @class3 tasubscripttelu' lookup SingleSubstitution19;
    sub [katelu gatelu tthatelu ratelu shatelu] @class3 ailengthmarktelu tasubscripttelu' lookup SingleSubstitution8;
    sub @class2 @class3 ailengthmarktelu tasubscripttelu' lookup SingleSubstitution9;
    sub ssatelu @class3 ailengthmarktelu tasubscripttelu' lookup SingleSubstitution19;
    sub @class11 [jasubscripttelu ttasubscripttelu ddasubscripttelu dasubscripttelu lasubscripttelu]' lookup SingleSubstitution19;
    sub @class11 @class3 [jasubscripttelu ttasubscripttelu ddasubscripttelu dasubscripttelu lasubscripttelu]' lookup SingleSubstitution19;
} ChainedContextualGSUB7;
```

After:


```
lookup contextta_telu {
    lookupflag 0;
    ;
    # Original source: GSUB 6  contextta_telu
    # Original source: 6
    sub [katelu gatelu tthatelu ratelu shatelu] tasubscripttelu' lookup narrowta_telu;
    sub @class2 tasubscripttelu' lookup wideta_telu;
    sub ssatelu tasubscripttelu' lookup lowtara_telu;
    sub [katelu gatelu tthatelu ratelu shatelu] @class3 tasubscripttelu' lookup narrowta_telu;
    sub @class2 @class3 tasubscripttelu' lookup wideta_telu;
    sub ssatelu @class3 tasubscripttelu' lookup lowtara_telu;
    sub [katelu gatelu tthatelu ratelu shatelu] @class3 ailengthmarktelu tasubscripttelu' lookup narrowta_telu;
    sub @class2 @class3 ailengthmarktelu tasubscripttelu' lookup wideta_telu;
    sub ssatelu @class3 ailengthmarktelu tasubscripttelu' lookup lowtara_telu;
    sub @class11 [jasubscripttelu ttasubscripttelu ddasubscripttelu dasubscripttelu lasubscripttelu]' lookup lowtara_telu;
    sub @class11 @class3 [jasubscripttelu ttasubscripttelu ddasubscripttelu dasu
bscripttelu lasubscripttelu]' lookup lowtara_telu;
} contextta_telu;
```