### PR TITLE
Better OTL builder errors

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -844,10 +844,15 @@ class Builder(object):
                 feature=None,
             )
             lookups.append(lookup)
-        try:
-            otLookups = [l.build() for l in lookups]
-        except OpenTypeLibError as e:
-            raise FeatureLibError(str(e), e.location) from e
+        otLookups = []
+        for l in lookups:
+            try:
+                otLookups.append(l.build())
+            except OpenTypeLibError as e:
+                raise FeatureLibError(str(e), e.location) from e
+            except Exception as e:
+                location = self.lookup_locations[tag][str(l.lookup_index)].location
+                raise FeatureLibError(str(e), location) from e
         return otLookups
 
     def makeTable(self, tag):

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -55,7 +55,11 @@ def buildCoverage(glyphs, glyphMap):
     if not glyphs:
         return None
     self = ot.Coverage()
-    self.glyphs = sorted(set(glyphs), key=glyphMap.__getitem__)
+    try:
+        self.glyphs = sorted(set(glyphs), key=glyphMap.__getitem__)
+    except KeyError as e:
+        raise ValueError(f"Could not find glyph {e} in font")
+
     return self
 
 

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -58,7 +58,7 @@ def buildCoverage(glyphs, glyphMap):
     try:
         self.glyphs = sorted(set(glyphs), key=glyphMap.__getitem__)
     except KeyError as e:
-        raise ValueError(f"Could not find glyph {e} in font")
+        raise ValueError(f"Could not find glyph {e} in font") from e
 
     return self
 


### PR DESCRIPTION
I'm forever getting errors like this:

```
fontmake: Error: In 'master_ufo/Foo.designspace': Generating fonts from Designspace failed: 'j'
```

which are not informative. This is slightly more informative:

```
fontmake: Error: In 'master_ufo/Foo.designspace': Generating fonts from Designspace failed:
 master_ufo/Foo-Regular-18pt.ufo/features.fea:1865:5: Could not find glyph 'j' in font
```