### PR TITLE
varLib: use sentinel to mark glyph metrics as sparse

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -563,9 +563,17 @@ def _get_advance_metrics(
 ):
     vhAdvanceDeltasAndSupports = {}
     vOrigDeltasAndSupports = {}
+    # HACK: we treat width 65535 and lsb -32768 as sentinel values to signal that a
+    # glyph from a non-default master should not participate in computing {H,V}VAR,
+    # as if it were missing. Allows to variate other glyph-related data independently
+    # from glyph metrics
+    sparse_metrics = (0xFFFF, -0x8000)
     for glyph in glyphOrder:
         vhAdvances = [
-            metrics[glyph][0] if glyph in metrics else None for metrics in advMetricses
+            metrics[glyph][0]
+            if glyph in metrics and metrics[glyph] != sparse_metrics
+            else None
+            for i, metrics in enumerate(advMetricses)
         ]
         vhAdvanceDeltasAndSupports[glyph] = masterModel.getDeltasAndSupports(
             vhAdvances, round=round

--- a/Tests/varLib/data/master_sparse_cff2_empty/SparseCFF-Bold.ttx
+++ b/Tests/varLib/data/master_sparse_cff2_empty/SparseCFF-Bold.ttx
@@ -294,7 +294,7 @@
   </GSUB>
 
   <hmtx>
-    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name=".notdef" width="800" lsb="200"/>
     <mtx name="a" width="600" lsb="9"/>
     <mtx name="e" width="600" lsb="9"/>
   </hmtx>

--- a/Tests/varLib/data/master_sparse_cff2_empty/SparseCFF-Medium.ttx
+++ b/Tests/varLib/data/master_sparse_cff2_empty/SparseCFF-Medium.ttx
@@ -93,7 +93,7 @@
   </CFF>
 
   <hmtx>
-    <mtx name=".notdef" width="500" lsb="0"/>
+    <mtx name=".notdef" width="65535" lsb="-32768"/>
     <mtx name="e" width="600" lsb="40"/>
   </hmtx>
 

--- a/Tests/varLib/data/test_results/SparseCFF2-VF.ttx
+++ b/Tests/varLib/data/test_results/SparseCFF2-VF.ttx
@@ -116,4 +116,56 @@
     </Axis>
   </fvar>
 
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="a" width="600" lsb="9"/>
+    <mtx name="e" width="600" lsb="40"/>
+  </hmtx>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=3 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="1">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="0.36365"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+        <Region index="2">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.36365"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=2 -->
+        <NumShorts value="1"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="0"/>
+        <Item index="0" value="[0]"/>
+        <Item index="1" value="[300]"/>
+      </VarData>
+    </VarStore>
+    <AdvWidthMap>
+      <Map glyph=".notdef" outer="0" inner="1"/>
+      <Map glyph="a" outer="0" inner="0"/>
+      <Map glyph="e" outer="0" inner="0"/>
+    </AdvWidthMap>
+  </HVAR>
+
 </ttFont>

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -1004,7 +1004,7 @@ Expected to see .ScriptCount==1, instead saw 0""",
         self._run_varlib_build_test(
             designspace_name="SparseCFF2",
             font_name="SparseCFF2",
-            tables=["GlyphOrder", "CFF2", "fvar"],
+            tables=["GlyphOrder", "CFF2", "fvar", "hmtx", "HVAR"],
             expected_ttx_name="SparseCFF2-VF",
             save_before_dump=True,
         )


### PR DESCRIPTION
as discussed in https://github.com/googlefonts/ufo2ft/issues/501, sometimes one wants to have a gyph in a non-default sparse master without it participating in HVAR/VVAR. For outlines (both glyf and CFF) we allow empty glyphs in non-default masters to mean the same as missing, thus non participating. This PR enables a similar thing for hmtx and vmtx advances and sidebearings (we don't actually build deltas for lsb/tsb the sentinel value includes both to make it less likely that it occurs in real world fonts).

With this PR, if a glyph has both an advance of 65535 (0xFFFF) and a left/top sidebearing of -32768 (-0x8000), it is ignored when building HVAR or VVAR, as if is were missing from a master.