### PR TITLE
[otlLib.optimize] Fix crash when the provided TTF does not contain a `GPOS`

### DIFF
--- a/Lib/fontTools/otlLib/optimize/gpos.py
+++ b/Lib/fontTools/otlLib/optimize/gpos.py
@@ -53,12 +53,18 @@ def compact(font: TTFont, level: int) -> TTFont:
     #     are not grouped together first; instead each subtable is treated
     #     independently, so currently this step is:
     #     Split existing subtables into more smaller subtables
-    gpos = font["GPOS"]
+    gpos = font.get("GPOS")
+
+    # If the font does not contain a GPOS table, there is nothing to do.
+    if gpos is None:
+        return font
+
     for lookup in gpos.table.LookupList.Lookup:
         if lookup.LookupType == 2:
             compact_lookup(font, level, lookup)
         elif lookup.LookupType == 9 and lookup.SubTable[0].ExtensionLookupType == 2:
             compact_ext_lookup(font, level, lookup)
+
     return font
 
 

--- a/Tests/otlLib/optimize_test.py
+++ b/Tests/otlLib/optimize_test.py
@@ -41,6 +41,37 @@ def test_main(tmpdir: Path):
     assert output.exists()
 
 
+def test_no_crash_with_missing_gpos(tmpdir: Path):
+    """Test that the optimize script gracefully handles TTFs with no GPOS."""
+
+    # Create a test TTF.
+    glyphs = ".notdef space A Aacute B D".split()
+    fb = FontBuilder(1000)
+    fb.setupGlyphOrder(glyphs)
+
+    # Confirm that it has no GPOS.
+    assert "GPOS" not in fb.font
+
+    # Save, and feed to the optimize CLI.
+    input = tmpdir / "in.ttf"
+    fb.save(str(input))
+
+    output = tmpdir / "out.ttf"
+    args = [
+        "--gpos-compression-level",
+        "5",
+        str(input),
+        "-o",
+        str(output),
+    ]
+    from fontTools.otlLib.optimize import main
+
+    # Assert that we did not crash, and saved an output font.
+    ret = main(args)
+    assert ret in (0, None)
+    assert output.exists()
+
+
 # Copy-pasted from https://stackoverflow.com/questions/2059482/python-temporarily-modify-the-current-processs-environment
 # TODO: remove when moving to the Config class
 @contextlib.contextmanager


### PR DESCRIPTION
This especially improves ergonomics when unconditionally invoking the otlLib optimizer as a script, e.g.:

```bash
python -m fontTools.otlLib.optimize Abc.ttf
```

If a `GPOS` table was not present, this would previously crash with `KeyError`; now the script can be used on any font instead.