### PR TITLE
Fix typing of script_horizontal_direction()

### DIFF
--- a/Lib/fontTools/unicodedata/__init__.py
+++ b/Lib/fontTools/unicodedata/__init__.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 from fontTools.misc.textTools import byteord, tostr
 
 import re
 from bisect import bisect_right
+from typing import Literal, TypeVar, overload
+
 
 try:
     # use unicodedata backport compatible with python2:
@@ -192,7 +196,25 @@ RTL_SCRIPTS = {
 }
 
 
-def script_horizontal_direction(script_code, default=KeyError):
+HorizDirection = Literal["RTL", "LTR"]
+T = TypeVar("T")
+
+
+@overload
+def script_horizontal_direction(script_code: str, default: T) -> HorizDirection | T:
+    ...
+
+
+@overload
+def script_horizontal_direction(
+    script_code: str, default: type[KeyError] = KeyError
+) -> HorizDirection:
+    ...
+
+
+def script_horizontal_direction(
+    script_code: str, default: T | type[KeyError] = KeyError
+) -> HorizDirection | T:
     """Return "RTL" for scripts that contain right-to-left characters
     according to the Bidi_Class property. Otherwise return "LTR".
     """

--- a/Lib/fontTools/unicodedata/__init__.py
+++ b/Lib/fontTools/unicodedata/__init__.py
@@ -15,33 +15,30 @@ from . import Blocks, Scripts, ScriptExtensions, OTTags
 
 
 __all__ = [
-    tostr(s)
-    for s in (
-        # names from built-in unicodedata module
-        "lookup",
-        "name",
-        "decimal",
-        "digit",
-        "numeric",
-        "category",
-        "bidirectional",
-        "combining",
-        "east_asian_width",
-        "mirrored",
-        "decomposition",
-        "normalize",
-        "unidata_version",
-        "ucd_3_2_0",
-        # additonal functions
-        "block",
-        "script",
-        "script_extension",
-        "script_name",
-        "script_code",
-        "script_horizontal_direction",
-        "ot_tags_from_script",
-        "ot_tag_to_script",
-    )
+    # names from built-in unicodedata module
+    "lookup",
+    "name",
+    "decimal",
+    "digit",
+    "numeric",
+    "category",
+    "bidirectional",
+    "combining",
+    "east_asian_width",
+    "mirrored",
+    "decomposition",
+    "normalize",
+    "unidata_version",
+    "ucd_3_2_0",
+    # additonal functions
+    "block",
+    "script",
+    "script_extension",
+    "script_name",
+    "script_code",
+    "script_horizontal_direction",
+    "ot_tags_from_script",
+    "ot_tag_to_script",
 ]
 
 
@@ -203,7 +200,7 @@ def script_horizontal_direction(script_code, default=KeyError):
         if isinstance(default, type) and issubclass(default, KeyError):
             raise default(script_code)
         return default
-    return str("RTL") if script_code in RTL_SCRIPTS else str("LTR")
+    return "RTL" if script_code in RTL_SCRIPTS else "LTR"
 
 
 def block(char):


### PR DESCRIPTION
Without explicit annotation, some type checkers inferred that the type of the 'default' argument could only be `type[KeyError]`. This was the case in unicodedata_test.py, where pyright disallowed `"LTR"`. This PR adds annotations to avoid this, fixing the issue in the test, and in external code depending on the API.

### Extras

Some explicit conversions of literals to `str` were removed, as Python 3 no longer requires them and in one case they would have required a less specific return type to be used.

### Caveats

* Some of the other functions in this file have the same semantics and suffer from the same type error, and so this fix could also be extended to them as usage requires.
* `HorizDirection` and `T` may become importable; do we want to avoid this for either?