### PR TITLE
Doc: Fix xml example of public.fontInfo

### DIFF
--- a/Doc/source/designspaceLib/xml.rst
+++ b/Doc/source/designspaceLib/xml.rst
@@ -869,9 +869,9 @@ info of the sources.
             <key>styleName</key>
             <string>Regular</string>
             <key>postscriptFontName</key>
-            <integer>MyFontNarrVF-Regular</integer>
+            <string>MyFontNarrVF-Regular</string>
             <key>trademark</key>
-            <integer>My Font Narrow VF is a registered trademark...</integer>
+            <string>My Font Narrow VF is a registered trademark...</string>
           </dict>
         </dict>
       </lib>


### PR DESCRIPTION
String values were using <integer> tag.