### PR TITLE
Escape `\` in subset docs

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -123,7 +123,7 @@ Other options
 
 For the other options listed below, to see the current value of the option,
 pass a value of '?' to it, with or without a '='. In some environments,
-you might need to escape the question mark, like this: '--glyph-names\?'.
+you might need to escape the question mark, like this: '--glyph-names\\?'.
 
 Examples::
 


### PR DESCRIPTION
In Python 3.12, it's a syntax error to use invalid escape sequences. `\?` is not a valid escape sequence but is used in a docs variable in `subset/__init__.py`. This PR escapes the backslash.