### PR TITLE
fix: avoid conflict with freezegun

### DIFF
--- a/Lib/fontTools/misc/loggingTools.py
+++ b/Lib/fontTools/misc/loggingTools.py
@@ -284,11 +284,12 @@ class Timer(object):
     """
 
     # timeit.default_timer choses the most accurate clock for each platform
-    _time = timeit.default_timer
+    _time: Callable[[], float]
     default_msg = "elapsed time: %(time).3fs"
     default_format = "Took %(time).3fs to %(msg)s"
 
     def __init__(self, logger=None, msg=None, level=None, start=None):
+        self._time = timeit.default_timer
         self.reset(start)
         if logger is None:
             for arg in ("msg", "level"):


### PR DESCRIPTION
The original implementation meant that self is passed to default_timer. When freezegun overrides this with a function that doesn't take an argument, it causes a runtime error.

By setting the _time value in the init method, self isn't passed automatically as the first argument

Although I found this issue using freezegun alongside fonttools, it affects anything that overrides time.perf_counter