### PR TITLE
Prune unused regions from HVAR and VVAR when using a direct mapping

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -555,6 +555,8 @@ def _add_VHVAR(font, axisTags, tableFields, getAdvanceMetrics):
             varData.addItem(vhAdvanceDeltasAndSupports[glyphName][0], round=noRound)
         varData.optimize()
         directStore = builder.buildVarStore(varTupleList, [varData])
+        # remove unused regions from VarRegionList
+        directStore.prune_regions()
 
     # Build optimized indirect mapping
     storeBuilder = varStore.OnlineVarStoreBuilder(axisTags)

--- a/Tests/varLib/data/test_results/Build.ttx
+++ b/Tests/varLib/data/test_results/Build.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.42">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.57">
 
   <GDEF>
     <Version value="0x00010003"/>
@@ -45,26 +45,19 @@
       </VarRegionList>
       <!-- VarDataCount=1 -->
       <VarData index="0">
-        <!-- ItemCount=5 -->
+        <!-- ItemCount=6 -->
         <NumShorts value="0"/>
         <!-- VarRegionCount=2 -->
         <VarRegionIndex index="0" value="0"/>
         <VarRegionIndex index="1" value="1"/>
-        <Item index="0" value="[-10, 17]"/>
-        <Item index="1" value="[-7, 63]"/>
-        <Item index="2" value="[-3, 32]"/>
-        <Item index="3" value="[0, 0]"/>
-        <Item index="4" value="[14, -28]"/>
+        <Item index="0" value="[0, 0]"/>
+        <Item index="1" value="[14, -28]"/>
+        <Item index="2" value="[-10, 17]"/>
+        <Item index="3" value="[-3, 32]"/>
+        <Item index="4" value="[-7, 63]"/>
+        <Item index="5" value="[-7, 63]"/>
       </VarData>
     </VarStore>
-    <AdvWidthMap>
-      <Map glyph=".notdef" outer="0" inner="3"/>
-      <Map glyph="uni0020" outer="0" inner="4"/>
-      <Map glyph="uni0024" outer="0" inner="1"/>
-      <Map glyph="uni0024.nostroke" outer="0" inner="1"/>
-      <Map glyph="uni0041" outer="0" inner="0"/>
-      <Map glyph="uni0061" outer="0" inner="2"/>
-    </AdvWidthMap>
   </HVAR>
 
   <MVAR>

--- a/Tests/varLib/data/test_results/BuildMain.ttx
+++ b/Tests/varLib/data/test_results/BuildMain.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.42">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.57">
 
   <GlyphOrder>
     <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
@@ -597,26 +597,19 @@
       </VarRegionList>
       <!-- VarDataCount=1 -->
       <VarData index="0">
-        <!-- ItemCount=5 -->
+        <!-- ItemCount=6 -->
         <NumShorts value="0"/>
         <!-- VarRegionCount=2 -->
         <VarRegionIndex index="0" value="0"/>
         <VarRegionIndex index="1" value="1"/>
-        <Item index="0" value="[-10, 17]"/>
-        <Item index="1" value="[-7, 63]"/>
-        <Item index="2" value="[-3, 32]"/>
-        <Item index="3" value="[0, 0]"/>
-        <Item index="4" value="[14, -28]"/>
+        <Item index="0" value="[0, 0]"/>
+        <Item index="1" value="[14, -28]"/>
+        <Item index="2" value="[-10, 17]"/>
+        <Item index="3" value="[-3, 32]"/>
+        <Item index="4" value="[-7, 63]"/>
+        <Item index="5" value="[-7, 63]"/>
       </VarData>
     </VarStore>
-    <AdvWidthMap>
-      <Map glyph=".notdef" outer="0" inner="3"/>
-      <Map glyph="uni0020" outer="0" inner="4"/>
-      <Map glyph="uni0024" outer="0" inner="1"/>
-      <Map glyph="uni0024.nostroke" outer="0" inner="1"/>
-      <Map glyph="uni0041" outer="0" inner="0"/>
-      <Map glyph="uni0061" outer="0" inner="2"/>
-    </AdvWidthMap>
   </HVAR>
 
   <MVAR>


### PR DESCRIPTION
This saves a handful of bytes for the common case where a font is variable but has no variation in its advances (e.g. for some monospace fonts across `wght`), and we include an empty metrics variation table so that the shaper can immediately ascertain this without interpolating phantom points.

e.g. a direct mapping is now preferred for the font in the included test case, shrinking the table from 47 to 42 bytes

```diff
--- before.xml
+++ after.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Version value="0x00010000"/>
 <VarStore Format="1">
   <Format value="1"/>
   <VarRegionList>
     <!-- RegionAxisCount=1 -->
     <!-- RegionCount=0 -->
   </VarRegionList>
   <!-- VarDataCount=1 -->
   <VarData index="0">
     <!-- ItemCount=1 -->
     <NumShorts value="0"/>
     <!-- VarRegionCount=0 -->
     <Item index="0" value="[]"/>
   </VarData>
 </VarStore>
-<AdvWidthMap>
-  <Map glyph="A" outer="0" inner="0"/>
-</AdvWidthMap>
```

This optimisation is mostly relevant as it brings fontTools in line with fontc's compilation of direct mappings (see googlefonts/fontc#1388).

This area of the API is a bit new to me though - would someone be willing to confirm that I am holding the `prune_regions()` function correctly?

<sub>Note: this is a personal contribution independent of my employer, and so I've submitted from a fork under my personal profile and email to make this distinction</sub>