### PR TITLE
[subset] fix another null-offset error in MarkLigPos

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -890,6 +890,8 @@ def prune_post_subset(self, font, options):
             if m.MarkAnchor:
                 m.MarkAnchor.prune_hints()
         for l in self.LigatureArray.LigatureAttach:
+            if l is None:
+              continue
             for c in l.ComponentRecord:
                 for a in c.LigatureAnchor:
                     if a:


### PR DESCRIPTION
Similar to this commit: https://github.com/fonttools/fonttools/commit/1d0f3c27fcefa4f3265afc04eebf10360a0eed0c