### PR TITLE
[mtiLib] only build `Debg` table if FONTTOOLS_LOOKUP_DEBUGGING env var is set

### DIFF
--- a/Lib/fontTools/mtiLib/__init__.py
+++ b/Lib/fontTools/mtiLib/__init__.py
@@ -13,8 +13,9 @@ from fontTools.ttLib.tables.otBase import ValueRecord, valueRecordFormatDict
 from fontTools.otlLib import builder as otl
 from contextlib import contextmanager
 from fontTools.ttLib import newTable
-from fontTools.feaLib.lookupDebugInfo import LOOKUP_DEBUG_INFO_KEY
+from fontTools.feaLib.lookupDebugInfo import LOOKUP_DEBUG_ENV_VAR, LOOKUP_DEBUG_INFO_KEY
 from operator import setitem
+import os
 import logging
 
 
@@ -1038,16 +1039,17 @@ def parseGSUBGPOS(lines, font, tableTag):
         self.LookupList.LookupCount = len(self.LookupList.Lookup)
     if lookupMap is not None:
         lookupMap.applyDeferredMappings()
-        if "Debg" not in font:
-            font["Debg"] = newTable("Debg")
-            font["Debg"].data = {}
-        debug = (
-            font["Debg"]
-            .data.setdefault(LOOKUP_DEBUG_INFO_KEY, {})
-            .setdefault(tableTag, {})
-        )
-        for name, lookup in lookupMap.items():
-            debug[str(lookup)] = ["", name, ""]
+        if os.environ.get(LOOKUP_DEBUG_ENV_VAR):
+            if "Debg" not in font:
+                font["Debg"] = newTable("Debg")
+                font["Debg"].data = {}
+            debug = (
+                font["Debg"]
+                .data.setdefault(LOOKUP_DEBUG_INFO_KEY, {})
+                .setdefault(tableTag, {})
+            )
+            for name, lookup in lookupMap.items():
+                debug[str(lookup)] = ["", name, ""]
 
         featureMap.applyDeferredMappings()
     container.table = self

--- a/Tests/mtiLib/mti_test.py
+++ b/Tests/mtiLib/mti_test.py
@@ -5,10 +5,10 @@ import difflib
 from io import StringIO
 import os
 import sys
-import unittest
+import pytest
 
 
-class MtiTest(unittest.TestCase):
+class MtiTest:
 
     GLYPH_ORDER = [
         ".notdef",
@@ -396,19 +396,6 @@ class MtiTest(unittest.TestCase):
     #        'mti/contextcoverage'
     #        'mti/context-glyph'
 
-    def __init__(self, methodName):
-        unittest.TestCase.__init__(self, methodName)
-        # Python 3 renamed assertRaisesRegexp to assertRaisesRegex,
-        # and fires deprecation warnings if a program uses the old name.
-        if not hasattr(self, "assertRaisesRegex"):
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     @staticmethod
     def getpath(testfile):
         path, _ = os.path.split(__file__)
@@ -423,7 +410,7 @@ class MtiTest(unittest.TestCase):
                 expected, actual, fromfile=fromfile, tofile=tofile
             ):
                 sys.stderr.write(line)
-            self.fail("TTX output is different from expected")
+            pytest.fail("TTX output is different from expected")
 
     @classmethod
     def create_font(celf):
@@ -445,7 +432,7 @@ class MtiTest(unittest.TestCase):
             table = mtiLib.build(f, font, tableTag=tableTag)
 
         if tableTag is not None:
-            self.assertEqual(tableTag, table.tableTag)
+            assert tableTag == table.tableTag
         tableTag = table.tableTag
 
         # Make sure it compiles.
@@ -523,4 +510,4 @@ if __name__ == "__main__":
 
         font = MtiTest.create_font()
         sys.exit(main(sys.argv[1:], font))
-    sys.exit(unittest.main())
+    sys.exit(pytest.main(sys.argv))

--- a/Tests/mtiLib/mti_test.py
+++ b/Tests/mtiLib/mti_test.py
@@ -1,11 +1,17 @@
 from fontTools.misc.xmlWriter import XMLWriter
 from fontTools.ttLib import TTFont
+from fontTools.feaLib.lookupDebugInfo import LOOKUP_DEBUG_ENV_VAR
 from fontTools import mtiLib
 import difflib
 from io import StringIO
 import os
 import sys
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def set_lookup_debug_env_var(monkeypatch):
+    monkeypatch.setenv(LOOKUP_DEBUG_ENV_VAR, "1")
 
 
 class MtiTest:


### PR DESCRIPTION
[We do the same for feaLib.builder ](https://github.com/fonttools/fonttools/blob/501353f3df2de69a126587da22cb0c6fb1db5acc/Lib/fontTools/feaLib/builder.py#L239-L240) to decide whether to build a Debg table or not: i.e. we check if FONTTOOLS_LOOKUP_DEBUGGING environment variable is defined and if so we go on to build one, otherwise we don't.

Fixes https://github.com/fonttools/fonttools/pull/3018