### PR TITLE
[otlLib.builder] Add future import for annotations

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import namedtuple, OrderedDict
 import itertools
 from typing import Dict, Union


### PR DESCRIPTION
Follow up to https://github.com/fonttools/fonttools/pull/3812.

No need to evaluate the types we added early.