### PR TITLE
Create a dflt LangSys in a ScriptRecord when adding variations later

### DIFF
--- a/Lib/fontTools/misc/symfont.py
+++ b/Lib/fontTools/misc/symfont.py
@@ -235,6 +235,7 @@ if __name__ == '__main__':
 
 if __name__ == "__main__":
     import sys
+
     if sys.argv[1:]:
         penName = sys.argv[1]
         funcs = [(name, eval(f)) for name, f in zip(sys.argv[2::2], sys.argv[3::2])]

--- a/Lib/fontTools/varLib/featureVars.py
+++ b/Lib/fontTools/varLib/featureVars.py
@@ -392,10 +392,13 @@ def addFeatureVariationsRaw(font, table, conditionalSubstitutions, featureTag="r
 
             for scriptRecord in table.ScriptList.ScriptRecord:
                 if scriptRecord.Script.DefaultLangSys is None:
-                    raise VarLibError(
-                        "Feature variations require that the script "
-                        f"'{scriptRecord.ScriptTag}' defines a default language system."
-                    )
+                    # We need to have a default LangSys to attach variations to.
+                    langSys = ot.LangSys()
+                    langSys.LookupOrder = None
+                    langSys.ReqFeatureIndex = 0xFFFF
+                    langSys.FeatureIndex = []
+                    langSys.FeatureCount = 0
+                    scriptRecord.Script.DefaultLangSys = langSys
                 langSystems = [lsr.LangSys for lsr in scriptRecord.Script.LangSysRecord]
                 for langSys in [scriptRecord.Script.DefaultLangSys] + langSystems:
                     langSys.FeatureIndex.append(varFeatureIndex)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,5 @@
+- [varLib] Create a dflt LangSys in a ScriptRecord when adding variations later, to fix an avoidable crash in an edge case (#3838).
+
 4.58.0 (released 2025-05-10)
 ----------------------------
 

--- a/Tests/varLib/data/test_results/FeatureVars_latn_dflt_var.ttx
+++ b/Tests/varLib/data/test_results/FeatureVars_latn_dflt_var.ttx
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.58">
+
+  <GSUB>
+    <Version value="0x00010001"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=1 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="CAT "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=2 -->
+              <FeatureIndex index="0" value="0"/>
+              <FeatureIndex index="1" value="1"/>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="locl"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="rclt"/>
+        <Feature>
+          <!-- LookupCount=0 -->
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=4 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="uni0061" out="uni0061"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="uni0024" out="uni0024.nostroke"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="uni0041" out="uni0061"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="uni0061" out="uni0041"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+    <FeatureVariations>
+      <Version value="0x00010000"/>
+      <!-- FeatureVariationCount=4 -->
+      <FeatureVariationRecord index="0">
+        <ConditionSet>
+          <!-- ConditionCount=2 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="1"/>
+            <FilterRangeMinValue value="0.75"/>
+            <FilterRangeMaxValue value="1.0"/>
+          </ConditionTable>
+          <ConditionTable index="1" Format="1">
+            <AxisIndex value="0"/>
+            <FilterRangeMinValue value="0.20886"/>
+            <FilterRangeMaxValue value="1.0"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="1"/>
+            <Feature>
+              <!-- LookupCount=2 -->
+              <LookupListIndex index="0" value="1"/>
+              <LookupListIndex index="1" value="2"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+      <FeatureVariationRecord index="1">
+        <ConditionSet>
+          <!-- ConditionCount=2 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="1"/>
+            <FilterRangeMinValue value="0.0"/>
+            <FilterRangeMaxValue value="0.25"/>
+          </ConditionTable>
+          <ConditionTable index="1" Format="1">
+            <AxisIndex value="0"/>
+            <FilterRangeMinValue value="-1.0"/>
+            <FilterRangeMaxValue value="-0.45654"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="1"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="3"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+      <FeatureVariationRecord index="2">
+        <ConditionSet>
+          <!-- ConditionCount=1 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="1"/>
+            <FilterRangeMinValue value="0.75"/>
+            <FilterRangeMaxValue value="1.0"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="1"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="2"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+      <FeatureVariationRecord index="3">
+        <ConditionSet>
+          <!-- ConditionCount=1 -->
+          <ConditionTable index="0" Format="1">
+            <AxisIndex value="0"/>
+            <FilterRangeMinValue value="0.20886"/>
+            <FilterRangeMaxValue value="1.0"/>
+          </ConditionTable>
+        </ConditionSet>
+        <FeatureTableSubstitution>
+          <Version value="0x00010000"/>
+          <!-- SubstitutionCount=1 -->
+          <SubstitutionRecord index="0">
+            <FeatureIndex value="1"/>
+            <Feature>
+              <!-- LookupCount=1 -->
+              <LookupListIndex index="0" value="1"/>
+            </Feature>
+          </SubstitutionRecord>
+        </FeatureTableSubstitution>
+      </FeatureVariationRecord>
+    </FeatureVariations>
+  </GSUB>
+
+</ttFont>

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -338,8 +338,8 @@ class BuildTest(unittest.TestCase):
         )
 
     def test_varlib_build_feature_variations_without_latn_dflt_feature(self):
-        """Test that a script gets a dflt language so that when we later add
-        variations, we can attach to something."""
+        """Test that when a script does not have a dflt language, it gets one
+        when we later add variations, we can attach them to it."""
 
         def add_features(font, savepath):
             features = """

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -337,6 +337,35 @@ class BuildTest(unittest.TestCase):
             post_process_master=add_rclt,
         )
 
+    def test_varlib_build_feature_variations_without_latn_dflt_feature(self):
+        """Test that a script gets a dflt language so that when we later add
+        variations, we can attach to something."""
+
+        def add_features(font, savepath):
+            features = """
+            languagesystem DFLT dflt;
+            languagesystem latn dflt;
+            languagesystem latn CAT;
+
+            feature locl {
+                script latn;
+                # Intentionally skip defining anything for `language dflt;`.
+                language CAT;
+                sub uni0061 by uni0061;
+            } locl;
+            """
+            addOpenTypeFeaturesFromString(font, features)
+            font.save(savepath)
+
+        self._run_varlib_build_test(
+            designspace_name="FeatureVars",
+            font_name="TestFamily",
+            tables=["GSUB"],
+            expected_ttx_name="FeatureVars_latn_dflt_var",
+            save_before_dump=True,
+            post_process_master=add_features,
+        )
+
     def test_varlib_gvar_explicit_delta(self):
         """The variable font contains a composite glyph odieresis which does not
         need a gvar entry.


### PR DESCRIPTION
We found this one during the development of a font. The GSUB table builder seems to discard defined language systems when they have no lookups. This is a problem when we add feature variations in a later step, like we do when we compile a Designspace with rules.

When like in the test code no lookup is defined for `latn` and `dflt`, just for the `CAT ` language, the GSUB table won't have a `dflt` LangSysRecord that https://github.com/fonttools/fonttools/blob/e89d7db4f457742a03d7a07121fd7348ca3ee1ca/Lib/fontTools/varLib/featureVars.py#L394 needs to attach itself to.

TODO:

- [x] Come up with a fix.