### PR TITLE
[cu2qu/ufo] return set of modified glyph names from fonts_to_quadratic

### DIFF
--- a/Tests/cu2qu/ufo_test.py
+++ b/Tests/cu2qu/ufo_test.py
@@ -35,8 +35,14 @@ def fonts():
 
 class FontsToQuadraticTest(object):
     def test_modified(self, fonts):
+        # previously this method returned True/False, now it returns a set of modified
+        # glyph names.
         modified = fonts_to_quadratic(fonts)
+        # the first assertion continues to work whether the return value is a bool/set
+        # so the change is backward compatible
         assert modified
+        assert len(modified) > 0
+        assert "B" in modified
 
     def test_stats(self, fonts):
         stats = {}


### PR DESCRIPTION
In ufo2ft preProcessor, we need to know which specific glyphs were actually modified (converted to quadratic), in order to do other things while processing filters, not simply whether the fonts were modified as a whole; thus, here I changed `cu2qu.ufo.fonts_to_quadratic` to return the set of modified glyph names instead of just True/False.
The change is backward compatible because client code that checks whether the returned value was True/False will continue to work since `bool(set)` is True for non-empty set, False for empty ones.