### PR TITLE
Merge tool improvements

### DIFF
--- a/Lib/fontTools/merge/__init__.py
+++ b/Lib/fontTools/merge/__init__.py
@@ -181,17 +181,13 @@ def main(args=None):
         args = sys.argv[1:]
 
     options = Options()
-    args = options.parse_opts(args, ignore_unknown=["output-file"])
-    outfile = "merged.ttf"
+    args = options.parse_opts(args)
     fontfiles = []
     for g in args:
-        if g.startswith("--output-file="):
-            outfile = g[14:]
-            continue
         fontfiles.append(g)
 
     if len(args) < 1:
-        print("usage: pyftmerge font...", file=sys.stderr)
+        print("usage: pyftmerge font... [--output-file=merged.ttf]", file=sys.stderr)
         return 1
 
     configLogger(level=logging.INFO if options.verbose else logging.WARNING)
@@ -203,7 +199,7 @@ def main(args=None):
     merger = Merger(options=options)
     font = merger.merge(fontfiles)
     with timer("compile and save font"):
-        font.save(outfile)
+        font.save(options.output_file)
 
 
 if __name__ == "__main__":

--- a/Lib/fontTools/merge/__init__.py
+++ b/Lib/fontTools/merge/__init__.py
@@ -202,6 +202,10 @@ def main(args=None):
 
     merger = Merger(options=options)
     font = merger.merge(fontfiles)
+    
+    if (options.import_file):
+        font.importXML(options.import_file)
+
     with timer("compile and save font"):
         font.save(options.output_file)
 

--- a/Lib/fontTools/merge/__init__.py
+++ b/Lib/fontTools/merge/__init__.py
@@ -139,6 +139,7 @@ class Merger(object):
             *(vars(table).keys() for table in tables if table is not NotImplemented),
         )
         for key in allKeys:
+            log.info(" %s", key)
             try:
                 mergeLogic = logic[key]
             except KeyError:

--- a/Lib/fontTools/merge/__init__.py
+++ b/Lib/fontTools/merge/__init__.py
@@ -190,7 +190,7 @@ def main(args=None):
         fontfiles.append(g)
     
     if len(fontfiles) < 1:
-        print("usage: pyftmerge font... [--output-file=merged.ttf]", file=sys.stderr)
+        print("usage: pyftmerge [--input-file=filelist.txt] font... [--output-file=merged.ttf] [--drop-tables=GDEF,head] [--verbose] [--timing]", file=sys.stderr)
         return 1
 
     configLogger(level=logging.INFO if options.verbose else logging.WARNING)

--- a/Lib/fontTools/merge/__init__.py
+++ b/Lib/fontTools/merge/__init__.py
@@ -191,7 +191,16 @@ def main(args=None):
         fontfiles.append(g)
     
     if len(fontfiles) < 1:
