### PR TITLE
[ttLib] Ignore component bounds if empty

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1225,7 +1225,7 @@ class Glyph(object):
                 if boundsDone is not None:
                     boundsDone.add(glyphName)
             # empty components shouldn't update the bounds of the parent glyph
-            if g.numberOfContours == 0:
+            if g.yMin == g.yMax and g.xMin == g.xMax:
                 continue
 
             x, y = compo.x, compo.y


### PR DESCRIPTION
That is, if the bounds of a component have zero area, do not consider it when computing the bounds of the parent.

This handles the case of a composite glyph where all the components are themselves empty, which if it sounds weird you're probably new around here.