### PR TITLE
[interpolatable] In starting-point test, consider contour sign as well

### DIFF
--- a/Lib/fontTools/varLib/interpolatableHelpers.py
+++ b/Lib/fontTools/varLib/interpolatableHelpers.py
@@ -4,7 +4,7 @@ from fontTools.pens.pointPen import AbstractPointPen, SegmentToPointPen
 from fontTools.pens.recordingPen import RecordingPen, DecomposingRecordingPen
 from fontTools.misc.transform import Transform
 from collections import defaultdict, deque
-from math import sqrt, copysign, atan2, pi
+from math import sqrt, copysign, atan2, pi, inf
 from enum import Enum
 import itertools
 
@@ -195,9 +195,10 @@ def contour_vector_from_stats(stats):
     # Don't change the order of items here.
     # It's okay to add to the end, but otherwise, other
     # code depends on it. Search for "covariance".
+    # Other code assumes that signed area is at the beginning.
     size = sqrt(abs(stats.area))
     return (
-        copysign((size), stats.area),
+        copysign(size, stats.area),
         stats.meanX,
         stats.meanY,
         stats.stddevX * 2,

--- a/Lib/fontTools/varLib/interpolatableTestStartingPoint.py
+++ b/Lib/fontTools/varLib/interpolatableTestStartingPoint.py
@@ -8,10 +8,17 @@ def test_starting_point(glyph0, glyph1, ix, tolerance, matching):
     contour1 = glyph1.isomorphisms[matching[ix]]
     m0Vectors = glyph0.greenVectors
     m1Vectors = [glyph1.greenVectors[i] for i in matching]
+    m0sign = 0 <= m0Vectors[ix][0]
+    m1sign = 0 <= m1Vectors[ix][0]
+    signMismatch = m0sign != m1sign
 
     c0 = contour0[0]
+    assert c0[2] == False  # Not reversed
     # Next few lines duplicated below.
-    costs = [vdiff_hypot2_complex(c0[0], c1[0]) for c1 in contour1]
+    costs = [
+        vdiff_hypot2_complex(c0[0], c1[0]) if c1[2] == signMismatch else inf
+        for c1 in contour1
+    ]
     min_cost_idx, min_cost = min(enumerate(costs), key=lambda x: x[1])
     first_cost = costs[0]
     proposed_point = contour1[min_cost_idx][1]
@@ -88,7 +95,12 @@ def test_starting_point(glyph0, glyph1, ix, tolerance, matching):
 
             # Next few lines duplicate from above.
             costs = [
-                vdiff_hypot2_complex(new_c0[0], new_c1[0]) for new_c1 in new_contour1
+                (
+                    vdiff_hypot2_complex(new_c0[0], new_c1[0])
+                    if new_c1[2] == signMismatch
+                    else inf
+                )
+                for new_c1 in new_contour1
             ]
             min_cost_idx, min_cost = min(enumerate(costs), key=lambda x: x[1])
             first_cost = costs[0]


### PR DESCRIPTION
Only try matching to an isomorphic rotation if the area signs match

Fixes https://github.com/fonttools/fonttools/issues/3503

Still testing it more broadly.