### PR TITLE
ttFont.getGlyphID should raise KeyError on missing glyphs

### DIFF
--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -660,6 +660,7 @@ class TTFont(object):
                     return int(glyphName[5:])
                 except (NameError, ValueError):
                     raise KeyError(glyphName)
+            raise
 
     def getGlyphIDMany(self, lst):
         """Converts a list of glyph names into a list of glyph IDs."""

--- a/Tests/ttLib/ttFont_test.py
+++ b/Tests/ttLib/ttFont_test.py
@@ -262,3 +262,13 @@ def test_font_normalizeLocation_no_VF():
     ttf = TTFont()
     with pytest.raises(TTLibError, match="Not a variable font"):
         ttf.normalizeLocation({})
+
+
+def test_getGlyphID():
+    font = TTFont()
+    font.importXML(os.path.join(DATA_DIR, "TestTTF-Regular.ttx"))
+
+    assert font.getGlyphID("space") == 3
+    assert font.getGlyphID("glyph12345") == 12345  # virtual glyph
+    with pytest.raises(KeyError):
+        font.getGlyphID("non_existent")

--- a/Tests/ttLib/ttFont_test.py
+++ b/Tests/ttLib/ttFont_test.py
@@ -272,3 +272,5 @@ def test_getGlyphID():
     assert font.getGlyphID("glyph12345") == 12345  # virtual glyph
     with pytest.raises(KeyError):
         font.getGlyphID("non_existent")
+    with pytest.raises(KeyError):
+        font.getGlyphID("glyph_prefix_but_invalid_id")


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/3030