### PR TITLE
Check for reStructuredText syntax errors in README+NEWS while running release command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -232,7 +232,8 @@ How to make a new release
 2) Use semantic versioning to decide whether the new release will be a 'major',
    'minor' or 'patch' release. It's usually one of the latter two, depending on
    whether new backward compatible APIs were added, or simply some bugs were fixed.
-3) Run ``python setup.py release`` command from the tip of the ``main`` branch.
+3) From inside a venv, first do ``pip install -r dev-requirements.txt``, then run
+   the ``python setup.py release`` command from the tip of the ``main`` branch.
    By default this bumps the third or 'patch' digit only, unless you pass ``--major``
    or ``--minor`` to bump respectively the first or second digit.
    This bumps the package version string, extracts the changes since the latest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ tox>=2.5
 bump2version>=0.5.6
 sphinx>=1.5.5
 mypy>=0.782
+readme_renderer[md]>=43.0
 
 # Pin black as each version could change formatting, breaking CI randomly.
 black==24.4.2


### PR DESCRIPTION
it happened a few times that one updates the NEWS.rst and doesn't check that it is still valid reStructuredText, only to find out later on while publishing the wheels that the `long_description` contains syntax error and would display as plain text on PyPI.
This ensures that we run the `readme_renderer` to render the .rst and check for any syntax errors _before_ it proceeds to bump the version in the same `python setup.py release` command.
This is the same thing that `twine check` does when verifying the metadata of a package.
I can't easily add a test for this, but rest assured that I have tried locally a few times and it works.
The release workflow does not change. The only gotcha is that it's preferable to install bump2version and readme_renderer in the venv before running `setup.py release`, otherwise the old (deprecated) `setup_requires` egg installation method would be used to fetch them and sometimes this fails for `package_readme` for reasons that I haven't figured out.