### PR TITLE
[feaLib.variableScalar] fix value_at_location() method

### DIFF
--- a/Lib/fontTools/feaLib/variableScalar.py
+++ b/Lib/fontTools/feaLib/variableScalar.py
@@ -75,10 +75,11 @@ class VariableScalar:
         return self.values[key]
 
     def value_at_location(self, location, model_cache=None, avar=None):
-        loc = location
+        loc = Location(location)
         if loc in self.values.keys():
             return self.values[loc]
         values = list(self.values.values())
+        loc = dict(self._normalized_location(loc))
         return self.model(model_cache, avar).interpolateFromMasters(loc, values)
 
     def model(self, model_cache=None, avar=None):


### PR DESCRIPTION
VariableScalar's value_at_location() method is untested and unused, but I find it useful (if only for playing and testing) and found that it's broken. I fixed it, but that makes an assumption about the intended call signature: I assume the intention was to feed it a location dict in user coordinates.