### PR TITLE
[varLib] "Fix" cython iup issue?

### DIFF
--- a/Lib/fontTools/varLib/iup.py
+++ b/Lib/fontTools/varLib/iup.py
@@ -77,7 +77,14 @@ def iup_segment(
                 d = d2
             else:
                 # Interpolate
-                d = d1 + (x - x1) * scale
+                #
+                # NOTE: we assign an explicit intermediate variable here in
+                # order to disable a fused mul-add optimization. See:
+                #
+                # - https://godbolt.org/z/YsP4T3TqK,
+                # - https://github.com/fonttools/fonttools/issues/3703
+                nudge = (x - x1) * scale
+                d = d1 + nudge
 
             out.append(d)
 


### PR DESCRIPTION
See #3703.


In some cases we were seeing different output from iup depending on whether or not we were running cython code.

I've tracked this particular issue down to the line that is changed in this diff, and the change introduced in this diff does (locally, for me, on one machine with one architecture and one compiler) seem to suppress the problem.

However... it feels pretty bad??

I'm not sure how motivated I am to try and generate a proper minimal test case and try to get this fixed upstream. I guess I'm.. medium motivated? But at the very least it would be nice to figure out a more robust way to prevent this optimization from happening, and at the very _very_ least it would be nice to figure out away to test this.

The solution I was hoping for was some way to write some actual hand-written C so we could have finer-grained control over what's going on, and use that just for this one little bit of arithmetic, but I didn't see an easy way to do that.

In any case, I'm going to PR this as a conversation starter at least, and we can try to figure out what the best solution looks like?