### PR TITLE
[COLRv1] Add method to automatically compute ClipBoxes, w/ optional quantization

### DIFF
--- a/Lib/fontTools/misc/arrayTools.py
+++ b/Lib/fontTools/misc/arrayTools.py
@@ -282,6 +282,27 @@ def intRect(rect):
     return (xMin, yMin, xMax, yMax)
 
 
+def quantizeRect(rect, factor=1):
+    """
+    >>> bounds = (72.3, -218.4, 1201.3, 919.1)
+    >>> quantizeRect(bounds)
+    (72, -219, 1202, 920)
+    >>> quantizeRect(bounds, factor=10)
+    (70, -220, 1210, 920)
+    >>> quantizeRect(bounds, factor=100)
+    (0, -300, 1300, 1000)
+    """
+    if factor < 1:
+        raise ValueError(f"Expected quantization factor >= 1, found: {factor!r}")
+    xMin, yMin, xMax, yMax = normRect(rect)
+    return (
+        int(math.floor(xMin / factor) * factor),
+        int(math.floor(yMin / factor) * factor),
+        int(math.ceil(xMax / factor) * factor),
+        int(math.ceil(yMax / factor) * factor),
+    )
+
+
 class Vector(_Vector):
     def __init__(self, *args, **kwargs):
         warnings.warn(

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -1667,11 +1667,11 @@ class Paint(getFormatSwitchingBaseTableClass("uint8")):
                 .translate(-self.centerX, -self.centerY)
             )
         elif self.Format == PaintFormat.PaintSkew:
-            return Identity.skew(radians(self.xSkewAngle), radians(self.ySkewAngle))
+            return Identity.skew(radians(-self.xSkewAngle), radians(self.ySkewAngle))
         elif self.Format == PaintFormat.PaintSkewAroundCenter:
             return (
                 Identity.translate(self.centerX, self.centerY)
-                .skew(radians(self.xSkewAngle), radians(self.ySkewAngle))
+                .skew(radians(-self.xSkewAngle), radians(self.ySkewAngle))
                 .translate(-self.centerX, -self.centerY)
             )
         if PaintFormat(self.Format).is_variable():

--- a/Lib/fontTools/ttLib/tables/otTraverse.py
+++ b/Lib/fontTools/ttLib/tables/otTraverse.py
@@ -31,6 +31,9 @@ def dfs_base_table(
     root_accessor: Optional[str] = None,
     skip_root: bool = False,
     predicate: Optional[Callable[[SubTablePath], bool]] = None,
+    iter_subtables_fn: Optional[
+        Callable[[BaseTable], Iterable[BaseTable.SubTableEntry]]
+    ] = None,
 ) -> Iterable[SubTablePath]:
     """Depth-first search tree of BaseTables.
 
@@ -43,6 +46,9 @@ def dfs_base_table(
         predicate (Optional[Callable[[SubTablePath], bool]]): function to filter out
             paths. If True, the path is yielded and its subtables are added to the
             queue. If False, the path is skipped and its subtables are not traversed.
+        iter_subtables_fn (Optional[Callable[[BaseTable], Iterable[BaseTable.SubTableEntry]]]):
+            function to iterate over subtables of a table. If None, the default
+            BaseTable.iterSubTables() is used.
 
     Yields:
         SubTablePath: tuples of BaseTable.SubTableEntry(name, table, index) namedtuples
@@ -56,6 +62,7 @@ def dfs_base_table(
         skip_root,
         predicate,
         lambda frontier, new: frontier.extendleft(reversed(new)),
+        iter_subtables_fn,
     )
 
 
@@ -64,11 +71,14 @@ def bfs_base_table(
     root_accessor: Optional[str] = None,
     skip_root: bool = False,
     predicate: Optional[Callable[[SubTablePath], bool]] = None,
+    iter_subtables_fn: Optional[
+        Callable[[BaseTable], Iterable[BaseTable.SubTableEntry]]
+    ] = None,
 ) -> Iterable[SubTablePath]:
     """Breadth-first search tree of BaseTables.
 
     Args:
-        root (BaseTable): the root of the tree.
+    the root of the tree.
         root_accessor (Optional[str]): attribute name for the root table, if any (mostly
             useful for debugging).
         skip_root (Optional[bool]): if True, the root itself is not visited, only its
