### PR TITLE
[designspace] Clarify in docs that <lib> is plist

### DIFF
--- a/Doc/source/designspaceLib/xml.rst
+++ b/Doc/source/designspaceLib/xml.rst
@@ -1097,6 +1097,8 @@ Example for MutatorMath
 The ``<lib>`` element contains arbitrary data.
 
 - Child element of ``<designspace>``, ``<variable-font>`` and ``<instance>``
+- If present, content must be an XML Property List (plist).
+  <https://en.wikipedia.org/wiki/Property_list>__
 - Contains arbitrary data about the whole document or about a specific
   variable font or instance.
 - Items in the dict need to use **reverse domain name notation**


### PR DESCRIPTION
I'm not really sure how the docs work, so this might not be right? lmk :)

closes #3224 