### PR TITLE
[feaLib] Remove duplicates from class pair pos classes

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1471,7 +1471,9 @@ class Builder(object):
         lookup = self.get_lookup_(location, PairPosBuilder)
         v1 = self.makeOpenTypeValueRecord(location, value1, pairPosContext=True)
         v2 = self.makeOpenTypeValueRecord(location, value2, pairPosContext=True)
-        lookup.addClassPair(location, glyphclass1, v1, glyphclass2, v2)
+        cls1 = tuple(sorted(set(glyphclass1)))
+        cls2 = tuple(sorted(set(glyphclass2)))
+        lookup.addClassPair(location, cls1, v1, cls2, v2)
 
     def add_specific_pair_pos(self, location, glyph1, value1, glyph2, value2):
         if not glyph1 or not glyph2:

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -92,6 +92,7 @@ class BuilderTest(unittest.TestCase):
         MarkLigPosSubtable
         MarkMarkPosSubtable
         single_pos_NULL
+        class_pair_pos_duplicates
     """.split()
 
     VARFONT_AXES = [

--- a/Tests/feaLib/data/class_pair_pos_duplicates.fea
+++ b/Tests/feaLib/data/class_pair_pos_duplicates.fea
@@ -1,0 +1,4 @@
+# This should result in a ValueFormat 0
+feature test {
+    pos [A A B C] [A A B C] -100;
+} test;

--- a/Tests/feaLib/data/class_pair_pos_duplicates.ttx
+++ b/Tests/feaLib/data/class_pair_pos_duplicates.ttx
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage>
+            <Glyph value="A"/>
+            <Glyph value="B"/>
+            <Glyph value="C"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1>
+          </ClassDef1>
+          <ClassDef2>
+            <ClassDef glyph="A" class="1"/>
+            <ClassDef glyph="B" class="1"/>
+            <ClassDef glyph="C" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=1 -->
+          <!-- Class2Count=2 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+              <Value1 XAdvance="0"/>
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XAdvance="-100"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>


### PR DESCRIPTION
AFDKO’s makeotf removes the duplicates and produces the following message:

    NOTE: [line     3 char  29] Removing duplicate glyph <A>
    NOTE: [line     3 char  29] Removing duplicate glyph <A>

While feaLib fails with:

    Traceback (most recent call last):
      File "/fonttools/Lib/fontTools/feaLib/builder.py", line 875, in buildLookups_
        otLookups.append(l.build())
                         ^^^^^^^^^
      File "/fonttools/Lib/fontTools/otlLib/builder.py", line 1460, in build
        builder.addPair(glyphclass1, value1, glyphclass2, value2)
      File "/fonttools/Lib/fontTools/otlLib/builder.py", line 1340, in addPair
        self.classDef1_.add(gc1)
      File "/fonttools/Lib/fontTools/otlLib/builder.py", line 2656, in add
        raise OpenTypeLibError(
    fontTools.otlLib.error.OpenTypeLibError: Glyph A is already present in class.