### PR TITLE
bezierTools: fix incorrectly typed cython local variable

### DIFF
--- a/Lib/fontTools/misc/bezierTools.py
+++ b/Lib/fontTools/misc/bezierTools.py
@@ -141,7 +141,7 @@ def _dot(v1, v2):
 @cython.cfunc
 @cython.inline
 @cython.returns(cython.double)
-@cython.locals(x=cython.complex)
+@cython.locals(x=cython.double)
 def _intSecAtan(x):
     # In : sympy.integrate(sp.sec(sp.atan(x)))
     # Out: x*sqrt(x**2 + 1)/2 + asinh(x)/2

--- a/Tests/misc/bezierTools_test.py
+++ b/Tests/misc/bezierTools_test.py
@@ -1,6 +1,7 @@
 import fontTools.misc.bezierTools as bezierTools
 from fontTools.misc.bezierTools import (
     calcQuadraticBounds,
+    calcQuadraticArcLength,
     calcCubicBounds,
     curveLineIntersections,
     segmentPointAtT,
@@ -181,3 +182,10 @@ def test_intersections_straight_line():
     e = (110, 0)
     pt = (109.05194805194802, 0.0)
     assert bezierTools._line_t_of_pt(s, e, pt) == pytest.approx(0.98958184)
+
+
+def test_calcQuadraticArcLength():
+    # https://github.com/fonttools/fonttools/issues/3287
+    assert calcQuadraticArcLength(
+        (210, 333), (289, 333), (326.5, 290.5)
+    ) == pytest.approx(127.9225)


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/3287