### PR TITLE
[cmap] Speed up glyphOrder loading from cmap

### DIFF
--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -1179,7 +1179,7 @@ class cmap_format_12_or_13(CmapSubtable):
             )
             pos += 12
             lenGroup = 1 + endCharCode - startCharCode
-            charCodes.extend(list(range(startCharCode, endCharCode + 1)))
+            charCodes.extend(range(startCharCode, endCharCode + 1))
             gids.extend(self._computeGIDs(glyphID, lenGroup))
         self.data = data = None
         self.cmap = _make_map(self.ttFont, charCodes, gids)
@@ -1310,7 +1310,7 @@ class cmap_format_12(cmap_format_12_or_13):
         cmap_format_12_or_13.__init__(self, format)
 
     def _computeGIDs(self, startingGlyph, numberOfGlyphs):
-        return list(range(startingGlyph, startingGlyph + numberOfGlyphs))
+        return range(startingGlyph, startingGlyph + numberOfGlyphs)
 
     def _IsInSameRun(self, glyphID, lastGlyphID, charCode, lastCharCode):
         return (glyphID == 1 + lastGlyphID) and (charCode == 1 + lastCharCode)

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -141,6 +141,17 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
                     result.setdefault(name, set()).add(codepoint)
         return result
 
+    def buildReversedMin(self):
+        result = {}
+        for subtable in self.tables:
+            if subtable.isUnicode():
+                for codepoint, name in subtable.cmap.items():
+                    if name in result:
+                        result[name] = min(result[name], codepoint)
+                    else:
+                        result[name] = codepoint
+        return result
+
     def decompile(self, data, ttFont):
         tableVersion, numSubTables = struct.unpack(">HH", data[:4])
         self.tableVersion = int(tableVersion)

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -1173,11 +1173,13 @@ class cmap_format_12_or_13(CmapSubtable):
         charCodes = []
         gids = []
         pos = 0
+        groups = array.array("I", data[: self.nGroups * 12])
+        if sys.byteorder != "big":
+            groups.byteswap()
         for i in range(self.nGroups):
-            startCharCode, endCharCode, glyphID = struct.unpack(
-                ">LLL", data[pos : pos + 12]
-            )
-            pos += 12
+            startCharCode = groups[i * 3]
+            endCharCode = groups[i * 3 + 1]
+            glyphID = groups[i * 3 + 2]
             lenGroup = 1 + endCharCode - startCharCode
             charCodes.extend(range(startCharCode, endCharCode + 1))
             gids.extend(self._computeGIDs(glyphID, lenGroup))

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -593,10 +593,8 @@ class TTFont(object):
         # temporary cmap and by the real cmap in case we don't find a unicode
         # cmap.
         numGlyphs = int(self["maxp"].numGlyphs)
-        glyphOrder = [None] * numGlyphs
+        glyphOrder = ["glyph%.5d" % i for i in range(numGlyphs)]
         glyphOrder[0] = ".notdef"
-        for i in range(1, numGlyphs):
-            glyphOrder[i] = "glyph%.5d" % i
         # Set the glyph order, so the cmap parser has something
         # to work with (so we don't get called recursively).
         self.glyphOrder = glyphOrder
@@ -606,7 +604,7 @@ class TTFont(object):
         # this naming table will usually not cover all glyphs in the font.
         # If the font has no Unicode cmap table, reversecmap will be empty.
         if "cmap" in self:
-            reversecmap = self["cmap"].buildReversed()
+            reversecmap = self["cmap"].buildReversedMin()
         else:
             reversecmap = {}
         useCount = {}
@@ -616,7 +614,7 @@ class TTFont(object):
                 # If a font maps both U+0041 LATIN CAPITAL LETTER A and
                 # U+0391 GREEK CAPITAL LETTER ALPHA to the same glyph,
                 # we prefer naming the glyph as "A".
-                glyphName = self._makeGlyphName(min(reversecmap[tempName]))
+                glyphName = self._makeGlyphName(reversecmap[tempName])
                 numUses = useCount[glyphName] = useCount.get(glyphName, 0) + 1
                 if numUses > 1:
                     glyphName = "%s.alt%d" % (glyphName, numUses - 1)


### PR DESCRIPTION
I see 10% or so loading glyph names from a large CJK font.