### PR TITLE
conf.py: Set navigation_with_keys to allow navigating documentation through arrow keys

### DIFF
--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -104,7 +104,10 @@ html_theme = "sphinx_rtd_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {"display_version": False}
+html_theme_options = {
+    "display_version": False,
+    "navigation_with_keys": True
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Feature from https://github.com/sphinx-doc/sphinx/pull/2064.
