### PR TITLE
Fix wrong created date in fontBuilder

### DIFF
--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -339,7 +339,7 @@ class FontBuilder(object):
             assert unitsPerEm is not None
             self.setupHead(
                 unitsPerEm=unitsPerEm,
-                create=now,
+                created=now,
                 modified=now,
                 glyphDataFormat=glyphDataFormat,
             )


### PR DESCRIPTION
Bug introduced in https://github.com/fonttools/fonttools/commit/a421f9045a4d1e130daece08350ed7c1ed300ee7#diff-c01f84c2ac99ae2b60f071d4a38ff88c2653d27f19e62e11bef3dc7fe7f68925R352

Causes created date to be set to 0 instead of the current timestamp.