### PR TITLE
[docs] Bump minimum Python version in docs, as 3.8 is now required

### DIFF
--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -20,7 +20,7 @@ Installation
 
 .. note::
 
-    fontTools requires `Python <http://www.python.org/download/>`_ 3.6 or later.
+    fontTools requires `Python <http://www.python.org/download/>`_ 3.8 or later.
 
 The package is listed in the Python Package Index (PyPI), so you can install it with `pip <https://pip.pypa.io/>`_::
 


### PR DESCRIPTION
Just a small PR to keep the docs up-to-date following [the change to require Python 3.8](https://github.com/fonttools/fonttools/blob/c87bcde/NEWS.rst#4390-released-2023-03-06) :)