### PR TITLE
[macCreatorType] preserve existing other metadata when setting filetype & creator

### DIFF
--- a/Lib/fontTools/misc/macCreatorType.py
+++ b/Lib/fontTools/misc/macCreatorType.py
@@ -52,5 +52,11 @@ def setMacCreatorAndType(path, fileCreator, fileType):
 
         if not all(len(s) == 4 for s in (fileCreator, fileType)):
             raise TypeError("arg must be string of 4 chars")
-        finderInfo = pad(bytesjoin([fileType, fileCreator]), 32)
+        try:
+            existingFinderInfo = xattr.getxattr(path, "com.apple.FinderInfo")
+        except (KeyError, IOError):
+            pass
+        else:
+            otherMetadata = existingFinderInfo[8:]
+        finderInfo = pad(bytesjoin([fileType, fileCreator, otherMetadata]), 32)
         xattr.setxattr(path, "com.apple.FinderInfo", finderInfo)


### PR DESCRIPTION
This addresses #3170.

I'll just note that I'm not fluent in Python, so I don't know if there'd be a better way to fix this than what I came up with.

