### PR TITLE
[feaLib] Correct ChainContextPosStatement and ChainContextSubstStatement

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -753,7 +753,7 @@ class ChainContextPosStatement(Statement):
             if len(self.suffix):
                 res += " " + " ".join(map(asFea, self.suffix))
         else:
-            res += " ".join(map(asFea, self.glyph))
+            res += " ".join(map(asFea, self.glyphs))
         res += ";"
         return res
 
@@ -811,7 +811,7 @@ class ChainContextSubstStatement(Statement):
             if len(self.suffix):
                 res += " " + " ".join(map(asFea, self.suffix))
         else:
-            res += " ".join(map(asFea, self.glyph))
+            res += " ".join(map(asFea, self.glyphs))
         res += ";"
         return res
 

--- a/README.rst
+++ b/README.rst
@@ -266,7 +266,7 @@ Vincent Connare, David Corbett, Simon Cozens, Dave Crossland, Simon Daniels,
 Peter Dekkers, Behdad Esfahbod, Behnam Esfahbod, Hannes Famira, Sam Fishman,
 Matt Fontaine, Takaaki Fuji, Rob Hagemans, Yannis Haralambous, Greg Hitchcock,
 Jeremie Hornus, Khaled Hosny, John Hudson, Denis Moyogo Jacquerye, Jack Jansen,
-Tom Kacvinsky, Jens Kutilek, Antoine Leca, Werner Lemberg, Tal Leming, Peter
+Tom Kacvinsky, Jens Kutilek, Antoine Leca, Werner Lemberg, Tal Leming, Liang Hai, Peter
 Lofting, Cosimo Lupo, Olli Meier, Masaya Nakamura, Dave Opstad, Laurence Penney,
 Roozbeh Pournader, Garret Rieger, Read Roberts, Colin Rofls, Guido van Rossum,
 Just van Rossum, Andreas Seidel, Georg Seifert, Chris Simpkins, Miguel Sousa,


### PR DESCRIPTION
They don’t really have `self.glyphs`. The erroneous `self.glyph` has been hiding in a branch of edge case (no prefix, no suffix, and no nested lookups).

It’s unclear if such an edge case should be serialized as a special case (without the `'` mark), therefore I’m only proposing a minimal fix for now.