### PR TITLE
DeltaValue writer fails to write

### DIFF
--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1681,7 +1681,7 @@ class DeltaValue(BaseConverter):
         StartSize = tableDict["StartSize"]
         EndSize = tableDict["EndSize"]
         DeltaFormat = tableDict["DeltaFormat"]
-        DeltaValue = value
+        DeltaValue = value[0]
         assert DeltaFormat in (1, 2, 3), "illegal DeltaFormat"
         nItems = EndSize - StartSize + 1
         nBits = 1 << DeltaFormat


### PR DESCRIPTION
I have a font with Delta values built into the `GPOS` table that I am trying to round-trip through TTX:

Here is an example of it:
```
              <BaseRecord index="3">
                <BaseAnchor index="0" Format="3">
                  <XCoordinate value="1460"/>
                  <YCoordinate value="0"/>
                  <XDeviceTable>
                    <StartSize value="23"/>
                    <EndSize value="35"/>
                    <DeltaFormat value="2"/>
                    <DeltaValue value="[2, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1]"/>
                  </XDeviceTable>
                  <YDeviceTable>
                    <StartSize value="11"/>
                    <EndSize value="35"/>
                    <DeltaFormat value="2"/>
                    <DeltaValue value="[2, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1]"/>
                  </YDeviceTable>
                </BaseAnchor>
```
However, every time I tried to build the font, fonttools errors on the deltavalues above. Stepping through the specific code in otConverters, I found that the problem is due to this line `assert len(DeltaValue) == nItems`. In manually counting the items, this assertion appears to be fine, but I discovered that the `value` that is being passed into `DeltaValue` is not `[2, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1]` as it should be, but `[[2, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1]]`, which is of course returning a `len` of 1 instead of 13. 

Adding `[0]` to the declaration for `DeltaValue` solves this problem.