### PR TITLE
Small docs cleanups

### DIFF
--- a/Doc/docs-requirements.txt
+++ b/Doc/docs-requirements.txt
@@ -1,4 +1,4 @@
-sphinx==8.0.2
+sphinx==7.4.3
 sphinx_rtd_theme==2.0.0
 reportlab==4.2.2
 freetype-py==2.4.0

--- a/Doc/source/colorLib/index.rst
+++ b/Doc/source/colorLib/index.rst
@@ -3,3 +3,4 @@ colorLib.builder: Build COLR/CPAL tables from scratch
 #####################################################
 
 .. automodule:: fontTools.colorLib.builder
+   :no-inherited-members:

--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -40,7 +40,7 @@ extensions = [
 
 autodoc_mock_imports = ["gtk", "reportlab"]
 
-autodoc_default_options = {"members": True, "inherited-members": True}
+autodoc_default_options = {"members": True, "inherited-members": True, "show-inheritance": True}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -78,7 +78,7 @@ release = "4.0"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -40,7 +40,11 @@ extensions = [
 
 autodoc_mock_imports = ["gtk", "reportlab"]
 
-autodoc_default_options = {"members": True, "inherited-members": True, "show-inheritance": True}
+autodoc_default_options = {
+    "members": True,
+    "inherited-members": True,
+    "show-inheritance": True,
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/Doc/source/designspaceLib/xml.rst
+++ b/Doc/source/designspaceLib/xml.rst
@@ -297,7 +297,7 @@ Example of all axis elements together
 
 
 ``<output>`` element
-...................
+....................
 
 -  Defines the output location of an axis mapping.
 -  Child element of ``<mapping>``

--- a/Doc/source/developer.rst
+++ b/Doc/source/developer.rst
@@ -1,4 +1,5 @@
 :orphan:
+
 .. _developerinfo:
 .. image:: ../../Icons/FontToolsIconGreenCircle.png
    :width: 200px

--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -6,7 +6,7 @@
 
 
 ---fontTools Documentation---
-=======
+=============================
 About
 -----
 

--- a/Doc/source/ttLib/ttFont.rst
+++ b/Doc/source/ttLib/ttFont.rst
@@ -14,4 +14,4 @@ ttFont: Read/write OpenType and TrueType fonts
 
 .. automodule:: fontTools.ttLib.ttFont
    :members: getTableModule, registerCustomTableClass, unregisterCustomTableClass, getCustomTableClass, getClassTag, newTable, tagToIdentifier, identifierToTag, tagToXML, xmlToTag, sortedTagList, reorderFontTables
-
+   :exclude-members: TTFont, GlyphOrder


### PR DESCRIPTION
These are pretty minor, but need to come before some reorg work on the autodoc configuration.

It does make a change to docs-requirements.txt, as described in #3606, which I think is necessary for the time being. I can only debug the output locally as long as the RTD theme is broken. I think a fix to the theme package is imminent, though.