### PR TITLE
Handle ValueError in 'instantiateVariableFont'

### DIFF
--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -1291,7 +1291,10 @@ def instantiateVariableFont(
 
     if updateFontNames:
         log.info("Updating name table")
-        names.updateNameTable(varfont, axisLimits)
+        try:
+            names.updateNameTable(varfont, axisLimits)
+        except ValueError as e:
+            log.info("Failed to update name table: %s", e)
 
     if "gvar" in varfont:
         instantiateGvar(varfont, normalizedLimits, optimize=optimize)


### PR DESCRIPTION
Wrapped the call to `updateNameTable` within a try-except clause to handle a potential ValueError exception. Now, rather than crashing, the function logs an error message when it fails to update the name table.