### PR TITLE
Correct docstring of AlternateSubstStatement

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -595,8 +595,8 @@ class MarkClassDefinition(Statement):
 class AlternateSubstStatement(Statement):
     """A ``sub ... from ...`` statement.
 
-    ``prefix``, ``glyph``, ``suffix`` and ``replacement`` should be lists of
-    `glyph-containing objects`_. ``glyph`` should be a `one element list`."""
+    ``glyph`` and ``replacement`` should be `glyph-containing objects`_. 
+    ``prefix`` and ``suffix`` should be lists of `glyph-containing objects`_."""
 
     def __init__(self, prefix, glyph, suffix, replacement, location=None):
         Statement.__init__(self, location)


### PR DESCRIPTION
The current docstring suggests that both `.glyph` and `.replacement` should be **lists** of “glyph-containing objects”:

https://github.com/fonttools/fonttools/blob/ef07e3b2cc6987a35ba32d8dcbb79a435965ba3b/Lib/fontTools/feaLib/ast.py#L595-L604

But the `asFea()` implementation actually expects `.glyph` and `.replacement` to be “glyph-containing objects”, not nested in lists:

https://github.com/fonttools/fonttools/blob/ef07e3b2cc6987a35ba32d8dcbb79a435965ba3b/Lib/fontTools/feaLib/ast.py#L616-L629