### PR TITLE
[interpolatable] Return master indices in addition to master names

### DIFF
--- a/Lib/fontTools/varLib/interpolatablePlot.py
+++ b/Lib/fontTools/varLib/interpolatablePlot.py
@@ -148,7 +148,9 @@ class InterpolatablePlot:
             current_glyph_problems = []
             for p in glyph_problems:
                 masters = (
-                    p["master"] if "master" in p else (p["master_1"], p["master_2"])
+                    p["master_idx"]
+                    if "master_idx" in p
+                    else (p["master_1_idx"], p["master_2_idx"])
                 )
                 if masters == last_masters:
                     current_glyph_problems.append(p)
@@ -176,10 +178,11 @@ class InterpolatablePlot:
         log.info("Drawing %s: %s", glyphname, problem_type)
 
         master_keys = (
-            ("master",) if "master" in problems[0] else ("master_1", "master_2")
+            ("master_idx",)
+            if "master_idx" in problems[0]
+            else ("master_1_idx", "master_2_idx")
         )
-        master_names = [problems[0][k] for k in master_keys]
-        master_indices = [self.names.index(n) for n in master_names]
+        master_indices = [problems[0][k] for k in master_keys]
 
         if problem_type == "missing":
             sample_glyph = next(

--- a/Tests/varLib/interpolatable_test.py
+++ b/Tests/varLib/interpolatable_test.py
@@ -136,18 +136,20 @@ class InterpolatableTest(unittest.TestCase):
         # without --ignore-missing
         problems = interpolatable_main(["--quiet"] + ttf_paths)
         self.assertEqual(
-            problems["a"], [{"type": "missing", "master": "SparseMasters-Medium"}]
+            problems["a"],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
-            problems["s"], [{"type": "missing", "master": "SparseMasters-Medium"}]
+            problems["s"],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
             problems["edotabove"],
-            [{"type": "missing", "master": "SparseMasters-Medium"}],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
             problems["dotabovecomb"],
-            [{"type": "missing", "master": "SparseMasters-Medium"}],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
 
         # normal order, with --ignore-missing
@@ -172,18 +174,20 @@ class InterpolatableTest(unittest.TestCase):
         # without --ignore-missing
         problems = interpolatable_main(["--quiet"] + ufo_paths)
         self.assertEqual(
-            problems["a"], [{"type": "missing", "master": "SparseMasters-Medium"}]
+            problems["a"],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
-            problems["s"], [{"type": "missing", "master": "SparseMasters-Medium"}]
+            problems["s"],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
             problems["edotabove"],
-            [{"type": "missing", "master": "SparseMasters-Medium"}],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
             problems["dotabovecomb"],
-            [{"type": "missing", "master": "SparseMasters-Medium"}],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
 
         # normal order, with --ignore-missing
@@ -206,18 +210,20 @@ class InterpolatableTest(unittest.TestCase):
 
         problems = interpolatable_main(["--quiet", designspace_path])
         self.assertEqual(
-            problems["a"], [{"type": "missing", "master": "SparseMasters-Medium"}]
+            problems["a"],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
-            problems["s"], [{"type": "missing", "master": "SparseMasters-Medium"}]
+            problems["s"],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
             problems["edotabove"],
-            [{"type": "missing", "master": "SparseMasters-Medium"}],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
             problems["dotabovecomb"],
-            [{"type": "missing", "master": "SparseMasters-Medium"}],
+            [{"type": "missing", "master": "SparseMasters-Medium", "master_idx": 1}],
         )
 
         # normal order, with --ignore-missing
@@ -229,18 +235,20 @@ class InterpolatableTest(unittest.TestCase):
 
         problems = interpolatable_main(["--quiet", glyphsapp_path])
         self.assertEqual(
-            problems["a"], [{"type": "missing", "master": "Sparse Masters-Medium"}]
+            problems["a"],
+            [{"type": "missing", "master": "Sparse Masters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
-            problems["s"], [{"type": "missing", "master": "Sparse Masters-Medium"}]
+            problems["s"],
+            [{"type": "missing", "master": "Sparse Masters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
             problems["edotabove"],
-            [{"type": "missing", "master": "Sparse Masters-Medium"}],
+            [{"type": "missing", "master": "Sparse Masters-Medium", "master_idx": 1}],
         )
         self.assertEqual(
             problems["dotabovecomb"],
-            [{"type": "missing", "master": "Sparse Masters-Medium"}],
+            [{"type": "missing", "master": "Sparse Masters-Medium", "master_idx": 1}],
         )
 
         # normal order, with --ignore-missing

--- a/Tests/varLib/interpolatable_test.py
+++ b/Tests/varLib/interpolatable_test.py
@@ -47,7 +47,7 @@ class InterpolatableTest(unittest.TestCase):
         for p in all_files:
             if p.startswith(prefix) and p.endswith(suffix):
                 file_list.append(os.path.abspath(os.path.join(folder, p)))
-        return file_list
+        return sorted(file_list)
 
     def temp_path(self, suffix):
         self.temp_dir()


### PR DESCRIPTION
Using names to refer to masters is weird. Return the index and the user can look up the name.

This changes the API in two ways:
- `test` and `test_gen` do not accept a `names` parameter anymore. If needed I can put it back there unused.
- `master`, `master1`, `master2` in the problem reports are now indices, not names. If this is undesirable, I can add separate `master_idx`, `master1_idx`, `master2_idx` instead. Maybe that's better.