### PR TITLE
Visitor inheritance

### DIFF
--- a/Lib/fontTools/misc/visitor.py
+++ b/Lib/fontTools/misc/visitor.py
@@ -61,9 +61,10 @@ class Visitor(object):
             if _visitors is None:
                 break
 
-            m = celf._visitors.get(typ, None)
-            if m is not None:
-                return m
+            for base in typ.mro():
+                m = celf._visitors.get(base, None)
+                if m is not None:
+                    return m
 
         return _default
 

--- a/Tests/misc/visitor_test.py
+++ b/Tests/misc/visitor_test.py
@@ -24,6 +24,10 @@ class B:
         self.a = A()
 
 
+class C(B):
+    pass
+
+
 class TestVisitor(Visitor):
     def __init__(self):
         self.value = []
@@ -71,3 +75,9 @@ class VisitorTest(object):
         visitor.defaultStop = True
         visitor.visit(b)
         assert visitor.value == ["B", "B a"]
+
+    def test_visitor_inheritance(self):
+        b = C()  # Should behave just like a B()
+        visitor = TestVisitor()
+        visitor.visit(b)
+        assert visitor.value == ["B", "B a", "A", 1, 2, 3, 5, 7, "e", E.E2, 10]


### PR DESCRIPTION
With this PR, a visitor object will look for registered visitors on an objects superclasses as well as on the object itself, fixes #3580.