-        print("usage: pyftmerge [--input-file=filelist.txt] font... [--output-file=merged.ttf] [--drop-tables=GDEF,head] [--verbose] [--timing]", file=sys.stderr)
+        print("usage: pyftmerge [font1 ... fontN] [--input-file=filelist.txt] [--output-file=merged.ttf] [--import-file=tables.ttx]", file=sys.stderr)
+        print("                                   [--drop-tables=tags] [--verbose] [--timing]", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(" font1 ... fontN              Files to merge.", file=sys.stderr)
+        print(" --input-file=<filename>      Read files to merge from a text file, each path new line. # Comment lines allowed.", file=sys.stderr)
+        print(" --output-file=<filename>     Specify output file name (default: merged.ttf).", file=sys.stderr)
+        print(" --import-file=<filename>     TTX file to import after merging. This can be used to set metadata.", file=sys.stderr)
+        print(" --drop-tables=<table tags>   Comma separated list of table tags to skip, case sensitive.", file=sys.stderr)
+        print(" --verbose                    Output progress information.", file=sys.stderr)
+        print(" --timing                     Output progress timing.", file=sys.stderr)
         return 1
 
     configLogger(level=logging.INFO if options.verbose else logging.WARNING)

--- a/Lib/fontTools/merge/__init__.py
+++ b/Lib/fontTools/merge/__init__.py
@@ -186,20 +186,45 @@ def main(args=None):
     fontfiles = []
     if options.input_file:
         with open(options.input_file) as inputfile:
-            fontfiles = [line.strip() for line in inputfile.readlines() if not line.lstrip().startswith("#")]
+            fontfiles = [
+                line.strip()
+                for line in inputfile.readlines()
+                if not line.lstrip().startswith("#")
+            ]
     for g in args:
         fontfiles.append(g)
-    
+
     if len(fontfiles) < 1:
-        print("usage: pyftmerge [font1 ... fontN] [--input-file=filelist.txt] [--output-file=merged.ttf] [--import-file=tables.ttx]", file=sys.stderr)
-        print("                                   [--drop-tables=tags] [--verbose] [--timing]", file=sys.stderr)
+        print(
+            "usage: pyftmerge [font1 ... fontN] [--input-file=filelist.txt] [--output-file=merged.ttf] [--import-file=tables.ttx]",
+            file=sys.stderr,
+        )
+        print(
+            "                                   [--drop-tables=tags] [--verbose] [--timing]",
+            file=sys.stderr,
+        )
         print("", file=sys.stderr)
         print(" font1 ... fontN              Files to merge.", file=sys.stderr)
-        print(" --input-file=<filename>      Read files to merge from a text file, each path new line. # Comment lines allowed.", file=sys.stderr)
-        print(" --output-file=<filename>     Specify output file name (default: merged.ttf).", file=sys.stderr)
-        print(" --import-file=<filename>     TTX file to import after merging. This can be used to set metadata.", file=sys.stderr)
-        print(" --drop-tables=<table tags>   Comma separated list of table tags to skip, case sensitive.", file=sys.stderr)
-        print(" --verbose                    Output progress information.", file=sys.stderr)
+        print(
+            " --input-file=<filename>      Read files to merge from a text file, each path new line. # Comment lines allowed.",
+            file=sys.stderr,
+        )
+        print(
+            " --output-file=<filename>     Specify output file name (default: merged.ttf).",
+            file=sys.stderr,
+        )
+        print(
+            " --import-file=<filename>     TTX file to import after merging. This can be used to set metadata.",
+            file=sys.stderr,
+        )
+        print(
+            " --drop-tables=<table tags>   Comma separated list of table tags to skip, case sensitive.",
+            file=sys.stderr,
+        )
+        print(
+            " --verbose                    Output progress information.",
+            file=sys.stderr,
+        )
         print(" --timing                     Output progress timing.", file=sys.stderr)
         return 1
 
@@ -211,8 +236,8 @@ def main(args=None):
 
     merger = Merger(options=options)
     font = merger.merge(fontfiles)
-    
-    if (options.import_file):
+
+    if options.import_file:
         font.importXML(options.import_file)
 
     with timer("compile and save font"):

--- a/Lib/fontTools/merge/__init__.py
+++ b/Lib/fontTools/merge/__init__.py
@@ -183,10 +183,13 @@ def main(args=None):
     options = Options()
     args = options.parse_opts(args)
     fontfiles = []
+    if options.input_file:
+        with open(options.input_file) as inputfile:
+            fontfiles = [line.strip() for line in inputfile.readlines() if not line.lstrip().startswith("#")]
     for g in args:
         fontfiles.append(g)
-
-    if len(args) < 1:
+    
+    if len(fontfiles) < 1:
         print("usage: pyftmerge font... [--output-file=merged.ttf]", file=sys.stderr)
         return 1
 

--- a/Lib/fontTools/merge/options.py
+++ b/Lib/fontTools/merge/options.py
@@ -11,6 +11,7 @@ class Options(object):
         self.verbose = False
         self.timing = False
         self.drop_tables = []
+        self.input_file = None
         self.output_file = "merged.ttf"
 
         self.set(**kwargs)

--- a/Lib/fontTools/merge/options.py
+++ b/Lib/fontTools/merge/options.py
@@ -13,6 +13,7 @@ class Options(object):
         self.drop_tables = []
         self.input_file = None
         self.output_file = "merged.ttf"
+        self.import_file = None
 
         self.set(**kwargs)
 

--- a/Lib/fontTools/merge/options.py
+++ b/Lib/fontTools/merge/options.py
@@ -11,6 +11,7 @@ class Options(object):
         self.verbose = False
         self.timing = False
         self.drop_tables = []
+        self.output_file = "merged.ttf"
 
         self.set(**kwargs)
 


### PR DESCRIPTION
- proper usage help
- print key names during merging when `--verbose` (so that failing fields of tables can be identified)

New options:
- `--input-file` to read file names from file instead of command line
- `--output-file` moved from `main` to `Options`
- `--import-file` to import TTX after merge

