### PR TITLE
Support calculating OS/2.ulCodePageRange* bits

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -407,6 +407,10 @@ Other font-specific options
     *not* be switched on if an intersection is found.  [default]
 --no-prune-unicode-ranges
     Don't change the 'OS/2 ulUnicodeRange*' bits.
+--prune-codepage-ranges
+    Update the 'OS/2 ulCodePageRange*' bits after subsetting.  [default]
+--no-prune-codepage-ranges
+    Don't change the 'OS/2 ulCodePageRange*' bits.
 --recalc-average-width
     Update the 'OS/2 xAvgCharWidth' field after subsetting.
 --no-recalc-average-width
@@ -3086,6 +3090,7 @@ class Options(object):
         self.recalc_bounds = False  # Recalculate font bounding boxes
         self.recalc_timestamp = False  # Recalculate font modified timestamp
         self.prune_unicode_ranges = True  # Clear unused 'ulUnicodeRange' bits
+        self.prune_codepage_ranges = True  # Clear unused 'ulCodePageRange' bits
         self.recalc_average_width = False  # update 'xAvgCharWidth'
         self.recalc_max_context = False  # update 'usMaxContext'
         self.canonical_order = None  # Order tables as recommended
@@ -3449,6 +3454,15 @@ class Subsetter(object):
                     if old_uniranges != new_uniranges:
                         log.info(
                             "%s Unicode ranges pruned: %s", tag, sorted(new_uniranges)
+                        )
+                if self.options.prune_codepage_ranges:
+                    old_codepages = font[tag].getCodePageRanges()
+                    new_codepages = font[tag].recalcCodePageRanges(font, pruneOnly=True)
+                    if old_codepages != new_codepages:
+                        log.info(
+                            "%s CodePage ranges pruned: %s",
+                            tag,
+                            sorted(new_codepages),
                         )
                 if self.options.recalc_average_width:
                     old_avg_width = font[tag].xAvgCharWidth

--- a/Lib/fontTools/ttLib/tables/O_S_2f_2.py
+++ b/Lib/fontTools/ttLib/tables/O_S_2f_2.py
@@ -340,6 +340,45 @@ class table_O_S_2f_2(DefaultTable.DefaultTable):
         self.setUnicodeRanges(bits)
         return bits
 
