### PR TITLE
[ttLib] Apply rounding more often in getCoordinates

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1285,11 +1285,7 @@ class Glyph(object):
                 # however, if the referenced component glyph is another composite, we
                 # must not round here but only at the end, after all the nested
                 # transforms have been applied, or else rounding errors will compound.
-                if (
-                    round is not noRound
-                    and g.numberOfContours > 0
-                    and not compo._hasOnlyIntegerTranslate()
-                ):
+                if round is not noRound and g.numberOfContours > 0:
                     coordinates.toInt(round=round)
                 if hasattr(compo, "firstPt"):
                     # component uses two reference points: we apply the transform _before_


### PR DESCRIPTION
Regardless of whether or not a component transform is simple, we still have to round the points before returning, or we risk the error propogating up to another component that might have a non-trivial transform.