### PR TITLE
[VARC] Special-case hidden axes when applying RESET_UNSPECIFIED_AXES to pen.addVarComponent()

### DIFF
--- a/Lib/fontTools/ttLib/ttGlyphSet.py
+++ b/Lib/fontTools/ttLib/ttGlyphSet.py
@@ -56,7 +56,7 @@ class _TTGlyphSet(Mapping):
         self.rawLocationStack.append(self.rawLocation)
         if reset:
             self.location = self.originalLocation.copy()
-            self.rawLocation = self.defaultLocationNormalized.copy()
+            self.rawLocation = self.originalLocation.copy()
         else:
             self.location = self.location.copy()
             self.rawLocation = {}


### PR DESCRIPTION
Alternative to #3541.

As explained in https://github.com/fonttools/fonttools/pull/3541#pullrequestreview-2088359154, the rawLocation mechanism is needed to meaningfully extract variable components via addVarComponent().

But this gives a bit of a conundrum with the new meaning of RESET_UNSPECIFIED_AXES.

Old meaning: when RESET_UNSPECIFIED_AXES is set, reset unspecified axes to default
New meaning: when RESET_UNSPECIFIED_AXES is set, reset unspecified axes the current font location

- to extract variable components for a glyph, we instantiate the glyph at all locations for which the glyph has variations
- this means we also need to specify values for the "private" axes used for variable components
- but _these_ values should not "leak" into descendants
- for normal rendering this is no problem, as the private axes are not user-settable (they are hidden), so the "global font location" for these axes is at default anyway

Long story short, to implement RESET_UNSPECIFIED_AXES in a useful way for addVarComponent(), we need to special case hidden axes.