### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,20 +33,22 @@ jobs:
     runs-on: ${{ matrix.platform }}
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10"]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-        exclude: # Only test on the latest supported stable Python on macOS and Windows.
+        python-version: ["3.8", "3.11", "3.12"]
+        platform: [ubuntu-latest]
+        include: # Only test on the latest supported stable Python on macOS and Windows.
           - platform: macos-latest
-            python-version: 3.8
+            python-version: 3.11
           - platform: windows-latest
-            python-version: 3.8
+            python-version: 3.11
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install packages
       run: pip install tox coverage
     - name: Run Tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
 # we use the official Brotli module on CPython and the CFFI-based
 # extension 'brotlipy' on PyPy
-brotli==1.0.9; platform_python_implementation != "PyPy"
-brotlicffi==1.0.9.2; platform_python_implementation == "PyPy"
+brotli==1.1.0; platform_python_implementation != "PyPy"
+brotlicffi==1.1.0.0; platform_python_implementation == "PyPy"
 unicodedata2==15.0.0; python_version <= '3.11'
 scipy==1.10.0; platform_python_implementation != "PyPy" and python_version <= '3.8'
-scipy==1.11.2; platform_python_implementation != "PyPy" and python_version >= '3.9'
+scipy==1.11.3; platform_python_implementation != "PyPy" and python_version >= '3.9'
 munkres==1.1.4; platform_python_implementation == "PyPy"
-zopfli==0.2.1
+zopfli==0.2.3
 fs==2.4.16
-skia-pathops==0.7.3; platform_python_implementation != "PyPy"
+skia-pathops==0.8.0.post1; platform_python_implementation != "PyPy"
 # this is only required to run Tests/cu2qu/{ufo,cli}_test.py
-ufoLib2==0.14.0
-ufo2ft==2.31.0
-pyobjc==9.0; sys_platform == "darwin"
-freetype-py==2.3.0
-uharfbuzz==0.32.0
-glyphsLib==6.2.1 # this is only required to run Tests/varLib/interpolatable_test.py
-lxml==4.9.2
+ufoLib2==0.16.0
+ufo2ft==2.33.4
+pyobjc==10.0; sys_platform == "darwin"
+freetype-py==2.4.0
+uharfbuzz==0.37.3
+glyphsLib==6.4.0 # this is only required to run Tests/varLib/interpolatable_test.py
+lxml==4.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@
 brotli==1.0.9; platform_python_implementation != "PyPy"
 brotlicffi==1.0.9.2; platform_python_implementation == "PyPy"
 unicodedata2==15.0.0; python_version <= '3.11'
-scipy==1.10.0; platform_python_implementation != "PyPy"
+scipy==1.10.0; platform_python_implementation != "PyPy" and python_version <= '3.8'
+scipy==1.11.2; platform_python_implementation != "PyPy" and python_version >= '3.9'
 munkres==1.1.4; platform_python_implementation == "PyPy"
 zopfli==0.2.1
 fs==2.4.16

--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,7 @@ classifiers = {
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3",
         "Topic :: Text Processing :: Fonts",
         "Topic :: Multimedia :: Graphics",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.0
-envlist = lint, py3{8,9,10,11}-cov, htmlcov
+envlist = lint, py3{8,9,10,11,12}-cov, htmlcov
 skip_missing_interpreters=true
 
 [testenv]


### PR DESCRIPTION
The [third Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc3-released-honestly-the-final-release-candidate-i-swear/34093?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

Python 3.12.0 final is due out on Monday: [2023-10-02](https://peps.python.org/pep-0693/).

See also https://dev.to/hugovk/help-test-python-312-beta-1508/