### PR TITLE
[ttLib.reorderGlyphs] Update CFF table charstrings and charset

### DIFF
--- a/Lib/fontTools/ttLib/reorderGlyphs.py
+++ b/Lib/fontTools/ttLib/reorderGlyphs.py
@@ -258,12 +258,6 @@ def reorderGlyphs(font: ttLib.TTFont, new_glyph_order: List[str]):
             f"* only in old: {set(old_glyph_order) - set(new_glyph_order)}"
         )
 
-    # Glyph 0 must be assigned to a .notdef glyph.
-    # https://learn.microsoft.com/en-us/typography/opentype/spec/recom#glyph-0-the-notdef-glyph
-    if ".notdef" in new_glyph_order:
-        new_glyph_order.remove(".notdef")
-        new_glyph_order.insert(0, ".notdef")
-
     # Changing the order of glyphs in a TTFont requires that all tables that use
     # glyph indexes have been fully.
     # Cf. https://github.com/fonttools/fonttools/issues/2060

--- a/Lib/fontTools/ttLib/reorderGlyphs.py
+++ b/Lib/fontTools/ttLib/reorderGlyphs.py
@@ -19,9 +19,7 @@ from typing import (
     Deque,
     Iterable,
     List,
-    NamedTuple,
     Tuple,
-    Union,
 )
 
 

--- a/Tests/ttLib/reorderGlyphs_test.py
+++ b/Tests/ttLib/reorderGlyphs_test.py
@@ -59,6 +59,17 @@ def test_ttfont_reorder_glyphs():
     assert list(reversed(old_coverage2)) == new_coverage2
 
 
+def test_reorder_glyphs_cff():
+    font_path = DATA_DIR / "TestVGID-Regular.otf"
+    font = TTFont(str(font_path))
+    ga = font.getGlyphOrder()
+    ga = list(reversed(ga))
+    reorderGlyphs(font, ga)
+
+    assert list(font["CFF "].cff.topDictIndex[0].CharStrings.charStrings.keys()) == ga
+    assert font["CFF "].cff.topDictIndex[0].charset == ga
+
+
 def test_reorder_glyphs_bad_length(caplog):
     font_path = DATA_DIR / "Test-Regular.ttf"
     font = TTFont(str(font_path))


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/3681

* Included logic to handle reordering of glyphs in CFF fonts by updating the `CharStrings` and `charset` properties.