### PR TITLE
Cache repeated subtables while building COLR

### DIFF
--- a/Lib/fontTools/colorLib/table_builder.py
+++ b/Lib/fontTools/colorLib/table_builder.py
@@ -5,6 +5,8 @@ colorLib.table_builder: Generic helper for filling in BaseTable derivatives from
 
 import collections
 import enum
+import json
+import copy
 from fontTools.ttLib.tables.otBase import (
     BaseTable,
     FormatSwitchingBaseTable,
@@ -84,6 +86,7 @@ class TableBuilder:
         if callbackTable is None:
             callbackTable = {}
         self._callbackTable = callbackTable
+        self.cache = {}
 
     def _convert(self, dest, field, converter, value):
         enumClass = getattr(converter, "enumClass", None)
@@ -123,6 +126,10 @@ class TableBuilder:
 
         if isinstance(source, cls):
             return source
+
+        key = json.dumps(source, sort_keys=True)
+        if key in self.cache:
+            return copy.deepcopy(self.cache[key])
 
         callbackKey = (cls,)
         fmt = None
@@ -177,6 +184,8 @@ class TableBuilder:
         dest = self._callbackTable.get(
             (BuildCallback.AFTER_BUILD,) + callbackKey, lambda d: d
         )(dest)
+
+        self.cache[key] = dest
 
         return dest
 

--- a/Lib/fontTools/colorLib/table_builder.py
+++ b/Lib/fontTools/colorLib/table_builder.py
@@ -127,9 +127,14 @@ class TableBuilder:
         if isinstance(source, cls):
             return source
 
-        key = json.dumps(source, sort_keys=True)
-        if key in self.cache:
-            return copy.deepcopy(self.cache[key])
+        cacheable = True
+        key = None
+        try:
+            key = json.dumps(source, sort_keys=True)
+            if key in self.cache:
+                return copy.deepcopy(self.cache[key])
+        except TypeError:
+            cacheable = False
 
         callbackKey = (cls,)
         fmt = None
@@ -185,7 +190,8 @@ class TableBuilder:
             (BuildCallback.AFTER_BUILD,) + callbackKey, lambda d: d
         )(dest)
 
-        self.cache[key] = dest
+        if cacheable:
+            self.cache[key] = dest
 
         return dest
 

--- a/Lib/fontTools/colorLib/table_builder.py
+++ b/Lib/fontTools/colorLib/table_builder.py
@@ -130,7 +130,7 @@ class TableBuilder:
         cacheable = True
         key = None
         try:
-            key = json.dumps(source, sort_keys=True)
+            key = hash(json.dumps(source, sort_keys=True))
             if key in self.cache:
                 return copy.deepcopy(self.cache[key])
         except TypeError:


### PR DESCRIPTION
When building a complex COLR table, particularly for a font with a large number of glyphs, there can be *many* repeated subtables. Instead of rebuilding each subtable from scratch, a simple cache can be used to speed up the build.

For example, building [Bitcount](https://bitcount.typenetwork.com) without the cache takes 274 seconds on my computer; with the cache,  it takes 94.