### PR TITLE
[feaLib] Simplify variable scalars that don’t vary

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1613,6 +1613,9 @@ class Builder(object):
             )
 
         varscalar.axes = self.axes
+        if not varscalar.does_vary:
+            return varscalar.default, None
+
         default, index = varscalar.add_to_variation_store(
             self.varstorebuilder, self.model_cache, self.font.get("avar")
         )

--- a/Tests/feaLib/data/variable_scalar_valuerecord.fea
+++ b/Tests/feaLib/data/variable_scalar_valuerecord.fea
@@ -2,4 +2,5 @@ languagesystem DFLT dflt;
 feature kern {
     pos one 1;
     pos two <0 (wght=200:12 wght=900:22 wdth=150,wght=900:42) 0 0>;
+    pos three <0 (wght=200:12 wght=900:12 wdth=150,wght=900:12) 0 0>;
 } kern;

--- a/Tests/feaLib/data/variable_scalar_valuerecord.ttx
+++ b/Tests/feaLib/data/variable_scalar_valuerecord.ttx
@@ -76,7 +76,7 @@
       <Lookup index="0">
         <LookupType value="1"/>
         <LookupFlag value="0"/>
-        <!-- SubTableCount=2 -->
+        <!-- SubTableCount=3 -->
         <SinglePos index="0" Format="1">
           <Coverage>
             <Glyph value="one"/>
@@ -96,6 +96,13 @@
               <DeltaFormat value="32768"/>
             </YPlaDevice>
           </Value>
+        </SinglePos>
+        <SinglePos index="2" Format="1">
+          <Coverage>
+            <Glyph value="three"/>
+          </Coverage>
+          <ValueFormat value="2"/>
+          <Value YPlacement="12"/>
         </SinglePos>
       </Lookup>
     </LookupList>


### PR DESCRIPTION
If a variable scalar does not vary (i.e. all values are the same), we can simplify it and use a simple value instead. Arguably users shouldn’t be using variable scalar in this case, but it helps when the feature code is auto generated so each feaLib users doesn’t have to do the check done here themselves.