### PR TITLE
[ttLib] Fix warning when calling addMultilingualName() with "ar" name

### DIFF
--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -258,7 +258,9 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
             raise ValueError("nameID must be less than 32768")
         return nameID
 
-    def findMultilingualName(self, names, windows=True, mac=True, minNameID=0):
+    def findMultilingualName(
+        self, names, windows=True, mac=True, minNameID=0, ttFont=None
+    ):
         """Return the name ID of an existing multilingual name that
         matches the 'names' dictionary, or None if not found.
 
@@ -293,7 +295,7 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
                         )
                     )
             if mac:
-                macName = _makeMacName(name, None, lang)
+                macName = _makeMacName(name, None, lang, ttFont)
                 if macName is not None:
                     reqNameSet.add(
                         (
@@ -352,7 +354,7 @@ class table__n_a_m_e(DefaultTable.DefaultTable):
         if nameID is None:
             # Reuse nameID if possible
             nameID = self.findMultilingualName(
-                names, windows=windows, mac=mac, minNameID=minNameID
+                names, windows=windows, mac=mac, minNameID=minNameID, ttFont=ttFont
             )
             if nameID is not None:
                 return nameID

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -324,6 +324,15 @@ class NameTableTest(unittest.TestCase):
             nameTable.addMultilingualName({"en": "A", "la": "ⱾƤℚⱤ"})
         captor.assertRegex("cannot store language la into 'ltag' table")
 
+    def test_addMultilingualName_TTFont(self):
+        # if ttFont argument is passed, it should not WARN about not being able
+        # to create ltag table.
+        font = FakeFont(glyphs=[".notdef", "A"])
+        nameTable = newTable("name")
+        with CapturingLogHandler(log, "WARNING") as captor:
+            nameTable.addMultilingualName({"en": "A", "ar": "ع"}, ttFont=font)
+        self.assertFalse(captor.records)
+
     def test_addMultilingualName_minNameID(self):
         table = table__n_a_m_e()
         names, namesSubSet, namesSuperSet = self._get_test_names()


### PR DESCRIPTION
I get warning from _makeMacName() because it does not have a TTFont, but the font is there, just not passed from addMultilingualName() -> findMultilingualName() -> _makeMacName().