### PR TITLE
[glyf] fix bbox of transformed components with un-rounded coordinates

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1187,7 +1187,7 @@ class Glyph(object):
         ):
             return
         try:
-            coords, endPts, flags = self.getCoordinates(glyfTable)
+            coords, endPts, flags = self.getCoordinates(glyfTable, round=otRound)
             self.xMin, self.yMin, self.xMax, self.yMax = coords.calcIntBounds()
         except NotImplementedError:
             pass
@@ -1241,7 +1241,7 @@ class Glyph(object):
         else:
             return self.numberOfContours == -1
 
-    def getCoordinates(self, glyfTable):
+    def getCoordinates(self, glyfTable, round=noRound):
         """Return the coordinates, end points and flags
 
         This method returns three values: A :py:class:`GlyphCoordinates` object,
@@ -1267,13 +1267,16 @@ class Glyph(object):
             for compo in self.components:
                 g = glyfTable[compo.glyphName]
                 try:
-                    coordinates, endPts, flags = g.getCoordinates(glyfTable)
+                    coordinates, endPts, flags = g.getCoordinates(
+                        glyfTable, round=round
+                    )
                 except RecursionError:
                     raise ttLib.TTLibError(
                         "glyph '%s' contains a recursive component reference"
                         % compo.glyphName
                     )
                 coordinates = GlyphCoordinates(coordinates)
+                coordinates.toInt(round=round)
                 if hasattr(compo, "firstPt"):
                     # component uses two reference points: we apply the transform _before_
                     # computing the offset between the points


### PR DESCRIPTION
The first commit reproduces the issue found in https://github.com/googlefonts/fontc/issues/1206, whereby the bounding box of a composite glyph with non-trivial transforms that references a base glyph in turn containing un-rounded floating-point coordinates, may end up with off-by-ones 

The fix (in a follow up commit) is to compute their bounding box on the rounded integer coordinates.

context: when building a VF, ufo2ft passes to fonttools TTGlyphs with unrounded coordinates, so that the latter can effectively drop implied off-curve glyf points (when that optional feature is enabled). We want to keep the coords unrounded (they will be eventually rounded anyway upon saving, after dropImpliedOncurvePoints has done its thing), but at the same time we want ufo2ft to compute the _final_ glyf bounding boxes from the to-be-rounded integer coordinates. We don't want that a bunch of composite glyphs' bboxes get "fixed" e.g. if one dumps the VF to xml and recompiles with ttx, for example.
