### PR TITLE
[cython] Simplify import more

### DIFF
--- a/Lib/fontTools/cu2qu/cu2qu.py
+++ b/Lib/fontTools/cu2qu/cu2qu.py
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # distutils: define_macros=CYTHON_TRACE_NOGIL=1
 
 # Copyright 2015 Google Inc. All Rights Reserved.
@@ -17,7 +16,7 @@
 
 try:
     import cython
-except (AttributeError, ImportError):
+except ImportError:
     # if cython not installed, use mock module with no-op decorators and types
     from fontTools.misc import cython
 COMPILED = cython.compiled

--- a/Lib/fontTools/misc/bezierTools.py
+++ b/Lib/fontTools/misc/bezierTools.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 
 try:
     import cython
-except (AttributeError, ImportError):
+except ImportError:
     # if cython not installed, use mock module with no-op decorators and types
     from fontTools.misc import cython
 COMPILED = cython.compiled

--- a/Lib/fontTools/misc/symfont.py
+++ b/Lib/fontTools/misc/symfont.py
@@ -121,7 +121,7 @@ def printGreenPen(penName, funcs, file=sys.stdout, docstring=None):
         """from fontTools.pens.basePen import BasePen, OpenContourError
 try:
 	import cython
-except (AttributeError, ImportError):
+except ImportError:
 	# if cython not installed, use mock module with no-op decorators and types
 	from fontTools.misc import cython
 COMPILED = cython.compiled

--- a/Lib/fontTools/pens/momentsPen.py
+++ b/Lib/fontTools/pens/momentsPen.py
@@ -2,7 +2,7 @@ from fontTools.pens.basePen import BasePen, OpenContourError
 
 try:
     import cython
-except (AttributeError, ImportError):
+except ImportError:
     # if cython not installed, use mock module with no-op decorators and types
     from fontTools.misc import cython
 COMPILED = cython.compiled

--- a/Lib/fontTools/qu2cu/qu2cu.py
+++ b/Lib/fontTools/qu2cu/qu2cu.py
@@ -18,7 +18,7 @@
 
 try:
     import cython
-except (AttributeError, ImportError):
+except ImportError:
     # if cython not installed, use mock module with no-op decorators and types
     from fontTools.misc import cython
 COMPILED = cython.compiled

--- a/Lib/fontTools/varLib/iup.py
+++ b/Lib/fontTools/varLib/iup.py
@@ -1,6 +1,6 @@
 try:
     import cython
-except (AttributeError, ImportError):
+except ImportError:
     # if cython not installed, use mock module with no-op decorators and types
     from fontTools.misc import cython
 COMPILED = cython.compiled


### PR DESCRIPTION
We're not accessing any attribute so it doesn't make sense to me. This was probably changed in:

  e037cea7261857d44ab6b797b3de7d493fb1927c

But even then, I'm not sure why cython module might not have the compiled attribute. At any rate, I think this is safe.