### PR TITLE
feaLib: Dedupe multiple substitutions with classes

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1272,15 +1272,18 @@ class MultipleSubstStatement(Statement):
             replaces.append(replace)
         replaces = list(zip(*replaces))
 
+        seen_originals = set()
         for i, original in enumerate(originals):
-            builder.add_multiple_subst(
-                self.location,
-                prefix,
-                original,
-                suffix,
-                replaces and replaces[i] or (),
-                self.forceChain,
-            )
+            if original not in seen_originals:
+                seen_originals.add(original)
+                builder.add_multiple_subst(
+                    self.location,
+                    prefix,
+                    original,
+                    suffix,
+                    replaces and replaces[i] or (),
+                    self.forceChain,
+                )
 
     def asFea(self, indent=""):
         res = "sub "

--- a/Tests/feaLib/data/GSUB_2.fea
+++ b/Tests/feaLib/data/GSUB_2.fea
@@ -29,3 +29,7 @@ lookup l1 {
 feature f5 {
    sub @class' lookup l1 [i l];
 } f5;
+
+feature f6 {
+    sub [f_i f_i]' j by [f f] [i i];
+} f6;

--- a/Tests/feaLib/data/GSUB_2.ttx
+++ b/Tests/feaLib/data/GSUB_2.ttx
@@ -10,19 +10,20 @@
         <Script>
           <DefaultLangSys>
             <ReqFeatureIndex value="65535"/>
-            <!-- FeatureCount=5 -->
+            <!-- FeatureCount=6 -->
             <FeatureIndex index="0" value="0"/>
             <FeatureIndex index="1" value="1"/>
             <FeatureIndex index="2" value="2"/>
             <FeatureIndex index="3" value="3"/>
             <FeatureIndex index="4" value="4"/>
+            <FeatureIndex index="5" value="5"/>
           </DefaultLangSys>
           <!-- LangSysCount=0 -->
         </Script>
       </ScriptRecord>
     </ScriptList>
     <FeatureList>
-      <!-- FeatureCount=5 -->
+      <!-- FeatureCount=6 -->
       <FeatureRecord index="0">
         <FeatureTag value="f1  "/>
         <Feature>
@@ -58,9 +59,16 @@
           <LookupListIndex index="0" value="5"/>
         </Feature>
       </FeatureRecord>
+      <FeatureRecord index="5">
+        <FeatureTag value="f6  "/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="6"/>
+        </Feature>
+      </FeatureRecord>
     </FeatureList>
     <LookupList>
-      <!-- LookupCount=6 -->
+      <!-- LookupCount=8 -->
       <Lookup index="0">
         <LookupType value="2"/>
         <LookupFlag value="0"/>
@@ -134,6 +142,35 @@
             <LookupListIndex value="4"/>
           </SubstLookupRecord>
         </ChainContextSubst>
+      </Lookup>
+      <Lookup index="6">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="3">
+          <!-- BacktrackGlyphCount=0 -->
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0">
+            <Glyph value="f_i"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=1 -->
+          <LookAheadCoverage index="0">
+            <Glyph value="j"/>
+          </LookAheadCoverage>
+          <!-- SubstCount=1 -->
+          <SubstLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="7"/>
+          </SubstLookupRecord>
+        </ChainContextSubst>
+      </Lookup>
+      <Lookup index="7">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <MultipleSubst index="0">
+          <Substitution in="f_i" out="f,i"/>
+        </MultipleSubst>
       </Lookup>
     </LookupList>
   </GSUB>


### PR DESCRIPTION
This is a follow-up to #3103. If the same glyph appears multiple times in the input class, only the first copy’s rule can ever be applied, so the rest can be skipped. Without this change, if the rule is in a chaining substitution lookup, `Builder.add_multiple_subst` creates duplicate multiple substitution lookups.