### PR TITLE
Apply `avar` also to variable locations

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1655,7 +1655,6 @@ class Builder(object):
             return None
 
         vr = {}
-        variable = False
         for astName, (otName, isDevice) in self._VALUEREC_ATTRS.items():
             val = getattr(v, astName, None)
             if not val:
@@ -1679,7 +1678,6 @@ class Builder(object):
                 vr[otName] = default
                 if index is not None and index != 0xFFFFFFFF:
                     vr[otDeviceName] = buildVarDevTable(index)
-                    variable = True
             else:
                 vr[otName] = val
 

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1596,7 +1596,8 @@ class Builder(object):
             mapping = self.font["avar"].segments
             value = {
                 axis: tuple(
-                    piecewiseLinearMap(v, mapping[axis]) for v in condition_range
+                    piecewiseLinearMap(v, mapping[axis]) if axis in mapping else v
+                    for v in condition_range
                 )
                 for axis, condition_range in value.items()
             }

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1614,6 +1614,7 @@ class Builder(object):
             deviceX = otl.buildDevice(dict(anchor.xDeviceTable))
         if anchor.yDeviceTable is not None:
             deviceY = otl.buildDevice(dict(anchor.yDeviceTable))
+        avar = self.font.get("avar")
         for dim in ("x", "y"):
             if not isinstance(getattr(anchor, dim), VariableScalar):
                 continue
@@ -1627,7 +1628,9 @@ class Builder(object):
                 )
             varscalar = getattr(anchor, dim)
             varscalar.axes = self.axes
-            default, index = varscalar.add_to_variation_store(self.varstorebuilder)
+            default, index = varscalar.add_to_variation_store(
+                self.varstorebuilder, avar
+            )
             setattr(anchor, dim, default)
             if index is not None and index != 0xFFFFFFFF:
                 if dim == "x":
@@ -1654,6 +1657,7 @@ class Builder(object):
         if not v:
             return None
 
+        avar = self.font.get("avar")
         vr = {}
         for astName, (otName, isDevice) in self._VALUEREC_ATTRS.items():
             val = getattr(v, astName, None)
@@ -1674,7 +1678,7 @@ class Builder(object):
                         location,
                     )
                 val.axes = self.axes
-                default, index = val.add_to_variation_store(self.varstorebuilder)
+                default, index = val.add_to_variation_store(self.varstorebuilder, avar)
                 vr[otName] = default
                 if index is not None and index != 0xFFFFFFFF:
                     vr[otDeviceName] = buildVarDevTable(index)

--- a/Lib/fontTools/feaLib/variableScalar.py
+++ b/Lib/fontTools/feaLib/variableScalar.py
@@ -1,4 +1,4 @@
-from fontTools.varLib.models import VariationModel, normalizeValue
+from fontTools.varLib.models import VariationModel, normalizeValue, piecewiseLinearMap
 
 
 def Location(loc):
@@ -83,29 +83,37 @@ class VariableScalar:
             # I *guess* we could interpolate one, but I don't know how.
         return self.values[key]
 
-    def value_at_location(self, location):
+    def value_at_location(self, location, avar=None):
         loc = location
         if loc in self.values.keys():
             return self.values[loc]
         values = list(self.values.values())
-        return self.model.interpolateFromMasters(loc, values)
+        return self.model(avar).interpolateFromMasters(loc, values)
 
-    @property
-    def model(self):
+    def model(self, avar=None):
         key = tuple(self.values.keys())
         if key in self.model_pool:
             return self.model_pool[key]
         locations = [dict(self._normalized_location(k)) for k in self.values.keys()]
+        if avar is not None:
+            mapping = avar.segments
+            locations = [
+                {
+                    k: piecewiseLinearMap(v, mapping[k]) if k in mapping else v
+                    for k, v in location.items()
+                }
+                for location in locations
+            ]
         m = VariationModel(locations)
         self.model_pool[key] = m
         return m
 
-    def get_deltas_and_supports(self):
+    def get_deltas_and_supports(self, avar=None):
         values = list(self.values.values())
-        return self.model.getDeltasAndSupports(values)
+        return self.model(avar).getDeltasAndSupports(values)
 
-    def add_to_variation_store(self, store_builder):
-        deltas, supports = self.get_deltas_and_supports()
+    def add_to_variation_store(self, store_builder, avar=None):
+        deltas, supports = self.get_deltas_and_supports(avar)
         store_builder.setSupports(supports)
         index = store_builder.storeDeltas(deltas)
         return int(self.default), index

--- a/Lib/fontTools/feaLib/variableScalar.py
+++ b/Lib/fontTools/feaLib/variableScalar.py
@@ -74,17 +74,18 @@ class VariableScalar:
             # I *guess* we could interpolate one, but I don't know how.
         return self.values[key]
 
-    def value_at_location(self, location, model_cache, avar=None):
+    def value_at_location(self, location, model_cache=None, avar=None):
         loc = location
         if loc in self.values.keys():
             return self.values[loc]
         values = list(self.values.values())
         return self.model(model_cache, avar).interpolateFromMasters(loc, values)
 
-    def model(self, model_cache, avar=None):
-        key = tuple(self.values.keys())
-        if key in model_cache:
-            return model_cache[key]
+    def model(self, model_cache=None, avar=None):
+        if model_cache is not None:
+            key = tuple(self.values.keys())
+            if key in model_cache:
+                return model_cache[key]
         locations = [dict(self._normalized_location(k)) for k in self.values.keys()]
         if avar is not None:
             mapping = avar.segments
@@ -96,14 +97,15 @@ class VariableScalar:
                 for location in locations
             ]
         m = VariationModel(locations)
-        model_cache[key] = m
+        if model_cache is not None:
+            model_cache[key] = m
         return m
 
-    def get_deltas_and_supports(self, model_cache, avar=None):
+    def get_deltas_and_supports(self, model_cache=None, avar=None):
         values = list(self.values.values())
         return self.model(model_cache, avar).getDeltasAndSupports(values)
 
-    def add_to_variation_store(self, store_builder, model_cache, avar=None):
+    def add_to_variation_store(self, store_builder, model_cache=None, avar=None):
         deltas, supports = self.get_deltas_and_supports(model_cache, avar)
         store_builder.setSupports(supports)
         index = store_builder.storeDeltas(deltas)


### PR DESCRIPTION
Follow-up to #3042.

1. Guard against missing `avar` entries when normalizing condition set locations
2. Apply `avar` also to variable locations

Closes #3040.