+    def getCodePageRanges(self):
+        """Return the set of 'ulCodePageRange*' bits currently enabled."""
+        bits = set()
+        ul1, ul2 = self.ulCodePageRange1, self.ulCodePageRange2
+        for i in range(32):
+            if ul1 & (1 << i):
+                bits.add(i)
+            if ul2 & (1 << i):
+                bits.add(i + 32)
+        return bits
+
+    def setCodePageRanges(self, bits):
+        """Set the 'ulCodePageRange*' fields to the specified 'bits'."""
+        ul1, ul2 = 0, 0
+        for bit in bits:
+            if 0 <= bit < 32:
+                ul1 |= 1 << bit
+            elif 32 <= bit < 64:
+                ul2 |= 1 << (bit - 32)
+            else:
+                raise ValueError(f"expected 0 <= int <= 63, found: {bit:r}")
+        self.ulCodePageRange1, self.ulCodePageRange2 = ul1, ul2
+
+    def recalcCodePageRanges(self, ttFont, pruneOnly=False):
+        unicodes = set()
+        for table in ttFont["cmap"].tables:
+            if table.isUnicode():
+                unicodes.update(table.cmap.keys())
+        bits = calcCodePageRanges(unicodes)
+        if pruneOnly:
+            bits &= self.getCodePageRanges()
+        # when no codepage ranges can be enabled, fall back to enabling bit 0
+        # (Latin 1) so that the font works in MS Word:
+        # https://github.com/googlei18n/fontmake/issues/468
+        if not bits:
+            bits = {0}
+        self.setCodePageRanges(bits)
+        return bits
+
     def recalcAvgCharWidth(self, ttFont):
         """Recalculate xAvgCharWidth using metrics from ttFont's 'hmtx' table.
 
@@ -609,6 +648,92 @@ def intersectUnicodeRanges(unicodes, inverse=False):
     if any(0x10000 <= code < 0x110000 for code in unicodes):
         bits.add(57)
     return set(range(len(OS2_UNICODE_RANGES))) - bits if inverse else bits
+
+
+def calcCodePageRanges(unicodes):
+    """Given a set of Unicode codepoints (integers), calculate the
+    corresponding OS/2 CodePage range bits.
+    This is a direct translation of FontForge implementation:
+    https://github.com/fontforge/fontforge/blob/7b2c074/fontforge/tottf.c#L3158
+    """
+    bits = set()
+    hasAscii = set(range(0x20, 0x7E)).issubset(unicodes)
+    hasLineart = ord("┤") in unicodes
+
+    for uni in unicodes:
+        if uni == ord("Þ") and hasAscii:
+            bits.add(0)  # Latin 1
+        elif uni == ord("Ľ") and hasAscii:
+            bits.add(1)  # Latin 2: Eastern Europe
+            if hasLineart:
+                bits.add(58)  # Latin 2
+        elif uni == ord("Б"):
+            bits.add(2)  # Cyrillic
+            if ord("Ѕ") in unicodes and hasLineart:
+                bits.add(57)  # IBM Cyrillic
+            if ord("╜") in unicodes and hasLineart:
+                bits.add(49)  # MS-DOS Russian
+        elif uni == ord("Ά"):
+            bits.add(3)  # Greek
+            if hasLineart and ord("½") in unicodes:
+                bits.add(48)  # IBM Greek
+            if hasLineart and ord("√") in unicodes:
+                bits.add(60)  # Greek, former 437 G
+        elif uni == ord("İ") and hasAscii:
+            bits.add(4)  # Turkish
+            if hasLineart:
+                bits.add(56)  # IBM turkish
+        elif uni == ord("א"):
+            bits.add(5)  # Hebrew
+            if hasLineart and ord("√") in unicodes:
+                bits.add(53)  # Hebrew
+        elif uni == ord("ر"):
+            bits.add(6)  # Arabic
+            if ord("√") in unicodes:
+                bits.add(51)  # Arabic
+            if hasLineart:
+                bits.add(61)  # Arabic; ASMO 708
+        elif uni == ord("ŗ") and hasAscii:
+            bits.add(7)  # Windows Baltic
+            if hasLineart:
+                bits.add(59)  # MS-DOS Baltic
+        elif uni == ord("₫") and hasAscii:
+            bits.add(8)  # Vietnamese
+        elif uni == ord("ๅ"):
+            bits.add(16)  # Thai
+        elif uni == ord("エ"):
+            bits.add(17)  # JIS/Japan
+        elif uni == ord("ㄅ"):
+            bits.add(18)  # Chinese: Simplified
+        elif uni == ord("ㄱ"):
+            bits.add(19)  # Korean wansung
+        elif uni == ord("央"):
+            bits.add(20)  # Chinese: Traditional
+        elif uni == ord("곴"):
+            bits.add(21)  # Korean Johab
+        elif uni == ord("♥") and hasAscii:
+            bits.add(30)  # OEM Character Set
+        # TODO: Symbol bit has a special meaning (check the spec), we need
+        # to confirm if this is wanted by default.
+        # elif chr(0xF000) <= char <= chr(0xF0FF):
+        #    codepageRanges.add(31)          # Symbol Character Set
+        elif uni == ord("þ") and hasAscii and hasLineart:
+            bits.add(54)  # MS-DOS Icelandic
+        elif uni == ord("╚") and hasAscii:
+            bits.add(62)  # WE/Latin 1
+            bits.add(63)  # US
+        elif hasAscii and hasLineart and ord("√") in unicodes:
+            if uni == ord("Å"):
+                bits.add(50)  # MS-DOS Nordic
+            elif uni == ord("é"):
+                bits.add(52)  # MS-DOS Canadian French
+            elif uni == ord("õ"):
+                bits.add(55)  # MS-DOS Portuguese
+
+    if hasAscii and ord("‰") in unicodes and ord("∑") in unicodes:
+        bits.add(29)  # Macintosh Character Set (US Roman)
+
+    return bits
 
 
 if __name__ == "__main__":

--- a/Tests/subset/data/NotoSansCJKjp-Regular.subset.ttx
+++ b/Tests/subset/data/NotoSansCJKjp-Regular.subset.ttx
@@ -98,7 +98,7 @@
     <sTypoLineGap value="0"/>
     <usWinAscent value="1160"/>
     <usWinDescent value="288"/>
-    <ulCodePageRange1 value="01100000 00101110 00000001 00000111"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
     <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
     <sxHeight value="543"/>
     <sCapHeight value="733"/>

--- a/Tests/subset/data/TestContextSubstFormat3.ttx
+++ b/Tests/subset/data/TestContextSubstFormat3.ttx
@@ -117,8 +117,8 @@
     <sTypoLineGap value="0"/>
     <usWinAscent value="977"/>
     <usWinDescent value="272"/>
-    <ulCodePageRange1 value="00100000 00000000 00000001 00011111"/>
-    <ulCodePageRange2 value="11000100 00000000 00000000 00000000"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
     <sxHeight value="530"/>
     <sCapHeight value="735"/>
     <usDefaultChar value="0"/>


### PR DESCRIPTION
Based on https://github.com/googlefonts/ufo2ft/blob/efb4658890ba645292a9c6bc055c91afe225c4a1/Lib/ufo2ft/util.py#L357.