### PR TITLE
feaLib: Drop glyph and class names length limit

### DIFF
--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -111,10 +111,6 @@ class Lexer(object):
             glyphclass = text[start + 1 : self.pos_]
             if len(glyphclass) < 1:
                 raise FeatureLibError("Expected glyph class name", location)
-            if len(glyphclass) > 63:
-                raise FeatureLibError(
-                    "Glyph class names must not be longer than 63 characters", location
-                )
             if not Lexer.RE_GLYPHCLASS.match(glyphclass):
                 raise FeatureLibError(
                     "Glyph class names must consist of letters, digits, "

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -2071,13 +2071,7 @@ class Parser(object):
     def expect_glyph_(self):
         self.advance_lexer_()
         if self.cur_token_type_ is Lexer.NAME:
-            self.cur_token_ = self.cur_token_.lstrip("\\")
-            if len(self.cur_token_) > 63:
-                raise FeatureLibError(
-                    "Glyph names must not be longer than 63 characters",
-                    self.cur_token_location_,
-                )
-            return self.cur_token_
+            return self.cur_token_.lstrip("\\")
         elif self.cur_token_type_ is Lexer.CID:
             return "cid%05d" % self.cur_token_
         raise FeatureLibError("Expected a glyph name or CID", self.cur_token_location_)

--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -41,9 +41,7 @@ class LexerTest(unittest.TestCase):
         self.assertEqual(lex("@Vowel-sc"), [(Lexer.GLYPHCLASS, "Vowel-sc")])
         self.assertRaisesRegex(FeatureLibError, "Expected glyph class", lex, "@(a)")
         self.assertRaisesRegex(FeatureLibError, "Expected glyph class", lex, "@ A")
-        self.assertRaisesRegex(
-            FeatureLibError, "not be longer than 63 characters", lex, "@" + ("A" * 64)
-        )
+        self.assertEqual(lex("@" + ("A" * 600)), [(Lexer.GLYPHCLASS, "A" * 600)])
         self.assertRaisesRegex(
             FeatureLibError, "Glyph class names must consist of", lex, "@Ab:c"
         )

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -54,6 +54,7 @@ GLYPHNAMES = (
 """
     ).split()
     + ["foo.%d" % i for i in range(1, 200)]
+    + ["G" * 600]
 )
 
 
@@ -327,12 +328,10 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(gc.glyphSet(), ("endash", "emdash", "figuredash"))
 
     def test_glyphclass_glyphNameTooLong(self):
-        self.assertRaisesRegex(
-            FeatureLibError,
-            "must not be longer than 63 characters",
-            self.parse,
-            "@GlyphClass = [%s];" % ("G" * 64),
-        )
+        gname = "G" * 600
+        [gc] = self.parse(f"@GlyphClass = [{gname}];").statements
+        self.assertEqual(gc.name, "GlyphClass")
+        self.assertEqual(gc.glyphSet(), (gname,))
 
     def test_glyphclass_bad(self):
         self.assertRaisesRegex(


### PR DESCRIPTION
These were implemented to follow FEA spec, but makeotf does not seem to have a length limit on class names, and the glyph names limit (if it still has it, I didn’t check) seems like an implementation detail we don’t have to enforce.

Fixes https://github.com/googlefonts/ufo2ft/issues/588
See also https://github.com/googlefonts/ufo2ft/pull/811#discussion_r1461667058