### PR TITLE
[varStore] use the same sorting for both input/output

### DIFF
--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -412,25 +412,6 @@ class _Encoding(object):
     def extend(self, lst):
         self.items.update(lst)
 
-    def get_room(self):
-        """Maximum number of bytes that can be added to characteristic
-        while still being beneficial to merge it into another one."""
-        count = len(self.items)
-        return max(0, (self.overhead - 1) // count - self.width)
-
-    room = property(get_room)
-
-    def get_gain(self):
-        """Maximum possible byte gain from merging this into another
-        characteristic."""
-        count = len(self.items)
-        return max(0, self.overhead - count)
-
-    gain = property(get_gain)
-
-    def gain_sort_key(self):
-        return self.gain, self.chars
-
     def width_sort_key(self):
         return self.width, self.chars
 
@@ -534,13 +515,9 @@ def VarStore_optimize(self, use_NO_VARIATION_INDEX=True, quantization=1):
     # of the old encoding is completely eliminated. However, each row
     # now would require more bytes to encode, to the tune of one byte
     # per characteristic bit that is active in the new encoding but not
-    # in the old one. The number of bits that can be added to an encoding
-    # while still beneficial to merge it into another encoding is called
-    # the "room" for that encoding.
+    # in the old one.
     #
-    # The "gain" of an encodings is the maximum number of bytes we can
-    # save by merging it into another encoding. The "gain" of merging
-    # two encodings is how many bytes we save by doing so.
+    # The "gain" of merging two encodings is how many bytes we save by doing so.
     #
     # High-level algorithm:
     #

--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -554,7 +554,11 @@ def VarStore_optimize(self, use_NO_VARIATION_INDEX=True, quantization=1):
     #
     # - Put all encodings into a "todo" list.
     #
-    # - Sort todo list by decreasing gain (for stability).
+    # - Sort todo list (for stability) by width_sort_key(), which is a tuple
+    #   of the following items:
+    #   * The "width" of the encoding.
+    #   * The characteristic bitmap of the encoding, with higher-numbered
+    #     columns compared first.
     #
     # - Make a priority-queue of the gain from combining each two
     #   encodings in the todo list. The priority queue is sorted by
@@ -575,16 +579,7 @@ def VarStore_optimize(self, use_NO_VARIATION_INDEX=True, quantization=1):
     #
     # The output is then sorted for stability, in the following way:
     # - The VarRegionList of the input is kept intact.
-    # - All encodings are sorted before the main algorithm, by
-    #   gain_key_sort(), which is a tuple of the following items:
-    #   * The gain of the encoding.
-    #   * The characteristic bitmap of the encoding, with higher-numbered
-    #     columns compared first.
-    # - The VarData is sorted by width_sort_key(), which is a tuple
-    #   of the following items:
-    #   * The "width" of the encoding.
-    #   * The characteristic bitmap of the encoding, with higher-numbered
-    #     columns compared first.
+    # - The VarData is sorted by the same width_sort_key() used at the beginning.
     # - Within each VarData, the items are sorted as vectors of numbers.
     #
     # Finally, each VarData is optimized to remove the empty columns and
@@ -626,7 +621,7 @@ def VarStore_optimize(self, use_NO_VARIATION_INDEX=True, quantization=1):
             front_mapping[(major << 16) + minor] = row
 
     # Prepare for the main algorithm.
-    todo = sorted(encodings.values(), key=_Encoding.gain_sort_key)
+    todo = sorted(encodings.values(), key=_Encoding.width_sort_key)
     del encodings
 
     # Repeatedly pick two best encodings to combine, and combine them.


### PR DESCRIPTION
When the VarStore.optimize() algorithm was improved with the addition of a priority queue, specifically with this commit https://github.com/fonttools/fonttools/commit/47ec18f788, a pre-sorting step of the todo list (before the queue itself was populated) was kept to make sure the algorithm continued to produce stable results no matter the order of the inputs.
The optimizer's output is itself sorted, again for stability, but using a different key function with_sort_key() from the one used on the input todo list gain_sort_key().
The rationale for a distinct gain_sort_key, where encodings get sorted by maximum theoretical gain (decreasing, initally, when reverse=True was set, then incrasing as reverse was somehow dropped), is no longer needed now that a priority queue is used (this sorts by actual gains from merging specific pairs of encodings) and as Behdad confirmedf in chat, is probably just a remnant of the previous algorithm.

I propose we do keep some pre-sorting to ensure stability (in case the priority queue initially contains multiple pairs with the same gain), but we reuse the same width_sort_key that is used at the end to sort the output.

Note this doesn't change the overall level of compression achieved by the optimizer, but makes the algorithm a bit less complicated, and easier to match in our alternative Rust implementation.