### PR TITLE
fix the order of prune_unused_regions

### DIFF
--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -633,15 +633,15 @@ def VarStore_optimize(self, use_NO_VARIATION_INDEX=True, quantization=1):
     for k, v in front_mapping.items():
         varidx_map[k] = back_mapping[v] if v is not None else NO_VARIATION_INDEX
 
-    # Remove unused regions.
-    self.prune_regions()
-
     # Recalculate things and go home.
     self.VarRegionList.RegionCount = len(self.VarRegionList.Region)
     self.VarDataCount = len(self.VarData)
     for data in self.VarData:
         data.ItemCount = len(data.Item)
         data.optimize()
+
+    # Remove unused regions.
+    self.prune_regions()
 
     return varidx_map
 

--- a/Tests/varLib/data/test_results/Build.ttx
+++ b/Tests/varLib/data/test_results/Build.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.17">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.42">
 
   <GDEF>
     <Version value="0x00010003"/>
@@ -17,7 +17,7 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=2 -->
-        <!-- RegionCount=5 -->
+        <!-- RegionCount=2 -->
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="-1.0"/>
@@ -42,58 +42,29 @@
             <EndCoord value="0.0"/>
           </VarRegionAxis>
         </Region>
-        <Region index="2">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="0.0"/>
-            <EndCoord value="0.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="3">
-          <VarRegionAxis index="0">
-            <StartCoord value="-1.0"/>
-            <PeakCoord value="-1.0"/>
-            <EndCoord value="0.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="4">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
       </VarRegionList>
       <!-- VarDataCount=1 -->
       <VarData index="0">
-        <!-- ItemCount=6 -->
+        <!-- ItemCount=5 -->
         <NumShorts value="0"/>
         <!-- VarRegionCount=2 -->
         <VarRegionIndex index="0" value="0"/>
         <VarRegionIndex index="1" value="1"/>
-        <Item index="0" value="[0, 0]"/>
-        <Item index="1" value="[14, -28]"/>
-        <Item index="2" value="[-10, 17]"/>
-        <Item index="3" value="[-3, 32]"/>
-        <Item index="4" value="[-7, 63]"/>
-        <Item index="5" value="[-7, 63]"/>
+        <Item index="0" value="[-10, 17]"/>
+        <Item index="1" value="[-7, 63]"/>
+        <Item index="2" value="[-3, 32]"/>
+        <Item index="3" value="[0, 0]"/>
+        <Item index="4" value="[14, -28]"/>
       </VarData>
     </VarStore>
+    <AdvWidthMap>
+      <Map glyph=".notdef" outer="0" inner="3"/>
+      <Map glyph="uni0020" outer="0" inner="4"/>
+      <Map glyph="uni0024" outer="0" inner="1"/>
+      <Map glyph="uni0024.nostroke" outer="0" inner="1"/>
+      <Map glyph="uni0041" outer="0" inner="0"/>
+      <Map glyph="uni0061" outer="0" inner="2"/>
+    </AdvWidthMap>
   </HVAR>
 
   <MVAR>
@@ -105,7 +76,7 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=2 -->
-        <!-- RegionCount=5 -->
+        <!-- RegionCount=2 -->
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="-1.0"/>
@@ -128,42 +99,6 @@
             <StartCoord value="0.0"/>
             <PeakCoord value="0.0"/>
             <EndCoord value="0.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="2">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="0.0"/>
-            <EndCoord value="0.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="3">
-          <VarRegionAxis index="0">
-            <StartCoord value="-1.0"/>
-            <PeakCoord value="-1.0"/>
-            <EndCoord value="0.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="4">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
       </VarRegionList>

--- a/Tests/varLib/data/test_results/BuildMain.ttx
+++ b/Tests/varLib/data/test_results/BuildMain.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.19">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.42">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -629,7 +629,7 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=2 -->
-        <!-- RegionCount=5 -->
+        <!-- RegionCount=2 -->
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="-1.0"/>
@@ -654,58 +654,29 @@
             <EndCoord value="0.0"/>
           </VarRegionAxis>
         </Region>
-        <Region index="2">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="0.0"/>
-            <EndCoord value="0.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="3">
-          <VarRegionAxis index="0">
-            <StartCoord value="-1.0"/>
-            <PeakCoord value="-1.0"/>
-            <EndCoord value="0.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="4">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
       </VarRegionList>
       <!-- VarDataCount=1 -->
       <VarData index="0">
-        <!-- ItemCount=6 -->
+        <!-- ItemCount=5 -->
         <NumShorts value="0"/>
         <!-- VarRegionCount=2 -->
         <VarRegionIndex index="0" value="0"/>
         <VarRegionIndex index="1" value="1"/>
-        <Item index="0" value="[0, 0]"/>
-        <Item index="1" value="[14, -28]"/>
-        <Item index="2" value="[-10, 17]"/>
-        <Item index="3" value="[-3, 32]"/>
-        <Item index="4" value="[-7, 63]"/>
-        <Item index="5" value="[-7, 63]"/>
+        <Item index="0" value="[-10, 17]"/>
+        <Item index="1" value="[-7, 63]"/>
+        <Item index="2" value="[-3, 32]"/>
+        <Item index="3" value="[0, 0]"/>
+        <Item index="4" value="[14, -28]"/>
       </VarData>
     </VarStore>
