### PR TITLE
[otlLib] Fix error message in `MarkBasePosBuilder`

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -990,7 +990,7 @@ class MarkBasePosBuilder(LookupBuilder):
             for mc, anchor in anchors.items():
                 if mc not in markClasses:
                     raise ValueError(
-                        "Mark class %s not found for base glyph %s" % (mc, mark)
+                        "Mark class %s not found for base glyph %s" % (mc, glyph)
                     )
                 bases[glyph][markClasses[mc]] = anchor
         subtables = buildMarkBasePos(marks, bases, self.glyphMap)


### PR DESCRIPTION
The old code used `mark` instead of `glyph` so it would either raise an `UnboundLocalError` or produce an error message with the wrong glyph name.