### PR TITLE
[FontBuilder] Propagate the 'hidden' flag to the fvar Axis instance

### DIFF
--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -971,6 +971,8 @@ def addFvar(font, axes, instances):
                 axis_def.maximum,
                 axis_def.name,
             )
+            if axis_def.hidden:
+                axis.flags = 0x0001  # HIDDEN_AXIS
 
         if isinstance(name, str):
             name = dict(en=name)


### PR DESCRIPTION
The `hidden` flag was not set on the fvar axis, when using FontBuilder's `setupFvar()` method. This PR fixes that.