### PR TITLE
[CI] adapt to new upload/download-artifact changes 

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -110,7 +110,7 @@ jobs:
     # only run if the commit is tagged...
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: artifact
         path: dist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build source distribution and pure-python wheel
       run: |
         python setup.py sdist bdist_wheel
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: |
           dist/*.whl
@@ -70,7 +70,7 @@ jobs:
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_ARCHS: ${{ matrix.arch }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
 
@@ -96,7 +96,7 @@ jobs:
       env:
         CIBW_BUILD: cp${{ matrix.python }}-*
         CIBW_ARCHS: ${{ matrix.arch }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,6 +34,7 @@ jobs:
         python setup.py sdist bdist_wheel
     - uses: actions/upload-artifact@v4
       with:
+        name: pure
         path: |
           dist/*.whl
           dist/*.tar.gz
@@ -72,6 +73,7 @@ jobs:
         CIBW_ARCHS: ${{ matrix.arch }}
     - uses: actions/upload-artifact@v4
       with:
+        name: wheels
         path: wheelhouse/*.whl
 
   build_arch_wheels:
@@ -98,6 +100,7 @@ jobs:
         CIBW_ARCHS: ${{ matrix.arch }}
     - uses: actions/upload-artifact@v4
       with:
+        name: aarch64-wheels
         path: wheelhouse/*.whl
 
   deploy:
@@ -112,7 +115,8 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: artifact
+        # so that all artifacts are downloaded in the same directory specified by 'path'
+        merge-multiple: true
         path: dist
     - uses: pypa/gh-action-pypi-publish@v1.8.11
       with:


### PR DESCRIPTION
https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

> Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

This caused the PyPI upload job to fail earlier. Hopefully this should fix it.