### PR TITLE
add filter pen that explicitly emits closing line when lastPt != movePt

### DIFF
--- a/Lib/fontTools/pens/explicitClosingLinePen.py
+++ b/Lib/fontTools/pens/explicitClosingLinePen.py
@@ -1,0 +1,101 @@
+from fontTools.pens.filterPen import ContourFilterPen
+
+
+class ExplicitClosingLinePen(ContourFilterPen):
+    """A filter pen that adds an explicit lineTo to the first point of each closed
+    contour if the end point of the last segment is not already the same as the first point.
+    Otherwise, it passes the contour through unchanged.
+
+    >>> from pprint import pprint
+    >>> from fontTools.pens.recordingPen import RecordingPen
+    >>> rec = RecordingPen()
+    >>> pen = ExplicitClosingLinePen(rec)
+    >>> pen.moveTo((0, 0))
+    >>> pen.lineTo((100, 0))
+    >>> pen.lineTo((100, 100))
+    >>> pen.closePath()
+    >>> pprint(rec.value)
+    [('moveTo', ((0, 0),)),
+     ('lineTo', ((100, 0),)),
+     ('lineTo', ((100, 100),)),
+     ('lineTo', ((0, 0),)),
+     ('closePath', ())]
+    >>> rec = RecordingPen()
+    >>> pen = ExplicitClosingLinePen(rec)
+    >>> pen.moveTo((0, 0))
+    >>> pen.lineTo((100, 0))
+    >>> pen.lineTo((100, 100))
+    >>> pen.lineTo((0, 0))
+    >>> pen.closePath()
+    >>> pprint(rec.value)
+    [('moveTo', ((0, 0),)),
+     ('lineTo', ((100, 0),)),
+     ('lineTo', ((100, 100),)),
+     ('lineTo', ((0, 0),)),
+     ('closePath', ())]
+    >>> rec = RecordingPen()
+    >>> pen = ExplicitClosingLinePen(rec)
+    >>> pen.moveTo((0, 0))
+    >>> pen.curveTo((100, 0), (0, 100), (100, 100))
+    >>> pen.closePath()
+    >>> pprint(rec.value)
+    [('moveTo', ((0, 0),)),
+     ('curveTo', ((100, 0), (0, 100), (100, 100))),
+     ('lineTo', ((0, 0),)),
+     ('closePath', ())]
+    >>> rec = RecordingPen()
+    >>> pen = ExplicitClosingLinePen(rec)
+    >>> pen.moveTo((0, 0))
+    >>> pen.curveTo((100, 0), (0, 100), (100, 100))
+    >>> pen.lineTo((0, 0))
+    >>> pen.closePath()
+    >>> pprint(rec.value)
+    [('moveTo', ((0, 0),)),
+     ('curveTo', ((100, 0), (0, 100), (100, 100))),
+     ('lineTo', ((0, 0),)),
+     ('closePath', ())]
+    >>> rec = RecordingPen()
+    >>> pen = ExplicitClosingLinePen(rec)
+    >>> pen.moveTo((0, 0))
+    >>> pen.curveTo((100, 0), (0, 100), (0, 0))
+    >>> pen.closePath()
+    >>> pprint(rec.value)
+    [('moveTo', ((0, 0),)),
+     ('curveTo', ((100, 0), (0, 100), (0, 0))),
+     ('closePath', ())]
+    >>> rec = RecordingPen()
+    >>> pen = ExplicitClosingLinePen(rec)
+    >>> pen.moveTo((0, 0))
+    >>> pen.closePath()
+    >>> pprint(rec.value)
+    [('moveTo', ((0, 0),)), ('closePath', ())]
+    >>> rec = RecordingPen()
+    >>> pen = ExplicitClosingLinePen(rec)
+    >>> pen.closePath()
+    >>> pprint(rec.value)
+    [('closePath', ())]
+    >>> rec = RecordingPen()
+    >>> pen = ExplicitClosingLinePen(rec)
+    >>> pen.moveTo((0, 0))
+    >>> pen.lineTo((100, 0))
+    >>> pen.lineTo((100, 100))
+    >>> pen.endPath()
+    >>> pprint(rec.value)
+    [('moveTo', ((0, 0),)),
+     ('lineTo', ((100, 0),)),
+     ('lineTo', ((100, 100),)),
+     ('endPath', ())]
+    """
+
+    def filterContour(self, contour):
+        if (
+            not contour
+            or contour[0][0] != "moveTo"
+            or contour[-1][0] != "closePath"
+            or len(contour) < 3
+        ):
+            return
+        movePt = contour[0][1][0]
+        lastSeg = contour[-2][1]
+        if lastSeg and movePt != lastSeg[-1]:
+            contour[-1:] = [("lineTo", (movePt,)), ("closePath", ())]


### PR DESCRIPTION
In the FontTools segment pen protocol, when the last segment of a closed contour is a line, the same contour can be represented in two alternative ways:
1) with an explicit lineTo command connecting the penultimate segment's end point to the first moveTo point: in this case, closePath does nothing else than signalling that the contour is "closed", i.e. the first and last point coincide, they are the very same point, not simply two overlapping endpoints of a zero-length line;
2) with an implicit closing line (the final lineTo omitted) implied by the closePath command, like PostScript `closepath` or SVG's `Z` commands.

This new filter pen makes sure that the final line segment (iff there is one, which is not necessarily the case for a closed contour may well end with a curve) is always drawing explicitly with its own lineTo command, and never left implicit by closePath. This is basically equivalent to doing `PointToSegmentPen(SegmentToPointPen(pen), outputImpliedClosingLine=True)`, but is more direct.
This can be useful when working with pen drawing commands (as opposed to unambiguously explicit contour points) and one intends to normalize two paths in order to test whether they are interpolation compatible (i.e. contain the same number/types of segments).

```python
>>> r1 = RecordingPen()
>>> p1 = ExplicitClosingLinePen(r1)
>>> p1.moveTo((0,0))
>>> p1.curveTo((1,1), (2,2), (3,3))
>>> p1.curveTo((4,4), (5,5), (0,0))
>>> p1.closePath()
>>> r2 = RecordingPen()
>>> p2 = ExplicitClosingLinePen(r2)
>>> p2.moveTo((0,0))
>>> p2.curveTo((1,1), (2,2), (3,3))
>>> p2.curveTo((4,4), (5,5), (6,6))
>>> p2.closePath()
>>> len(r1.value) != len(r2.value)  # different number of segments
>>> r1.value
[('moveTo', ((0, 0),)),
 ('curveTo', ((1, 1), (2, 2), (3, 3))),
 ('curveTo', ((4, 4), (5, 5), (0, 0))),
 ('closePath', ())]
>>> r2.value
[('moveTo', ((0, 0),)),
 ('curveTo', ((1, 1), (2, 2), (3, 3))),
 ('curveTo', ((4, 4), (5, 5), (6, 6))),
 ('lineTo', ((0, 0),)),
 ('closePath', ())]
```