### PR TITLE
implied oncurve points for interpolatable glyphs

### DIFF
--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -17,48 +17,57 @@ import math
 __all__ = ["TTGlyphPen", "TTGlyphPointPen"]
 
 
-def drop_implied_oncurves(glyph):
-    drop = set()
-    start = 0
-    flags = glyph.flags
-    coords = glyph.coordinates
-    for last in glyph.endPtsOfContours:
-        for i in range(start, last + 1):
-            if not (flags[i] & flagOnCurve):
-                continue
-            prv = i - 1 if i > start else last
-            nxt = i + 1 if i < last else start
-            if (flags[prv] & flagOnCurve) or flags[prv] != flags[nxt]:
-                continue
-            p0 = coords[prv]
-            p1 = coords[i]
-            p2 = coords[nxt]
-            if not math.isclose(p1[0] - p0[0], p2[0] - p1[0]) or not math.isclose(
-                p1[1] - p0[1], p2[1] - p1[1]
-            ):
-                continue
+def drop_implied_oncurves(*interpolatable_glyphs):
+    drop = None
+    for glyph in interpolatable_glyphs:
+        may_drop = set()
+        start = 0
+        flags = glyph.flags
+        coords = glyph.coordinates
+        for last in glyph.endPtsOfContours:
+            for i in range(start, last + 1):
+                if not (flags[i] & flagOnCurve):
+                    continue
+                prv = i - 1 if i > start else last
+                nxt = i + 1 if i < last else start
+                if (flags[prv] & flagOnCurve) or flags[prv] != flags[nxt]:
+                    continue
+                p0 = coords[prv]
+                p1 = coords[i]
+                p2 = coords[nxt]
+                if not math.isclose(p1[0] - p0[0], p2[0] - p1[0]) or not math.isclose(
+                    p1[1] - p0[1], p2[1] - p1[1]
+                ):
+                    continue
 
-            drop.add(i)
+                may_drop.add(i)
+        # we only want to drop if ALL interpolatable glyphs have the same implied oncurves
+        if drop is None:
+            drop = may_drop
+        else:
+            drop.intersection_update(may_drop)
+
     if drop:
         # Do the actual dropping
-        glyph.coordinates = GlyphCoordinates(
-            coords[i] for i in range(len(coords)) if i not in drop
-        )
-        glyph.flags = array("B", (flags[i] for i in range(len(flags)) if i not in drop))
+        for glyph in interpolatable_glyphs:
+            glyph.coordinates = GlyphCoordinates(
+                coords[i] for i in range(len(coords)) if i not in drop
+            )
+            glyph.flags = array("B", (flags[i] for i in range(len(flags)) if i not in drop))
 
-        endPts = glyph.endPtsOfContours
-        newEndPts = []
-        i = 0
-        delta = 0
-        for d in sorted(drop):
-            while d > endPts[i]:
+            endPts = glyph.endPtsOfContours
+            newEndPts = []
+            i = 0
+            delta = 0
+            for d in sorted(drop):
+                while d > endPts[i]:
+                    newEndPts.append(endPts[i] - delta)
+                    i += 1
+                delta += 1
+            while i < len(endPts):
                 newEndPts.append(endPts[i] - delta)
                 i += 1
-            delta += 1
-        while i < len(endPts):
-            newEndPts.append(endPts[i] - delta)
-            i += 1
-        glyph.endPtsOfContours = newEndPts
+            glyph.endPtsOfContours = newEndPts
 
 
 class _TTGlyphBasePen:

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1531,7 +1531,20 @@ class Glyph(object):
         return result if result is NotImplemented else not result
 
 
-def dropImpliedOnCurvePoints(*interpolatable_glyphs):
+def dropImpliedOnCurvePoints(*interpolatable_glyphs: Glyph) -> None:
+    """Drop impliable on-curve points from the (simple) glyph or glyphs.
+
+    In TrueType glyf outlines, on-curve points can be implied when they are located at
+    the midpoint of the line connecting two consecutive off-curve points.
+
+    If more than one glyphs are passed, these are assumed to be interpolatable masters
+    of the same glyph impliable, and thus only the on-curve points that are impliable
+    for all of them will actually be implied.
+    The input glyph(s) is/are modified in-place.
+
+    Reference:
+    https://developer.apple.com/fonts/TrueType-Reference-Manual/RM01/Chap1.html
+    """
     drop = None
     for glyph in interpolatable_glyphs:
         may_drop = set()

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -28,6 +28,7 @@ from fontTools.misc import xmlWriter
 from fontTools.misc.filenames import userNameToFileName
 from fontTools.misc.loggingTools import deprecateFunction
 from enum import IntFlag
+from typing import Set
 
 log = logging.getLogger(__name__)
 
@@ -1531,7 +1532,7 @@ class Glyph(object):
         return result if result is NotImplemented else not result
 
 
-def dropImpliedOnCurvePoints(*interpolatable_glyphs: Glyph) -> None:
+def dropImpliedOnCurvePoints(*interpolatable_glyphs: Glyph) -> Set[int]:
     """Drop impliable on-curve points from the (simple) glyph or glyphs.
 
     In TrueType glyf outlines, on-curve points can be implied when they are located at
@@ -1542,9 +1543,17 @@ def dropImpliedOnCurvePoints(*interpolatable_glyphs: Glyph) -> None:
     for all of them will actually be implied.
     The input glyph(s) is/are modified in-place.
 
+    Args:
+        interpolatable_glyphs: The glyph or glyphs to modify in-place.
+
+    Returns:
+        The set of point indices that were dropped if any.
+
     Reference:
     https://developer.apple.com/fonts/TrueType-Reference-Manual/RM01/Chap1.html
     """
+    assert len(interpolatable_glyphs) > 0
+
     drop = None
     for glyph in interpolatable_glyphs:
         may_drop = set()
@@ -1598,6 +1607,8 @@ def dropImpliedOnCurvePoints(*interpolatable_glyphs: Glyph) -> None:
                 newEndPts.append(endPts[i] - delta)
                 i += 1
             glyph.endPtsOfContours = newEndPts
+
+    return drop
 
 
 class GlyphComponent(object):


### PR DESCRIPTION
we have a drop_implied_oncurves function inside ttGlyphPen, but that being a pen only works for a single glyph.

Thus I modified this to work on one or more (interpolatable) glyphs and to only prune oncurve points that are impliable for _all_ of the input glyphs, such that the modified glyphs maintain interpolability.

I also moved it to the glyf table module. I'd like to use this in ufo2ft to massage the glyphs of master TTFs before it calls varLib.build.

fontc does a similarly eager pruning of oncurve points and I'd like to have this done (optionally) in fontmake-py as well.