### PR TITLE
Bug fix for `TypeError` in `_reverseBytes()` in module `E_B_D_T_`, currently breaks on `bytes` arguments longer than 1

### DIFF
--- a/Lib/fontTools/ttLib/tables/E_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_D_T_.py
@@ -258,7 +258,7 @@ def _memoize(f):
     class memodict(dict):
         def __missing__(self, key):
             ret = f(key)
-            if len(key) == 1:
+            if isinstance(key, int) or len(key) == 1:
                 self[key] = ret
             return ret
 

--- a/Lib/fontTools/ttLib/tables/E_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_D_T_.py
@@ -271,7 +271,7 @@ def _memoize(f):
 # opposite of what makes sense algorithmically and hence this function.
 @_memoize
 def _reverseBytes(data):
-    if len(data) != 1:
+    if isinstance(data, bytes) and len(data) != 1:
         return bytesjoin(map(_reverseBytes, data))
     byte = byteord(data)
     result = 0

--- a/Lib/fontTools/ttLib/tables/E_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_D_T_.py
@@ -271,6 +271,12 @@ def _memoize(f):
 # opposite of what makes sense algorithmically and hence this function.
 @_memoize
 def _reverseBytes(data):
+    r"""
+    >>> bin(ord(_reverseBytes(0b00100111)))
+    '0b11100100'
+    >>> _reverseBytes(b'\x00\xf0')
+    b'\x00\x0f'
+    """
     if isinstance(data, bytes) and len(data) != 1:
         return bytesjoin(map(_reverseBytes, data))
     byte = byteord(data)

--- a/README.rst
+++ b/README.rst
@@ -253,17 +253,16 @@ Acknowledgements
 In alphabetical order:
 
 aschmitz, Olivier Berten, Samyak Bhuta, Erik van Blokland, Petr van Blokland,
-Jelle Bosma, Sascha Brawer, Tom Byrer, Antonio Cavedoni, Frédéric
-Coiffier, Vincent Connare, David Corbett, Simon Cozens, Dave Crossland,
-Simon Daniels, Peter Dekkers, Behdad Esfahbod, Behnam Esfahbod, Hannes
-Famira, Sam Fishman, Matt Fontaine, Takaaki Fuji, Yannis Haralambous, Greg
-Hitchcock, Jeremie Hornus, Khaled Hosny, John Hudson, Denis Moyogo Jacquerye,
-Jack Jansen, Tom Kacvinsky, Jens Kutilek, Antoine Leca, Werner Lemberg, Tal
-Leming, Peter Lofting, Cosimo Lupo, Olli Meier, Masaya Nakamura, Dave Opstad,
-Laurence Penney, Roozbeh Pournader, Garret Rieger, Read Roberts, Colin Rofls,
-Guido van Rossum, Just van Rossum, Andreas Seidel, Georg Seifert, Chris
-Simpkins, Miguel Sousa, Adam Twardoch, Adrien Tétar, Vitaly Volkov,
-Paul Wise.
+Jelle Bosma, Sascha Brawer, Tom Byrer, Antonio Cavedoni, Frédéric Coiffier,
+Vincent Connare, David Corbett, Simon Cozens, Dave Crossland, Simon Daniels,
+Peter Dekkers, Behdad Esfahbod, Behnam Esfahbod, Hannes Famira, Sam Fishman,
+Matt Fontaine, Takaaki Fuji, Rob Hagemans, Yannis Haralambous, Greg Hitchcock,
+Jeremie Hornus, Khaled Hosny, John Hudson, Denis Moyogo Jacquerye, Jack Jansen,
+Tom Kacvinsky, Jens Kutilek, Antoine Leca, Werner Lemberg, Tal Leming, Peter
+Lofting, Cosimo Lupo, Olli Meier, Masaya Nakamura, Dave Opstad, Laurence Penney,
+Roozbeh Pournader, Garret Rieger, Read Roberts, Colin Rofls, Guido van Rossum,
+Just van Rossum, Andreas Seidel, Georg Seifert, Chris Simpkins, Miguel Sousa,
+Adam Twardoch, Adrien Tétar, Vitaly Volkov, Paul Wise.
 
 Copyrights
 ~~~~~~~~~~


### PR DESCRIPTION
In the `E_B_D_T_` module, `_reverseBytes()` with `bytes` arguments longer than 1 lead to a recursive call from a loop. However, a loop over `bytes` produces `int`s, which have no `len()`, leading to a `TypeError`.

Fixed with `isinstance` as it appears the function is intended to be applicable to both `int` and `bytes` arguments.

Contributing guidelines suggest pull request authors should be listed in the README - let me know if I should add my name there, happy to do so but this is a kinda trivial edit.