+    <AdvWidthMap>
+      <Map glyph=".notdef" outer="0" inner="3"/>
+      <Map glyph="uni0020" outer="0" inner="4"/>
+      <Map glyph="uni0024" outer="0" inner="1"/>
+      <Map glyph="uni0024.nostroke" outer="0" inner="1"/>
+      <Map glyph="uni0041" outer="0" inner="0"/>
+      <Map glyph="uni0061" outer="0" inner="2"/>
+    </AdvWidthMap>
   </HVAR>
 
   <MVAR>
@@ -717,7 +688,7 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=2 -->
-        <!-- RegionCount=5 -->
+        <!-- RegionCount=2 -->
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="-1.0"/>
@@ -740,42 +711,6 @@
             <StartCoord value="0.0"/>
             <PeakCoord value="0.0"/>
             <EndCoord value="0.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="2">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="0.0"/>
-            <EndCoord value="0.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="3">
-          <VarRegionAxis index="0">
-            <StartCoord value="-1.0"/>
-            <PeakCoord value="-1.0"/>
-            <EndCoord value="0.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="4">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-          <VarRegionAxis index="1">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
           </VarRegionAxis>
         </Region>
       </VarRegionList>

--- a/Tests/varLib/data/test_results/SparseCFF2-VF.ttx
+++ b/Tests/varLib/data/test_results/SparseCFF2-VF.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="OTTO" ttLibVersion="4.41">
+<ttFont sfntVersion="OTTO" ttLibVersion="4.42">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -128,24 +128,10 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=1 -->
-        <!-- RegionCount=3 -->
+        <!-- RegionCount=1 -->
         <Region index="0">
           <VarRegionAxis index="0">
             <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="1">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="0.36365"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="2">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.36365"/>
             <PeakCoord value="1.0"/>
             <EndCoord value="1.0"/>
           </VarRegionAxis>

--- a/Tests/varLib/data/test_results/SparseMasters.ttx
+++ b/Tests/varLib/data/test_results/SparseMasters.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.35">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.42">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -440,28 +440,7 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=1 -->
-        <!-- RegionCount=3 -->
-        <Region index="0">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="0.36365"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="1">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.36365"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
-        <Region index="2">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
+        <!-- RegionCount=0 -->
       </VarRegionList>
       <!-- VarDataCount=1 -->
       <VarData index="0">

--- a/Tests/varLib/data/test_results/TestVVAR.ttx
+++ b/Tests/varLib/data/test_results/TestVVAR.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="OTTO" ttLibVersion="3.39">
+<ttFont sfntVersion="OTTO" ttLibVersion="4.42">
 
   <VVAR>
     <Version value="0x00010000"/>
@@ -7,14 +7,7 @@
       <Format value="1"/>
       <VarRegionList>
         <!-- RegionAxisCount=1 -->
-        <!-- RegionCount=1 -->
-        <Region index="0">
-          <VarRegionAxis index="0">
-            <StartCoord value="0.0"/>
-            <PeakCoord value="1.0"/>
-            <EndCoord value="1.0"/>
-          </VarRegionAxis>
-        </Region>
+        <!-- RegionCount=0 -->
       </VarRegionList>
       <!-- VarDataCount=1 -->
       <VarData index="0">

--- a/Tests/varLib/varStore_test.py
+++ b/Tests/varLib/varStore_test.py
@@ -94,7 +94,7 @@ def buildAxis(axisTag):
                 {3: 300},
             ],
             1,
-            156,
+            126,
         ),
         (
             5,
@@ -212,8 +212,8 @@ def test_optimize(numRegions, varData, expectedNumVarData, expectedBytes):
         (3, 170),
         (4, 175),
         (8, 170),
-        (32, 152),
-        (64, 146),
+        (32, 92),
+        (64, 56),
     ],
 )
 def test_quantize(quantization, expectedBytes):


### PR DESCRIPTION
It should be after each vardata optimization. 
Here's a testcase, I used this command `fonttools varLib.instancer --no-overlap-flag --no-recalc-timestamp --no-optimize --output=ft.ttf test/subset/data/fonts/NotoSans-VF.abc.ttf wght=200:600 wdth=80:90 CTGR=20:60`
File used is this: https://github.com/harfbuzz/harfbuzz/blob/main/test/subset/data/fonts/NotoSans-VF.abc.ttf
And generated MVAR table is like below:

    <VarStore Format="1">
      <Format value="1"/>
      <VarRegionList>
        <!-- RegionAxisCount=3 -->
        <!-- RegionCount=4 -->
        <Region index="0">
      <!-- VarDataCount=1 -->
      <VarData index="0">
        <!-- ItemCount=2 -->
        <NumShorts value="0"/>
        <!-- VarRegionCount=2 -->
        <VarRegionIndex index="0" value="0"/>
        <VarRegionIndex index="1" value="3"/>
        <Item index="0" value="[-7, 6]"/>
        <Item index="1" value="[-4, 4]"/>
      </VarData>
    </VarStore>

2 regions indexed at 1 and 2 are not used and not pruned. 
This PR will fix it.