### PR TITLE
[ttGlyphSet] Add option to not recalculate glyf bounds

### DIFF
--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -735,7 +735,9 @@ class TTFont(object):
         else:
             raise KeyError(tag)
 
-    def getGlyphSet(self, preferCFF=True, location=None, normalized=False):
+    def getGlyphSet(
+        self, preferCFF=True, location=None, normalized=False, recalcBounds=True
+    ):
         """Return a generic GlyphSet, which is a dict-like object
         mapping glyph names to glyph objects. The returned glyph objects
         have a ``.draw()`` method that supports the Pen protocol, and will
@@ -766,7 +768,7 @@ class TTFont(object):
         if ("CFF " in self or "CFF2" in self) and (preferCFF or "glyf" not in self):
             return _TTGlyphSetCFF(self, location)
         elif "glyf" in self:
-            return _TTGlyphSetGlyf(self, location)
+            return _TTGlyphSetGlyf(self, location, recalcBounds=recalcBounds)
         else:
             raise TTLibError("Font contains no outlines")
 

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -876,7 +876,7 @@ def main(args=None):
                         locTuple = tuple(loc)
                         if locTuple not in ttGlyphSets:
                             ttGlyphSets[locTuple] = font.getGlyphSet(
-                                location=locDict, normalized=True
+                                location=locDict, normalized=True, recalcBounds=False
                             )
 
                         recursivelyAddGlyph(


### PR DESCRIPTION
Avoids unnecessary work in the interpolator.

What do you think?