### PR TITLE
fix ttx split tables option to work on filenames containing '%' fixes #3095

### DIFF
--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -323,12 +323,11 @@ class TTFont(object):
             writer.newline()
         else:
             path, ext = os.path.splitext(writer.filename)
-            fileNameTemplate = path + ".%s" + ext
 
         for i in range(numTables):
             tag = tables[i]
             if splitTables:
-                tablePath = fileNameTemplate % tagToIdentifier(tag)
+                tablePath = path + "." + tagToIdentifier(tag) + ext
                 tableWriter = xmlWriter.XMLWriter(
                     tablePath, newlinestr=writer.newlinestr
                 )


### PR DESCRIPTION
This PR fixes https://github.com/fonttools/fonttools/issues/3095 .

This exception was being caused by the use of a filename template string `fileNameTemplate = path + ".%s" + ext` that is then used with the % operator to fill in the split table type ` tablePath = fileNameTemplate % tagToIdentifier(tag)`

This PR changes the code to just create the `tablePath` string without using a `fileNameTemplate` string, so filenames containing `%` are no longer an issue.