@@ -76,6 +86,9 @@ def bfs_base_table(
         predicate (Optional[Callable[[SubTablePath], bool]]): function to filter out
             paths. If True, the path is yielded and its subtables are added to the
             queue. If False, the path is skipped and its subtables are not traversed.
+        iter_subtables_fn (Optional[Callable[[BaseTable], Iterable[BaseTable.SubTableEntry]]]):
+            function to iterate over subtables of a table. If None, the default
+            BaseTable.iterSubTables() is used.
 
     Yields:
         SubTablePath: tuples of BaseTable.SubTableEntry(name, table, index) namedtuples
@@ -89,6 +102,7 @@ def bfs_base_table(
         skip_root,
         predicate,
         lambda frontier, new: frontier.extend(new),
+        iter_subtables_fn,
     )
 
 
@@ -98,6 +112,9 @@ def _traverse_ot_data(
     skip_root: bool,
     predicate: Optional[Callable[[SubTablePath], bool]],
     add_to_frontier_fn: AddToFrontierFn,
+    iter_subtables_fn: Optional[
+        Callable[[BaseTable], Iterable[BaseTable.SubTableEntry]]
+    ] = None,
 ) -> Iterable[SubTablePath]:
     # no visited because general otData cannot cycle (forward-offset only)
     if root_accessor is None:
@@ -108,6 +125,11 @@ def _traverse_ot_data(
         def predicate(path):
             return True
 
+    if iter_subtables_fn is None:
+
+        def iter_subtables_fn(table):
+            return table.iterSubTables()
+
     frontier: Deque[SubTablePath] = deque()
 
     root_entry = BaseTable.SubTableEntry(root_accessor, root)
@@ -116,7 +138,10 @@ def _traverse_ot_data(
     else:
         add_to_frontier_fn(
             frontier,
-            [(root_entry, subtable_entry) for subtable_entry in root.iterSubTables()],
+            [
+                (root_entry, subtable_entry)
+                for subtable_entry in iter_subtables_fn(root)
+            ],
         )
 
     while frontier:
@@ -130,7 +155,7 @@ def _traverse_ot_data(
         yield SubTablePath(path)
 
         new_entries = [
-            path + (subtable_entry,) for subtable_entry in current.iterSubTables()
+            path + (subtable_entry,) for subtable_entry in iter_subtables_fn(current)
         ]
 
         add_to_frontier_fn(frontier, new_entries)

--- a/Tests/ttLib/tables/data/COLRv1-clip-boxes-cff.ttx
+++ b/Tests/ttLib/tables/data/COLRv1-clip-boxes-cff.ttx
@@ -1,0 +1,1213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="4.37">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name=".null"/>
+    <GlyphID id="2" name="upem_box_glyph"/>
+    <GlyphID id="3" name="cross_glyph"/>
+    <GlyphID id="4" name="one"/>
+    <GlyphID id="5" name="zero"/>
+    <GlyphID id="6" name="scale_0.5_1.5_center_500.0_500.0"/>
+    <GlyphID id="7" name="scale_1.5_1.5_center_500.0_500.0"/>
+    <GlyphID id="8" name="scale_0.5_1.5_center_0_0"/>
+    <GlyphID id="9" name="scale_1.5_1.5_center_0_0"/>
+    <GlyphID id="10" name="scale_0.5_1.5_center_1000_1000"/>
+    <GlyphID id="11" name="scale_1.5_1.5_center_1000_1000"/>
+    <GlyphID id="12" name="rotate_10_center_0_0"/>
+    <GlyphID id="13" name="rotate_-10_center_1000_1000"/>
+    <GlyphID id="14" name="rotate_25_center_500.0_500.0"/>
+    <GlyphID id="15" name="rotate_-15_center_500.0_500.0"/>
+    <GlyphID id="16" name="skew_25_0_center_0_0"/>
+    <GlyphID id="17" name="skew_25_0_center_500.0_500.0"/>
+    <GlyphID id="18" name="skew_0_15_center_0_0"/>
+    <GlyphID id="19" name="skew_0_15_center_500.0_500.0"/>
+    <GlyphID id="20" name="skew_-10_20_center_500.0_500.0"/>
+    <GlyphID id="21" name="skew_-10_20_center_1000_1000"/>
+    <GlyphID id="22" name="transform_matrix_1_0_0_1_125_125"/>
+    <GlyphID id="23" name="transform_matrix_1.5_0_0_1.5_0_0"/>
+    <GlyphID id="24" name="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/>
+    <GlyphID id="25" name="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/>
+    <GlyphID id="26" name="translate_0_0"/>
+    <GlyphID id="27" name="translate_0_100"/>
+    <GlyphID id="28" name="translate_0_-100"/>
+    <GlyphID id="29" name="translate_100_0"/>
+    <GlyphID id="30" name="translate_-100_0"/>
+    <GlyphID id="31" name="translate_200_200"/>
+    <GlyphID id="32" name="translate_-200_-200"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0x4b7ffe68"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Mar 10 15:01:34 2023"/>
+    <modified value="Fri Mar 10 15:01:34 2023"/>
+    <xMin value="0"/>
+    <yMin value="0"/>
+    <xMax value="1000"/>
+    <yMax value="1000"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="950"/>
+    <descent value="-250"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="1000"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="0"/>
+    <xMaxExtent value="1000"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="3"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="33"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="988"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="0"/>
+    <ySubscriptYSize value="0"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="0"/>
+    <ySuperscriptXSize value="0"/>
+    <ySuperscriptYSize value="0"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="0"/>
+    <yStrikeoutSize value="0"/>
+    <yStrikeoutPosition value="0"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000010 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000100 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="????"/>
+    <fsSelection value="00000000 10000000"/>
+    <usFirstCharIndex value="65535"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="950"/>
+    <sTypoDescender value="0"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="950"/>
+    <usWinDescent value="250"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="0"/>
+    <sCapHeight value="0"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <name>
+    <namerecord nameID="1" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      COLRv1 Static Test Glyphs
+    </namerecord>
+    <namerecord nameID="2" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      COLRv1 Static Test Glyphs 2023-03-10T15:01:34.955294
+    </namerecord>
+    <namerecord nameID="4" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      COLRv1 Static Test Glyphs Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      2023-03-10T15:01:34.955294
+    </namerecord>
+    <namerecord nameID="6" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      COLRv1StaticTestGlyphs-Regular
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      COLRv1 Static Test Glyphs
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      COLRv1 Static Test Glyphs 2023-03-10T15:01:34.955294
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      COLRv1 Static Test Glyphs Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      2023-03-10T15:01:34.955294
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      COLRv1StaticTestGlyphs-Regular
+    </namerecord>
+  </name>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+    </cmap_format_4>
+    <cmap_format_12 platformID="3" platEncID="10" format="12" reserved="0" length="88" language="0" nGroups="6">
+      <map code="0xf0300" name="scale_0.5_1.5_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0301" name="scale_1.5_1.5_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0302" name="scale_0.5_1.5_center_0_0"/><!-- ???? -->
+      <map code="0xf0303" name="scale_1.5_1.5_center_0_0"/><!-- ???? -->
+      <map code="0xf0304" name="scale_0.5_1.5_center_1000_1000"/><!-- ???? -->
+      <map code="0xf0305" name="scale_1.5_1.5_center_1000_1000"/><!-- ???? -->
+      <map code="0xf0600" name="rotate_10_center_0_0"/><!-- ???? -->
+      <map code="0xf0601" name="rotate_-10_center_1000_1000"/><!-- ???? -->
+      <map code="0xf0602" name="rotate_25_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0603" name="rotate_-15_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0700" name="skew_25_0_center_0_0"/><!-- ???? -->
+      <map code="0xf0701" name="skew_25_0_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0702" name="skew_0_15_center_0_0"/><!-- ???? -->
+      <map code="0xf0703" name="skew_0_15_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0704" name="skew_-10_20_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0705" name="skew_-10_20_center_1000_1000"/><!-- ???? -->
+      <map code="0xf0800" name="transform_matrix_1_0_0_1_125_125"/><!-- ???? -->
+      <map code="0xf0801" name="transform_matrix_1.5_0_0_1.5_0_0"/><!-- ???? -->
+      <map code="0xf0802" name="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/><!-- ???? -->
+      <map code="0xf0803" name="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/><!-- ???? -->
+      <map code="0xf0900" name="translate_0_0"/><!-- ???? -->
+      <map code="0xf0901" name="translate_0_100"/><!-- ???? -->
+      <map code="0xf0902" name="translate_0_-100"/><!-- ???? -->
+      <map code="0xf0903" name="translate_100_0"/><!-- ???? -->
+      <map code="0xf0904" name="translate_-100_0"/><!-- ???? -->
+      <map code="0xf0905" name="translate_200_200"/><!-- ???? -->
+      <map code="0xf0906" name="translate_-200_-200"/><!-- ???? -->
+      <map code="0xfe001" name=".null"/><!-- ???? -->
+      <map code="0xfe002" name="upem_box_glyph"/><!-- ???? -->
+      <map code="0xfe003" name="cross_glyph"/><!-- ???? -->
+      <map code="0xfe004" name="one"/><!-- ???? -->
+      <map code="0xfe005" name="zero"/><!-- ???? -->
+    </cmap_format_12>
+  </cmap>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="0"/>
+    <underlineThickness value="0"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="COLRv1StaticTestGlyphs-Regular">
+      <FullName value="COLRv1StaticTestGlyphs-Regular"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="0"/>
+      <UnderlinePosition value="-100"/>
+      <UnderlineThickness value="50"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="0 0 1000 1000"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <ForceBold value="0"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="0"/>
+        <nominalWidthX value="0"/>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          600 endchar
+        </CharString>
+        <CharString name=".null">
+          0 endchar
+        </CharString>
+        <CharString name="cross_glyph">
+          1000 475 525 rmoveto
+          225 50 -225 225 -50 -225 -225 -50 225 -225 50 vlineto
+          endchar
+        </CharString>
+        <CharString name="one">
+          1000 296 543 rmoveto
+          -293 -37 247 vlineto
+          -75 -31 0 37 106 40 rlineto
+          endchar
+        </CharString>
+        <CharString name="rotate_-10_center_1000_1000">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="rotate_-15_center_500.0_500.0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="rotate_10_center_0_0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="rotate_25_center_500.0_500.0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="scale_0.5_1.5_center_0_0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="scale_0.5_1.5_center_1000_1000">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="scale_0.5_1.5_center_500.0_500.0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="scale_1.5_1.5_center_0_0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="scale_1.5_1.5_center_1000_1000">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="scale_1.5_1.5_center_500.0_500.0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="skew_-10_20_center_1000_1000">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="skew_-10_20_center_500.0_500.0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="skew_0_15_center_0_0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="skew_0_15_center_500.0_500.0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="skew_25_0_center_0_0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="skew_25_0_center_500.0_500.0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="transform_matrix_1.5_0_0_1.5_0_0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="transform_matrix_1_0_0_1_125_125">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="translate_-100_0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="translate_-200_-200">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="translate_0_-100">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="translate_0_0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="translate_0_100">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="translate_100_0">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="translate_200_200">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="upem_box_glyph">
+          1000 0 hmoveto
+          1000 1000 -1000 vlineto
+          endchar
+        </CharString>
+        <CharString name="zero">
+          1000 357 374 rmoveto
+          -47 -8 -34 -17 -19 vhcurveto
+          -19 -16 -23 -9 -28 hhcurveto
+          -28 -22 9 19 -17 hvcurveto
+          -17 19 -8 34 47 vvcurveto
+          45 vlineto
+          47 8 33 17 19 vhcurveto
+          18 17 22 9 28 hhcurveto
+          28 23 -9 -18 16 hvcurveto
+          17 -19 8 -33 -47 vvcurveto
+          -37 6 rmoveto
+          33 -5 23 -9 14 vhcurveto
+          13 -10 -13 7 -18 hhcurveto
+          -18 -13 -7 -13 -10 hvcurveto
+          -9 -14 -5 -23 -33 vvcurveto
+          -57 vlineto
+          -32 5 -24 10 -14 vhcurveto
+          -14 9 14 -8 17 hhcurveto
+          18 14 8 14 9 hvcurveto
+          9 14 5 24 32 vvcurveto
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+  <COLR>
+    <Version value="1"/>
+    <!-- BaseGlyphRecordCount=0 -->
+    <!-- LayerRecordCount=0 -->
+    <BaseGlyphList>
+      <!-- BaseGlyphCount=27 -->
+      <BaseGlyphPaintRecord index="0">
+        <BaseGlyph value="scale_0.5_1.5_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="18"><!-- PaintScaleAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="1">
+        <BaseGlyph value="scale_1.5_1.5_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="22"><!-- PaintScaleUniformAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="2">
+        <BaseGlyph value="scale_0.5_1.5_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="16"><!-- PaintScale -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="3">
+        <BaseGlyph value="scale_1.5_1.5_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="20"><!-- PaintScaleUniform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="4">
+        <BaseGlyph value="scale_0.5_1.5_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="18"><!-- PaintScaleAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="5">
+        <BaseGlyph value="scale_1.5_1.5_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="22"><!-- PaintScaleUniformAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="6">
+        <BaseGlyph value="rotate_10_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="24"><!-- PaintRotate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="10.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="7">
+        <BaseGlyph value="rotate_-10_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="-10.0"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="8">
+        <BaseGlyph value="rotate_25_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="25.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="9">
+        <BaseGlyph value="rotate_-15_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="-15.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="10">
+        <BaseGlyph value="skew_25_0_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="28"><!-- PaintSkew -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="25.0"/>
+            <ySkewAngle value="0.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="11">
+        <BaseGlyph value="skew_25_0_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="25.0"/>
+            <ySkewAngle value="0.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="12">
+        <BaseGlyph value="skew_0_15_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="28"><!-- PaintSkew -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="0.0"/>
+            <ySkewAngle value="15.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="13">
+        <BaseGlyph value="skew_0_15_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="0.0"/>
+            <ySkewAngle value="15.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="14">
+        <BaseGlyph value="skew_-10_20_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="-10.0"/>
+            <ySkewAngle value="20.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="15">
+        <BaseGlyph value="skew_-10_20_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="-10.0"/>
+            <ySkewAngle value="20.0"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="16">
+        <BaseGlyph value="transform_matrix_1_0_0_1_125_125"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.0"/>
+              <yx value="0.0"/>
+              <xy value="0.0"/>
+              <yy value="1.0"/>
+              <dx value="125.0"/>
+              <dy value="125.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="17">
+        <BaseGlyph value="transform_matrix_1.5_0_0_1.5_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.5"/>
+              <yx value="0.0"/>
+              <xy value="0.0"/>
+              <yy value="1.5"/>
+              <dx value="0.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="18">
+        <BaseGlyph value="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="0.9659"/>
+              <yx value="0.2588"/>
+              <xy value="-0.2588"/>
+              <yy value="0.9659"/>
+              <dx value="0.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="19">
+        <BaseGlyph value="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.0"/>
+              <yx value="0.0"/>
+              <xy value="0.6"/>
+              <yy value="1.0"/>
+              <dx value="-300.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="20">
+        <BaseGlyph value="translate_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="21">
+        <BaseGlyph value="translate_0_100"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="100"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="22">
+        <BaseGlyph value="translate_0_-100"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="-100"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="23">
+        <BaseGlyph value="translate_100_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="100"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="24">
+        <BaseGlyph value="translate_-100_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="-100"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="25">
+        <BaseGlyph value="translate_200_200"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="200"/>
+            <dy value="200"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="26">
+        <BaseGlyph value="translate_-200_-200"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="-200"/>
+            <dy value="-200"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+    </BaseGlyphList>
+  </COLR>
+
+  <CPAL>
+    <version value="1"/>
+    <numPaletteEntries value="7"/>
+    <palette index="0">
+      <color index="0" value="#FF0000FF"/>
+      <color index="1" value="#FFA500FF"/>
+      <color index="2" value="#FFFF00FF"/>
+      <color index="3" value="#008000FF"/>
+      <color index="4" value="#0000FFFF"/>
+      <color index="5" value="#4B0082FF"/>
+      <color index="6" value="#EE82EEFF"/>
+    </palette>
+    <palette index="1" type="2">
+      <color index="0" value="#2A294AFF"/>
+      <color index="1" value="#244163FF"/>
+      <color index="2" value="#1B6388FF"/>
+      <color index="3" value="#157DA3FF"/>
+      <color index="4" value="#0E9AC2FF"/>
+      <color index="5" value="#05BEE8FF"/>
+      <color index="6" value="#00D4FFFF"/>
+    </palette>
+    <palette index="2" type="1">
+      <color index="0" value="#FC7118FF"/>
+      <color index="1" value="#FB8115FF"/>
+      <color index="2" value="#FA9511FF"/>
+      <color index="3" value="#FAA80DFF"/>
+      <color index="4" value="#F9BE09FF"/>
+      <color index="5" value="#F8D304FF"/>
+      <color index="6" value="#F8E700FF"/>
+    </palette>
+  </CPAL>
+
+  <hmtx>
+    <mtx name=".notdef" width="600" lsb="0"/>
+    <mtx name=".null" width="0" lsb="0"/>
+    <mtx name="cross_glyph" width="1000" lsb="250"/>
+    <mtx name="one" width="1000" lsb="184"/>
+    <mtx name="rotate_-10_center_1000_1000" width="1000" lsb="0"/>
+    <mtx name="rotate_-15_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="rotate_10_center_0_0" width="1000" lsb="0"/>
+    <mtx name="rotate_25_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="scale_0.5_1.5_center_0_0" width="1000" lsb="0"/>
+    <mtx name="scale_0.5_1.5_center_1000_1000" width="1000" lsb="0"/>
+    <mtx name="scale_0.5_1.5_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="scale_1.5_1.5_center_0_0" width="1000" lsb="0"/>
+    <mtx name="scale_1.5_1.5_center_1000_1000" width="1000" lsb="0"/>
+    <mtx name="scale_1.5_1.5_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="skew_-10_20_center_1000_1000" width="1000" lsb="0"/>
+    <mtx name="skew_-10_20_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="skew_0_15_center_0_0" width="1000" lsb="0"/>
+    <mtx name="skew_0_15_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="skew_25_0_center_0_0" width="1000" lsb="0"/>
+    <mtx name="skew_25_0_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0" width="1000" lsb="0"/>
+    <mtx name="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0" width="1000" lsb="0"/>
+    <mtx name="transform_matrix_1.5_0_0_1.5_0_0" width="1000" lsb="0"/>
+    <mtx name="transform_matrix_1_0_0_1_125_125" width="1000" lsb="0"/>
+    <mtx name="translate_-100_0" width="1000" lsb="0"/>
+    <mtx name="translate_-200_-200" width="1000" lsb="0"/>
+    <mtx name="translate_0_-100" width="1000" lsb="0"/>
+    <mtx name="translate_0_0" width="1000" lsb="0"/>
+    <mtx name="translate_0_100" width="1000" lsb="0"/>
+    <mtx name="translate_100_0" width="1000" lsb="0"/>
+    <mtx name="translate_200_200" width="1000" lsb="0"/>
+    <mtx name="upem_box_glyph" width="1000" lsb="0"/>
+    <mtx name="zero" width="1000" lsb="173"/>
+  </hmtx>
+
+</ttFont>

--- a/Tests/ttLib/tables/data/COLRv1-clip-boxes-glyf.ttx
+++ b/Tests/ttLib/tables/data/COLRv1-clip-boxes-glyf.ttx
@@ -1,0 +1,1414 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.37">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name=".null"/>
+    <GlyphID id="2" name="upem_box_glyph"/>
+    <GlyphID id="3" name="cross_glyph"/>
+    <GlyphID id="4" name="one"/>
+    <GlyphID id="5" name="zero"/>
+    <GlyphID id="6" name="scale_0.5_1.5_center_500.0_500.0"/>
+    <GlyphID id="7" name="scale_1.5_1.5_center_500.0_500.0"/>
+    <GlyphID id="8" name="scale_0.5_1.5_center_0_0"/>
+    <GlyphID id="9" name="scale_1.5_1.5_center_0_0"/>
+    <GlyphID id="10" name="scale_0.5_1.5_center_1000_1000"/>
+    <GlyphID id="11" name="scale_1.5_1.5_center_1000_1000"/>
+    <GlyphID id="12" name="rotate_10_center_0_0"/>
+    <GlyphID id="13" name="rotate_-10_center_1000_1000"/>
+    <GlyphID id="14" name="rotate_25_center_500.0_500.0"/>
+    <GlyphID id="15" name="rotate_-15_center_500.0_500.0"/>
+    <GlyphID id="16" name="skew_25_0_center_0_0"/>
+    <GlyphID id="17" name="skew_25_0_center_500.0_500.0"/>
+    <GlyphID id="18" name="skew_0_15_center_0_0"/>
+    <GlyphID id="19" name="skew_0_15_center_500.0_500.0"/>
+    <GlyphID id="20" name="skew_-10_20_center_500.0_500.0"/>
+    <GlyphID id="21" name="skew_-10_20_center_1000_1000"/>
+    <GlyphID id="22" name="transform_matrix_1_0_0_1_125_125"/>
+    <GlyphID id="23" name="transform_matrix_1.5_0_0_1.5_0_0"/>
+    <GlyphID id="24" name="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/>
+    <GlyphID id="25" name="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/>
+    <GlyphID id="26" name="translate_0_0"/>
+    <GlyphID id="27" name="translate_0_100"/>
+    <GlyphID id="28" name="translate_0_-100"/>
+    <GlyphID id="29" name="translate_100_0"/>
+    <GlyphID id="30" name="translate_-100_0"/>
+    <GlyphID id="31" name="translate_200_200"/>
+    <GlyphID id="32" name="translate_-200_-200"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0x5a54e94d"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Mar 10 15:07:35 2023"/>
+    <modified value="Fri Mar 10 15:07:35 2023"/>
+    <xMin value="0"/>
+    <yMin value="0"/>
+    <xMax value="1000"/>
+    <yMax value="1000"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="3"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="950"/>
+    <descent value="-250"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="1000"/>
+    <minLeftSideBearing value="0"/>
+    <minRightSideBearing value="0"/>
+    <xMaxExtent value="1000"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="3"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="33"/>
+    <maxPoints value="28"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="2"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="988"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="0"/>
+    <ySubscriptYSize value="0"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="0"/>
+    <ySuperscriptXSize value="0"/>
+    <ySuperscriptYSize value="0"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="0"/>
+    <yStrikeoutSize value="0"/>
+    <yStrikeoutPosition value="0"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange2 value="00000010 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000100 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="????"/>
+    <fsSelection value="00000000 10000000"/>
+    <usFirstCharIndex value="65535"/>
+    <usLastCharIndex value="65535"/>
+    <sTypoAscender value="950"/>
+    <sTypoDescender value="0"/>
+    <sTypoLineGap value="0"/>
+    <usWinAscent value="950"/>
+    <usWinDescent value="250"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000000"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="0"/>
+    <sCapHeight value="0"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="600" lsb="0"/>
+    <mtx name=".null" width="0" lsb="0"/>
+    <mtx name="cross_glyph" width="1000" lsb="250"/>
+    <mtx name="one" width="1000" lsb="184"/>
+    <mtx name="rotate_-10_center_1000_1000" width="1000" lsb="0"/>
+    <mtx name="rotate_-15_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="rotate_10_center_0_0" width="1000" lsb="0"/>
+    <mtx name="rotate_25_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="scale_0.5_1.5_center_0_0" width="1000" lsb="0"/>
+    <mtx name="scale_0.5_1.5_center_1000_1000" width="1000" lsb="0"/>
+    <mtx name="scale_0.5_1.5_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="scale_1.5_1.5_center_0_0" width="1000" lsb="0"/>
+    <mtx name="scale_1.5_1.5_center_1000_1000" width="1000" lsb="0"/>
+    <mtx name="scale_1.5_1.5_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="skew_-10_20_center_1000_1000" width="1000" lsb="0"/>
+    <mtx name="skew_-10_20_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="skew_0_15_center_0_0" width="1000" lsb="0"/>
+    <mtx name="skew_0_15_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="skew_25_0_center_0_0" width="1000" lsb="0"/>
+    <mtx name="skew_25_0_center_500.0_500.0" width="1000" lsb="0"/>
+    <mtx name="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0" width="1000" lsb="0"/>
+    <mtx name="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0" width="1000" lsb="0"/>
+    <mtx name="transform_matrix_1.5_0_0_1.5_0_0" width="1000" lsb="0"/>
+    <mtx name="transform_matrix_1_0_0_1_125_125" width="1000" lsb="0"/>
+    <mtx name="translate_-100_0" width="1000" lsb="0"/>
+    <mtx name="translate_-200_-200" width="1000" lsb="0"/>
+    <mtx name="translate_0_-100" width="1000" lsb="0"/>
+    <mtx name="translate_0_0" width="1000" lsb="0"/>
+    <mtx name="translate_0_100" width="1000" lsb="0"/>
+    <mtx name="translate_100_0" width="1000" lsb="0"/>
+    <mtx name="translate_200_200" width="1000" lsb="0"/>
+    <mtx name="upem_box_glyph" width="1000" lsb="0"/>
+    <mtx name="zero" width="1000" lsb="173"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+    </cmap_format_4>
+    <cmap_format_12 platformID="3" platEncID="10" format="12" reserved="0" length="88" language="0" nGroups="6">
+      <map code="0xf0300" name="scale_0.5_1.5_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0301" name="scale_1.5_1.5_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0302" name="scale_0.5_1.5_center_0_0"/><!-- ???? -->
+      <map code="0xf0303" name="scale_1.5_1.5_center_0_0"/><!-- ???? -->
+      <map code="0xf0304" name="scale_0.5_1.5_center_1000_1000"/><!-- ???? -->
+      <map code="0xf0305" name="scale_1.5_1.5_center_1000_1000"/><!-- ???? -->
+      <map code="0xf0600" name="rotate_10_center_0_0"/><!-- ???? -->
+      <map code="0xf0601" name="rotate_-10_center_1000_1000"/><!-- ???? -->
+      <map code="0xf0602" name="rotate_25_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0603" name="rotate_-15_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0700" name="skew_25_0_center_0_0"/><!-- ???? -->
+      <map code="0xf0701" name="skew_25_0_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0702" name="skew_0_15_center_0_0"/><!-- ???? -->
+      <map code="0xf0703" name="skew_0_15_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0704" name="skew_-10_20_center_500.0_500.0"/><!-- ???? -->
+      <map code="0xf0705" name="skew_-10_20_center_1000_1000"/><!-- ???? -->
+      <map code="0xf0800" name="transform_matrix_1_0_0_1_125_125"/><!-- ???? -->
+      <map code="0xf0801" name="transform_matrix_1.5_0_0_1.5_0_0"/><!-- ???? -->
+      <map code="0xf0802" name="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/><!-- ???? -->
+      <map code="0xf0803" name="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/><!-- ???? -->
+      <map code="0xf0900" name="translate_0_0"/><!-- ???? -->
+      <map code="0xf0901" name="translate_0_100"/><!-- ???? -->
+      <map code="0xf0902" name="translate_0_-100"/><!-- ???? -->
+      <map code="0xf0903" name="translate_100_0"/><!-- ???? -->
+      <map code="0xf0904" name="translate_-100_0"/><!-- ???? -->
+      <map code="0xf0905" name="translate_200_200"/><!-- ???? -->
+      <map code="0xf0906" name="translate_-200_-200"/><!-- ???? -->
+      <map code="0xfe001" name=".null"/><!-- ???? -->
+      <map code="0xfe002" name="upem_box_glyph"/><!-- ???? -->
+      <map code="0xfe003" name="cross_glyph"/><!-- ???? -->
+      <map code="0xfe004" name="one"/><!-- ???? -->
+      <map code="0xfe005" name="zero"/><!-- ???? -->
+    </cmap_format_12>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef"/><!-- contains no outline data -->
+
+    <TTGlyph name=".null"/><!-- contains no outline data -->
+
+    <TTGlyph name="cross_glyph" xMin="250" yMin="250" xMax="750" yMax="750">
+      <contour>
+        <pt x="475" y="525" on="1"/>
+        <pt x="475" y="750" on="1"/>
+        <pt x="525" y="750" on="1"/>
+        <pt x="525" y="525" on="1"/>
+        <pt x="750" y="525" on="1"/>
+        <pt x="750" y="475" on="1"/>
+        <pt x="525" y="475" on="1"/>
+        <pt x="525" y="250" on="1"/>
+        <pt x="475" y="250" on="1"/>
+        <pt x="475" y="475" on="1"/>
+        <pt x="250" y="475" on="1"/>
+        <pt x="250" y="525" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="one" xMin="184" yMin="250" xMax="296" yMax="543">
+      <contour>
+        <pt x="296" y="543" on="1"/>
+        <pt x="296" y="250" on="1"/>
+        <pt x="259" y="250" on="1"/>
+        <pt x="259" y="497" on="1"/>
+        <pt x="184" y="466" on="1"/>
+        <pt x="184" y="503" on="1"/>
+        <pt x="290" y="543" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="rotate_-10_center_1000_1000" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="rotate_-15_center_500.0_500.0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="rotate_10_center_0_0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="rotate_25_center_500.0_500.0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="scale_0.5_1.5_center_0_0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="scale_0.5_1.5_center_1000_1000" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="scale_0.5_1.5_center_500.0_500.0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="scale_1.5_1.5_center_0_0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="scale_1.5_1.5_center_1000_1000" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="scale_1.5_1.5_center_500.0_500.0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="skew_-10_20_center_1000_1000" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="skew_-10_20_center_500.0_500.0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="skew_0_15_center_0_0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="skew_0_15_center_500.0_500.0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="skew_25_0_center_0_0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="skew_25_0_center_500.0_500.0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="transform_matrix_1.5_0_0_1.5_0_0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="transform_matrix_1_0_0_1_125_125" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="translate_-100_0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="translate_-200_-200" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="translate_0_-100" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="translate_0_0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="translate_0_100" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="translate_100_0" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="translate_200_200" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="upem_box_glyph" xMin="0" yMin="0" xMax="1000" yMax="1000">
+      <contour>
+        <pt x="0" y="0" on="1"/>
+        <pt x="0" y="1000" on="1"/>
+        <pt x="1000" y="1000" on="1"/>
+        <pt x="1000" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="zero" xMin="173" yMin="246" xMax="357" yMax="545">
+      <contour>
+        <pt x="357" y="374" on="1"/>
+        <pt x="357" y="303" on="0"/>
+        <pt x="308" y="246" on="0"/>
+        <pt x="265" y="246" on="1"/>
+        <pt x="223" y="246" on="0"/>
+        <pt x="173" y="303" on="0"/>
+        <pt x="173" y="374" on="1"/>
+        <pt x="173" y="419" on="1"/>
+        <pt x="173" y="490" on="0"/>
+        <pt x="223" y="545" on="0"/>
+        <pt x="265" y="545" on="1"/>
+        <pt x="307" y="545" on="0"/>
+        <pt x="357" y="490" on="0"/>
+        <pt x="357" y="419" on="1"/>
+      </contour>
+      <contour>
+        <pt x="320" y="425" on="1"/>
+        <pt x="320" y="474" on="0"/>
+        <pt x="292" y="515" on="0"/>
+        <pt x="265" y="515" on="1"/>
+        <pt x="238" y="515" on="0"/>
+        <pt x="210" y="474" on="0"/>
+        <pt x="210" y="425" on="1"/>
+        <pt x="210" y="368" on="1"/>
+        <pt x="210" y="320" on="0"/>
+        <pt x="239" y="276" on="0"/>
+        <pt x="265" y="276" on="1"/>
+        <pt x="292" y="276" on="0"/>
+        <pt x="320" y="320" on="0"/>
+        <pt x="320" y="368" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="1" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      COLRv1 Static Test Glyphs
+    </namerecord>
+    <namerecord nameID="2" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      COLRv1 Static Test Glyphs 2023-03-10T15:07:35.658876
+    </namerecord>
+    <namerecord nameID="4" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      COLRv1 Static Test Glyphs Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      2023-03-10T15:07:35.658876
+    </namerecord>
+    <namerecord nameID="6" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      COLRv1StaticTestGlyphs-Regular
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      COLRv1 Static Test Glyphs
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      COLRv1 Static Test Glyphs 2023-03-10T15:07:35.658876
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      COLRv1 Static Test Glyphs Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      2023-03-10T15:07:35.658876
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      COLRv1StaticTestGlyphs-Regular
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="0"/>
+    <underlineThickness value="0"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="upem_box_glyph"/>
+      <psName name="cross_glyph"/>
+      <psName name="scale_0.5_1.5_center_500.0_500.0"/>
+      <psName name="scale_1.5_1.5_center_500.0_500.0"/>
+      <psName name="scale_0.5_1.5_center_0_0"/>
+      <psName name="scale_1.5_1.5_center_0_0"/>
+      <psName name="scale_0.5_1.5_center_1000_1000"/>
+      <psName name="scale_1.5_1.5_center_1000_1000"/>
+      <psName name="rotate_10_center_0_0"/>
+      <psName name="rotate_-10_center_1000_1000"/>
+      <psName name="rotate_25_center_500.0_500.0"/>
+      <psName name="rotate_-15_center_500.0_500.0"/>
+      <psName name="skew_25_0_center_0_0"/>
+      <psName name="skew_25_0_center_500.0_500.0"/>
+      <psName name="skew_0_15_center_0_0"/>
+      <psName name="skew_0_15_center_500.0_500.0"/>
+      <psName name="skew_-10_20_center_500.0_500.0"/>
+      <psName name="skew_-10_20_center_1000_1000"/>
+      <psName name="transform_matrix_1_0_0_1_125_125"/>
+      <psName name="transform_matrix_1.5_0_0_1.5_0_0"/>
+      <psName name="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/>
+      <psName name="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/>
+      <psName name="translate_0_0"/>
+      <psName name="translate_0_100"/>
+      <psName name="translate_0_-100"/>
+      <psName name="translate_100_0"/>
+      <psName name="translate_-100_0"/>
+      <psName name="translate_200_200"/>
+      <psName name="translate_-200_-200"/>
+    </extraNames>
+  </post>
+
+  <COLR>
+    <Version value="1"/>
+    <!-- BaseGlyphRecordCount=0 -->
+    <!-- LayerRecordCount=0 -->
+    <BaseGlyphList>
+      <!-- BaseGlyphCount=27 -->
+      <BaseGlyphPaintRecord index="0">
+        <BaseGlyph value="scale_0.5_1.5_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="18"><!-- PaintScaleAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="1">
+        <BaseGlyph value="scale_1.5_1.5_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="22"><!-- PaintScaleUniformAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="2">
+        <BaseGlyph value="scale_0.5_1.5_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="16"><!-- PaintScale -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="3">
+        <BaseGlyph value="scale_1.5_1.5_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="20"><!-- PaintScaleUniform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="4">
+        <BaseGlyph value="scale_0.5_1.5_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="18"><!-- PaintScaleAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="5">
+        <BaseGlyph value="scale_1.5_1.5_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="22"><!-- PaintScaleUniformAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="6">
+        <BaseGlyph value="rotate_10_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="24"><!-- PaintRotate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="10.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="7">
+        <BaseGlyph value="rotate_-10_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="-10.0"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="8">
+        <BaseGlyph value="rotate_25_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="25.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="9">
+        <BaseGlyph value="rotate_-15_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="-15.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="10">
+        <BaseGlyph value="skew_25_0_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="28"><!-- PaintSkew -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="25.0"/>
+            <ySkewAngle value="0.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="11">
+        <BaseGlyph value="skew_25_0_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="25.0"/>
+            <ySkewAngle value="0.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="12">
+        <BaseGlyph value="skew_0_15_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="28"><!-- PaintSkew -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="0.0"/>
+            <ySkewAngle value="15.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="13">
+        <BaseGlyph value="skew_0_15_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="0.0"/>
+            <ySkewAngle value="15.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="14">
+        <BaseGlyph value="skew_-10_20_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="-10.0"/>
+            <ySkewAngle value="20.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="15">
+        <BaseGlyph value="skew_-10_20_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="-10.0"/>
+            <ySkewAngle value="20.0"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="16">
+        <BaseGlyph value="transform_matrix_1_0_0_1_125_125"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.0"/>
+              <yx value="0.0"/>
+              <xy value="0.0"/>
+              <yy value="1.0"/>
+              <dx value="125.0"/>
+              <dy value="125.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="17">
+        <BaseGlyph value="transform_matrix_1.5_0_0_1.5_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.5"/>
+              <yx value="0.0"/>
+              <xy value="0.0"/>
+              <yy value="1.5"/>
+              <dx value="0.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="18">
+        <BaseGlyph value="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="0.9659"/>
+              <yx value="0.2588"/>
+              <xy value="-0.2588"/>
+              <yy value="0.9659"/>
+              <dx value="0.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="19">
+        <BaseGlyph value="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.0"/>
+              <yx value="0.0"/>
+              <xy value="0.6"/>
+              <yy value="1.0"/>
+              <dx value="-300.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="20">
+        <BaseGlyph value="translate_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="21">
+        <BaseGlyph value="translate_0_100"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="100"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="22">
+        <BaseGlyph value="translate_0_-100"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="-100"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="23">
+        <BaseGlyph value="translate_100_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="100"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="24">
+        <BaseGlyph value="translate_-100_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="-100"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="25">
+        <BaseGlyph value="translate_200_200"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="200"/>
+            <dy value="200"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="26">
+        <BaseGlyph value="translate_-200_-200"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="-200"/>
+            <dy value="-200"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+    </BaseGlyphList>
+  </COLR>
+
+  <CPAL>
+    <version value="1"/>
+    <numPaletteEntries value="7"/>
+    <palette index="0">
+      <color index="0" value="#FF0000FF"/>
+      <color index="1" value="#FFA500FF"/>
+      <color index="2" value="#FFFF00FF"/>
+      <color index="3" value="#008000FF"/>
+      <color index="4" value="#0000FFFF"/>
+      <color index="5" value="#4B0082FF"/>
+      <color index="6" value="#EE82EEFF"/>
+    </palette>
+    <palette index="1" type="2">
+      <color index="0" value="#2A294AFF"/>
+      <color index="1" value="#244163FF"/>
+      <color index="2" value="#1B6388FF"/>
+      <color index="3" value="#157DA3FF"/>
+      <color index="4" value="#0E9AC2FF"/>
+      <color index="5" value="#05BEE8FF"/>
+      <color index="6" value="#00D4FFFF"/>
+    </palette>
+    <palette index="2" type="1">
+      <color index="0" value="#FC7118FF"/>
+      <color index="1" value="#FB8115FF"/>
+      <color index="2" value="#FA9511FF"/>
+      <color index="3" value="#FAA80DFF"/>
+      <color index="4" value="#F9BE09FF"/>
+      <color index="5" value="#F8D304FF"/>
+      <color index="6" value="#F8E700FF"/>
+    </palette>
+  </CPAL>
+
+</ttFont>

--- a/Tests/ttLib/tables/data/COLRv1-clip-boxes-q1-expected.ttx
+++ b/Tests/ttLib/tables/data/COLRv1-clip-boxes-q1-expected.ttx
@@ -1,0 +1,919 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.39">
+
+  <COLR>
+    <Version value="1"/>
+    <BaseGlyphList>
+      <!-- BaseGlyphCount=27 -->
+      <BaseGlyphPaintRecord index="0">
+        <BaseGlyph value="scale_0.5_1.5_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="18"><!-- PaintScaleAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="1">
+        <BaseGlyph value="scale_1.5_1.5_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="22"><!-- PaintScaleUniformAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="2">
+        <BaseGlyph value="scale_0.5_1.5_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="16"><!-- PaintScale -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="3">
+        <BaseGlyph value="scale_1.5_1.5_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="20"><!-- PaintScaleUniform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="4">
+        <BaseGlyph value="scale_0.5_1.5_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="18"><!-- PaintScaleAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="5">
+        <BaseGlyph value="scale_1.5_1.5_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="22"><!-- PaintScaleUniformAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="6">
+        <BaseGlyph value="rotate_10_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="24"><!-- PaintRotate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="10.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="7">
+        <BaseGlyph value="rotate_-10_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="-10.0"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="8">
+        <BaseGlyph value="rotate_25_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="25.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="9">
+        <BaseGlyph value="rotate_-15_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="-15.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="10">
+        <BaseGlyph value="skew_25_0_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="28"><!-- PaintSkew -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="25.0"/>
+            <ySkewAngle value="0.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="11">
+        <BaseGlyph value="skew_25_0_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="25.0"/>
+            <ySkewAngle value="0.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="12">
+        <BaseGlyph value="skew_0_15_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="28"><!-- PaintSkew -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="0.0"/>
+            <ySkewAngle value="15.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="13">
+        <BaseGlyph value="skew_0_15_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="0.0"/>
+            <ySkewAngle value="15.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="14">
+        <BaseGlyph value="skew_-10_20_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="-10.0"/>
+            <ySkewAngle value="20.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="15">
+        <BaseGlyph value="skew_-10_20_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="-10.0"/>
+            <ySkewAngle value="20.0"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="16">
+        <BaseGlyph value="transform_matrix_1_0_0_1_125_125"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.0"/>
+              <yx value="0.0"/>
+              <xy value="0.0"/>
+              <yy value="1.0"/>
+              <dx value="125.0"/>
+              <dy value="125.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="17">
+        <BaseGlyph value="transform_matrix_1.5_0_0_1.5_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.5"/>
+              <yx value="0.0"/>
+              <xy value="0.0"/>
+              <yy value="1.5"/>
+              <dx value="0.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="18">
+        <BaseGlyph value="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="0.9659"/>
+              <yx value="0.2588"/>
+              <xy value="-0.2588"/>
+              <yy value="0.9659"/>
+              <dx value="0.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="19">
+        <BaseGlyph value="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.0"/>
+              <yx value="0.0"/>
+              <xy value="0.6"/>
+              <yy value="1.0"/>
+              <dx value="-300.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="20">
+        <BaseGlyph value="translate_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="21">
+        <BaseGlyph value="translate_0_100"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="100"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="22">
+        <BaseGlyph value="translate_0_-100"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="-100"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="23">
+        <BaseGlyph value="translate_100_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="100"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="24">
+        <BaseGlyph value="translate_-100_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="-100"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="25">
+        <BaseGlyph value="translate_200_200"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="200"/>
+            <dy value="200"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="26">
+        <BaseGlyph value="translate_-200_-200"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="-200"/>
+            <dy value="-200"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+    </BaseGlyphList>
+    <ClipList Format="1">
+      <Clip>
+        <Glyph value="rotate_-10_center_1000_1000"/>
+        <ClipBox Format="1">
+          <xMin value="170"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="845"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="rotate_-15_center_500.0_500.0"/>
+        <Glyph value="rotate_25_center_500.0_500.0"/>
+        <Glyph value="translate_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="rotate_10_center_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="155"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="830"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_0.5_1.5_center_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="125"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="1125"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_0.5_1.5_center_1000_1000"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="-125"/>
+          <xMax value="875"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_0.5_1.5_center_500.0_500.0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="125"/>
+          <xMax value="750"/>
+          <yMax value="875"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_1.5_1.5_center_0_0"/>
+        <Glyph value="transform_matrix_1.5_0_0_1.5_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="1125"/>
+          <yMax value="1125"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_1.5_1.5_center_1000_1000"/>
+        <ClipBox Format="1">
+          <xMin value="-125"/>
+          <yMin value="-125"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_1.5_1.5_center_500.0_500.0"/>
+        <ClipBox Format="1">
+          <xMin value="125"/>
+          <yMin value="125"/>
+          <xMax value="875"/>
+          <yMax value="875"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_-10_20_center_1000_1000"/>
+        <ClipBox Format="1">
+          <xMin value="157"/>
+          <yMin value="58"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_-10_20_center_500.0_500.0"/>
+        <ClipBox Format="1">
+          <xMin value="245"/>
+          <yMin value="240"/>
+          <xMax value="755"/>
+          <yMax value="760"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_0_15_center_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="891"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_0_15_center_500.0_500.0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="243"/>
+          <xMax value="750"/>
+          <yMax value="757"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_25_0_center_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="5"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_25_0_center_500.0_500.0"/>
+        <ClipBox Format="1">
+          <xMin value="238"/>
+          <yMin value="250"/>
+          <xMax value="762"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="105"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="861"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/>
+        <ClipBox Format="1">
+          <xMin value="235"/>
+          <yMin value="250"/>
+          <xMax value="766"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="transform_matrix_1_0_0_1_125_125"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="875"/>
+          <yMax value="875"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_-100_0"/>
+        <ClipBox Format="1">
+          <xMin value="150"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_-200_-200"/>
+        <ClipBox Format="1">
+          <xMin value="50"/>
+          <yMin value="50"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_0_-100"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="150"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_0_100"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="850"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_100_0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="850"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_200_200"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="950"/>
+          <yMax value="950"/>
+        </ClipBox>
+      </Clip>
+    </ClipList>
+  </COLR>
+
+</ttFont>

--- a/Tests/ttLib/tables/data/COLRv1-clip-boxes-q10-expected.ttx
+++ b/Tests/ttLib/tables/data/COLRv1-clip-boxes-q10-expected.ttx
@@ -1,0 +1,911 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.39">
+
+  <COLR>
+    <Version value="1"/>
+    <BaseGlyphList>
+      <!-- BaseGlyphCount=27 -->
+      <BaseGlyphPaintRecord index="0">
+        <BaseGlyph value="scale_0.5_1.5_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="18"><!-- PaintScaleAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="1">
+        <BaseGlyph value="scale_1.5_1.5_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="22"><!-- PaintScaleUniformAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="2">
+        <BaseGlyph value="scale_0.5_1.5_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="16"><!-- PaintScale -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="3">
+        <BaseGlyph value="scale_1.5_1.5_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="20"><!-- PaintScaleUniform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="4">
+        <BaseGlyph value="scale_0.5_1.5_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="18"><!-- PaintScaleAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="5">
+        <BaseGlyph value="scale_1.5_1.5_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="22"><!-- PaintScaleUniformAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="6">
+        <BaseGlyph value="rotate_10_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="24"><!-- PaintRotate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="10.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="7">
+        <BaseGlyph value="rotate_-10_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="-10.0"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="8">
+        <BaseGlyph value="rotate_25_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="25.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="9">
+        <BaseGlyph value="rotate_-15_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="-15.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="10">
+        <BaseGlyph value="skew_25_0_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="28"><!-- PaintSkew -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="25.0"/>
+            <ySkewAngle value="0.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="11">
+        <BaseGlyph value="skew_25_0_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="25.0"/>
+            <ySkewAngle value="0.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="12">
+        <BaseGlyph value="skew_0_15_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="28"><!-- PaintSkew -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="0.0"/>
+            <ySkewAngle value="15.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="13">
+        <BaseGlyph value="skew_0_15_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="0.0"/>
+            <ySkewAngle value="15.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="14">
+        <BaseGlyph value="skew_-10_20_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="-10.0"/>
+            <ySkewAngle value="20.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="15">
+        <BaseGlyph value="skew_-10_20_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="-10.0"/>
+            <ySkewAngle value="20.0"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="16">
+        <BaseGlyph value="transform_matrix_1_0_0_1_125_125"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.0"/>
+              <yx value="0.0"/>
+              <xy value="0.0"/>
+              <yy value="1.0"/>
+              <dx value="125.0"/>
+              <dy value="125.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="17">
+        <BaseGlyph value="transform_matrix_1.5_0_0_1.5_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.5"/>
+              <yx value="0.0"/>
+              <xy value="0.0"/>
+              <yy value="1.5"/>
+              <dx value="0.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="18">
+        <BaseGlyph value="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="0.9659"/>
+              <yx value="0.2588"/>
+              <xy value="-0.2588"/>
+              <yy value="0.9659"/>
+              <dx value="0.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="19">
+        <BaseGlyph value="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.0"/>
+              <yx value="0.0"/>
+              <xy value="0.6"/>
+              <yy value="1.0"/>
+              <dx value="-300.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="20">
+        <BaseGlyph value="translate_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="21">
+        <BaseGlyph value="translate_0_100"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="100"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="22">
+        <BaseGlyph value="translate_0_-100"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="-100"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="23">
+        <BaseGlyph value="translate_100_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="100"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="24">
+        <BaseGlyph value="translate_-100_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="-100"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="25">
+        <BaseGlyph value="translate_200_200"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="200"/>
+            <dy value="200"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="26">
+        <BaseGlyph value="translate_-200_-200"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="-200"/>
+            <dy value="-200"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+    </BaseGlyphList>
+    <ClipList Format="1">
+      <Clip>
+        <Glyph value="rotate_-10_center_1000_1000"/>
+        <ClipBox Format="1">
+          <xMin value="170"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="850"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="rotate_-15_center_500.0_500.0"/>
+        <Glyph value="rotate_25_center_500.0_500.0"/>
+        <Glyph value="translate_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="rotate_10_center_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="150"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="830"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_0.5_1.5_center_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="120"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="1130"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_0.5_1.5_center_1000_1000"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="-130"/>
+          <xMax value="880"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_0.5_1.5_center_500.0_500.0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="120"/>
+          <xMax value="750"/>
+          <yMax value="880"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_1.5_1.5_center_0_0"/>
+        <Glyph value="transform_matrix_1.5_0_0_1.5_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="1130"/>
+          <yMax value="1130"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_1.5_1.5_center_1000_1000"/>
+        <ClipBox Format="1">
+          <xMin value="-130"/>
+          <yMin value="-130"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_1.5_1.5_center_500.0_500.0"/>
+        <ClipBox Format="1">
+          <xMin value="120"/>
+          <yMin value="120"/>
+          <xMax value="880"/>
+          <yMax value="880"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_-10_20_center_1000_1000"/>
+        <ClipBox Format="1">
+          <xMin value="150"/>
+          <yMin value="50"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_-10_20_center_500.0_500.0"/>
+        <ClipBox Format="1">
+          <xMin value="240"/>
+          <yMin value="240"/>
+          <xMax value="760"/>
+          <yMax value="760"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_0_15_center_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="900"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_0_15_center_500.0_500.0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="240"/>
+          <xMax value="750"/>
+          <yMax value="760"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_25_0_center_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="0"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_25_0_center_500.0_500.0"/>
+        <Glyph value="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/>
+        <ClipBox Format="1">
+          <xMin value="230"/>
+          <yMin value="250"/>
+          <xMax value="770"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="100"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="870"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="transform_matrix_1_0_0_1_125_125"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="880"/>
+          <yMax value="880"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_-100_0"/>
+        <ClipBox Format="1">
+          <xMin value="150"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_-200_-200"/>
+        <ClipBox Format="1">
+          <xMin value="50"/>
+          <yMin value="50"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_0_-100"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="150"/>
+          <xMax value="750"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_0_100"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="750"/>
+          <yMax value="850"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_100_0"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="850"/>
+          <yMax value="750"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_200_200"/>
+        <ClipBox Format="1">
+          <xMin value="250"/>
+          <yMin value="250"/>
+          <xMax value="950"/>
+          <yMax value="950"/>
+        </ClipBox>
+      </Clip>
+    </ClipList>
+  </COLR>
+
+</ttFont>

--- a/Tests/ttLib/tables/data/COLRv1-clip-boxes-q100-expected.ttx
+++ b/Tests/ttLib/tables/data/COLRv1-clip-boxes-q100-expected.ttx
@@ -1,0 +1,863 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.39">
+
+  <COLR>
+    <Version value="1"/>
+    <BaseGlyphList>
+      <!-- BaseGlyphCount=27 -->
+      <BaseGlyphPaintRecord index="0">
+        <BaseGlyph value="scale_0.5_1.5_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="18"><!-- PaintScaleAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="1">
+        <BaseGlyph value="scale_1.5_1.5_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="22"><!-- PaintScaleUniformAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="2">
+        <BaseGlyph value="scale_0.5_1.5_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="16"><!-- PaintScale -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="3">
+        <BaseGlyph value="scale_1.5_1.5_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="20"><!-- PaintScaleUniform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="4">
+        <BaseGlyph value="scale_0.5_1.5_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="18"><!-- PaintScaleAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scaleX value="0.5"/>
+            <scaleY value="1.5"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="5">
+        <BaseGlyph value="scale_1.5_1.5_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="22"><!-- PaintScaleUniformAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <scale value="1.5"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="6">
+        <BaseGlyph value="rotate_10_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="24"><!-- PaintRotate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="10.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="7">
+        <BaseGlyph value="rotate_-10_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="-10.0"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="8">
+        <BaseGlyph value="rotate_25_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="25.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="9">
+        <BaseGlyph value="rotate_-15_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="26"><!-- PaintRotateAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <angle value="-15.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="10">
+        <BaseGlyph value="skew_25_0_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="28"><!-- PaintSkew -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="25.0"/>
+            <ySkewAngle value="0.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="11">
+        <BaseGlyph value="skew_25_0_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="25.0"/>
+            <ySkewAngle value="0.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="12">
+        <BaseGlyph value="skew_0_15_center_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="28"><!-- PaintSkew -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="0.0"/>
+            <ySkewAngle value="15.0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="13">
+        <BaseGlyph value="skew_0_15_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="0.0"/>
+            <ySkewAngle value="15.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="14">
+        <BaseGlyph value="skew_-10_20_center_500.0_500.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="-10.0"/>
+            <ySkewAngle value="20.0"/>
+            <centerX value="500"/>
+            <centerY value="500"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="15">
+        <BaseGlyph value="skew_-10_20_center_1000_1000"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="30"><!-- PaintSkewAroundCenter -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <xSkewAngle value="-10.0"/>
+            <ySkewAngle value="20.0"/>
+            <centerX value="1000"/>
+            <centerY value="1000"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="16">
+        <BaseGlyph value="transform_matrix_1_0_0_1_125_125"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.0"/>
+              <yx value="0.0"/>
+              <xy value="0.0"/>
+              <yy value="1.0"/>
+              <dx value="125.0"/>
+              <dy value="125.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="17">
+        <BaseGlyph value="transform_matrix_1.5_0_0_1.5_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.5"/>
+              <yx value="0.0"/>
+              <xy value="0.0"/>
+              <yy value="1.5"/>
+              <dx value="0.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="18">
+        <BaseGlyph value="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="0.9659"/>
+              <yx value="0.2588"/>
+              <xy value="-0.2588"/>
+              <yy value="0.9659"/>
+              <dx value="0.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="19">
+        <BaseGlyph value="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="12"><!-- PaintTransform -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <Transform>
+              <xx value="1.0"/>
+              <yx value="0.0"/>
+              <xy value="0.6"/>
+              <yy value="1.0"/>
+              <dx value="-300.0"/>
+              <dy value="0.0"/>
+            </Transform>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="20">
+        <BaseGlyph value="translate_0_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="21">
+        <BaseGlyph value="translate_0_100"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="100"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="22">
+        <BaseGlyph value="translate_0_-100"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="0"/>
+            <dy value="-100"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="23">
+        <BaseGlyph value="translate_100_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="100"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="24">
+        <BaseGlyph value="translate_-100_0"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="-100"/>
+            <dy value="0"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="25">
+        <BaseGlyph value="translate_200_200"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="200"/>
+            <dy value="200"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+      <BaseGlyphPaintRecord index="26">
+        <BaseGlyph value="translate_-200_-200"/>
+        <Paint Format="32"><!-- PaintComposite -->
+          <SourcePaint Format="14"><!-- PaintTranslate -->
+            <Paint Format="10"><!-- PaintGlyph -->
+              <Paint Format="2"><!-- PaintSolid -->
+                <PaletteIndex value="1"/>
+                <Alpha value="0.7"/>
+              </Paint>
+              <Glyph value="cross_glyph"/>
+            </Paint>
+            <dx value="-200"/>
+            <dy value="-200"/>
+          </SourcePaint>
+          <CompositeMode value="dest_over"/>
+          <BackdropPaint Format="10"><!-- PaintGlyph -->
+            <Paint Format="2"><!-- PaintSolid -->
+              <PaletteIndex value="4"/>
+              <Alpha value="0.5"/>
+            </Paint>
+            <Glyph value="cross_glyph"/>
+          </BackdropPaint>
+        </Paint>
+      </BaseGlyphPaintRecord>
+    </BaseGlyphList>
+    <ClipList Format="1">
+      <Clip>
+        <Glyph value="rotate_-10_center_1000_1000"/>
+        <Glyph value="rotate_10_center_0_0"/>
+        <Glyph value="transform_matrix_0.9659_0.2588_-0.2588_0.9659_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="100"/>
+          <yMin value="200"/>
+          <xMax value="800"/>
+          <yMax value="900"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="rotate_-15_center_500.0_500.0"/>
+        <Glyph value="rotate_25_center_500.0_500.0"/>
+        <Glyph value="skew_-10_20_center_500.0_500.0"/>
+        <Glyph value="skew_0_15_center_500.0_500.0"/>
+        <Glyph value="skew_25_0_center_500.0_500.0"/>
+        <Glyph value="transform_matrix_1.0_0.0_0.6_1.0_-300.0_0.0"/>
+        <Glyph value="translate_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="200"/>
+          <yMin value="200"/>
+          <xMax value="800"/>
+          <yMax value="800"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_0.5_1.5_center_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="100"/>
+          <yMin value="200"/>
+          <xMax value="800"/>
+          <yMax value="1200"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_0.5_1.5_center_1000_1000"/>
+        <ClipBox Format="1">
+          <xMin value="200"/>
+          <yMin value="-200"/>
+          <xMax value="900"/>
+          <yMax value="800"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_0.5_1.5_center_500.0_500.0"/>
+        <ClipBox Format="1">
+          <xMin value="200"/>
+          <yMin value="100"/>
+          <xMax value="800"/>
+          <yMax value="900"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_1.5_1.5_center_0_0"/>
+        <Glyph value="transform_matrix_1.5_0_0_1.5_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="200"/>
+          <yMin value="200"/>
+          <xMax value="1200"/>
+          <yMax value="1200"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_1.5_1.5_center_1000_1000"/>
+        <ClipBox Format="1">
+          <xMin value="-200"/>
+          <yMin value="-200"/>
+          <xMax value="800"/>
+          <yMax value="800"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="scale_1.5_1.5_center_500.0_500.0"/>
+        <ClipBox Format="1">
+          <xMin value="100"/>
+          <yMin value="100"/>
+          <xMax value="900"/>
+          <yMax value="900"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_-10_20_center_1000_1000"/>
+        <ClipBox Format="1">
+          <xMin value="100"/>
+          <yMin value="0"/>
+          <xMax value="800"/>
+          <yMax value="800"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_0_15_center_0_0"/>
+        <Glyph value="translate_0_100"/>
+        <ClipBox Format="1">
+          <xMin value="200"/>
+          <yMin value="200"/>
+          <xMax value="800"/>
+          <yMax value="900"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="skew_25_0_center_0_0"/>
+        <ClipBox Format="1">
+          <xMin value="0"/>
+          <yMin value="200"/>
+          <xMax value="800"/>
+          <yMax value="800"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="transform_matrix_1_0_0_1_125_125"/>
+        <ClipBox Format="1">
+          <xMin value="200"/>
+          <yMin value="200"/>
+          <xMax value="900"/>
+          <yMax value="900"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_-100_0"/>
+        <ClipBox Format="1">
+          <xMin value="100"/>
+          <yMin value="200"/>
+          <xMax value="800"/>
+          <yMax value="800"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_-200_-200"/>
+        <ClipBox Format="1">
+          <xMin value="0"/>
+          <yMin value="0"/>
+          <xMax value="800"/>
+          <yMax value="800"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_0_-100"/>
+        <ClipBox Format="1">
+          <xMin value="200"/>
+          <yMin value="100"/>
+          <xMax value="800"/>
+          <yMax value="800"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_100_0"/>
+        <ClipBox Format="1">
+          <xMin value="200"/>
+          <yMin value="200"/>
+          <xMax value="900"/>
+          <yMax value="800"/>
+        </ClipBox>
+      </Clip>
+      <Clip>
+        <Glyph value="translate_200_200"/>
+        <ClipBox Format="1">
+          <xMin value="200"/>
+          <yMin value="200"/>
+          <xMax value="1000"/>
+          <yMax value="1000"/>
+        </ClipBox>
+      </Clip>
+    </ClipList>
+  </COLR>
+
+</ttFont>


### PR DESCRIPTION
ClipBoxes are optional in COLRv1 but can make rendering more efficient. Currently colorLib.builder.buildCOLR takes an optional clipBoxes parameter with user-defined clipBoxes (nanoemoji computes those upfront and provides them to colorLib). Other clients like glyphsLib don't compute the clipBoxes for us, so COLRv1 fonts built from fontmake via glyphsLib have no clip boxes.
This adds a method so one can ask fonttools to compute them, taking into account various paint transforms.
For example one can do:

```python
from fontTools.ttLib import TTFont

font = TTFont("path/to/input/font.ttf")
font["COLR"].table.computeClipBoxes(font.getGlyphSet(), quantization=100)
font.save("path/to/output/font.ttf")
```

This currently only works for static, non variable COLRv1 tables, which is OK, since for variable COLR is probably preferable _not_ to provide explicit clipboxes and let renderer derive them at runtime, since computing a bounding box that works throughout the entire variation space is non trivial in presence of variable rotation/skew.

This can also be handy for https://github.com/googlefonts/glyphsLib/issues/847