### PR TITLE
Check unicode elements have required hex attribute

### DIFF
--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -1191,12 +1191,12 @@ def _readGlyphFromTreeFormat1(
             haveSeenAdvance = True
             _readAdvance(glyphObject, element)
         elif element.tag == "unicode":
-            if element.get("hex") is None:
+            v = element.get("hex")
+            if v is None:
                 raise GlifLibError(
                     "A unicode element is missing its required hex attribute."
                 )
             try:
-                v = element.get("hex")
                 v = int(v, 16)
                 if v not in unicodes:
                     unicodes.append(v)
@@ -1258,12 +1258,12 @@ def _readGlyphFromTreeFormat2(
             haveSeenAdvance = True
             _readAdvance(glyphObject, element)
         elif element.tag == "unicode":
-            if element.get("hex") is None:
+            v = element.get("hex")
+            if v is None:
                 raise GlifLibError(
                     "A unicode element is missing its required hex attribute."
                 )
             try:
-                v = element.get("hex")
                 v = int(v, 16)
                 if v not in unicodes:
                     unicodes.append(v)

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -1191,6 +1191,10 @@ def _readGlyphFromTreeFormat1(
             haveSeenAdvance = True
             _readAdvance(glyphObject, element)
         elif element.tag == "unicode":
+            if element.get("hex") is None:
+                raise GlifLibError(
+                    "A unicode element is missing its required hex attribute."
+                )
             try:
                 v = element.get("hex")
                 v = int(v, 16)
@@ -1254,6 +1258,10 @@ def _readGlyphFromTreeFormat2(
             haveSeenAdvance = True
             _readAdvance(glyphObject, element)
         elif element.tag == "unicode":
+            if element.get("hex") is None:
+                raise GlifLibError(
+                    "A unicode element is missing its required hex attribute."
+                )
             try:
                 v = element.get("hex")
                 v = int(v, 16)

--- a/Tests/ufoLib/GLIF1_test.py
+++ b/Tests/ufoLib/GLIF1_test.py
@@ -300,6 +300,22 @@ class TestGLIF1(unittest.TestCase):
         self.assertRaises(GlifLibError, self.pyToGLIF, py)
         self.assertRaises(GlifLibError, self.glifToPy, glif)
 
+    def testUnicodes_hex_present(self):
+        """Test that a present <unicode> element must have a
+        'hex' attribute; by testing that an invalid <unicode>
+        element raises an appropriate error.
+        """
+
+        # illegal
+        glif = """
+		<glyph name="a" format="1">
+			<unicode />
+			<outline>
+			</outline>
+		</glyph>
+		"""
+        self.assertRaises(GlifLibError, self.glifToPy, glif)
+
     def testNote(self):
         glif = """
 		<glyph name="a" format="1">

--- a/Tests/ufoLib/GLIF2_test.py
+++ b/Tests/ufoLib/GLIF2_test.py
@@ -300,6 +300,22 @@ class TestGLIF2(unittest.TestCase):
         self.assertRaises(GlifLibError, self.pyToGLIF, py)
         self.assertRaises(GlifLibError, self.glifToPy, glif)
 
+    def testUnicodes_hex_present(self):
+        """Test that a present <unicode> element must have a
+        'hex' attribute; by testing that an invalid <unicode>
+        element raises an appropriate error.
+        """
+
+        # illegal
+        glif = """
+		<glyph name="a" format="1">
+			<unicode />
+			<outline>
+			</outline>
+		</glyph>
+		"""
+        self.assertRaises(GlifLibError, self.glifToPy, glif)
+
     def testNote(self):
         glif = """
 		<glyph name="a" format="2">

--- a/Tests/ufoLib/GLIF2_test.py
+++ b/Tests/ufoLib/GLIF2_test.py
@@ -308,7 +308,7 @@ class TestGLIF2(unittest.TestCase):
 
         # illegal
         glif = """
-		<glyph name="a" format="1">
+		<glyph name="a" format="2">
 			<unicode />
 			<outline>
 			</outline>


### PR DESCRIPTION
I created a UFO that erroneously had a `<unicode>` element without a `hex` attribute. Naturally instead of just fixing this in my own code, i poked about inside fonttools to work out how to improve the validation, run the tests, and blah blah blah.