### PR TITLE
[transform] Fix typing, test, and tidy

### DIFF
--- a/Lib/fontTools/misc/transform.py
+++ b/Lib/fontTools/misc/transform.py
@@ -253,8 +253,6 @@ class Transform(NamedTuple):
                 <Transform [0 1 -1 0 0 0]>
                 >>>
         """
-        import math
-
         c = _normSinCos(math.cos(angle))
         s = _normSinCos(math.sin(angle))
         return self.transform((c, s, -s, c, 0, 0))
@@ -269,8 +267,6 @@ class Transform(NamedTuple):
                 <Transform [1 0 1 1 0 0]>
                 >>>
         """
-        import math
-
         return self.transform((1, math.tan(y), math.tan(x), 1, 0, 0))
 
     def transform(self, other):

--- a/Lib/fontTools/misc/transform.py
+++ b/Lib/fontTools/misc/transform.py
@@ -67,7 +67,7 @@ _ONE_EPSILON = 1 - _EPSILON
 _MINUS_ONE_EPSILON = -1 + _EPSILON
 
 
-def _normSinCos(v):
+def _normSinCos(v: float) -> float:
     if abs(v) < _EPSILON:
         v = 0
     elif v > _ONE_EPSILON:
@@ -243,7 +243,7 @@ class Transform(NamedTuple):
             y = x
         return self.transform((x, 0, 0, y, 0, 0))
 
-    def rotate(self, angle):
+    def rotate(self, angle: float):
         """Return a new transformation, rotated by 'angle' (radians).
 
         :Example:
@@ -334,7 +334,7 @@ class Transform(NamedTuple):
         dx, dy = -xx * dx - yx * dy, -xy * dx - yy * dy
         return self.__class__(xx, xy, yx, yy, dx, dy)
 
-    def toPS(self):
+    def toPS(self) -> str:
         """Return a PostScript representation
 
         :Example:
@@ -350,7 +350,7 @@ class Transform(NamedTuple):
         """Decompose into a DecomposedTransform."""
         return DecomposedTransform.fromTransform(self)
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Returns True if transform is not identity, False otherwise.
 
         :Example:
@@ -372,14 +372,14 @@ class Transform(NamedTuple):
         """
         return self != Identity
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s [%g %g %g %g %g %g]>" % ((self.__class__.__name__,) + self)
 
 
 Identity = Transform()
 
 
-def Offset(x: float = 0, y: float = 0):
+def Offset(x: float = 0, y: float = 0) -> Transform:
     """Return the identity transformation offset by x, y.
 
     :Example:
@@ -390,7 +390,7 @@ def Offset(x: float = 0, y: float = 0):
     return Transform(1, 0, 0, 1, x, y)
 
 
-def Scale(x: float, y: float | None = None):
+def Scale(x: float, y: float | None = None) -> Transform:
     """Return the identity transformation scaled by x, y. The 'y' argument
     may be None, which implies to use the x value for y as well.
 
@@ -490,7 +490,7 @@ class DecomposedTransform:
             0,
         )
 
-    def toTransform(self):
+    def toTransform(self) -> Transform:
         """Return the Transform() equivalent of this transformation.
 
         :Example:

--- a/Lib/fontTools/misc/transform.py
+++ b/Lib/fontTools/misc/transform.py
@@ -52,6 +52,8 @@ translate, rotation, scale, skew, and transformation-center components.
 	>>>
 """
 
+from __future__ import annotations
+
 import math
 from typing import NamedTuple
 from dataclasses import dataclass
@@ -214,7 +216,7 @@ class Transform(NamedTuple):
         xx, xy, yx, yy = self[:4]
         return [(xx * dx + yx * dy, xy * dx + yy * dy) for dx, dy in vectors]
 
-    def translate(self, x=0, y=0):
+    def translate(self, x: float = 0, y: float = 0):
         """Return a new transformation, translated (offset) by x, y.
 
         :Example:
@@ -225,7 +227,7 @@ class Transform(NamedTuple):
         """
         return self.transform((1, 0, 0, 1, x, y))
 
-    def scale(self, x=1, y=None):
+    def scale(self, x: float = 1, y: float | None = None):
         """Return a new transformation, scaled by x, y. The 'y' argument
         may be None, which implies to use the x value for y as well.
 
@@ -257,7 +259,7 @@ class Transform(NamedTuple):
         s = _normSinCos(math.sin(angle))
         return self.transform((c, s, -s, c, 0, 0))
 
-    def skew(self, x=0, y=0):
+    def skew(self, x: float = 0, y: float = 0):
         """Return a new transformation, skewed by x and y.
 
         :Example:
@@ -381,7 +383,7 @@ class Transform(NamedTuple):
 Identity = Transform()
 
 
-def Offset(x=0, y=0):
+def Offset(x: float = 0, y: float = 0):
     """Return the identity transformation offset by x, y.
 
     :Example:
@@ -392,7 +394,7 @@ def Offset(x=0, y=0):
     return Transform(1, 0, 0, 1, x, y)
 
 
-def Scale(x, y=None):
+def Scale(x: float, y: float | None = None):
     """Return the identity transformation scaled by x, y. The 'y' argument
     may be None, which implies to use the x value for y as well.
 

--- a/Tests/misc/transform_test.py
+++ b/Tests/misc/transform_test.py
@@ -123,7 +123,6 @@ class TransformTest(object):
         assert d.translateX == 5
         assert d.translateY == 7
 
-    def test_decompose(self):
         t = Transform(-1, 0, 0, 1, 0, 0)
         d = t.toDecomposed()
         assert d.scaleX == -1


### PR DESCRIPTION
This PR adds explicit type annotations to more of the `Transform` class and friends, to stop eager type checkers from implicitly assuming that we cannot pass `float`s to function arguments that have `int` or `None` defaults.

In addition, the PR contains a few other smaller fixes/tidies that were made while in the neighbourhood:
- Fix test obscured by overlapping function name
- Remove now-redundant inline `math` imports
- Add a few more type annotations, where there was low-hanging fruit

---

Ideally in the future we can explicitly type more of the `Transform` class's return values too, but we will need Python 3.11's `typing.Self` to represent its current behaviour exactly.