### PR TITLE
[instancer] Fix output filename decision-making

### DIFF
--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -1880,7 +1880,9 @@ def main(args=None):
     )
 
     isFullInstance = {
-        axisTag for axisTag, limit in axisLimits.items() if not isinstance(limit, tuple)
+        axisTag
+        for axisTag, limit in axisLimits.items()
+        if limit is None or limit[0] == limit[2]
     }.issuperset(axis.axisTag for axis in varfont["fvar"].axes)
 
     instantiateVariableFont(


### PR DESCRIPTION
All limits are tuples now when not None. The old logic was broken and for the following command:

$ fonttools varLib.instancer  AdobeVFPrototype.otf CNTR=50:80 wght=900

it was saving the output with the name suffix `-instance`, whereas it's clearly a partial instantiation. This fixes that.