### PR TITLE
Add `public.fontInfo` to designSpaceLib specification

### DIFF
--- a/Doc/source/designspaceLib/index.rst
+++ b/Doc/source/designspaceLib/index.rst
@@ -120,6 +120,34 @@ any of the UFOs. If the lib key is empty or not present in the Designspace, all
 glyphs should be exported, regardless of what the same lib key in any of the
 UFOs says.
 
+public.fontInfo
+-----------------------
+
+This lib key, when included in the ``<lib>`` element inside an ``<instance>`` or 
+``<variable-font>`` tag, allows for direct manipulation of font info data in 
+instances and variable fonts. The lib value should follow the 
+`UFO3 fontinfo.plist specification <https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/>`_,
+and should functionally appear to be a property list dictionary with the same 
+structure as the ``fontinfo.plist`` file in a UFO.
+
+
+All font info items in the UFO fontinfo.plist specification should be able to 
+be defined in the ``public.fontInfo`` lib. Checking validity of the data using 
+``fontTools.ufoLib.validators`` is recommended but not required. 
+
+A tool generating the font should copy the font info directly from the 
+``public.fontInfo`` lib item to the instance or the variable font, superceding 
+all other settings. All info **not** supplied in ``public.fontInfo`` should be 
+inherited from the name attributes in the ``<instance>`` or ``<variable-font>`` 
+elements (first) and the UFO font info from the source at the origin (second). 
+Absence of a key from the ``public.fontInfo`` lib does **not** mean a that piece 
+of font info should be interpreted as being undefined unless it is also left 
+undefined in the other locations. In the case of information in ``public.fontInfo`` 
+conflicting with supplied name strings in the ``<instance>`` or ``<variable-font>`` 
+elements, or the info supplied from the source at the origin, the data in 
+``public.fontInfo`` should supercede that information because it is understood 
+that the designer is using ``public.fontInfo`` to gain more granular control 
+over the resulting font. 
 
 Implementation and differences
 ==============================

--- a/Doc/source/designspaceLib/xml.rst
+++ b/Doc/source/designspaceLib/xml.rst
@@ -790,7 +790,7 @@ The ``<variable-fonts>`` element contains one or more ``<variable-font>`` elemen
      but the design space is sliced at the given location. *Note:* While valid to have a
      specific value that doesn’t have a matching ``<source>`` at that value, currently there
      isn’t an implentation that supports this. See `this fontmake issue
-     <https://github.com/googlefonts/fontmake/issues/920>`.
+     <https://github.com/googlefonts/fontmake/issues/920>`_.
 
      .. code:: xml
 
@@ -841,6 +841,38 @@ Arbitrary data about this variable font.
 .. versionadded:: 5.0
 
 .. seealso:: :ref:`lib`
+
+Here is an example of using the ``public.fontInfo`` lib key to gain more granular
+control over the font info of a variable font, in this case setting some names to
+reflect the fact that this is a Narrow variable font subset from the larger designspace. 
+This lib key allows font info in variable fonts to be more specific than the font 
+info of the sources.
+
+.. rubric:: Example
+
+.. code:: xml
+
+    <variable-font name="MyFontNarrVF">
+      <axis-subsets>
+        <axis-subset name="Weight"/>
+        <axis-subset name="Width" uservalue="75"/>
+      </axis-subsets>
+      <lib>
+        <dict>
+          <key>public.fontInfo</key>
+          <dict>
+            <key>familyName</key>
+            <string>My Font Narrow VF</string>
+            <key>styleName</key>
+            <string>Regular</string>
+            <key>postscriptFontName</key>
+            <integer>MyFontNarrVF-Regular</integer>
+            <key>trademark</key>
+            <integer>My Font Narrow VF is a registered trademark...</integer>
+          </dict>
+        </dict>
+      </lib>
+    </variable-font>
 
 
 Instances included in the variable font
@@ -989,6 +1021,57 @@ instance directly.
         </instances>
     </designspace>
 
+Here is an example of using the ``public.fontInfo`` lib key to gain more granular
+control over the font info of the instances. 
+
+``openTypeNameWWSFamilyName`` and ``openTypeNameWWSSubfamilyName`` are not able to 
+be set by attributes on the ``<instance>`` element. The ``openTypeOS2WeightClass`` 
+key is superceding the value that would have been set by the ``weight`` axis value. 
+The ``trademark`` key is superceding the value that would have been set by UFO source 
+at the origin. If the designer wishes to set name records for other encodings, 
+platforms or laguages, they should do so using the ``openTypeNameRecords`` key, like 
+they would in a UFO source.
+
+See `UFO3 fontinfo.plist specification <https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/>`_.
+
+.. code:: xml
+
+    <instance familyname="My Font" stylename="Text Light" filename="instances/MyFont-TextLight.ufo" postscriptfontname="MyFont-TextLight" stylemapfamilyname="My Font Text Light" stylemapstylename="regular">
+        <location>
+            <dimension name="optical" xvalue="6"/>
+            <dimension name="weight" xvalue="325"/>
+        </location>
+        <lib>
+            <dict>
+                <key>public.fontInfo</key>
+                <dict>
+                    <key>openTypeNameWWSFamilyName</key>
+                    <string>My Font Text</string>
+                    <key>openTypeNameWWSSubfamilyName</key>
+                    <string>Light</string>
+                    <key>openTypeOS2WeightClass</key>
+                    <integer>300</integer>
+                    <key>trademark</key>
+                    <string>My Font Text Light is a registered trademark...</string>
+                    <key>openTypeNameRecords</key>
+                    <array>
+                        <dict>
+                            <key>encodingID</key>
+                            <integer>1</integer>
+                            <key>languageID</key>
+                            <integer>1031</integer>
+                            <key>nameID</key>
+                            <integer>7</integer>
+                            <key>platformID</key>
+                            <integer>3</integer>
+                            <key>string</key>
+                            <string>Meine Schrift Text Leicht ist eine registrierte Marke...</string>
+                        </dict>
+                    </array>
+                </dict>
+            </dict>
+        </lib>
+    </instance>
 
 ``<glyphs>`` element (instance)
 -------------------------------


### PR DESCRIPTION
Fixes #2608, Fixes #2606, and Fixes #3272.

This PR was [requested](https://github.com/fonttools/fonttools/issues/2608#issuecomment-1820571580) by @belluzj.

This PR adds the proposed `public.fontInfo` lib item to the `designSpaceLib` specification, with examples as discussed in #2608.

@belluzj @khaledhosny @anthrotype I very much welcome a review and feedback. This is my first time contributing to the designSpaceLib specification and I'm sure I got something wrong here or there. I really believe in the power and flexibility this lib item could provide if it is supported by build tools, so I tried to be as specific as possible in its description.

Thanks!
