### PR TITLE
Pad the OS/2 achVendID value with spaces per the OpenType specification.

### DIFF
--- a/Lib/fontTools/ttLib/tables/O_S_2f_2.py
+++ b/Lib/fontTools/ttLib/tables/O_S_2f_2.py
@@ -165,6 +165,10 @@ class table_O_S_2f_2(DefaultTable.DefaultTable):
                 "OS/2 table version 4 and up: version %s",
                 self.version,
             )
+
+        if self.achVendID:
+            self.achVendID = self.padVendorID(self.achVendID)
+
         self.panose = sstruct.pack(panoseFormat, self.panose)
         if self.version == 0:
             data = sstruct.pack(OS2_format_0, self)
@@ -353,6 +357,11 @@ class table_O_S_2f_2(DefaultTable.DefaultTable):
                 avg_width = otRound(sum(widths) / len(widths))
         self.xAvgCharWidth = avg_width
         return avg_width
+
+    def padVendorID(self, achVendorID):
+        """Pad the Vendor ID with spaces as required for Tag types
+        in the OpenType specification."""
+        return achVendorID.ljust(4)
 
 
 # Unicode ranges data from the OpenType OS/2 table specification v1.7

--- a/Tests/ttLib/tables/O_S_2f_2_test.py
+++ b/Tests/ttLib/tables/O_S_2f_2_test.py
@@ -55,6 +55,11 @@ class OS2TableTest(unittest.TestCase):
             (set(range(123)) - {9, 57, 122}),
         )
 
+    def test_vendorIdPadding(self):
+        os2 = newTable("OS/2")
+        self.assertEqual(os2.padVendorID("T"), "T   ")
+        self.assertEqual(os2.padVendorID("TEST"), "TEST")
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
Fixes #3280.