### PR TITLE
Fix UnbouldLocalError and let {h,v}hea be no-op when no {v,h}mtx is present

### DIFF
--- a/Lib/fontTools/ttLib/tables/_h_h_e_a.py
+++ b/Lib/fontTools/ttLib/tables/_h_h_e_a.py
@@ -67,9 +67,11 @@ class table__h_h_e_a(DefaultTable.DefaultTable):
         return sstruct.pack(hheaFormat, self)
 
     def recalc(self, ttFont):
-        if "hmtx" in ttFont:
-            hmtxTable = ttFont["hmtx"]
-            self.advanceWidthMax = max(adv for adv, _ in hmtxTable.metrics.values())
+        if "hmtx" not in ttFont:
+            return
+
+        hmtxTable = ttFont["hmtx"]
+        self.advanceWidthMax = max(adv for adv, _ in hmtxTable.metrics.values())
 
         boundsWidthDict = {}
         if "glyf" in ttFont:

--- a/Lib/fontTools/ttLib/tables/_v_h_e_a.py
+++ b/Lib/fontTools/ttLib/tables/_v_h_e_a.py
@@ -50,9 +50,11 @@ class table__v_h_e_a(DefaultTable.DefaultTable):
         return sstruct.pack(vheaFormat, self)
 
     def recalc(self, ttFont):
-        if "vmtx" in ttFont:
-            vmtxTable = ttFont["vmtx"]
-            self.advanceHeightMax = max(adv for adv, _ in vmtxTable.metrics.values())
+        if "vmtx" not in ttFont:
+            return
+
+        vmtxTable = ttFont["vmtx"]
+        self.advanceHeightMax = max(adv for adv, _ in vmtxTable.metrics.values())
 
         boundsHeightDict = {}
         if "glyf" in ttFont:


### PR DESCRIPTION
I believe that was the spirit of this code, do have recalc() do nothing if the metrics tables are missing

Fixes https://github.com/fonttools/fonttools/issues/3289