### PR TITLE
Check for name ID in other platforms if needed

### DIFF
--- a/Lib/fontTools/varLib/instancer/names.py
+++ b/Lib/fontTools/varLib/instancer/names.py
@@ -221,9 +221,18 @@ def _updateNameRecords(varfont, axisValues):
             getName(n, *platform).toUnicode() for n in ribbiNameIDs
         )
         if nonRibbiNameIDs:
-            typoSubFamilyName = " ".join(
-                getName(n, *platform).toUnicode() for n in axisValueNameIDs
-            )
+            try:
+                typoSubFamilyName = " ".join(
+                    getName(n, *platform).toUnicode() for n in axisValueNameIDs
+                )
+            # not every name ID exists for every plaform, so get this from another platform if needed
+            except AttributeError:
+                for nameID in axisValueNameIDs:
+                    for platform in platforms:
+                        if getName(nameID, *platform):
+                            typoSubFamilyName = getName(nameID, *platform).toUnicode()
+                            break
+
         else:
             typoSubFamilyName = None
 
@@ -235,9 +244,17 @@ def _updateNameRecords(varfont, axisValues):
             else:
                 typoSubFamilyName = getName(elidedNameID, *platform).toUnicode()
 
-        familyNameSuffix = " ".join(
-            getName(n, *platform).toUnicode() for n in nonRibbiNameIDs
-        )
+        try:
+            familyNameSuffix = " ".join(
+                getName(n, *platform).toUnicode() for n in nonRibbiNameIDs
+            )
+        # not every name ID exists for every plaform, so get this from another platform if needed
+        except AttributeError:
+            for nameID in nonRibbiNameIDs:
+                for platform in platforms:
+                    if getName(nameID, *platform):
+                        familyNameSuffix = getName(nameID, *platform).toUnicode()
+                        break
 
         _updateNameTableStyleRecords(
             varfont,


### PR DESCRIPTION
I’m running into a similar issue as is described at https://github.com/fonttools/fonttools/issues/3478#issuecomment-2051372683

I’m attempting to create instances from a variable font that has all name entries for `platformID="3" platEncID="1"`, but only a limited set for `platformID="1" platEncID="0"` (basically, just names 0–14). From what I’ve observed, this is fairly common.

The instancing fails because the name handling comes across a name entry that doesn’t exist, and tries to convert that NoneType to Unicode. I think this happens because the name handling is trying to update names across each platform, but doesn’t account for some platforms having only a subset of entries.

This solution first tries the previous approach, but if an `AttributeError` is thrown, it then goes and checks for that entry in other platforms, and carries on once it finds a value.

In my current use case, this seems to work well. However, my understanding of the full picture here is somewhat limited, so I may be missing something. I’m happy for any feedback or suggestions!

Thanks.

UPDATE:

Oh no... this doesn’t quite work yet. I’m getting a doubling of style names. Not sure if that is from this adjustment, or from something else. Will adjust this if I find the solution.