### PR TITLE
Optimization on load

### DIFF
--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -153,6 +153,8 @@ class BaseConverter(object):
         self.name = name
         self.repeat = repeat
         self.aux = aux
+        if self.aux and not self.repeat:
+            self.aux = compile(self.aux, "<string>", "eval")
         self.tableClass = tableClass
         self.isCount = name.endswith("Count") or name in [
             "DesignAxisRecordSize",


### PR DESCRIPTION
Some OT tables rely on "aux" fields which are conditions written as strings; a classic example is the Device field which has the condition "DeltaFormat in (1,2,3)". This is currently stored as a string in the Convertor object, and is `eval`ed for each Device table it decompiles.

`eval` is very slow. You can get a small speedup - quite a large speedup for fonts with lots of Device/VariationIndex tables - by compiling the string and `eval`ing the compiled version later.