### PR TITLE
Fix OS/2.usMaxContext for reverse GSUB rules

### DIFF
--- a/Lib/fontTools/otlLib/maxContextCalc.py
+++ b/Lib/fontTools/otlLib/maxContextCalc.py
@@ -92,5 +92,5 @@ def maxCtxContextualRule(maxCtx, st, chain):
     if not chain:
         return max(maxCtx, st.GlyphCount)
     elif chain == "Reverse":
-        return max(maxCtx, st.GlyphCount + st.LookAheadGlyphCount)
+        return max(maxCtx, 1 + st.LookAheadGlyphCount)
     return max(maxCtx, st.InputGlyphCount + st.LookAheadGlyphCount)

--- a/Tests/otlLib/maxContextCalc_test.py
+++ b/Tests/otlLib/maxContextCalc_test.py
@@ -39,8 +39,8 @@ def test_max_ctx_calc_features():
         rsub a' by b;
         rsub a b' by c;
         rsub a b' c by A;
+        rsub [a b] [a b c]' [a b] by B;
         rsub [a b] c' by A;
-        rsub [a b] c' [a b] by B;
         lookup GSUB_EXT;
     } sub1;
 


### PR DESCRIPTION
This PR fixes `maxCtxContextualRule`, which was returning too high results for reverse chaining contextual single substitutions. Its `GlyphCount` field is the number of glyphs in the coverage table, not the number of glyphs in the input sequence. The input sequence is always 1 glyph long because it is a reverse chaining contextual _single_ substitution.