### PR TITLE
Revert "[svgPen] Write two digits after decimal by default"

### DIFF
--- a/Lib/fontTools/pens/svgPathPen.py
+++ b/Lib/fontTools/pens/svgPathPen.py
@@ -2,7 +2,7 @@ from typing import Callable
 from fontTools.pens.basePen import BasePen
 
 
-def pointToString(pt, ntos):
+def pointToString(pt, ntos=str):
     return " ".join(ntos(i) for i in pt)
 
 
@@ -37,13 +37,7 @@ class SVGPathPen(BasePen):
             print(tpen.getCommands())
     """
 
-    def __init__(
-        self,
-        glyphSet,
-        ntos: Callable[[float], str] = (
-            lambda x: ("%.2f" % x) if x != int(x) else str(int(x))
-        ),
-    ):
+    def __init__(self, glyphSet, ntos: Callable[[float], str] = str):
         BasePen.__init__(self, glyphSet)
         self._commands = []
         self._lastCommand = None

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,5 @@
+- [SVGPathPen] Revert rounding coordinates to two decimal places by default.
+
 4.52.4 (released 2024-05-27)
 ----------------------------
 


### PR DESCRIPTION
This reverts commit 42d6b6b4fedf51dd741d3134da74df04339335b4.

As discussed with @anthrotype, this changed default behavior.