### PR TITLE
[ttLib] Fix `AttributeError` when reporting table overflow

### DIFF
--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -398,6 +398,7 @@ class OTTableWriter(object):
         self.localState = localState
         self.tableTag = tableTag
         self.parent = None
+        self.name = "<none>"
 
     def __setitem__(self, name, value):
         state = self.localState.copy() if self.localState else dict()


### PR DESCRIPTION
The `OTTableWriter.getOverflowErrorRecord()` method accesses `name` attribute unconditionally, but `OTTableWriter()` constructor does not set it and instead call sites like in otConvertor.py set the name.

But not all call sites set the name. In my case an overflow is happening `otlLib.builder.ChainContextualBuilder.getCompiledSize_()` which constructs an `OTTableWriter` and uses it without setting a name. I don’t even know what name it should use, and it feels less error prune for `OTTableWriter` constructor to set an initial name.