### PR TITLE
Update shebang

### DIFF
--- a/Lib/fontTools/mtiLib/__init__.py
+++ b/Lib/fontTools/mtiLib/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # FontDame-to-FontTools for OpenType Layout tables
 #

--- a/Lib/fontTools/mtiLib/__init__.py
+++ b/Lib/fontTools/mtiLib/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # FontDame-to-FontTools for OpenType Layout tables
 #
 # Source language spec is available at:


### PR DESCRIPTION
Shebang was hardcoded to `/usr/bin/python` which will fail on many modern OSes.