### PR TITLE
Cache repeated COLR subtables (2)

### DIFF
--- a/Lib/fontTools/colorLib/table_builder.py
+++ b/Lib/fontTools/colorLib/table_builder.py
@@ -130,7 +130,8 @@ class TableBuilder:
 
         key = sha256(pickle.dumps(source)).digest()
         if key in self.cache:
-            return copy.deepcopy(self.cache[key])
+            # pickle/unpickle is faster than copy.deepcopy
+            return pickle.loads(pickle.dumps(self.cache[key]))
 
         callbackKey = (cls,)
         fmt = None

--- a/Lib/fontTools/colorLib/table_builder.py
+++ b/Lib/fontTools/colorLib/table_builder.py
@@ -128,7 +128,7 @@ class TableBuilder:
         if isinstance(source, cls):
             return source
 
-        key = sha256(pickle.dumps(source)).digest()
+        key = (cls, sha256(pickle.dumps(source)).digest())
         if key in self.cache:
             # pickle/unpickle is faster than copy.deepcopy
             return pickle.loads(pickle.dumps(self.cache[key]))


### PR DESCRIPTION
Some improvements to #3215 to use pickle (faster than json), sha256 for the digest to mitigate collisions, and a LRU cache to avoid it growing unbounded.
I'm still unsure regarding the cache max size (I used 128 like lru_cache but don't know what a good number is in general for this task).
I'm also hesitant to enable this unconditionally and would rather it be opt in, as it's not guaranteed to lead to faster builds given the overhead of pickling+hashing objects mutliple times (the TableBuilder.build is called recursively for each struct fields in a table tree). 