### PR TITLE
Docs: fill out ttLib table section

### DIFF
--- a/Doc/source/ttLib/tables.rst
+++ b/Doc/source/ttLib/tables.rst
@@ -1,13 +1,131 @@
-###############################
-TrueType/OpenType Table Modules
-###############################
+#######################################
+tables: Access TrueType/OpenType tables
+#######################################
+
+.. contents:: On this page
+    :local:
+
+
+.. rubric:: Overview
+   :heading-level: 2
 
 This folder is a subpackage of :py:mod:`fontTools.ttLib`. Each module here is a
-specialized TT/OT table converter: they can convert raw data
-to Python objects and vice versa. Usually you don't need to
-use the modules directly: they are imported and used
-automatically when needed by :py:mod:`fontTools.ttLib`. The tables currently
-supported are:
+specialized TrueType/OpenType table converter: they can convert raw data
+to Python objects and vice versa. Usually you do not need to
+use these modules directly: they are imported and used
+automatically when needed by :py:mod:`fontTools.ttLib`.
+
+In addition to the tables defined in the official TrueType/OpenType
+specification documents, several specialty tables are supported that
+are used by specific vendors (including the Graphite shaping engine
+and Apple's AAT). Note that fontTools supports the tables that provide
+the core functionality of AAT, but does not guarantee everything.
+
+Similarly, fontTools supports some third-party tables used by external
+applications (such as FontForge and Microsoft's VTT), but may not
+support every private table employed by those applications.
+
+
+Accessing tables
+----------------
+
+The Python modules representing the tables have pretty strange names: this is due to the
+fact that we need to map TT/OT table tags (which are case sensitive)
+to filenames (which on macOS and Windows are not case sensitive) as well
+as to Python identifiers. The latter means that each table identifier
+can only contain ``[A-Za-z0-9_]`` and cannot start with a number.
+
+The convention adopted is that capital letters in a table tag are
+transformed into the letter followed by an underscore (e.g., ``A_``), while lowercase
+letters and numbers are preceded by an underscore (e.g., ``_a``).
+
+:py:mod:`fontTools.ttLib` provides functions to expand a tag into the format used here::
+
+    >>> from fontTools import ttLib
+    >>> ttLib.tagToIdentifier("FOO ")
+    'F_O_O_'
+    >>> ttLib.tagToIdentifier("cvt ")
+    '_c_v_t'
+    >>> ttLib.tagToIdentifier("OS/2")
+    'O_S_2f_2'
+    >>> ttLib.tagToIdentifier("glyf")
+    '_g_l_y_f'
+    >>>
+
+And vice versa::
+
+    >>> ttLib.identifierToTag("F_O_O_")
+    'FOO '
+    >>> ttLib.identifierToTag("_c_v_t")
+    'cvt '
+    >>> ttLib.identifierToTag("O_S_2f_2")
+    'OS/2'
+    >>> ttLib.identifierToTag("_g_l_y_f")
+    'glyf'
+    >>>
+
+Eg. the 'glyf' table converter lives in a Python file called::
+
+	_g_l_y_f.py
+
+The converter itself is a class, named ``table_`` + expandedtag. Eg::
+
+
+	class table__g_l_y_f:
+		etc.
+
+Note that if you _do_ need to use such modules or classes manually,
+there are two convenient API functions that let you find them by tag::
+
+    >>> ttLib.getTableModule('glyf')
+    <module 'ttLib.tables._g_l_y_f'>
+    >>> ttLib.getTableClass('glyf')
+    <class ttLib.tables._g_l_y_f.table__g_l_y_f at 645f400>
+    >>
+
+
+Helper modules
+--------------
+
+In addition to the core table-conversion implementations, a set of
+helper and utility modules is also found in this package. 
+You should not normally need to access these modules directly,
+but consulting them might be valuable if you need to add fontTools
+support for a new table type.
+ 
+In that case, a good place to start is with the documentation for
+the base table classes:
+ 
+.. toctree::
+   :maxdepth: 1
+ 
+   tables/table_api
+ 
+The modules that provide lower-level helper functionality
+include implementations of common OpenType data structures, support
+for OpenType font variations, and various classes needed for
+tables containing bitmap data or for tables used by the Graphite engine:
+ 	
+.. toctree::
+   :maxdepth: 1
+ 
+   tables/OpenType_related
+   tables/TupleVariation
+   tables/Bitmap_related
+   tables/grUtils
+ 
+A module is also included for assembling and disassembling
+TrueType bytecode:
+ 
+.. toctree::
+   :maxdepth: 1
+
+   tables/ttProgram
+       
+
+    
+Tables currently supported
+--------------------------
 
 .. toctree::
    :maxdepth: 1
@@ -84,106 +202,7 @@ supported are:
    tables/VTT_related
    tables/V_V_A_R_
 
-The Python modules representing the tables have pretty strange names: this is due to the
-fact that we need to map TT table tags (which are case sensitive)
-to filenames (which on Mac and Win aren't case sensitive) as well
-as to Python identifiers. The latter means it can only contain
-``[A-Za-z0-9_]`` and cannot start with a number.
-
-:py:mod:`fontTools.ttLib` provides functions to expand a tag into the format used here::
-
-    >>> from fontTools import ttLib
-    >>> ttLib.tagToIdentifier("FOO ")
-    'F_O_O_'
-    >>> ttLib.tagToIdentifier("cvt ")
-    '_c_v_t'
-    >>> ttLib.tagToIdentifier("OS/2")
-    'O_S_2f_2'
-    >>> ttLib.tagToIdentifier("glyf")
-    '_g_l_y_f'
-    >>>
-
-And vice versa::
-
-    >>> ttLib.identifierToTag("F_O_O_")
-    'FOO '
-    >>> ttLib.identifierToTag("_c_v_t")
-    'cvt '
-    >>> ttLib.identifierToTag("O_S_2f_2")
-    'OS/2'
-    >>> ttLib.identifierToTag("_g_l_y_f")
-    'glyf'
-    >>>
-
-Eg. the 'glyf' table converter lives in a Python file called::
-
-	_g_l_y_f.py
-
-The converter itself is a class, named ``table_`` + expandedtag. Eg::
-
-
-	class table__g_l_y_f:
-		etc.
-
-Note that if you _do_ need to use such modules or classes manually,
-there are two convenient API functions that let you find them by tag::
-
-    >>> ttLib.getTableModule('glyf')
-    <module 'ttLib.tables._g_l_y_f'>
-    >>> ttLib.getTableClass('glyf')
-    <class ttLib.tables._g_l_y_f.table__g_l_y_f at 645f400>
-    >>
-
-ttProgram: TrueType bytecode assembler/disassembler
----------------------------------------------------
-
-.. automodule:: fontTools.ttLib.tables.ttProgram
-   :inherited-members:
-   :members:
-   :undoc-members:
-
-Contributing your own table convertors
---------------------------------------
-
-To add support for a new font table that fontTools does not currently implement,
-you must subclass from :py:mod:`fontTools.ttLib.tables.DefaultTable.DefaultTable`.
-It provides some default behavior, as well as a constructor method (``__init__``)
-that you don't need to override.
-
-Your converter should minimally provide two methods::
-
-
-    class table_F_O_O_(DefaultTable.DefaultTable): # converter for table 'FOO '
-
-        def decompile(self, data, ttFont):
-            # 'data' is the raw table data. Unpack it into a
-            # Python data structure.
-            # 'ttFont' is a ttLib.TTfile instance, enabling you to
-            # refer to other tables. Do ***not*** keep a reference to
-            # it: it will cause a circular reference (ttFont saves
-            # a reference to us), and that means we'll be leaking
-            # memory. If you need to use it in other methods, just
-            # pass it around as a method argument.
-
-        def compile(self, ttFont):
-            # Return the raw data, as converted from the Python
-            # data structure.
-            # Again, 'ttFont' is there so you can access other tables.
-            # Same warning applies.
-
-
-If you want to support TTX import/export as well, you need to provide two
-additional methods::
-
-
-   def toXML(self, writer, ttFont):
-      # XXX
-
-   def fromXML(self, (name, attrs, content), ttFont):
-      # XXX
-
 .. automodule:: fontTools.ttLib.tables
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/B_A_S_E_.rst
+++ b/Doc/source/ttLib/tables/B_A_S_E_.rst
@@ -1,8 +1,9 @@
-``BASE``: Baseline Table
+``BASE``: Baseline table
 ------------------------
 
+The ``BASE`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.B_A_S_E_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/Bitmap_related.rst
+++ b/Doc/source/ttLib/tables/Bitmap_related.rst
@@ -8,10 +8,10 @@ Bitmap-data helper modules
 .. rubric:: Overview:
    :heading-level: 2
 
-The :mod:`fontTools.ttLib.ttCollection` module is a helper for
-:mod:`fontTools.ttLib` that implements lower-level support for various
+The modules documented on this page are helpers for
+:mod:`fontTools.ttLib` that implement lower-level support for various
 table converters that need to interact with bitmapped data. The
-:mod:`.BitmapGlyphmetrics` module is used for the ``EBDT``/``EBLC`` and
+:mod:`.BitmapGlyphMetrics` module is used for the ``EBDT``/``EBLC`` and
 ``CBDT``/``CBLC`` tables, and :mod:`.sbixGlyph` and :mod:`.sbixStrike`
 are used for the ``sbix`` table.
 

--- a/Doc/source/ttLib/tables/Bitmap_related.rst
+++ b/Doc/source/ttLib/tables/Bitmap_related.rst
@@ -1,0 +1,36 @@
+##########################
+Bitmap-data helper modules
+##########################
+
+.. contents:: On this page:
+    :local:
+
+.. rubric:: Overview:
+   :heading-level: 2
+
+The :mod:`fontTools.ttLib.ttCollection` module is a helper for
+:mod:`fontTools.ttLib` that implements lower-level support for various
+table converters that need to interact with bitmapped data. The
+:mod:`.BitmapGlyphmetrics` module is used for the ``EBDT``/``EBLC`` and
+``CBDT``/``CBLC`` tables, and :mod:`.sbixGlyph` and :mod:`.sbixStrike`
+are used for the ``sbix`` table.
+
+fontTools.ttLib.tables.BitmapGlyphMetrics
+-----------------------------------------
+.. automodule:: fontTools.ttLib.tables.BitmapGlyphMetrics
+   :members:
+   :undoc-members:
+
+      
+fontTools.ttLib.tables.sbixGlyph
+--------------------------------
+.. automodule:: fontTools.ttLib.tables.sbixGlyph
+   :members:
+   :undoc-members:
+
+      
+fontTools.ttLib.tables.sbixStrike
+---------------------------------
+.. automodule:: fontTools.ttLib.tables.sbixStrike
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/C_B_D_T_.rst
+++ b/Doc/source/ttLib/tables/C_B_D_T_.rst
@@ -1,8 +1,9 @@
-``CBDT``: Color Bitmap Data Table
+``CBDT``: Color Bitmap Data table
 ---------------------------------
 
+The ``CBDT`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.C_B_D_T_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/C_B_D_T_.rst
+++ b/Doc/source/ttLib/tables/C_B_D_T_.rst
@@ -3,6 +3,10 @@
 
 The ``CBDT`` table is an OpenType table.
 
+This ``CBDT`` table converter module depends on the
+:mod:`.BitmapGlyphMetrics` module, which it shares with the ``EBDT``,
+``EBLC``, and ``CBLC`` converters.
+
 .. automodule:: fontTools.ttLib.tables.C_B_D_T_
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/C_B_L_C_.rst
+++ b/Doc/source/ttLib/tables/C_B_L_C_.rst
@@ -3,6 +3,10 @@
 
 The ``CBLC`` table is an OpenType table.
 
+This ``CBLC`` table converter module depends on the
+:mod:`.BitmapGlyphMetrics` module, which it shares with the ``EBDT``,
+``EBLC``, and ``CBDT`` converters.
+
 .. automodule:: fontTools.ttLib.tables.C_B_L_C_
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/C_B_L_C_.rst
+++ b/Doc/source/ttLib/tables/C_B_L_C_.rst
@@ -1,8 +1,9 @@
-``CBLC``: Color Bitmap Location Table
+``CBLC``: Color Bitmap Location table
 -------------------------------------
 
+The ``CBLC`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.C_B_L_C_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/C_F_F_.rst
+++ b/Doc/source/ttLib/tables/C_F_F_.rst
@@ -1,8 +1,9 @@
-``CFF``: Compact Font Format Table
+``CFF``: Compact Font Format table
 ----------------------------------
 
+The ``CFF`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.C_F_F_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/C_F_F__2.rst
+++ b/Doc/source/ttLib/tables/C_F_F__2.rst
@@ -1,8 +1,9 @@
-``CFF2``: Compact Font Format (CFF) Version 2
----------------------------------------------
+``CFF2``: Compact Font Format (CFF) Version 2 table
+---------------------------------------------------
+
+The ``CFF2`` table is an OpenType table.
 
 .. automodule:: fontTools.ttLib.tables.C_F_F__2
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/C_O_L_R_.rst
+++ b/Doc/source/ttLib/tables/C_O_L_R_.rst
@@ -1,7 +1,8 @@
-``COLR``: Color Table
+``COLR``: Color table
 ---------------------
 
+The ``COLR`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.C_O_L_R_
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/C_P_A_L_.rst
+++ b/Doc/source/ttLib/tables/C_P_A_L_.rst
@@ -1,8 +1,9 @@
-``CPAL``: Color Palette Table
+``CPAL``: Color Palette table
 -----------------------------
 
+The ``CPAL`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.C_P_A_L_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/D_S_I_G_.rst
+++ b/Doc/source/ttLib/tables/D_S_I_G_.rst
@@ -1,8 +1,9 @@
-``DSIG``: Digital Signature Table
+``DSIG``: Digital Signature table
 ---------------------------------
 
+The ``DSIG`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.D_S_I_G_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/E_B_D_T_.rst
+++ b/Doc/source/ttLib/tables/E_B_D_T_.rst
@@ -3,16 +3,11 @@
 
 The ``EBDT`` table is an OpenType table.
 
+This ``EBDT`` table converter module depends on the
+:mod:`.BitmapGlyphMetrics` module, which it shares with the ``EBLC``,
+``CBDT``, and ``CBLC`` converters.
+
 .. automodule:: fontTools.ttLib.tables.E_B_D_T_
-   :members:
-   :undoc-members:
-
-
-BitmapGlyphMetrics
-^^^^^^^^^^^^^^^^^^
-
-.. automodule:: fontTools.ttLib.tables.BitmapGlyphMetrics
-   :noindex:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/E_B_D_T_.rst
+++ b/Doc/source/ttLib/tables/E_B_D_T_.rst
@@ -1,8 +1,9 @@
-``EBDT``: Embedded Bitmap Data Table
+``EBDT``: Embedded Bitmap Data table
 ------------------------------------
 
+The ``EBDT`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.E_B_D_T_
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -12,7 +13,6 @@ BitmapGlyphMetrics
 
 .. automodule:: fontTools.ttLib.tables.BitmapGlyphMetrics
    :noindex:
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/E_B_L_C_.rst
+++ b/Doc/source/ttLib/tables/E_B_L_C_.rst
@@ -1,8 +1,9 @@
-``EBLC``: Embedded Bitmap Location Table
+``EBLC``: Embedded Bitmap Location table
 ----------------------------------------
 
+The ``EBLC`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.E_B_L_C_
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -12,7 +13,6 @@ BitmapGlyphMetrics
 
 .. automodule:: fontTools.ttLib.tables.BitmapGlyphMetrics
    :noindex:
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/E_B_L_C_.rst
+++ b/Doc/source/ttLib/tables/E_B_L_C_.rst
@@ -3,16 +3,10 @@
 
 The ``EBLC`` table is an OpenType table.
 
+This ``EBLC`` table converter module depends on the
+:mod:`.BitmapGlyphMetrics` module, which it shares with the ``EBDT``,
+``CBDT``, and ``CBLC`` converters.
+
 .. automodule:: fontTools.ttLib.tables.E_B_L_C_
    :members:
    :undoc-members:
-
-
-BitmapGlyphMetrics
-^^^^^^^^^^^^^^^^^^
-
-.. automodule:: fontTools.ttLib.tables.BitmapGlyphMetrics
-   :noindex:
-   :members:
-   :undoc-members:
-

--- a/Doc/source/ttLib/tables/F_F_T_M_.rst
+++ b/Doc/source/ttLib/tables/F_F_T_M_.rst
@@ -1,8 +1,9 @@
-``FFTM``: FontForge Time Stamp Table
+``FFTM``: FontForge Time Stamp table
 ------------------------------------
 
+The ``FFTM`` table is used by the FontForge font editor.
+
 .. automodule:: fontTools.ttLib.tables.F_F_T_M_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/F__e_a_t.rst
+++ b/Doc/source/ttLib/tables/F__e_a_t.rst
@@ -1,8 +1,9 @@
-``Feat``: Graphite Feature Table
+``Feat``: Graphite Feature table
 --------------------------------
 
+The ``Feat`` table is a Graphite table.
+
 .. automodule:: fontTools.ttLib.tables.F__e_a_t
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/G_D_E_F_.rst
+++ b/Doc/source/ttLib/tables/G_D_E_F_.rst
@@ -1,8 +1,9 @@
-``GDEF``: Glyph Definition Table
+``GDEF``: Glyph Definition table
 --------------------------------
 
+The ``GDEF`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.G_D_E_F_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/G_M_A_P_.rst
+++ b/Doc/source/ttLib/tables/G_M_A_P_.rst
@@ -1,8 +1,9 @@
-``GMAP``: SING Glyphlet Summary Table
+``GMAP``: SING Glyphlet Summary table
 -------------------------------------
 
+The ``GMAP`` table is an Adobe Glyphlets table.
+
 .. automodule:: fontTools.ttLib.tables.G_M_A_P_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/G_P_K_G_.rst
+++ b/Doc/source/ttLib/tables/G_P_K_G_.rst
@@ -1,8 +1,9 @@
-``GPKG``: SING Glyphlet Wrapper Table
+``GPKG``: SING Glyphlet Wrapper table
 -------------------------------------
 
+The ``GPKG`` table is an Adobe Glyphlets table.
+
 .. automodule:: fontTools.ttLib.tables.G_P_K_G_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/G_P_O_S_.rst
+++ b/Doc/source/ttLib/tables/G_P_O_S_.rst
@@ -1,8 +1,9 @@
-``GPOS``: Glyph Positioning Table
+``GPOS``: Glyph Positioning table
 ---------------------------------
 
+The ``GPOS`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.G_P_O_S_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/G_S_U_B_.rst
+++ b/Doc/source/ttLib/tables/G_S_U_B_.rst
@@ -1,8 +1,9 @@
-``GSUB``: Glyph Substitution Table
+``GSUB``: Glyph Substitution table
 ----------------------------------
 
+The ``GSUB`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.G_S_U_B_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/G__l_a_t.rst
+++ b/Doc/source/ttLib/tables/G__l_a_t.rst
@@ -1,8 +1,9 @@
-``Glat``: Graphite Glyph Attributes Table
+``Glat``: Graphite Glyph Attributes table
 -----------------------------------------
 
+The ``Glat`` table is a Graphite table.
+
 .. automodule:: fontTools.ttLib.tables.G__l_a_t
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/G__l_o_c.rst
+++ b/Doc/source/ttLib/tables/G__l_o_c.rst
@@ -1,8 +1,9 @@
 ``Gloc``: Graphite index to glyph attributes table
 --------------------------------------------------
 
+The ``Gloc`` table is a Graphite table.
+
 .. automodule:: fontTools.ttLib.tables.G__l_o_c
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/H_V_A_R_.rst
+++ b/Doc/source/ttLib/tables/H_V_A_R_.rst
@@ -1,7 +1,8 @@
-``HVAR``:Horizontal Metrics Variations Table
---------------------------------------------
+``HVAR``: Horizontal Metrics Variations table
+---------------------------------------------
+
+The ``HVAR`` table is an OpenType table.
 
 .. automodule:: fontTools.ttLib.tables.H_V_A_R_
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/J_S_T_F_.rst
+++ b/Doc/source/ttLib/tables/J_S_T_F_.rst
@@ -1,7 +1,8 @@
-``JSTF``: Justification Table
+``JSTF``: Justification table
 -----------------------------
 
+The ``JSTF`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.J_S_T_F_
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/L_T_S_H_.rst
+++ b/Doc/source/ttLib/tables/L_T_S_H_.rst
@@ -1,8 +1,9 @@
-``LTSH``: Linear Threshold
---------------------------
+``LTSH``: Linear Threshold table
+--------------------------------
+
+The ``LTSH`` table is an OpenType table.
 
 .. automodule:: fontTools.ttLib.tables.L_T_S_H_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/M_A_T_H_.rst
+++ b/Doc/source/ttLib/tables/M_A_T_H_.rst
@@ -1,7 +1,8 @@
-``MATH``: Mathematical Typesetting Table
+``MATH``: Mathematical Typesetting table
 ----------------------------------------
 
+The ``MATH`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.M_A_T_H_
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/M_E_T_A_.rst
+++ b/Doc/source/ttLib/tables/M_E_T_A_.rst
@@ -1,7 +1,8 @@
-``META``: SING Glyphlet Metadata Table
+``META``: SING Glyphlet Metadata table
 --------------------------------------
 
+The ``META`` table is an Adobe Glyphlets table.
+
 .. automodule:: fontTools.ttLib.tables.M_E_T_A_
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/M_V_A_R_.rst
+++ b/Doc/source/ttLib/tables/M_V_A_R_.rst
@@ -1,7 +1,8 @@
-``MVAR``: Metrics Variations Table
+``MVAR``: Metrics Variations table
 ----------------------------------
 
+The ``MVAR`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.M_V_A_R_
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/O_S_2f_2.rst
+++ b/Doc/source/ttLib/tables/O_S_2f_2.rst
@@ -1,7 +1,8 @@
-``OS/2``: OS/2 and Windows Metrics Table
+``OS/2``: OS/2 and Windows Metrics table
 ----------------------------------------
 
+The ``OS/2`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.O_S_2f_2
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/OpenType_related.rst
+++ b/Doc/source/ttLib/tables/OpenType_related.rst
@@ -1,0 +1,46 @@
+#############################
+OpenType-table helper modules
+#############################
+
+.. contents:: On this page:
+    :local:
+
+       
+.. rubric:: Overview:
+   :heading-level: 2
+
+The OpenType-table helper modules documented on this page provide
+support for OpenType's common table (and subtable) data formats.
+
+Most users should not need to access these modules directly.
+
+
+fontTools.ttLib.tables.otTables
+-------------------------------
+
+.. automodule:: fontTools.ttLib.tables.otTables
+   :members:
+   :undoc-members:
+
+      
+fontTools.ttLib.tables.otData
+-----------------------------
+
+.. automodule:: fontTools.ttLib.tables.otData
+   :members:
+   :undoc-members:
+
+      
+fontTools.ttLib.tables.otConverters
+-----------------------------------
+
+.. automodule:: fontTools.ttLib.tables.otConverters
+   :members:
+   :undoc-members:
+
+      
+fontTools.ttLib.tables.otTraverse
+---------------------------------
+.. automodule:: fontTools.ttLib.tables.otTraverse
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/S_I_N_G_.rst
+++ b/Doc/source/ttLib/tables/S_I_N_G_.rst
@@ -1,7 +1,8 @@
-``SING``: SING Glyphlet Basic Information Table
+``SING``: SING Glyphlet Basic Information table
 -----------------------------------------------
 
+The ``SING`` table is an Adobe Glyphlets table.
+
 .. automodule:: fontTools.ttLib.tables.S_I_N_G_
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/S_T_A_T_.rst
+++ b/Doc/source/ttLib/tables/S_T_A_T_.rst
@@ -1,7 +1,8 @@
-``STAT``: Style Attributes Table
+``STAT``: Style Attributes table
 --------------------------------
 
+The ``STAT`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.S_T_A_T_
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/S_V_G_.rst
+++ b/Doc/source/ttLib/tables/S_V_G_.rst
@@ -1,8 +1,9 @@
-``SVG``: SVG (Scalable Vector Graphics) Table
+``SVG``: SVG (Scalable Vector Graphics) table
 ---------------------------------------------
 
+The ``SVG`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.S_V_G_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/S__i_l_f.rst
+++ b/Doc/source/ttLib/tables/S__i_l_f.rst
@@ -1,7 +1,8 @@
-``Silf``: Graphite Rules Table
+``Silf``: Graphite Rules table
 ------------------------------
 
+The ``Silf`` table is a Graphite table.
+
 .. automodule:: fontTools.ttLib.tables.S__i_l_f
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/S__i_l_l.rst
+++ b/Doc/source/ttLib/tables/S__i_l_l.rst
@@ -1,7 +1,8 @@
-``Sill``: Graphite Languages Table
+``Sill``: Graphite Languages table
 ----------------------------------
 
+The ``Sill`` table is a Graphite table.
+
 .. automodule:: fontTools.ttLib.tables.S__i_l_l
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/T_T_F_A_.rst
+++ b/Doc/source/ttLib/tables/T_T_F_A_.rst
@@ -1,8 +1,9 @@
-``TTFA``: ``ttfautohint`` Parameter Table
+``TTFA``: ttfautohint Parameter table
 -----------------------------------------
 
+The ``TTFA`` table is used by the ``ttfautohint`` hinting program.
+
 .. automodule:: fontTools.ttLib.tables.T_T_F_A_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/TupleVariation.rst
+++ b/Doc/source/ttLib/tables/TupleVariation.rst
@@ -1,0 +1,16 @@
+#################################
+OpenType variations helper module
+#################################
+
+.. rubric:: Overview:
+   :heading-level: 2
+
+The :mod:`fontTools.ttLib.tables.TupleVariation` module is a helper for
+:mod:`fontTools.ttLib` that implements lower-level support for
+variable-font table converters.
+
+
+
+.. automodule:: fontTools.ttLib.tables.TupleVariation
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/VTT_related.rst
+++ b/Doc/source/ttLib/tables/VTT_related.rst
@@ -1,11 +1,17 @@
-Visual TrueType Private Tables
-==============================
+``VTT*`` Visual TrueType private tables
+=======================================
+
+The tables listed on this page are used by Microsoft's Visual TrueType
+application.
+
+.. contents:: On this page:
+    :local:
+
 
 ``TSI0``: Glyph Program Text Indices
 ------------------------------------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I__0
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -13,7 +19,6 @@ Visual TrueType Private Tables
 --------------------------------------------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I__1
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -21,7 +26,6 @@ Visual TrueType Private Tables
 -------------------------------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I__2
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -29,7 +33,6 @@ Visual TrueType Private Tables
 ----------------------------------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I__3
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -37,15 +40,13 @@ Visual TrueType Private Tables
 ----------------------------------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I__5
-   :inherited-members:
    :members:
    :undoc-members:
 
-``TSIB``
---------
+``TSIB``: VTT BASE Table Text Source
+------------------------------------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I_B_
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -53,7 +54,6 @@ Visual TrueType Private Tables
 -----------------------------------------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I_C_
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -61,7 +61,6 @@ Visual TrueType Private Tables
 ------------------------------------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I_D_
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -69,7 +68,6 @@ Visual TrueType Private Tables
 ------------------------------------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I_J_
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -77,7 +75,6 @@ Visual TrueType Private Tables
 ------------------------------------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I_P_
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -85,7 +82,6 @@ Visual TrueType Private Tables
 ------------------------------------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I_S_
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -93,7 +89,6 @@ Visual TrueType Private Tables
 --------
 
 .. automodule:: fontTools.ttLib.tables.T_S_I_V_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/V_D_M_X_.rst
+++ b/Doc/source/ttLib/tables/V_D_M_X_.rst
@@ -1,7 +1,8 @@
-``VDMX``: Vertical Device Metrics
----------------------------------
+``VDMX``: Vertical Device Metrics table
+---------------------------------------
+
+The ``VDMX`` table is an OpenType table.
 
 .. automodule:: fontTools.ttLib.tables.V_D_M_X_
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/V_O_R_G_.rst
+++ b/Doc/source/ttLib/tables/V_O_R_G_.rst
@@ -1,8 +1,9 @@
-``VORG``: Vertical Origin Table
+``VORG``: Vertical Origin table
 -------------------------------
 
+The ``VORG`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.V_O_R_G_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/V_V_A_R_.rst
+++ b/Doc/source/ttLib/tables/V_V_A_R_.rst
@@ -1,8 +1,9 @@
-``VVAR``: Vertical Metrics Variations Table
+``VVAR``: Vertical Metrics Variations table
 -------------------------------------------
 
+The ``VVAR`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables.V_V_A_R_
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_a_n_k_r.rst
+++ b/Doc/source/ttLib/tables/_a_n_k_r.rst
@@ -1,7 +1,8 @@
-``ankr``: Anchor Point Table
+``ankr``: Anchor Point table
 ----------------------------
 
+The ``ankr`` table is an Apple Advanced Typography (AAT) table.
+
 .. automodule:: fontTools.ttLib.tables._a_n_k_r
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/_a_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_a_v_a_r.rst
@@ -1,8 +1,9 @@
-``avar``: Axis Variations Table
+``avar``: Axis Variations table
 -------------------------------
 
+The ``avar`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._a_v_a_r
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_b_s_l_n.rst
+++ b/Doc/source/ttLib/tables/_b_s_l_n.rst
@@ -1,7 +1,8 @@
 ``bsln``: Baseline
 ------------------
 
+The ``bsln`` table is an Apple Advanced Typography (AAT) table.
+
 .. automodule:: fontTools.ttLib.tables._b_s_l_n
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/_c_i_d_g.rst
+++ b/Doc/source/ttLib/tables/_c_i_d_g.rst
@@ -1,7 +1,8 @@
 ``cidg``: CID to Glyph ID table
 -------------------------------
 
+The ``cidg`` table is an Apple Advanced Typography (AAT) table.
+
 .. automodule:: fontTools.ttLib.tables._c_i_d_g
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/_c_m_a_p.rst
+++ b/Doc/source/ttLib/tables/_c_m_a_p.rst
@@ -1,5 +1,7 @@
-``cmap``: Character to Glyph Index Mapping Table
+``cmap``: Character to Glyph Index Mapping table
 ------------------------------------------------
+
+The ``cmap`` table is an OpenType table.
 
 .. autoclass:: fontTools.ttLib.tables._c_m_a_p.table__c_m_a_p
 

--- a/Doc/source/ttLib/tables/_c_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_c_v_a_r.rst
@@ -1,8 +1,9 @@
-``cvar``: CVT Variations Table
+``cvar``: CVT Variations table
 ------------------------------
 
+The ``cvar`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._c_v_a_r
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -12,6 +13,5 @@ TupleVariation
 
 .. automodule:: fontTools.ttLib.tables.TupleVariation
    :noindex:
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/_c_v_t.rst
+++ b/Doc/source/ttLib/tables/_c_v_t.rst
@@ -1,8 +1,9 @@
 ``cvt``:  Control Value Table
 -----------------------------
 
+The ``cvt`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._c_v_t
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_f_e_a_t.rst
+++ b/Doc/source/ttLib/tables/_f_e_a_t.rst
@@ -1,7 +1,8 @@
 ``feat``: Feature name table
 ----------------------------
 
+The ``feat`` table is an Apple Advanced Typography (AAT) table.
+
 .. automodule:: fontTools.ttLib.tables._f_e_a_t
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/_f_p_g_m.rst
+++ b/Doc/source/ttLib/tables/_f_p_g_m.rst
@@ -1,7 +1,8 @@
-``fpgm``: Font Program
-----------------------
+``fpgm``: Font Program table
+----------------------------
+
+The ``fpgm`` table is an OpenType table.
 
 .. automodule:: fontTools.ttLib.tables._f_p_g_m
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/_f_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_f_v_a_r.rst
@@ -1,8 +1,9 @@
-``fvar``: Font Variations Table
+``fvar``: Font Variations table
 -------------------------------
 
+The ``fvar`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._f_v_a_r
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_g_a_s_p.rst
+++ b/Doc/source/ttLib/tables/_g_a_s_p.rst
@@ -1,8 +1,9 @@
-``gasp``: Grid-fitting and Scan-conversion Procedure Table
+``gasp``: Grid-fitting and Scan-conversion Procedure table
 ----------------------------------------------------------
 
+The ``gasp`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._g_a_s_p
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_g_c_i_d.rst
+++ b/Doc/source/ttLib/tables/_g_c_i_d.rst
@@ -1,7 +1,8 @@
 ``gcid``: Glyph ID to CID table
 -------------------------------
 
+The ``gcid`` table is an Apple Advanced Typography (AAT) table.
+
 .. automodule:: fontTools.ttLib.tables._g_c_i_d
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/_g_l_y_f.rst
+++ b/Doc/source/ttLib/tables/_g_l_y_f.rst
@@ -1,5 +1,7 @@
-``glyf``: Glyph Data
---------------------
+``glyf``: Glyph Data table
+--------------------------
+
+The ``glyf`` table is an OpenType table.
 
 .. autoclass:: fontTools.ttLib.tables._g_l_y_f.table__g_l_y_f
    :members:

--- a/Doc/source/ttLib/tables/_g_v_a_r.rst
+++ b/Doc/source/ttLib/tables/_g_v_a_r.rst
@@ -1,8 +1,9 @@
-``gvar``:  Glyph Variations Table
+``gvar``:  Glyph Variations table
 ---------------------------------
 
+The ``gvar`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._g_v_a_r
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -11,6 +12,5 @@ TupleVariation
 ^^^^^^^^^^^^^^
 
 .. automodule:: fontTools.ttLib.tables.TupleVariation
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/_h_d_m_x.rst
+++ b/Doc/source/ttLib/tables/_h_d_m_x.rst
@@ -1,8 +1,9 @@
-``hdmx``: Horizontal Device Metrics
------------------------------------
+``hdmx``: Horizontal Device Metrics table
+-----------------------------------------
+
+The ``hdmx`` table is an OpenType table.
 
 .. automodule:: fontTools.ttLib.tables._h_d_m_x
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_h_e_a_d.rst
+++ b/Doc/source/ttLib/tables/_h_e_a_d.rst
@@ -1,8 +1,9 @@
-``head``: Font Header Table
+``head``: Font Header table
 ---------------------------
 
+The ``head`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._h_e_a_d
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_h_h_e_a.rst
+++ b/Doc/source/ttLib/tables/_h_h_e_a.rst
@@ -1,8 +1,9 @@
-``hhea``: Horizontal Header Table
+``hhea``: Horizontal Header table
 ---------------------------------
 
+The ``hhea`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._h_h_e_a
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_h_m_t_x.rst
+++ b/Doc/source/ttLib/tables/_h_m_t_x.rst
@@ -1,8 +1,9 @@
-``hmtx``: Horizontal Metrics Table
+``hmtx``: Horizontal Metrics table
 ----------------------------------
 
+The ``hmtx`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._h_m_t_x
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_k_e_r_n.rst
+++ b/Doc/source/ttLib/tables/_k_e_r_n.rst
@@ -1,8 +1,9 @@
-``kern``: Kerning
------------------
+``kern``: Kerning table
+-----------------------
+
+The ``kern`` table is an OpenType table.
 
 .. automodule:: fontTools.ttLib.tables._k_e_r_n
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_l_c_a_r.rst
+++ b/Doc/source/ttLib/tables/_l_c_a_r.rst
@@ -1,8 +1,9 @@
 ``lcar``: Ligature Caret Table
 ------------------------------
 
+The ``lcar`` table is an Apple Advanced Typography (AAT) table.
+
 .. automodule:: fontTools.ttLib.tables._l_c_a_r
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_l_o_c_a.rst
+++ b/Doc/source/ttLib/tables/_l_o_c_a.rst
@@ -1,8 +1,9 @@
-``loca``: Index to Location
----------------------------
+``loca``: Index to Location table
+---------------------------------
+
+The ``loca`` table is an OpenType table.
 
 .. automodule:: fontTools.ttLib.tables._l_o_c_a
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_l_t_a_g.rst
+++ b/Doc/source/ttLib/tables/_l_t_a_g.rst
@@ -1,8 +1,9 @@
-``ltag``: Language Tag
-----------------------
+``ltag``: Language Tag table
+----------------------------
+
+The ``ltag`` table is an Apple Advanced Typography (AAT) table.
 
 .. automodule:: fontTools.ttLib.tables._l_t_a_g
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_m_a_x_p.rst
+++ b/Doc/source/ttLib/tables/_m_a_x_p.rst
@@ -1,8 +1,9 @@
-``maxp``: Maximum Profile
--------------------------
+``maxp``: Maximum Profile table
+-------------------------------
+
+The ``maxp`` table is an OpenType table.
 
 .. automodule:: fontTools.ttLib.tables._m_a_x_p
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_m_e_t_a.rst
+++ b/Doc/source/ttLib/tables/_m_e_t_a.rst
@@ -1,8 +1,9 @@
-``meta``: Metadata Table
+``meta``: Metadata table
 ------------------------
 
+The ``meta`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._m_e_t_a
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_m_o_r_t.rst
+++ b/Doc/source/ttLib/tables/_m_o_r_t.rst
@@ -1,8 +1,9 @@
 ``mort``: Glyph Metamorphosis Table
 -----------------------------------
 
+The ``mort`` table is an Apple Advanced Typography (AAT) table.
+
 .. automodule:: fontTools.ttLib.tables._m_o_r_t
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_m_o_r_x.rst
+++ b/Doc/source/ttLib/tables/_m_o_r_x.rst
@@ -1,8 +1,9 @@
 ``morx``: Extended Glyph Metamorphosis Table
 --------------------------------------------
 
+The ``morx`` table is an Apple Advanced Typography (AAT) table.
+
 .. automodule:: fontTools.ttLib.tables._m_o_r_x
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_n_a_m_e.rst
+++ b/Doc/source/ttLib/tables/_n_a_m_e.rst
@@ -1,8 +1,9 @@
-``name``: Naming Table
+``name``: Naming table
 ----------------------
 
+The ``name`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._n_a_m_e
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_o_p_b_d.rst
+++ b/Doc/source/ttLib/tables/_o_p_b_d.rst
@@ -1,8 +1,9 @@
 ``opbd``: Optical Bounds Table
 ------------------------------
 
+The ``opbd`` table is an Apple Advanced Typography (AAT) table.
+
 .. automodule:: fontTools.ttLib.tables._o_p_b_d
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_p_o_s_t.rst
+++ b/Doc/source/ttLib/tables/_p_o_s_t.rst
@@ -1,8 +1,9 @@
-``post``: PostScript Table
+``post``: PostScript table
 --------------------------
 
+The ``post`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._p_o_s_t
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_p_r_e_p.rst
+++ b/Doc/source/ttLib/tables/_p_r_e_p.rst
@@ -1,8 +1,9 @@
-``prep``: Control Value Program
--------------------------------
+``prep``: Control Value Program table
+-------------------------------------
+
+The ``prep`` table is an OpenType table.
 
 .. automodule:: fontTools.ttLib.tables._p_r_e_p
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_p_r_o_p.rst
+++ b/Doc/source/ttLib/tables/_p_r_o_p.rst
@@ -1,8 +1,9 @@
 ``prop``: Glyph Properties Table
 --------------------------------
 
+The ``prop`` table is an Apple Advanced Typography (AAT) table.
+
 .. automodule:: fontTools.ttLib.tables._p_r_o_p
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_s_b_i_x.rst
+++ b/Doc/source/ttLib/tables/_s_b_i_x.rst
@@ -3,22 +3,10 @@
 
 The ``sbix`` table is an OpenType table.
 
+This ``sbix`` table converter module depends on the
+:mod:`.sbixGlyph` and :mod:`.sbixStrike` modules.
+
+
 .. automodule:: fontTools.ttLib.tables._s_b_i_x
-   :members:
-   :undoc-members:
-
-
-
-sbixGlyph
-^^^^^^^^^
-
-.. automodule:: fontTools.ttLib.tables.sbixGlyph
-   :members:
-   :undoc-members:
-
-sbixStrike
-^^^^^^^^^^
-
-.. automodule:: fontTools.ttLib.tables.sbixStrike
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/_s_b_i_x.rst
+++ b/Doc/source/ttLib/tables/_s_b_i_x.rst
@@ -1,8 +1,9 @@
-``sbix``: Standard Bitmap Graphics Table
+``sbix``: Standard Bitmap Graphics table
 ----------------------------------------
 
+The ``sbix`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._s_b_i_x
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -12,7 +13,6 @@ sbixGlyph
 ^^^^^^^^^
 
 .. automodule:: fontTools.ttLib.tables.sbixGlyph
-   :inherited-members:
    :members:
    :undoc-members:
 
@@ -20,6 +20,5 @@ sbixStrike
 ^^^^^^^^^^
 
 .. automodule:: fontTools.ttLib.tables.sbixStrike
-   :inherited-members:
    :members:
    :undoc-members:

--- a/Doc/source/ttLib/tables/_t_r_a_k.rst
+++ b/Doc/source/ttLib/tables/_t_r_a_k.rst
@@ -1,8 +1,9 @@
 ``trak``: Tracking table
 ------------------------
 
+The ``trak`` table is an Apple Advanced Typography (AAT) table.
+
 .. automodule:: fontTools.ttLib.tables._t_r_a_k
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_v_h_e_a.rst
+++ b/Doc/source/ttLib/tables/_v_h_e_a.rst
@@ -1,8 +1,9 @@
-``vhea``: Vertical Header Table
+``vhea``: Vertical Header table
 -------------------------------
 
+The ``vhea`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._v_h_e_a
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/_v_m_t_x.rst
+++ b/Doc/source/ttLib/tables/_v_m_t_x.rst
@@ -1,8 +1,9 @@
-``vmtx``: Vertical Metrics Table
+``vmtx``: Vertical Metrics table
 --------------------------------
 
+The ``vmtx`` table is an OpenType table.
+
 .. automodule:: fontTools.ttLib.tables._v_m_t_x
-   :inherited-members:
    :members:
    :undoc-members:
 

--- a/Doc/source/ttLib/tables/grUtils.rst
+++ b/Doc/source/ttLib/tables/grUtils.rst
@@ -1,0 +1,17 @@
+############################
+Graphite table helper module
+############################
+
+.. rubric:: Overview:
+   :heading-level: 2
+
+The :mod:`grUtils` module is a helper for :mod:`fontTools.ttLib` that
+provides lower-level support for Graphite table converters.
+
+.. rubric:: Module members:
+   :heading-level: 2
+
+.. automodule:: fontTools.ttLib.tables.grUtils
+   :inherited-members:
+   :members:
+   :undoc-members:

--- a/Doc/source/ttLib/tables/table_api.rst
+++ b/Doc/source/ttLib/tables/table_api.rst
@@ -1,0 +1,83 @@
+##########################
+Base table classes and API
+##########################
+
+.. contents:: On this page:
+    :local:
+
+.. rubric:: Overview:
+   :heading-level: 2
+
+The modules documented on this page are the base classes on which the
+:mod:`fontTools.ttLib` table converters are built. The
+:class:`.DefaultTable` is the most general; :class:`.asciiTable` is a
+simpler option for storing text-based data. For OpenType and TrueType
+fonts, the :class:`.otBase.BaseTTXConverter` leverages the model used
+by the majority of existing OpenType/TrueType converters.
+
+
+Contributing your own table convertors
+--------------------------------------
+
+To add support for a new font table that fontTools does not currently implement,
+you must subclass from :py:mod:`fontTools.ttLib.tables.DefaultTable.DefaultTable`.
+It provides some default behavior, as well as a constructor method (``__init__``)
+that you don't need to override.
+
+Your converter should minimally provide two methods::
+
+
+    class table_F_O_O_(DefaultTable.DefaultTable): # converter for table 'FOO '
+
+        def decompile(self, data, ttFont):
+            # 'data' is the raw table data. Unpack it into a
+            # Python data structure.
+            # 'ttFont' is a ttLib.TTfile instance, enabling you to
+            # refer to other tables. Do ***not*** keep a reference to
+            # it: it will cause a circular reference (ttFont saves
+            # a reference to us), and that means we'll be leaking
+            # memory. If you need to use it in other methods, just
+            # pass it around as a method argument.
+
+        def compile(self, ttFont):
+            # Return the raw data, as converted from the Python
+            # data structure.
+            # Again, 'ttFont' is there so you can access other tables.
+            # Same warning applies.
+
+
+If you want to support TTX import/export as well, you need to provide two
+additional methods::
+
+
+   def toXML(self, writer, ttFont):
+      # XXX
+
+   def fromXML(self, (name, attrs, content), ttFont):
+      # XXX
+
+      
+
+fontTools.ttLib.tables.DefaultTable
+-----------------------------------
+
+.. automodule:: fontTools.ttLib.tables.DefaultTable
+   :members:
+   :undoc-members:
+
+
+fontTools.ttLib.tables.asciiTable
+---------------------------------
+
+.. automodule:: fontTools.ttLib.tables.asciiTable
+   :members:
+   :undoc-members:
+
+
+fontTools.ttLib.tables.otBase
+-----------------------------
+
+.. automodule:: fontTools.ttLib.tables.otBase
+   :members:
+   :undoc-members:
+

--- a/Doc/source/ttLib/tables/ttProgram.rst
+++ b/Doc/source/ttLib/tables/ttProgram.rst
@@ -1,0 +1,16 @@
+###################################################
+ttProgram: TrueType bytecode assembler/disassembler
+###################################################
+
+.. rubric:: Overview:
+   :heading-level: 2
+
+The :mod:`fontTools.ttLib.ttProgram` module is a helper for
+:mod:`fontTools.ttLib`.
+
+.. automodule:: fontTools.ttLib.tables.ttProgram
+   :members:
+   :undoc-members:
+    
+    .. rubric:: Module members:
+       :heading-level: 2

--- a/Lib/fontTools/ttLib/tables/B_A_S_E_.py
+++ b/Lib/fontTools/ttLib/tables/B_A_S_E_.py
@@ -2,4 +2,13 @@ from .otBase import BaseTTXConverter
 
 
 class table_B_A_S_E_(BaseTTXConverter):
+    """Baseline table
+
+    The ``BASE`` table contains information needed to align glyphs in
+    different scripts, from different fonts, or at different sizes
+    within the same line of text.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/base
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/C_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/C_B_D_T_.py
@@ -21,6 +21,16 @@ import struct
 
 
 class table_C_B_D_T_(E_B_D_T_.table_E_B_D_T_):
+    """Color Bitmap Data table
+
+    The ``CBDT`` table contains color bitmap data for glyphs. It must
+    be used in concert with the ``CBLC`` table.
+
+    It is backwards-compatible with the monochrome/grayscale ``EBDT`` table.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/cbdt
+    """
+
     # Change the data locator table being referenced.
     locatorName = "CBLC"
 

--- a/Lib/fontTools/ttLib/tables/C_B_L_C_.py
+++ b/Lib/fontTools/ttLib/tables/C_B_L_C_.py
@@ -6,4 +6,14 @@ from . import E_B_L_C_
 
 
 class table_C_B_L_C_(E_B_L_C_.table_E_B_L_C_):
+    """Color Bitmap Location table
+
+    The ``CBLC`` table contains the locations of color bitmaps for glyphs. It must
+    be used in concert with the ``CBDT`` table.
+
+    It is backwards-compatible with the monochrome/grayscale ``EBLC`` table.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/cblc
+    """
+
     dependencies = ["CBDT"]

--- a/Lib/fontTools/ttLib/tables/C_F_F_.py
+++ b/Lib/fontTools/ttLib/tables/C_F_F_.py
@@ -4,6 +4,21 @@ from . import DefaultTable
 
 
 class table_C_F_F_(DefaultTable.DefaultTable):
+    """Compact Font Format table (version 1)
+
+    The ``CFF`` table embeds a CFF-formatted font. The CFF font format
+    predates OpenType and could be used as a standalone font file, but the
+    ``CFF`` table is also used to package CFF fonts into an OpenType
+    container.
+
+    .. note::
+       ``CFF`` has been succeeded by ``CFF2``, which eliminates much of
+       the redundancy incurred by embedding CFF version 1 in an OpenType
+       font.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/cff
+    """
+
     def __init__(self, tag=None):
         DefaultTable.DefaultTable.__init__(self, tag)
         self.cff = cffLib.CFFFontSet()

--- a/Lib/fontTools/ttLib/tables/C_F_F__2.py
+++ b/Lib/fontTools/ttLib/tables/C_F_F__2.py
@@ -3,6 +3,19 @@ from fontTools.ttLib.tables.C_F_F_ import table_C_F_F_
 
 
 class table_C_F_F__2(table_C_F_F_):
+    """Compact Font Format version 2 table
+
+    The ``CFF2`` table contains glyph data for a CFF2-flavored OpenType
+    font.
+
+    .. note::
+       ``CFF2`` is the successor to ``CFF``, and eliminates much of
+       the redundancy incurred by embedding CFF version 1 in an OpenType
+       font.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/cff2
+    """
+
     def decompile(self, data, otFont):
         self.cff.decompile(BytesIO(data), otFont, isCFF2=True)
         assert len(self.cff) == 1, "can't deal with multi-font CFF tables."

--- a/Lib/fontTools/ttLib/tables/C_O_L_R_.py
+++ b/Lib/fontTools/ttLib/tables/C_O_L_R_.py
@@ -7,11 +7,19 @@ from . import DefaultTable
 
 
 class table_C_O_L_R_(DefaultTable.DefaultTable):
-    """This table is structured so that you can treat it like a dictionary keyed by glyph name.
+    """Color table
+
+    The ``COLR`` table defines color presentation of outline glyphs. It must
+    be used in concert with the ``CPAL`` table, which contains the color
+    descriptors used.
+
+    This table is structured so that you can treat it like a dictionary keyed by glyph name.
 
     ``ttFont['COLR'][<glyphName>]`` will return the color layers for any glyph.
 
     ``ttFont['COLR'][<glyphName>] = <value>`` will set the color layers for any glyph.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/colr
     """
 
     @staticmethod

--- a/Lib/fontTools/ttLib/tables/C_P_A_L_.py
+++ b/Lib/fontTools/ttLib/tables/C_P_A_L_.py
@@ -11,6 +11,15 @@ import sys
 
 
 class table_C_P_A_L_(DefaultTable.DefaultTable):
+    """Color Palette table
+
+    The ``CPAL`` table contains a set of one or more color palettes. The color
+    records in each palette can be referenced by the ``COLR`` table to specify
+    the colors used in a color glyph.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/cpal
+    """
+
     NO_NAME_ID = 0xFFFF
     DEFAULT_PALETTE_TYPE = 0
 

--- a/Lib/fontTools/ttLib/tables/D_S_I_G_.py
+++ b/Lib/fontTools/ttLib/tables/D_S_I_G_.py
@@ -39,6 +39,13 @@ DSIG_SignatureBlockFormat = """
 
 
 class table_D_S_I_G_(DefaultTable.DefaultTable):
+    """Digital Signature table
+
+    The ``DSIG`` table contains cryptographic signatures for the font.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/dsig
+    """
+
     def decompile(self, data, ttFont):
         dummy, newData = sstruct.unpack2(DSIG_HeaderFormat, data, self)
         assert self.ulVersion == 1, "DSIG ulVersion must be 1"

--- a/Lib/fontTools/ttLib/tables/E_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_D_T_.py
@@ -38,6 +38,14 @@ ebdtComponentFormat = """
 
 
 class table_E_B_D_T_(DefaultTable.DefaultTable):
+    """Embedded Bitmap Data table
+
+    The ``EBDT`` table contains monochrome or grayscale bitmap data for
+    glyphs. It must be used in concert with the ``EBLC`` table.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/ebdt
+    """
+
     # Keep a reference to the name of the data locator table.
     locatorName = "EBLC"
 

--- a/Lib/fontTools/ttLib/tables/E_B_L_C_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_L_C_.py
@@ -66,6 +66,14 @@ codeOffsetPairSize = struct.calcsize(codeOffsetPairFormat)
 
 
 class table_E_B_L_C_(DefaultTable.DefaultTable):
+    """Embedded Bitmap Location table
+
+    The ``EBLC`` table contains the locations of monochrome or grayscale
+    bitmaps for glyphs. It must be used in concert with the ``EBDT`` table.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/eblc
+    """
+
     dependencies = ["EBDT"]
 
     # This method can be overridden in subclasses to support new formats

--- a/Lib/fontTools/ttLib/tables/F_F_T_M_.py
+++ b/Lib/fontTools/ttLib/tables/F_F_T_M_.py
@@ -13,6 +13,16 @@ FFTMFormat = """
 
 
 class table_F_F_T_M_(DefaultTable.DefaultTable):
+    """FontForge Time Stamp table
+
+    The ``FFTM`` table is used by the free-software font editor
+    FontForge to record timestamps for the creation and modification
+    of font source (.sfd) files and a timestamp for FontForge's
+    own source code.
+
+    See also https://fontforge.org/docs/techref/non-standard.html
+    """
+
     def decompile(self, data, ttFont):
         dummy, rest = sstruct.unpack2(FFTMFormat, data, self)
 

--- a/Lib/fontTools/ttLib/tables/F__e_a_t.py
+++ b/Lib/fontTools/ttLib/tables/F__e_a_t.py
@@ -12,12 +12,17 @@ Feat_hdr_format = """
 
 
 class table_F__e_a_t(DefaultTable.DefaultTable):
-    """The ``Feat`` table is used exclusively by the Graphite shaping engine
+    """Feature table
+
+    The ``Feat`` table is used exclusively by the Graphite shaping engine
     to store features and possible settings specified in GDL. Graphite features
     determine what rules are applied to transform a glyph stream.
 
     Not to be confused with ``feat``, or the OpenType Layout tables
-    ``GSUB``/``GPOS``."""
+    ``GSUB``/``GPOS``.
+
+    See also https://graphite.sil.org/graphite_techAbout#graphite-font-tables
+    """
 
     def __init__(self, tag=None):
         DefaultTable.DefaultTable.__init__(self, tag)

--- a/Lib/fontTools/ttLib/tables/G_D_E_F_.py
+++ b/Lib/fontTools/ttLib/tables/G_D_E_F_.py
@@ -2,4 +2,12 @@ from .otBase import BaseTTXConverter
 
 
 class table_G_D_E_F_(BaseTTXConverter):
+    """Glyph Definition table
+
+    The ``GDEF`` table stores various glyph properties that are used
+    by OpenType Layout.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/gdef
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/G_M_A_P_.py
+++ b/Lib/fontTools/ttLib/tables/G_M_A_P_.py
@@ -81,6 +81,13 @@ class GMAPRecord(object):
 
 
 class table_G_M_A_P_(DefaultTable.DefaultTable):
+    """Glyphlets GMAP table
+
+    The ``GMAP`` table is used by Adobe's SING Glyphlets.
+
+    See also https://web.archive.org/web/20080627183635/http://www.adobe.com/devnet/opentype/gdk/topic.html
+    """
+
     dependencies = []
 
     def decompile(self, data, ttFont):

--- a/Lib/fontTools/ttLib/tables/G_P_K_G_.py
+++ b/Lib/fontTools/ttLib/tables/G_P_K_G_.py
@@ -16,6 +16,13 @@ GPKGFormat = """
 
 
 class table_G_P_K_G_(DefaultTable.DefaultTable):
+    """Glyphlets GPKG table
+
+    The ``GPKG`` table is used by Adobe's SING Glyphlets.
+
+    See also https://web.archive.org/web/20080627183635/http://www.adobe.com/devnet/opentype/gdk/topic.html
+    """
+
     def decompile(self, data, ttFont):
         dummy, newData = sstruct.unpack2(GPKGFormat, data, self)
 

--- a/Lib/fontTools/ttLib/tables/G_P_O_S_.py
+++ b/Lib/fontTools/ttLib/tables/G_P_O_S_.py
@@ -2,4 +2,13 @@ from .otBase import BaseTTXConverter
 
 
 class table_G_P_O_S_(BaseTTXConverter):
+    """Glyph Positioning table
+
+    The ``GPOS`` table stores advanced glyph-positioning data
+    used in OpenType Layout features, such as mark attachment,
+    cursive attachment, kerning, and other position adjustments.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/gpos
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/G_S_U_B_.py
+++ b/Lib/fontTools/ttLib/tables/G_S_U_B_.py
@@ -2,4 +2,12 @@ from .otBase import BaseTTXConverter
 
 
 class table_G_S_U_B_(BaseTTXConverter):
+    """Glyph Substitution table
+
+    The ``GSUB`` table contains glyph-substitution rules used in
+    OpenType Layout.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/gsub
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/G__l_a_t.py
+++ b/Lib/fontTools/ttLib/tables/G__l_a_t.py
@@ -62,8 +62,9 @@ class _Dict(dict):
 
 
 class table_G__l_a_t(DefaultTable.DefaultTable):
-    """
-    Support Graphite Glat tables
+    """Graphite Glyph Attributes table
+
+    See also https://graphite.sil.org/graphite_techAbout#graphite-font-tables
     """
 
     def __init__(self, tag=None):

--- a/Lib/fontTools/ttLib/tables/G__l_o_c.py
+++ b/Lib/fontTools/ttLib/tables/G__l_o_c.py
@@ -15,8 +15,9 @@ Gloc_header = """
 
 
 class table_G__l_o_c(DefaultTable.DefaultTable):
-    """
-    Support Graphite Gloc tables
+    """Graphite Index to Glyph Atttributes table
+
+    See also https://graphite.sil.org/graphite_techAbout#graphite-font-tables
     """
 
     dependencies = ["Glat"]

--- a/Lib/fontTools/ttLib/tables/H_V_A_R_.py
+++ b/Lib/fontTools/ttLib/tables/H_V_A_R_.py
@@ -2,4 +2,12 @@ from .otBase import BaseTTXConverter
 
 
 class table_H_V_A_R_(BaseTTXConverter):
+    """Horizontal Metrics Variations table
+
+    The ``HVAR`` table contains variations in horizontal glyph metrics
+    in variable fonts.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/hvar
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/J_S_T_F_.py
+++ b/Lib/fontTools/ttLib/tables/J_S_T_F_.py
@@ -2,4 +2,12 @@ from .otBase import BaseTTXConverter
 
 
 class table_J_S_T_F_(BaseTTXConverter):
+    """Justification table
+
+    The ``JSTF`` table contains glyph substitution and positioning
+    data used to perform text justification.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/jstf
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/L_T_S_H_.py
+++ b/Lib/fontTools/ttLib/tables/L_T_S_H_.py
@@ -9,6 +9,16 @@ import array
 
 
 class table_L_T_S_H_(DefaultTable.DefaultTable):
+    """Linear Threshold table
+
+    The ``LTSH`` table contains per-glyph settings indicating the ppem sizes
+    at which the advance width metric should be scaled linearly, despite the
+    effects of any TrueType instructions that might otherwise alter the
+    advance width.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/ltsh
+    """
+
     def decompile(self, data, ttFont):
         version, numGlyphs = struct.unpack(">HH", data[:4])
         data = data[4:]

--- a/Lib/fontTools/ttLib/tables/M_A_T_H_.py
+++ b/Lib/fontTools/ttLib/tables/M_A_T_H_.py
@@ -2,4 +2,12 @@ from .otBase import BaseTTXConverter
 
 
 class table_M_A_T_H_(BaseTTXConverter):
+    """Mathematical Typesetting table
+
+    The ``MATH`` table contains a variety of information needed to
+    typeset glyphs in mathematical formulas and expressions.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/math
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/M_E_T_A_.py
+++ b/Lib/fontTools/ttLib/tables/M_E_T_A_.py
@@ -68,6 +68,13 @@ def getLabelString(labelID):
 
 
 class table_M_E_T_A_(DefaultTable.DefaultTable):
+    """Glyphlets META table
+
+    The ``META`` table is used by Adobe's SING Glyphlets.
+
+    See also https://web.archive.org/web/20080627183635/http://www.adobe.com/devnet/opentype/gdk/topic.html
+    """
+
     dependencies = []
 
     def decompile(self, data, ttFont):

--- a/Lib/fontTools/ttLib/tables/M_V_A_R_.py
+++ b/Lib/fontTools/ttLib/tables/M_V_A_R_.py
@@ -2,4 +2,12 @@ from .otBase import BaseTTXConverter
 
 
 class table_M_V_A_R_(BaseTTXConverter):
+    """Metrics Variations table
+
+    The ``MVAR`` table contains variation information for font-wide
+    metrics in a variable font.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/mvar
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/O_S_2f_2.py
+++ b/Lib/fontTools/ttLib/tables/O_S_2f_2.py
@@ -113,7 +113,14 @@ OS2_format_5_addition = bigendian + OS2_format_5_addition
 
 
 class table_O_S_2f_2(DefaultTable.DefaultTable):
-    """the OS/2 table"""
+    """OS/2 and Windows Metrics table
+
+    The ``OS/2`` table contains a variety of font-wide metrics and
+    parameters that may be useful to an operating system or other
+    software for system-integration purposes.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/os2
+    """
 
     dependencies = ["head"]
 

--- a/Lib/fontTools/ttLib/tables/S_I_N_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_I_N_G_.py
@@ -20,6 +20,13 @@ SINGFormat = """
 
 
 class table_S_I_N_G_(DefaultTable.DefaultTable):
+    """Glyphlets SING table
+
+    The ``SING`` table is used by Adobe's SING Glyphlets.
+
+    See also https://web.archive.org/web/20080627183635/http://www.adobe.com/devnet/opentype/gdk/topic.html
+    """
+
     dependencies = []
 
     def decompile(self, data, ttFont):

--- a/Lib/fontTools/ttLib/tables/S_T_A_T_.py
+++ b/Lib/fontTools/ttLib/tables/S_T_A_T_.py
@@ -2,4 +2,14 @@ from .otBase import BaseTTXConverter
 
 
 class table_S_T_A_T_(BaseTTXConverter):
+    """Style Attributes table
+
+    The ``STAT`` table records stylistic or typeface-design attributes that
+    differentiate the individual fonts within a font family from one another.
+    Those attributes can be used to assist users when navigating the style
+    variations of a variable font or a family of static fonts.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/stat
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/S_V_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_V_G_.py
@@ -51,6 +51,14 @@ doc_index_entry_format_0Size = sstruct.calcsize(doc_index_entry_format_0)
 
 
 class table_S_V_G_(DefaultTable.DefaultTable):
+    """Scalable Vector Graphics table
+
+    The ``SVG`` table contains representations for glyphs in the SVG
+    image format.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/stat
+    """
+
     def decompile(self, data, ttFont):
         self.docList = []
         # Version 0 is the standardized version of the table; and current.

--- a/Lib/fontTools/ttLib/tables/S__i_l_f.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_f.py
@@ -343,7 +343,10 @@ class _Object:
 
 
 class table_S__i_l_f(DefaultTable.DefaultTable):
-    """Silf table support"""
+    """Graphite Rules table
+
+    See also https://graphite.sil.org/graphite_techAbout#graphite-font-tables
+    """
 
     def __init__(self, tag=None):
         DefaultTable.DefaultTable.__init__(self, tag)

--- a/Lib/fontTools/ttLib/tables/S__i_l_l.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_l.py
@@ -12,6 +12,11 @@ Sill_hdr = """
 
 
 class table_S__i_l_l(DefaultTable.DefaultTable):
+    """Graphite Languages table
+
+    See also https://graphite.sil.org/graphite_techAbout#graphite-font-tables
+    """
+
     def __init__(self, tag=None):
         DefaultTable.DefaultTable.__init__(self, tag)
         self.langs = {}

--- a/Lib/fontTools/ttLib/tables/T_S_I_B_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_B_.py
@@ -1,3 +1,11 @@
+""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+tool to store its table source data.
+
+TSIB contains the source text for the ``BASE`` table.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
+"""
+
 from .T_S_I_V_ import table_T_S_I_V_
 
 

--- a/Lib/fontTools/ttLib/tables/T_S_I_C_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_C_.py
@@ -1,3 +1,12 @@
+""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+tool to store its table source data.
+
+TSIC contains the source text for the Variation CVT window and data for
+the ``cvar`` table.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
+"""
+
 from .otBase import BaseTTXConverter
 
 

--- a/Lib/fontTools/ttLib/tables/T_S_I_D_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_D_.py
@@ -1,3 +1,11 @@
+""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+tool to store its table source data.
+
+TSID contains the source text for the ``GDEF`` table.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
+"""
+
 from .T_S_I_V_ import table_T_S_I_V_
 
 

--- a/Lib/fontTools/ttLib/tables/T_S_I_J_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_J_.py
@@ -1,3 +1,11 @@
+""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+tool to store its table source data.
+
+TSIJ contains the source text for the ``JSTF`` table.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
+"""
+
 from .T_S_I_V_ import table_T_S_I_V_
 
 

--- a/Lib/fontTools/ttLib/tables/T_S_I_P_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_P_.py
@@ -1,3 +1,11 @@
+""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+tool to store its table source data.
+
+TSIP contains the source text for the ``GPOS`` table.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
+"""
+
 from .T_S_I_V_ import table_T_S_I_V_
 
 

--- a/Lib/fontTools/ttLib/tables/T_S_I_S_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_S_.py
@@ -1,3 +1,11 @@
+""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+tool to store its table source data.
+
+TSIS contains the source text for the ``GSUB`` table.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
+"""
+
 from .T_S_I_V_ import table_T_S_I_V_
 
 

--- a/Lib/fontTools/ttLib/tables/T_S_I_V_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_V_.py
@@ -1,3 +1,9 @@
+""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+tool to store its table source data.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
+"""
+
 from fontTools.misc.textTools import strjoin, tobytes, tostr
 from . import asciiTable
 

--- a/Lib/fontTools/ttLib/tables/T_S_I__0.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__0.py
@@ -4,6 +4,8 @@ tool to store its hinting source data.
 TSI0 is the index table containing the lengths and offsets for the glyph
 programs and 'extra' programs ('fpgm', 'prep', and 'cvt') that are contained
 in the TSI1 table.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
 """
 
 from . import DefaultTable

--- a/Lib/fontTools/ttLib/tables/T_S_I__1.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__1.py
@@ -3,6 +3,8 @@ tool to store its hinting source data.
 
 TSI1 contains the text of the glyph programs in the form of low-level assembly
 code, as well as the 'extra' programs 'fpgm', 'ppgm' (i.e. 'prep'), and 'cvt'.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
 """
 
 from . import DefaultTable

--- a/Lib/fontTools/ttLib/tables/T_S_I__2.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__2.py
@@ -4,6 +4,8 @@ tool to store its hinting source data.
 TSI2 is the index table containing the lengths and offsets for the glyph
 programs that are contained in the TSI3 table. It uses the same format as
 the TSI0 table.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
 """
 
 from fontTools import ttLib

--- a/Lib/fontTools/ttLib/tables/T_S_I__3.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__3.py
@@ -2,6 +2,8 @@
 tool to store its hinting source data.
 
 TSI3 contains the text of the glyph programs in the form of 'VTTTalk' code.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
 """
 
 from fontTools import ttLib

--- a/Lib/fontTools/ttLib/tables/T_S_I__5.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__5.py
@@ -2,6 +2,8 @@
 tool to store its hinting source data.
 
 TSI5 contains the VTT character groups.
+
+See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
 """
 
 from fontTools.misc.textTools import safeEval

--- a/Lib/fontTools/ttLib/tables/T_T_F_A_.py
+++ b/Lib/fontTools/ttLib/tables/T_T_F_A_.py
@@ -2,4 +2,13 @@ from . import asciiTable
 
 
 class table_T_T_F_A_(asciiTable.asciiTable):
+    """ttfautohint parameters table
+
+    The ``TTFA`` table is used by the free-software `ttfautohint` program
+    to record the parameters that `ttfautohint` was called with when it
+    was used to auto-hint the font.
+
+    See also http://freetype.org/ttfautohint/doc/ttfautohint.html#miscellaneous-1
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/V_A_R_C_.py
+++ b/Lib/fontTools/ttLib/tables/V_A_R_C_.py
@@ -2,4 +2,11 @@ from .otBase import BaseTTXConverter
 
 
 class table_V_A_R_C_(BaseTTXConverter):
+    """Variable Components table
+
+    The ``VARC`` table contains variation information for composite glyphs.
+
+    See also https://github.com/harfbuzz/boring-expansion-spec/blob/main/VARC.md
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/V_D_M_X_.py
+++ b/Lib/fontTools/ttLib/tables/V_D_M_X_.py
@@ -37,6 +37,14 @@ VDMX_vTableFmt = """
 
 
 class table_V_D_M_X_(DefaultTable.DefaultTable):
+    """Vertical Device Metrics table
+
+    The ``VDMX`` table records changes to the vertical glyph minima
+    and maxima that result from Truetype instructions.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/vdmx
+    """
+
     def decompile(self, data, ttFont):
         pos = 0  # track current position from to start of VDMX table
         dummy, data = sstruct.unpack2(VDMX_HeaderFmt, data, self)

--- a/Lib/fontTools/ttLib/tables/V_O_R_G_.py
+++ b/Lib/fontTools/ttLib/tables/V_O_R_G_.py
@@ -4,11 +4,18 @@ import struct
 
 
 class table_V_O_R_G_(DefaultTable.DefaultTable):
-    """This table is structured so that you can treat it like a dictionary keyed by glyph name.
+    """Vertical Origin table
+
+    The ``VORG`` table contains the vertical origin of each glyph
+    in a `CFF` or `CFF2` font.
+
+    This table is structured so that you can treat it like a dictionary keyed by glyph name.
 
     ``ttFont['VORG'][<glyphName>]`` will return the vertical origin for any glyph.
 
     ``ttFont['VORG'][<glyphName>] = <value>`` will set the vertical origin for any glyph.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/vorg
     """
 
     def decompile(self, data, ttFont):

--- a/Lib/fontTools/ttLib/tables/V_V_A_R_.py
+++ b/Lib/fontTools/ttLib/tables/V_V_A_R_.py
@@ -2,4 +2,12 @@ from .otBase import BaseTTXConverter
 
 
 class table_V_V_A_R_(BaseTTXConverter):
+    """Vertical Metrics Variations table
+
+    The ``VVAR`` table contains variation data for per-glyph vertical metrics
+    in a variable font.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/vvar
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/_a_n_k_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_n_k_r.py
@@ -2,11 +2,12 @@ from .otBase import BaseTTXConverter
 
 
 class table__a_n_k_r(BaseTTXConverter):
-    """
+    """Anchor Point table
+
     The anchor point table provides a way to define anchor points.
     These are points within the coordinate space of a given glyph,
     independent of the control points used to render the glyph.
-    Anchor points are used in conjunction with the 'kerx' table.
+    Anchor points are used in conjunction with the ``kerx`` table.
 
     See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6ankr.html
     """

--- a/Lib/fontTools/ttLib/tables/_a_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r.py
@@ -22,7 +22,7 @@ from .otBase import BaseTTXConverter
 
 
 class table__a_v_a_r(BaseTTXConverter):
-    """Axis Variations Table
+    """Axis Variations table
 
     This class represents the ``avar`` table of a variable font. The object has one
     substantive attribute, ``segments``, which maps axis tags to a segments dictionary::
@@ -43,6 +43,8 @@ class table__a_v_a_r(BaseTTXConverter):
     ``avar`` segment mapping must contain the entries ``-1.0: -1.0, 0.0: 0.0, 1.0: 1.0``.
     fontTools does not enforce this, so it is your responsibility to ensure that
     mappings are valid.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/avar
     """
 
     dependencies = ["fvar"]

--- a/Lib/fontTools/ttLib/tables/_b_s_l_n.py
+++ b/Lib/fontTools/ttLib/tables/_b_s_l_n.py
@@ -3,4 +3,13 @@ from .otBase import BaseTTXConverter
 
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6bsln.html
 class table__b_s_l_n(BaseTTXConverter):
+    """Baseline table
+
+    The AAT ``bsln`` table is similar in purpose to the OpenType ``BASE``
+    table; it stores per-script baselines to support automatic alignment
+    of lines of text.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6bsln.html
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/_c_i_d_g.py
+++ b/Lib/fontTools/ttLib/tables/_c_i_d_g.py
@@ -3,7 +3,9 @@ from .otBase import BaseTTXConverter
 
 
 class table__c_i_d_g(BaseTTXConverter):
-    """The AAT ``cidg`` table has almost the same structure as ``gidc``,
+    """CID to Glyph ID table
+
+    The AAT ``cidg`` table has almost the same structure as ``gidc``,
     just mapping CIDs to GlyphIDs instead of the reverse direction.
 
     It is useful for fonts that may be used by a PDF renderer in lieu of
@@ -14,6 +16,9 @@ class table__c_i_d_g(BaseTTXConverter):
     obsoleted by ``cidg``.
 
     For example, the first font in ``/System/Library/Fonts/PingFang.ttc``
-    (which Apple ships pre-installed on MacOS 10.12.6) has a ``cidg`` table."""
+    (which Apple ships pre-installed on MacOS 10.12.6) has a ``cidg`` table.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6gcid.html
+    """
 
     pass

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -54,6 +54,8 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
             cmap = newTable("cmap")
             cmap.tableVersion = 0
             cmap.tables = [cmap4_0_3]
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/cmap
     """
 
     def getcmap(self, platformID, platEncID):

--- a/Lib/fontTools/ttLib/tables/_c_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_c_v_a_r.py
@@ -24,6 +24,14 @@ CVAR_HEADER_SIZE = sstruct.calcsize(CVAR_HEADER_FORMAT)
 
 
 class table__c_v_a_r(DefaultTable.DefaultTable):
+    """Control Value Table (CVT) variations table
+
+    The ``cvar`` table contains variations for the values in a ``cvt``
+    table.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/cvar
+    """
+
     dependencies = ["cvt ", "fvar"]
 
     def __init__(self, tag=None):

--- a/Lib/fontTools/ttLib/tables/_c_v_t.py
+++ b/Lib/fontTools/ttLib/tables/_c_v_t.py
@@ -5,6 +5,14 @@ import array
 
 
 class table__c_v_t(DefaultTable.DefaultTable):
+    """Control Value Table
+
+    The Control Value Table holds a list of values that can be referenced
+    by TrueType font instructions.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/cvt
+    """
+
     def decompile(self, data, ttFont):
         values = array.array("h")
         values.frombytes(data)

--- a/Lib/fontTools/ttLib/tables/_f_e_a_t.py
+++ b/Lib/fontTools/ttLib/tables/_f_e_a_t.py
@@ -2,11 +2,14 @@ from .otBase import BaseTTXConverter
 
 
 class table__f_e_a_t(BaseTTXConverter):
-    """The feature name table is an AAT (Apple Advanced Typography) table for
+    """Feature name table
+
+    The feature name table is an AAT (Apple Advanced Typography) table for
     storing font features, settings, and their human-readable names. It should
     not be confused with the ``Feat`` table or the OpenType Layout ``GSUB``/``GPOS``
-    tables. See `Feature Name Table <https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6feat.html>`_
-    in the TrueType Reference Manual for more information on the structure and
-    purpose of this table."""
+    tables.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6feat.html
+    """
 
     pass

--- a/Lib/fontTools/ttLib/tables/_f_p_g_m.py
+++ b/Lib/fontTools/ttLib/tables/_f_p_g_m.py
@@ -3,6 +3,17 @@ from . import ttProgram
 
 
 class table__f_p_g_m(DefaultTable.DefaultTable):
+    """Font Program table
+
+    The ``fpgm`` table typically contains function defintions that are
+    used by font instructions. This Font Program is similar to the Control
+    Value Program that is stored in the ``prep`` table, but
+    the ``fpgm`` table is only executed one time, when the font is first
+    used.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/fpgm
+    """
+
     def decompile(self, data, ttFont):
         program = ttProgram.Program()
         program.fromBytecode(data)

--- a/Lib/fontTools/ttLib/tables/_f_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_f_v_a_r.py
@@ -43,6 +43,14 @@ FVAR_INSTANCE_FORMAT = """
 
 
 class table__f_v_a_r(DefaultTable.DefaultTable):
+    """FonT Variations table
+
+    The ``fvar`` table contains records of the variation axes and of the
+    named instances in a variable font.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6fvar.html
+    """
+
     dependencies = ["name"]
 
     def __init__(self, tag=None):

--- a/Lib/fontTools/ttLib/tables/_g_a_s_p.py
+++ b/Lib/fontTools/ttLib/tables/_g_a_s_p.py
@@ -10,6 +10,14 @@ GASP_GRIDFIT = 0x0001
 
 
 class table__g_a_s_p(DefaultTable.DefaultTable):
+    """Grid-fitting and Scan-conversion Procedure table
+
+    The ``gasp`` table defines the preferred rasterization settings for
+    the font when rendered on monochrome and greyscale output devices.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/gasp
+    """
+
     def decompile(self, data, ttFont):
         self.version, numRanges = struct.unpack(">HH", data[:4])
         assert 0 <= self.version <= 1, "unknown 'gasp' format: %s" % self.version

--- a/Lib/fontTools/ttLib/tables/_g_c_i_d.py
+++ b/Lib/fontTools/ttLib/tables/_g_c_i_d.py
@@ -3,4 +3,11 @@ from .otBase import BaseTTXConverter
 
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6gcid.html
 class table__g_c_i_d(BaseTTXConverter):
+    """Glyph ID to CID table
+
+    The AAT ``gcid` table stores glyphID-to-CID mappings.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6gcid.html
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/_g_c_i_d.py
+++ b/Lib/fontTools/ttLib/tables/_g_c_i_d.py
@@ -5,7 +5,7 @@ from .otBase import BaseTTXConverter
 class table__g_c_i_d(BaseTTXConverter):
     """Glyph ID to CID table
 
-    The AAT ``gcid` table stores glyphID-to-CID mappings.
+    The AAT ``gcid`` table stores glyphID-to-CID mappings.
 
     See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6gcid.html
     """

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -54,7 +54,7 @@ SCALE_COMPONENT_OFFSET_DEFAULT = 0  # 0 == MS, 1 == Apple
 
 
 class table__g_l_y_f(DefaultTable.DefaultTable):
-    """Glyph Data Table
+    """Glyph Data table
 
     This class represents the `glyf <https://docs.microsoft.com/en-us/typography/opentype/spec/glyf>`_
     table, which contains outlines for glyphs in TrueType format. In many cases,

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -41,6 +41,16 @@ GVAR_HEADER_SIZE = sstruct.calcsize(GVAR_HEADER_FORMAT)
 
 
 class table__g_v_a_r(DefaultTable.DefaultTable):
+    """Glyph Variations table
+
+    The ``gvar`` table provides the per-glyph variation data that
+    describe how glyph outlines in the ``glyf`` table change across
+    the variation space that is defined for the font in the ``fvar``
+    table.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/gvar
+    """
+
     dependencies = ["fvar", "glyf"]
 
     def __init__(self, tag=None):

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -3,6 +3,7 @@ from functools import partial
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval
 from fontTools.misc.lazyTools import LazyDict
+from fontTools.ttLib.tables.TupleVariation import TupleVariation
 from . import DefaultTable
 import array
 import itertools
@@ -11,10 +12,7 @@ import struct
 import sys
 import fontTools.ttLib.tables.TupleVariation as tv
 
-
 log = logging.getLogger(__name__)
-TupleVariation = tv.TupleVariation
-
 
 # https://www.microsoft.com/typography/otspec/gvar.htm
 # https://www.microsoft.com/typography/otspec/otvarcommonformats.htm

--- a/Lib/fontTools/ttLib/tables/_h_d_m_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_d_m_x.py
@@ -31,6 +31,14 @@ class _GlyphnamedList(Mapping):
 
 
 class table__h_d_m_x(DefaultTable.DefaultTable):
+    """Horizontal Device Metrics table
+
+    The ``hdmx`` table is an optional table that stores advance widths for
+    glyph outlines at specified pixel sizes.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/hdmx
+    """
+
     def decompile(self, data, ttFont):
         numGlyphs = ttFont["maxp"].numGlyphs
         glyphOrder = ttFont.getGlyphOrder()

--- a/Lib/fontTools/ttLib/tables/_h_e_a_d.py
+++ b/Lib/fontTools/ttLib/tables/_h_e_a_d.py
@@ -37,6 +37,13 @@ headFormat = """
 
 
 class table__h_e_a_d(DefaultTable.DefaultTable):
+    """Font Header table
+
+    The ``head`` table contains a variety of font-wide information.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/head
+    """
+
     dependencies = ["maxp", "loca", "CFF ", "CFF2"]
 
     def decompile(self, data, ttFont):

--- a/Lib/fontTools/ttLib/tables/_h_h_e_a.py
+++ b/Lib/fontTools/ttLib/tables/_h_h_e_a.py
@@ -31,6 +31,18 @@ hheaFormat = """
 
 
 class table__h_h_e_a(DefaultTable.DefaultTable):
+    """Horizontal Header table
+
+    The ``hhea`` table contains information needed during horizontal
+    text layout.
+
+    .. note::
+       This converter class is kept in sync with the :class:`._v_h_e_a.table__v_h_e_a`
+       table constructor.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/hhea
+    """
+
     # Note: Keep in sync with table__v_h_e_a
 
     dependencies = ["hmtx", "glyf", "CFF ", "CFF2"]

--- a/Lib/fontTools/ttLib/tables/_h_m_t_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x.py
@@ -12,6 +12,15 @@ log = logging.getLogger(__name__)
 
 
 class table__h_m_t_x(DefaultTable.DefaultTable):
+    """Horizontal Metrics table
+
+    The ``hmtx`` table contains per-glyph metrics for the glyphs in a
+    ``glyf``, ``CFF ``, or ``CFF2`` table, as needed for horizontal text
+    layout.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/hmtx
+    """
+
     headerTag = "hhea"
     advanceName = "width"
     sideBearingName = "lsb"

--- a/Lib/fontTools/ttLib/tables/_k_e_r_n.py
+++ b/Lib/fontTools/ttLib/tables/_k_e_r_n.py
@@ -12,6 +12,17 @@ log = logging.getLogger(__name__)
 
 
 class table__k_e_r_n(DefaultTable.DefaultTable):
+    """Kerning table
+
+    The ``kern`` table contains values that contextually adjust the inter-glyph
+    spacing for the glyphs in a ``glyf`` table.
+
+    Note that similar contextual spacing adjustments can also be stored
+    in the "kern" feature of a ``GPOS`` table.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/kern
+    """
+
     def getkern(self, format):
         for subtable in self.kernTables:
             if subtable.format == format:

--- a/Lib/fontTools/ttLib/tables/_l_c_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_l_c_a_r.py
@@ -2,4 +2,12 @@ from .otBase import BaseTTXConverter
 
 
 class table__l_c_a_r(BaseTTXConverter):
+    """Ligature Caret table
+
+    The AAT ``lcar`` table stores division points within ligatures, which applications
+    can use to position carets properly between the logical parts of the ligature.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6lcar.html
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/_l_o_c_a.py
+++ b/Lib/fontTools/ttLib/tables/_l_o_c_a.py
@@ -8,6 +8,14 @@ log = logging.getLogger(__name__)
 
 
 class table__l_o_c_a(DefaultTable.DefaultTable):
+    """Index to Location table
+
+    The ``loca`` table stores the offsets in the ``glyf`` table that correspond
+    to the descriptions of each glyph. The glyphs are references by Glyph ID.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/loca
+    """
+
     dependencies = ["glyf"]
 
     def decompile(self, data, ttFont):

--- a/Lib/fontTools/ttLib/tables/_l_t_a_g.py
+++ b/Lib/fontTools/ttLib/tables/_l_t_a_g.py
@@ -6,6 +6,14 @@ import struct
 
 
 class table__l_t_a_g(DefaultTable.DefaultTable):
+    """Language Tag table
+
+    The AAT ``ltag`` table contains mappings between the numeric codes used
+    in the language field of the ``name`` table and IETF language tags.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6ltag.html
+    """
+
     def __init__(self, tag=None):
         DefaultTable.DefaultTable.__init__(self, tag)
         self.version, self.flags = 1, 0

--- a/Lib/fontTools/ttLib/tables/_m_a_x_p.py
+++ b/Lib/fontTools/ttLib/tables/_m_a_x_p.py
@@ -27,6 +27,14 @@ maxpFormat_1_0_add = """
 
 
 class table__m_a_x_p(DefaultTable.DefaultTable):
+    """Maximum Profile table
+
+    The ``maxp`` table contains the memory requirements for the data in
+    the font.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/maxp
+    """
+
     dependencies = ["glyf"]
 
     def decompile(self, data, ttFont):

--- a/Lib/fontTools/ttLib/tables/_m_e_t_a.py
+++ b/Lib/fontTools/ttLib/tables/_m_e_t_a.py
@@ -24,6 +24,14 @@ DATA_MAP_FORMAT = """
 
 
 class table__m_e_t_a(DefaultTable.DefaultTable):
+    """Metadata table
+
+    The ``meta`` table contains various metadata values for the font. Each
+    category of metadata in the table is identified by a four-character tag.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/meta
+    """
+
     def __init__(self, tag=None):
         DefaultTable.DefaultTable.__init__(self, tag)
         self.data = {}

--- a/Lib/fontTools/ttLib/tables/_m_o_r_t.py
+++ b/Lib/fontTools/ttLib/tables/_m_o_r_t.py
@@ -3,4 +3,12 @@ from .otBase import BaseTTXConverter
 
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6mort.html
 class table__m_o_r_t(BaseTTXConverter):
+    """The AAT ``mort`` table contains glyph transformations used for script shaping and
+    for various other optional smart features.
+
+    Note: ``mort`` has been deprecated in favor of the newer ``morx`` table.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6mort.html
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/_m_o_r_x.py
+++ b/Lib/fontTools/ttLib/tables/_m_o_r_x.py
@@ -3,4 +3,13 @@ from .otBase import BaseTTXConverter
 
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6morx.html
 class table__m_o_r_x(BaseTTXConverter):
+    """The AAT ``morx`` table contains glyph transformations used for script shaping and
+    for various other optional smart features, akin to ``GSUB`` and ``GPOS`` features
+    in OpenType Layout.
+
+    Note: ``morx`` is a replacement for the now deprecated ``mort`` table.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6morx.html
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -36,6 +36,16 @@ nameRecordSize = sstruct.calcsize(nameRecordFormat)
 
 
 class table__n_a_m_e(DefaultTable.DefaultTable):
+    """Naming table
+
+    The ``name`` table is used to store a variety of strings that can be
+    associated with user-facing font information. Records in the ``name``
+    table can be tagged with language tags to support multilingual naming
+    and can support platform-specific character-encoding variants.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/name
+    """
+
     dependencies = ["ltag"]
 
     def decompile(self, data, ttFont):

--- a/Lib/fontTools/ttLib/tables/_o_p_b_d.py
+++ b/Lib/fontTools/ttLib/tables/_o_p_b_d.py
@@ -3,4 +3,12 @@ from .otBase import BaseTTXConverter
 
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6opbd.html
 class table__o_p_b_d(BaseTTXConverter):
+    """Optical Bounds table
+
+    The AAT ``opbd`` table contains optical boundary points for glyphs, which
+    applications can use for the visual alignment of lines of text.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6opbd.html
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/_p_o_s_t.py
+++ b/Lib/fontTools/ttLib/tables/_p_o_s_t.py
@@ -27,6 +27,15 @@ postFormatSize = sstruct.calcsize(postFormat)
 
 
 class table__p_o_s_t(DefaultTable.DefaultTable):
+    """PostScript table
+
+    The ``post`` table contains information needed to use the font on
+    PostScript printers, including the PostScript names of glyphs and
+    data that was stored in the ``FontInfo`` dictionary for Type 1 fonts.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/post
+    """
+
     def decompile(self, data, ttFont):
         sstruct.unpack(postFormat, data[:postFormatSize], self)
         data = data[postFormatSize:]

--- a/Lib/fontTools/ttLib/tables/_p_r_e_p.py
+++ b/Lib/fontTools/ttLib/tables/_p_r_e_p.py
@@ -4,4 +4,13 @@ superclass = ttLib.getTableClass("fpgm")
 
 
 class table__p_r_e_p(superclass):
+    """Control Value Program table
+
+    The ``prep`` table contains TrueType instructions that can makee font-wide
+    alterations to the Control Value Table. It may potentially be executed
+    before any glyph is processed.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/prep
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/_p_r_o_p.py
+++ b/Lib/fontTools/ttLib/tables/_p_r_o_p.py
@@ -3,4 +3,10 @@ from .otBase import BaseTTXConverter
 
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6prop.html
 class table__p_r_o_p(BaseTTXConverter):
+    """The AAT ``prop`` table can store a variety of per-glyph properties, such as
+       Unicode directionality or whether glyphs are non-spacing marks.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6prop.html
+    """
+
     pass

--- a/Lib/fontTools/ttLib/tables/_s_b_i_x.py
+++ b/Lib/fontTools/ttLib/tables/_s_b_i_x.py
@@ -28,6 +28,16 @@ sbixStrikeOffsetFormatSize = sstruct.calcsize(sbixStrikeOffsetFormat)
 
 
 class table__s_b_i_x(DefaultTable.DefaultTable):
+    """Standard Bitmap Graphics table
+
+    The ``sbix`` table stores bitmap image data in standard graphics formats
+    like JPEG, PNG, or TIFF. The glyphs for which the ``sbix`` table provides
+    data are indexed by Glyph ID. For each such glyph, the ``sbix`` table can
+    hold different data for different sizes, called "strikes."
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/sbix
+    """
+
     def __init__(self, tag=None):
         DefaultTable.DefaultTable.__init__(self, tag)
         self.version = 1

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k.py
@@ -58,6 +58,13 @@ PER_SIZE_VALUE_FORMAT_SIZE = struct.calcsize(PER_SIZE_VALUE_FORMAT)
 
 
 class table__t_r_a_k(DefaultTable.DefaultTable):
+    """The AAT ``trak`` table can store per-size adjustments to each glyph's
+    sidebearings to make when tracking is enabled, which applications can
+    use to provide more visually balanced line spacing.
+
+    See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6trak.html
+    """
+
     dependencies = ["name"]
 
     def compile(self, ttFont):

--- a/Lib/fontTools/ttLib/tables/_v_h_e_a.py
+++ b/Lib/fontTools/ttLib/tables/_v_h_e_a.py
@@ -31,6 +31,18 @@ vheaFormat = """
 
 
 class table__v_h_e_a(DefaultTable.DefaultTable):
+    """Vertical Header table
+
+    The ``vhea`` table contains information needed during vertical
+    text layout.
+
+    .. note::
+       This converter class is kept in sync with the :class:`._h_h_e_a.table__h_h_e_a`
+       table constructor.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/vhea
+    """
+
     # Note: Keep in sync with table__h_h_e_a
 
     dependencies = ["vmtx", "glyf", "CFF ", "CFF2"]

--- a/Lib/fontTools/ttLib/tables/_v_m_t_x.py
+++ b/Lib/fontTools/ttLib/tables/_v_m_t_x.py
@@ -4,6 +4,15 @@ superclass = ttLib.getTableClass("hmtx")
 
 
 class table__v_m_t_x(superclass):
+    """Vertical Metrics table
+
+    The ``vmtx`` table contains per-glyph metrics for the glyphs in a
+    ``glyf``, ``CFF ``, or ``CFF2`` table, as needed for vertical text
+    layout.
+
+    See also https://learn.microsoft.com/en-us/typography/opentype/spec/vmtx
+    """
+
     headerTag = "vhea"
     advanceName = "height"
     sideBearingName = "tsb"


### PR DESCRIPTION
This is primarily repetitive stuff, adding some basic information to each module page under `ttLib/tables` in the Docs hierarchy and some basic docstring content to the modules themselves — at least, for the ones that didn't already have it.

I think there are a number of table modules that could use more, mainly as a "newcomer-friendly" feature that can point them in the right direction if they're needing to access or manipulate something specific. This .rst+docstring setup should allow that to go either place.