### PR TITLE
Set isfinal to true in XML parser for proper resource cleanup

### DIFF
--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -38,7 +38,7 @@ def parseXML(xmlSnippet):
             % type(xmlSnippet).__name__
         )
     xml += b"</root>"
-    reader.parser.Parse(xml, 0)
+    reader.parser.Parse(xml, 1)
     return reader.root[2]
 
 

--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -38,7 +38,7 @@ def parseXML(xmlSnippet):
             % type(xmlSnippet).__name__
         )
     xml += b"</root>"
-    reader.parser.Parse(xml, 1)
+    reader.parser.Parse(xml, isfinal=True)
     return reader.root[2]
 
 

--- a/Lib/fontTools/misc/xmlReader.py
+++ b/Lib/fontTools/misc/xmlReader.py
@@ -70,12 +70,12 @@ class XMLReader(object):
         while True:
             chunk = file.read(BUFSIZE)
             if not chunk:
-                parser.Parse(chunk, 1)
+                parser.Parse(chunk, isfinal=True)
                 break
             pos = pos + len(chunk)
             if self.progress:
                 self.progress.set(pos // 100)
-            parser.Parse(chunk, 0)
+            parser.Parse(chunk, isfinal=False)
 
     def _startElementHandler(self, name, attrs):
         if self.stackSize == 1 and self.contentOnly:

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -1765,7 +1765,7 @@ class _BaseParser:
         parser = ParserCreate()
         parser.StartElementHandler = self.startElementHandler
         parser.EndElementHandler = self.endElementHandler
-        parser.Parse(text, 1)
+        parser.Parse(text, isfinal=True)
 
     def startElementHandler(self, name, attrs):
         self._elementStack.append(name)

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -1765,7 +1765,7 @@ class _BaseParser:
         parser = ParserCreate()
         parser.StartElementHandler = self.startElementHandler
         parser.EndElementHandler = self.endElementHandler
-        parser.Parse(text)
+        parser.Parse(text, 1)
 
     def startElementHandler(self, name, attrs):
         self._elementStack.append(name)


### PR DESCRIPTION
### Summary

Set `isfinal=1` in `Parse()` calls to ensure proper resource finalization after parsing.

### Reference:

[Python XML Parser Documentation](https://docs.python.org/3/library/pyexpat.html#xml.parsers.expat.xmlparser.Parse)
