### PR TITLE
Docs: fix Sphinx builds

### DIFF
--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -31,9 +31,9 @@ needs_sphinx = "1.3"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
-    "sphinx.ext.napoleon",
     "sphinx.ext.coverage",
     "sphinx.ext.autosectionlabel",
 ]

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1,3 +1,9 @@
+"""
+    designSpaceDocument
+
+    - Read and write designspace files
+"""
+
 from __future__ import annotations
 
 import collections
@@ -15,11 +21,6 @@ from fontTools.misc import plistlib
 from fontTools.misc.loggingTools import LogMixin
 from fontTools.misc.textTools import tobytes, tostr
 
-"""
-    designSpaceDocument
-
-    - read and write designspace files
-"""
 
 __all__ = [
     "AxisDescriptor",

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -1,26 +1,3 @@
-import os
-from copy import deepcopy
-from os import fsdecode
-import logging
-import zipfile
-import enum
-from collections import OrderedDict
-import fs
-import fs.base
-import fs.subfs
-import fs.errors
-import fs.copy
-import fs.osfs
-import fs.zipfs
-import fs.tempfs
-import fs.tools
-from fontTools.misc import plistlib
-from fontTools.ufoLib.validators import *
-from fontTools.ufoLib.filenames import userNameToFileName
-from fontTools.ufoLib.converters import convertUFO1OrUFO2KerningToUFO3Kerning
-from fontTools.ufoLib.errors import UFOLibError
-from fontTools.ufoLib.utils import numberTypes, _VersionTupleEnumMixin
-
 """
 A library for importing .ufo files and their descendants.
 Refer to http://unifiedfontobject.com for the UFO specification.
@@ -50,6 +27,29 @@ fontinfo.plist values between the possible format versions.
 	convertFontInfoValueForAttributeFromVersion2ToVersion3
 	convertFontInfoValueForAttributeFromVersion3ToVersion2
 """
+
+import os
+from copy import deepcopy
+from os import fsdecode
+import logging
+import zipfile
+import enum
+from collections import OrderedDict
+import fs
+import fs.base
+import fs.subfs
+import fs.errors
+import fs.copy
+import fs.osfs
+import fs.zipfs
+import fs.tempfs
+import fs.tools
+from fontTools.misc import plistlib
+from fontTools.ufoLib.validators import *
+from fontTools.ufoLib.filenames import userNameToFileName
+from fontTools.ufoLib.converters import convertUFO1OrUFO2KerningToUFO3Kerning
+from fontTools.ufoLib.errors import UFOLibError
+from fontTools.ufoLib.utils import numberTypes, _VersionTupleEnumMixin
 
 __all__ = [
     "makeUFOPath",


### PR DESCRIPTION
This changes the Sphnix config to keep the napoleon and autodoc extensions from interfering with each other, and it moves the module docstrings for designspaceLib and ufoLib (in the respective `__init__.py`s) to the start of the file. That's more in line with PEP257, but more practically, autodoc will not see those docstrings unless they are absolutely first.