### PR TITLE
Small tweaks to pyftsubset documentation

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -128,9 +128,9 @@ Examples::
 
     $ pyftsubset --glyph-names?
     Current setting for 'glyph-names' is: False
-    $ ./pyftsubset --name-IDs=?
+    $ pyftsubset --name-IDs=?
     Current setting for 'name-IDs' is: [0, 1, 2, 3, 4, 5, 6]
-    $ ./pyftsubset --hinting? --no-hinting --hinting?
+    $ pyftsubset --hinting? --no-hinting --hinting?
     Current setting for 'hinting' is: True
     Current setting for 'hinting' is: False
 

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -122,7 +122,8 @@ Other options
 ^^^^^^^^^^^^^
 
 For the other options listed below, to see the current value of the option,
-pass a value of '?' to it, with or without a '='.
+pass a value of '?' to it, with or without a '='. In some environments,
+you might need to escape the question mark, like this: '--glyph-names\?'.
 
 Examples::
 


### PR DESCRIPTION
Two small things I noticed in the docs:

1. Remove `./` from example (32617523eebf6723c24bbd0126bbc4f7df181e4d)
2. Add note to escape the `?` from arguments (41854749d7f2eedf860b9ec082aca3565be641ea)