### PR TITLE
[otlLib.builder._addName] raise exception if nameID does not exist

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -2881,8 +2881,10 @@ def _buildAxisValuesFormat4(locations, axes, ttFont, windowsNames=True, macNames
 
 def _addName(ttFont, value, minNameID=0, windows=True, mac=True):
     nameTable = ttFont["name"]
+    # Already a nameID
     if isinstance(value, int):
-        # Already a nameID
+        if not any(nr.nameID == value for nr in nameTable.names):
+            raise ValueError(f"NameID {value} not found in name table")
         return value
     if isinstance(value, str):
         names = dict(en=value)


### PR DESCRIPTION
`buildStatTable` in otlLib builds a STAT table from a python dictionary. AxisValue names can either be a string or an int. If an int is used, it'll simply find a name table name record with the same nameID as the int. This pr will raise an exception if a user tries to get a name record that doesn't exist.


I uncovered this issue while working on Merriweather. The family's opsz axis has the following yaml:

```YAML
  - name: Weight
    ...
  - name: Optical Size
    tag: opsz
    values:
    - name: 12
      value: 12
    - name: 14
      value: 14
    - name: 16
      value: 16
    - name: 24
      value: 24
    - name: 48
      value: 48
    - name: 64
      value: 64
    - name: 72
      value: 72
    - name: 144
      value: 144
```

if i ttx the table, I get:


```XML
 <AxisValue index="13" Format="1">
        <AxisIndex value="2"/>
        <Flags value="0"/>
        <ValueNameID value="24"/>  <!-- missing from name table -->
        <Value value="24.0"/>
      </AxisValue>
      <AxisValue index="14" Format="1">
        <AxisIndex value="2"/>
        <Flags value="0"/>
        <ValueNameID value="48"/>  <!-- missing from name table -->
        <Value value="48.0"/>
      </AxisValue>
      <AxisValue index="15" Format="1">
        <AxisIndex value="2"/>
        <Flags value="0"/>
        <ValueNameID value="64"/>  <!-- missing from name table -->
        <Value value="64.0"/>
      </AxisValue>
      <AxisValue index="16" Format="1">
        <AxisIndex value="2"/>
        <Flags value="0"/>
        <ValueNameID value="72"/>  <!-- missing from name table -->
        <Value value="72.0"/>
      </AxisValue>
      <AxisValue index="17" Format="1">
        <AxisIndex value="2"/>
        <Flags value="0"/>
        <ValueNameID value="144"/>  <!-- missing from name table -->
        <Value value="144.0"/>
```

What the author actually wanted is for the names to be strings such as "12pt", "144pt" etc.

Happy to fix tests if current approach is accepted.