### PR TITLE
Better failure mode for sstruct

### DIFF
--- a/Lib/fontTools/ttLib/tables/E_B_L_C_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_L_C_.py
@@ -298,9 +298,9 @@ class BitmapSizeTable(object):
     # cares about in terms of XML creation.
     def _getXMLMetricNames(self):
         dataNames = sstruct.getformat(bitmapSizeTableFormatPart1)[1]
-        dataNames = dataNames + sstruct.getformat(bitmapSizeTableFormatPart2)[1]
+        dataNames = {**dataNames, **sstruct.getformat(bitmapSizeTableFormatPart2)[1]}
         # Skip the first 3 data names because they are byte offsets and counts.
-        return dataNames[3:]
+        return list(dataNames.keys())[3:]
 
     def toXML(self, writer, ttFont):
         writer.begintag("bitmapSizeTable")

--- a/Lib/fontTools/ttLib/tables/_m_a_x_p.py
+++ b/Lib/fontTools/ttLib/tables/_m_a_x_p.py
@@ -127,7 +127,7 @@ class table__m_a_x_p(DefaultTable.DefaultTable):
         formatstring, names, fixes = sstruct.getformat(maxpFormat_0_5)
         if self.tableVersion != 0x00005000:
             formatstring, names_1_0, fixes = sstruct.getformat(maxpFormat_1_0_add)
-            names = names + names_1_0
+            names = {**names, **names_1_0}
         for name in names:
             value = getattr(self, name)
             if name == "tableVersion":


### PR DESCRIPTION
Currently if you give a field value - any field value - a number it isn't expecting for whatever reason (float when uint is expected, number out of range, etc.), you get this:

```
font["OS/2"].usWinDescent = -600
font.save("foo.ttf")

...

  File "/opt/homebrew/lib/python3.11/site-packages/fontTools/ttLib/tables/O_S_2f_2.py", line 173, in compile
    data = sstruct.pack(OS2_format_2, self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/fontTools/misc/sstruct.py", line 75, in pack
    data = struct.pack(*(formatstring,) + tuple(elements))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
struct.error: argument out of range
```

Which at least leads you to the right table, but nothing more than that. With this PR, you get:

```
    data = sstruct.pack(OS2_format_2, self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/simon/others-repos/fonttools/Lib/fontTools/misc/sstruct.py", line 82, in pack
    raise ValueError(
ValueError: Value -600 does not fit in format H for usWinDescent
```