### PR TITLE
Support Glyphs App “standalone” lookups

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -428,18 +428,22 @@ class NestedBlock(Block):
 class LookupBlock(Block):
     """A named lookup, containing ``statements``."""
 
-    def __init__(self, name, use_extension=False, location=None):
+    def __init__(self, name, use_extension=False, location=None, standalone=False):
         Block.__init__(self, location)
         self.name, self.use_extension = name, use_extension
+        self.standalone = standalone
 
     def build(self, builder):
         # TODO(sascha): Handle use_extension.
-        builder.start_lookup_block(self.location, self.name)
+        builder.start_lookup_block(self.location, self.name, standalone=self.standalone)
         Block.build(self, builder)
         builder.end_lookup_block()
 
     def asFea(self, indent=""):
-        res = "lookup {} ".format(self.name)
+        res = ""
+        if self.standalone:
+            res += "standalone "
+        res += "lookup {} ".format(self.name)
         if self.use_extension:
             res += "useExtension "
         res += "{\n"

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -131,6 +131,7 @@ class Builder(object):
         self.named_lookups_ = {}
         self.cur_lookup_ = None
         self.cur_lookup_name_ = None
+        self.cur_lookup_is_standalone = False
         self.cur_feature_name_ = None
         self.lookups_ = []
         self.lookup_locations = {"GSUB": {}, "GPOS": {}}
@@ -276,7 +277,7 @@ class Builder(object):
         if self.cur_lookup_name_:
             # We are starting a lookup rule inside a named lookup block.
             self.named_lookups_[self.cur_lookup_name_] = self.cur_lookup_
-        if self.cur_feature_name_:
+        if self.cur_feature_name_ and not self.cur_lookup_is_standalone:
             # We are starting a lookup rule inside a feature. This includes
             # lookup rules inside named lookups inside features.
             self.add_lookup_to_feature_(self.cur_lookup_, self.cur_feature_name_)
@@ -1043,7 +1044,7 @@ class Builder(object):
         self.lookupflag_ = 0
         self.lookupflag_markFilterSet_ = None
 
-    def start_lookup_block(self, location, name):
+    def start_lookup_block(self, location, name, standalone=False):
         if name in self.named_lookups_:
             raise FeatureLibError(
                 'Lookup "%s" has already been defined' % name, location
@@ -1057,6 +1058,7 @@ class Builder(object):
         self.cur_lookup_name_ = name
         self.named_lookups_[name] = None
         self.cur_lookup_ = None
+        self.cur_lookup_is_standalone = standalone
         if self.cur_feature_name_ is None:
             self.lookupflag_ = 0
             self.lookupflag_markFilterSet_ = None
@@ -1065,6 +1067,7 @@ class Builder(object):
         assert self.cur_lookup_name_ is not None
         self.cur_lookup_name_ = None
         self.cur_lookup_ = None
+        self.cur_lookup_is_standalone = False
         if self.cur_feature_name_ is None:
             self.lookupflag_ = 0
             self.lookupflag_markFilterSet_ = None

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -98,6 +98,9 @@ class Parser(object):
                 statements.append(self.parse_languagesystem_())
             elif self.is_cur_keyword_("lookup"):
                 statements.append(self.parse_lookup_(vertical=False))
+            elif self.is_cur_keyword_("standalone"):
+                self.expect_keyword_("lookup")
+                statements.append(self.parse_lookup_(vertical=False, standalone=True))
             elif self.is_cur_keyword_("markClass"):
                 statements.append(self.parse_markClass_())
             elif self.is_cur_keyword_("feature"):
@@ -608,7 +611,7 @@ class Parser(object):
         self.expect_symbol_(";")
         return self.ast.LigatureCaretByPosStatement(glyphs, carets, location=location)
 
-    def parse_lookup_(self, vertical):
+    def parse_lookup_(self, vertical, standalone=False):
         # Parses a ``lookup`` - either a lookup block, or a lookup reference
         # inside a feature.
         assert self.is_cur_keyword_("lookup")
@@ -628,7 +631,9 @@ class Parser(object):
             self.expect_keyword_("useExtension")
             use_extension = True
 
-        block = self.ast.LookupBlock(name, use_extension, location=location)
+        block = self.ast.LookupBlock(
+            name, use_extension, location=location, standalone=standalone
+        )
         self.parse_block_(block, vertical)
         self.lookups_.define(name, block)
         return block
@@ -1954,6 +1959,9 @@ class Parser(object):
                 statements.append(self.parse_language_())
             elif self.is_cur_keyword_("lookup"):
                 statements.append(self.parse_lookup_(vertical))
+            elif self.is_cur_keyword_("standalone"):
+                self.expect_keyword_("lookup")
+                statements.append(self.parse_lookup_(vertical, standalone=True))
             elif self.is_cur_keyword_("lookupflag"):
                 statements.append(self.parse_lookupflag_())
             elif self.is_cur_keyword_("markClass"):

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -81,7 +81,7 @@ class BuilderTest(unittest.TestCase):
         MultipleLookupsPerGlyph MultipleLookupsPerGlyph2 GSUB_6_formats
         GSUB_5_formats delete_glyph STAT_test STAT_test_elidedFallbackNameID
         variable_scalar_valuerecord variable_scalar_anchor variable_conditionset
-        variable_mark_anchor
+        variable_mark_anchor standalone_lookup
     """.split()
 
     VARFONT_AXES = [

--- a/Tests/feaLib/data/standalone_lookup.fea
+++ b/Tests/feaLib/data/standalone_lookup.fea
@@ -1,0 +1,16 @@
+standalone lookup test_1 {
+  sub a by b;
+} test_1;
+
+feature test {
+  lookup test_2 {
+    sub a by c;
+  } test_2;
+
+  standalone lookup test_3 {
+    sub c by d;
+  } test_3;
+
+  sub a' lookup test_1 x;
+  sub c' lookup test_3 x;
+} test;

--- a/Tests/feaLib/data/standalone_lookup.ttx
+++ b/Tests/feaLib/data/standalone_lookup.ttx
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=2 -->
+          <LookupListIndex index="0" value="1"/>
+          <LookupListIndex index="1" value="3"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=4 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="b"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="c"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="c" out="d"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="1">
+          <Coverage>
+            <Glyph value="a"/>
+            <Glyph value="c"/>
+          </Coverage>
+          <!-- ChainSubRuleSetCount=2 -->
+          <ChainSubRuleSet index="0">
+            <!-- ChainSubRuleCount=1 -->
+            <ChainSubRule index="0">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="x"/>
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="0"/>
+              </SubstLookupRecord>
+            </ChainSubRule>
+          </ChainSubRuleSet>
+          <ChainSubRuleSet index="1">
+            <!-- ChainSubRuleCount=1 -->
+            <ChainSubRule index="0">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="x"/>
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="2"/>
+              </SubstLookupRecord>
+            </ChainSubRule>
+          </ChainSubRuleSet>
+        </ChainContextSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
A Glyphs App extension that allows defining lookups inside feature blocks without referencing them (i.e. as if the lookup was defined outside of the feature block).

https://handbook.glyphsapp.com/en/layout/standalone-lookups/