### PR TITLE
[Debg] fix parsing from XML; add roundtrip tests

### DIFF
--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -46,7 +46,8 @@ def parseXmlInto(font, parseInto, xmlSnippet):
     parsed_xml = [e for e in parseXML(xmlSnippet.strip()) if not isinstance(e, str)]
     for name, attrs, content in parsed_xml:
         parseInto.fromXML(name, attrs, content, font)
-    parseInto.populateDefaults()
+    if hasattr(parseInto, "populateDefaults"):
+        parseInto.populateDefaults()
     return parseInto
 
 

--- a/Lib/fontTools/ttLib/tables/D__e_b_g.py
+++ b/Lib/fontTools/ttLib/tables/D__e_b_g.py
@@ -1,9 +1,15 @@
 import json
+from textwrap import indent
 
 from . import DefaultTable
+from fontTools.misc.textTools import tostr
 
 
 class table_D__e_b_g(DefaultTable.DefaultTable):
+    def __init__(self, tag=None):
+        DefaultTable.DefaultTable.__init__(self, tag)
+        self.data = {}
+
     def decompile(self, data, ttFont):
         self.data = json.loads(data)
 
@@ -11,7 +17,19 @@ class table_D__e_b_g(DefaultTable.DefaultTable):
         return json.dumps(self.data).encode("utf-8")
 
     def toXML(self, writer, ttFont):
-        writer.writecdata(json.dumps(self.data, indent=2))
+        # make sure json indentation inside CDATA block matches XMLWriter's
+        data = json.dumps(self.data, indent=len(writer.indentwhite))
+        prefix = tostr(writer.indentwhite) * (writer.indentlevel + 1)
+        # but don't indent the first json line so it's adjacent to `<![CDATA[{`
+        cdata = indent(data, prefix, lambda ln: ln != "{\n")
+
+        writer.begintag("json")
+        writer.newline()
+        writer.writecdata(cdata)
+        writer.newline()
+        writer.endtag("json")
+        writer.newline()
 
     def fromXML(self, name, attrs, content, ttFont):
-        self.data = json.loads(content)
+        if name == "json":
+            self.data = json.loads("".join(content))

--- a/Tests/ttLib/tables/D__e_b_g_test.py
+++ b/Tests/ttLib/tables/D__e_b_g_test.py
@@ -1,0 +1,52 @@
+from fontTools.misc.testTools import parseXmlInto, getXML
+from fontTools.ttLib.tables.D__e_b_g import table_D__e_b_g
+
+
+DEBG_DATA = {
+    "com.github.fonttools.feaLib": {
+        "GPOS": {"0": ["<features>:6:5", "kern_Default", ["DFLT", "dflt", "kern"]]}
+    }
+}
+
+
+DEBG_XML = """\
+<json>
+  <![CDATA[{
+    "com.github.fonttools.feaLib": {
+      "GPOS": {
+        "0": [
+          "<features>:6:5",
+          "kern_Default",
+          [
+            "DFLT",
+            "dflt",
+            "kern"
+          ]
+        ]
+      }
+    }
+  }]]>
+</json>
+"""
+
+
+def test_compile_decompile_and_roundtrip_ttx():
+    ttFont = None
+    table = table_D__e_b_g()
+    assert table.tableTag == "Debg"
+    assert table.data == {}
+    table.data = DEBG_DATA
+
+    data = table.compile(ttFont)
+
+    table2 = table_D__e_b_g()
+    table2.decompile(data, ttFont)
+
+    assert table.data == table2.data
+
+    assert getXML(table2.toXML) == DEBG_XML.splitlines()
+
+    table3 = table_D__e_b_g()
+    parseXmlInto(ttFont, table3, DEBG_XML)
+
+    assert table3.data == DEBG_DATA


### PR DESCRIPTION
Fixes https://github.com/fonttools/fonttools/issues/3779

note this changes the ttx dump of 'Debg' table in that it wraps the CDATA block inside a `<json>` sub-element, which is required for the XMLReader to be able to parse it back from TTX.

Since parsing was silently broken until now, we shouldn't worry about backward compatibility but treat this as a bug fix.

It's also a private table which shouldn't be in production fonts so we are probably free to change as needed.