### PR TITLE
[feaLib] Correctly handle <NULL> in single pos lookups

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1583,7 +1583,9 @@ class SinglePosStatement(Statement):
                 res += " ".join(map(asFea, self.prefix)) + " "
             res += " ".join(
                 [
-                    asFea(x[0]) + "'" + ((" " + x[1].asFea()) if x[1] else "")
+                    asFea(x[0])
+                    + "'"
+                    + ((" " + x[1].asFea()) if x[1] is not None else "")
                     for x in self.pos
                 ]
             )
@@ -1591,7 +1593,10 @@ class SinglePosStatement(Statement):
                 res += " " + " ".join(map(asFea, self.suffix))
         else:
             res += " ".join(
-                [asFea(x[0]) + " " + (x[1].asFea() if x[1] else "") for x in self.pos]
+                [
+                    asFea(x[0]) + " " + (x[1].asFea() if x[1] is not None else "")
+                    for x in self.pos
+                ]
             )
         res += ";"
         return res

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -1545,6 +1545,8 @@ class SinglePosBuilder(LookupBuilder):
             otValueRection: A ``otTables.ValueRecord`` used to position the
                 glyph.
         """
+        if otValueRecord is None:
+            otValueRecord = ValueRecord()
         if not self.can_add(glyph, otValueRecord):
             otherLoc = self.locations[glyph]
             raise OpenTypeLibError(

--- a/Tests/feaLib/ast_test.py
+++ b/Tests/feaLib/ast_test.py
@@ -13,11 +13,33 @@ class AstTest(unittest.TestCase):
         statement = ast.ValueRecord(xPlacement=10, xAdvance=20)
         self.assertEqual(statement.asFea(), "<10 0 20 0>")
 
+    def test_valuerecord_empty(self):
+        statement = ast.ValueRecord()
+        self.assertEqual(statement.asFea(), "<NULL>")
+
     def test_non_object_location(self):
         el = ast.Element(location=("file.fea", 1, 2))
         self.assertEqual(el.location.file, "file.fea")
         self.assertEqual(el.location.line, 1)
         self.assertEqual(el.location.column, 2)
+
+    def test_single_pos_statement_empty_valuerecord(self):
+        statement = ast.SinglePosStatement(
+            pos=[(ast.GlyphName("a"), ast.ValueRecord())],
+            prefix=[],
+            suffix=[],
+            forceChain=False,
+        )
+        self.assertEqual(statement.asFea(), "pos a <NULL>;")
+
+    def test_single_pos_statement_empty_valuerecord_chain(self):
+        statement = ast.SinglePosStatement(
+            pos=[(ast.GlyphName("a"), ast.ValueRecord())],
+            prefix=[],
+            suffix=[],
+            forceChain=True,
+        )
+        self.assertEqual(statement.asFea(), "pos a' <NULL>;")
 
 
 if __name__ == "__main__":

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -91,6 +91,7 @@ class BuilderTest(unittest.TestCase):
         MarkBasePosSubtable
         MarkLigPosSubtable
         MarkMarkPosSubtable
+        single_pos_NULL
     """.split()
 
     VARFONT_AXES = [

--- a/Tests/feaLib/data/single_pos_NULL.fea
+++ b/Tests/feaLib/data/single_pos_NULL.fea
@@ -1,0 +1,8 @@
+# Both lookups should result in SinglePos lookup with a ValueFormat 0
+lookup test1 {
+    pos A <NULL>;
+} test1;
+
+lookup test2 {
+    pos B' <NULL>;
+} test2;

--- a/Tests/feaLib/data/single_pos_NULL.ttx
+++ b/Tests/feaLib/data/single_pos_NULL.ttx
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=3 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="A"/>
+          </Coverage>
+          <ValueFormat value="0"/>
+        </SinglePos>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="8"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextPos index="0" Format="3">
+          <!-- BacktrackGlyphCount=0 -->
+          <!-- InputGlyphCount=1 -->
+          <InputCoverage index="0">
+            <Glyph value="B"/>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- PosCount=1 -->
+          <PosLookupRecord index="0">
+            <SequenceIndex value="0"/>
+            <LookupListIndex value="2"/>
+          </PosLookupRecord>
+        </ChainContextPos>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="B"/>
+          </Coverage>
+          <ValueFormat value="0"/>
+        </SinglePos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1021,6 +1021,16 @@ class ParserTest(unittest.TestCase):
         with self.assertRaisesRegex(FeatureLibError, "Positioning values are allowed"):
             doc = self.parse("feature kern {" "    pos a' b c 123 d;" "} kern;")
 
+    def test_gpos_type_1_null(self):
+        doc = self.parse("feature test {pos a <NULL>;} test;")
+        pos = doc.statements[0].statements[0]
+        self.assertEqual(pos.asFea(), "pos a <NULL>;")
+
+    def test_gpos_type_1_null_chained(self):
+        doc = self.parse("feature test {pos a' <NULL>;} test;")
+        pos = doc.statements[0].statements[0]
+        self.assertEqual(pos.asFea(), "pos a' <NULL>;")
+
     def test_gpos_type_2_format_a(self):
         doc = self.parse(
             "feature kern {" "    pos [T V] -60 [a b c] <1 2 3 4>;" "} kern;"


### PR DESCRIPTION
* Serializing `<NULL>` in single pos statements was broken (it was skipped resulting in invalid feature code).
* Building such lookups was broken as well.

AFDKO’s makeotf does not support `<NULL>` at all, but we support it in pair pos lookups, so this is not much different. It might not be of much value, but it is something OpenType layout supports and it is causing round tripping issue for some code I’m working on.