### PR TITLE
[feaLib] Make FeatureLibError pickleable (#3762)

### DIFF
--- a/Lib/fontTools/feaLib/error.py
+++ b/Lib/fontTools/feaLib/error.py
@@ -1,5 +1,5 @@
 class FeatureLibError(Exception):
-    def __init__(self, message, location):
+    def __init__(self, message, location=None):
         Exception.__init__(self, message)
         self.location = location
 


### PR DESCRIPTION
Adding a default value for `location` makes `FeatureLibError` pickleable and thus useable with multiprocessing.