### PR TITLE
[FontBuilder] Update setupAvar() to also support avar-2, fixing _add_avar() call site

### DIFF
--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -707,7 +707,7 @@ class FontBuilder(object):
 
         addFvar(self.font, axes, instances)
 
-    def setupAvar(self, axes):
+    def setupAvar(self, axes, mappings=None):
         """Adds an axis variations table to the font.
 
         Args:
@@ -715,7 +715,11 @@ class FontBuilder(object):
         """
         from .varLib import _add_avar
 
-        _add_avar(self.font, OrderedDict(enumerate(axes)))  # Only values are used
+        if "fvar" not in self.font:
+            raise KeyError("'fvar' table is missing; can't add FeatureVariations.")
+        axisTags = [axis.axisTag for axis in self.font["fvar"].axes]
+        axes = OrderedDict(enumerate(axes))  # Only values are used
+        _add_avar(self.font, axes, mappings, axisTags)
 
     def setupGvar(self, variations):
         gvar = self.font["gvar"] = newTable("gvar")

--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -716,7 +716,8 @@ class FontBuilder(object):
         from .varLib import _add_avar
 
         if "fvar" not in self.font:
-            raise KeyError("'fvar' table is missing; can't add FeatureVariations.")
+            raise KeyError("'fvar' table is missing; can't add 'avar'.")
+
         axisTags = [axis.axisTag for axis in self.font["fvar"].axes]
         axes = OrderedDict(enumerate(axes))  # Only values are used
         _add_avar(self.font, axes, mappings, axisTags)

--- a/Tests/fontBuilder/data/test_var.otf.ttx
+++ b/Tests/fontBuilder/data/test_var.otf.ttx
@@ -273,6 +273,16 @@
     </GlobalSubrs>
   </CFF2>
 
+  <avar>
+    <version major="1" minor="0"/>
+    <segment axis="TEST">
+      <mapping from="-1.0" to="-1.0"/>
+      <mapping from="0.0" to="0.0"/>
+      <mapping from="0.4" to="0.6"/>
+      <mapping from="1.0" to="1.0"/>
+    </segment>
+  </avar>
+
   <fvar>
 
     <!-- Test Axis -->

--- a/Tests/fontBuilder/fontBuilder_test.py
+++ b/Tests/fontBuilder/fontBuilder_test.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from fontTools.designspaceLib import AxisDescriptor
 from fontTools.ttLib import TTFont
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.pens.t2CharStringPen import T2CharStringPen
@@ -44,14 +45,20 @@ def _setupFontBuilder(isTTF, unitsPerEm=1024):
 def _setupFontBuilderFvar(fb):
     assert "name" in fb.font, "Must run setupNameTable() first."
 
-    axes = [
-        ("TEST", 0, 0, 100, "Test Axis"),
-    ]
+    testAxis = AxisDescriptor()
+    testAxis.name = "Test Axis"
+    testAxis.tag = "TEST"
+    testAxis.minimum = 0
+    testAxis.default = 0
+    testAxis.maximum = 100
+    testAxis.map = [(0, 0), (40, 60), (100, 100)]
+    axes = [testAxis]
     instances = [
         dict(location=dict(TEST=0), stylename="TotallyNormal"),
         dict(location=dict(TEST=100), stylename="TotallyTested"),
     ]
     fb.setupFvar(axes, instances)
+    fb.setupAvar(axes)
 
     return fb
 


### PR DESCRIPTION
Fixes #3182.

The avar-2 bit is untested, but I did add a minimal FontBuilder avar test that would have caught #3182.