### PR TITLE
[feaLib] Add promoted single substitutions to aalt feature

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -883,6 +883,14 @@ class LigatureSubstBuilder(LookupBuilder):
         )
         return self.buildLookup_(subtables)
 
+    def getAlternateGlyphs(self):
+        # https://github.com/fonttools/fonttools/issues/3845
+        return {
+            components[0]: [ligature]
+            for components, ligature in self.ligatures.items()
+            if len(components) == 1
+        }
+
     def add_subtable_break(self, location):
         self.ligatures[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_
 
@@ -920,6 +928,14 @@ class MultipleSubstBuilder(LookupBuilder):
     def build(self):
         subtables = self.build_subst_subtables(self.mapping, buildMultipleSubstSubtable)
         return self.buildLookup_(subtables)
+
+    def getAlternateGlyphs(self):
+        # https://github.com/fonttools/fonttools/issues/3845
+        return {
+            glyph: replacements
+            for glyph, replacements in self.mapping.items()
+            if len(replacements) == 1
+        }
 
     def add_subtable_break(self, location):
         self.mapping[(self.SUBTABLE_BREAK_, location)] = self.SUBTABLE_BREAK_

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -333,6 +333,39 @@ class BuilderTest(unittest.TestCase):
             },
         )
 
+    def test_mixed_singleSubst_multipleSubst_aalt(self):
+        font = self.build(
+            dedent(
+                """
+                feature aalt {
+                  feature ccmp;
+                } aalt;
+
+                feature ccmp {
+                  sub f_f   by f f;
+                  sub f     by f;
+                  sub f_f_i by f f i;
+                  sub [A A.sc] by A;
+                  sub [B B.sc] by [B B.sc];
+                } ccmp;
+                """
+            )
+        )
+
+        assert "GSUB" in font
+        st = font["GSUB"].table.LookupList.Lookup[0].SubTable[0]
+        self.assertEqual(st.LookupType, 1)
+        self.assertEqual(
+            st.mapping,
+            {
+                "A": "A",
+                "A.sc": "A",
+                "B": "B",
+                "B.sc": "B.sc",
+                "f": "f",
+            },
+        )
+
     def test_mixed_singleSubst_ligatureSubst(self):
         font = self.build(
             "lookup test {"
@@ -357,6 +390,28 @@ class BuilderTest(unittest.TestCase):
         self.assertEqual(len(st.ligatures["A"]), 1)
         self.assertEqual(st.ligatures["A"][0].LigGlyph, "A.sc")
         self.assertEqual(len(st.ligatures["A"][0].Component), 0)
+
+    def test_mixed_singleSubst_ligatureSubst_aalt(self):
+        font = self.build(
+            dedent(
+                """
+                feature aalt {
+                  feature liga;
+                } aalt;
+
+                feature liga {
+                  sub f f   by f_f;
+                  sub f f i by f_f_i;
+                  sub A     by A.sc;
+                } liga;
+                """
+            )
+        )
+
+        assert "GSUB" in font
+        st = font["GSUB"].table.LookupList.Lookup[0].SubTable[0]
+        self.assertEqual(st.LookupType, 1)
+        self.assertEqual(st.mapping, {"A": "A.sc"})
 
     def test_mixed_singleSubst_multipleSubst_ligatureSubst(self):
         self.assertRaisesRegex(

--- a/Tests/feaLib/data/spec8a.ttx
+++ b/Tests/feaLib/data/spec8a.ttx
@@ -89,8 +89,6 @@
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
-          <Substitution in="b" out="b.alt"/>
-          <Substitution in="c" out="c.mid"/>
           <Substitution in="e" out="e.mid"/>
         </SingleSubst>
       </Lookup>
@@ -103,6 +101,15 @@
             <Alternate glyph="a.alt1"/>
             <Alternate glyph="a.alt2"/>
             <Alternate glyph="a.alt3"/>
+            <Alternate glyph="A.sc"/>
+          </AlternateSet>
+          <AlternateSet glyph="b">
+            <Alternate glyph="b.alt"/>
+            <Alternate glyph="B.sc"/>
+          </AlternateSet>
+          <AlternateSet glyph="c">
+            <Alternate glyph="c.mid"/>
+            <Alternate glyph="C.sc"/>
           </AlternateSet>
           <AlternateSet glyph="d">
             <Alternate glyph="d.alt"/>

--- a/Tests/feaLib/data/spec8a_2.ttx
+++ b/Tests/feaLib/data/spec8a_2.ttx
@@ -91,8 +91,6 @@
         <ExtensionSubst index="0" Format="1">
           <ExtensionLookupType value="1"/>
           <SingleSubst>
-            <Substitution in="b" out="b.alt"/>
-            <Substitution in="c" out="c.mid"/>
             <Substitution in="e" out="e.mid"/>
           </SingleSubst>
         </ExtensionSubst>
@@ -108,6 +106,15 @@
               <Alternate glyph="a.alt1"/>
               <Alternate glyph="a.alt2"/>
               <Alternate glyph="a.alt3"/>
+              <Alternate glyph="A.sc"/>
+            </AlternateSet>
+            <AlternateSet glyph="b">
+              <Alternate glyph="b.alt"/>
+              <Alternate glyph="B.sc"/>
+            </AlternateSet>
+            <AlternateSet glyph="c">
+              <Alternate glyph="c.mid"/>
+              <Alternate glyph="C.sc"/>
             </AlternateSet>
             <AlternateSet glyph="d">
               <Alternate glyph="d.alt"/>


### PR DESCRIPTION
If a single substitution was promoted to a multiple or ligature substitutions, we would no longer add it to aalt feature (when requested) since only single and alternate substations are added there.

This can be considered a regression from lookup promotion. Since a single-looking substitution wouldn’t occurs in ligature or multiple substitution unless we promoted it, it should be safe to add these to allt feature.

Fixes https://github.com/fonttools/fonttools/issues/3845