### PR TITLE
Copy name IDs in use before scrapping or scrambling them for webfonts

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -3108,10 +3108,12 @@ def _remap_select_name_ids(font: ttLib.TTFont, needRemapping: set[int]) -> None:
         return
     elidedNameID = stat.table.ElidedFallbackNameID
     stat.table.ElidedFallbackNameID = remapping.get(elidedNameID, elidedNameID)
-    for axis in stat.table.DesignAxisRecord.Axis:
-        axis.AxisNameID = remapping.get(axis.AxisNameID, axis.AxisNameID)
-    for value in stat.table.AxisValueArray.AxisValue:
-        value.ValueNameID = remapping.get(value.ValueNameID, value.ValueNameID)
+    if stat.table.DesignAxisRecord:
+        for axis in stat.table.DesignAxisRecord.Axis:
+            axis.AxisNameID = remapping.get(axis.AxisNameID, axis.AxisNameID)
+    if stat.table.AxisValueArray:
+        for value in stat.table.AxisValueArray.AxisValue:
+            value.ValueNameID = remapping.get(value.ValueNameID, value.ValueNameID)
 
 
 @_add_method(ttLib.getTableClass("head"))

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -473,7 +473,7 @@ timer = Timer(logger=logging.getLogger("fontTools.subset.timer"))
 
 
 def _dict_subset(d, glyphs):
-    return {g: d[g] for g in glyphs}
+    return {g: d[g] for g in glyphs if g in d}
 
 
 def _list_subset(l, indices):

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -472,7 +472,7 @@ timer = Timer(logger=logging.getLogger("fontTools.subset.timer"))
 
 
 def _dict_subset(d, glyphs):
-    return {g: d[g] for g in glyphs if g in d}
+    return {g: d[g] for g in glyphs}
 
 
 def _list_subset(l, indices):

--- a/Tests/subset/data/PreserveSillyNamesTest.ttx
+++ b/Tests/subset/data/PreserveSillyNamesTest.ttx
@@ -550,9 +550,4 @@
     </NamedInstance>
   </fvar>
 
-  <gvar>
-    <version value="1"/>
-    <reserved value="0"/>
-  </gvar>
-
 </ttFont>

--- a/Tests/subset/data/PreserveSillyNamesTest.ttx
+++ b/Tests/subset/data/PreserveSillyNamesTest.ttx
@@ -1,0 +1,669 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.58">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="A"/>
+    <GlyphID id="2" name="A.something"/>
+    <GlyphID id="3" name="B"/>
+    <GlyphID id="4" name="B.cv01"/>
+    <GlyphID id="5" name="C"/>
+    <GlyphID id="6" name="C.cv01"/>
+    <GlyphID id="7" name="a"/>
+    <GlyphID id="8" name="a.color1"/>
+    <GlyphID id="9" name="a.color2"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="0.0"/>
+    <checkSumAdjustment value="0x27ccc17e"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Thu Jun  5 10:19:07 2025"/>
+    <modified value="Thu Jun  5 10:19:07 2025"/>
+    <xMin value="36"/>
+    <yMin value="-200"/>
+    <xMax value="485"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="500"/>
+    <minLeftSideBearing value="36"/>
+    <minRightSideBearing value="15"/>
+    <xMaxExtent value="485"/>
+    <caretSlopeRise value="1000"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="8"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="10"/>
+    <maxPoints value="16"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="0"/>
+    <maxCompositeContours value="0"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="0"/>
+    <maxComponentDepth value="0"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="500"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000100"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="65"/>
+    <usLastCharIndex value="97"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="1"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="A" width="0" lsb="0"/>
+    <mtx name="A.something" width="0" lsb="0"/>
+    <mtx name="B" width="0" lsb="0"/>
+    <mtx name="B.cv01" width="0" lsb="0"/>
+    <mtx name="C" width="0" lsb="0"/>
+    <mtx name="C.cv01" width="0" lsb="0"/>
+    <mtx name="a" width="500" lsb="36"/>
+    <mtx name="a.color1" width="500" lsb="111"/>
+    <mtx name="a.color2" width="500" lsb="195"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
+      <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
+      <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
+      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="A"/><!-- contains no outline data -->
+
+    <TTGlyph name="A.something"/><!-- contains no outline data -->
+
+    <TTGlyph name="B"/><!-- contains no outline data -->
+
+    <TTGlyph name="B.cv01"/><!-- contains no outline data -->
+
+    <TTGlyph name="C"/><!-- contains no outline data -->
+
+    <TTGlyph name="C.cv01"/><!-- contains no outline data -->
+
+    <TTGlyph name="a" xMin="36" yMin="77" xMax="318" yMax="458">
+      <contour>
+        <pt x="36" y="77" on="1"/>
+        <pt x="36" y="458" on="1"/>
+        <pt x="318" y="458" on="1"/>
+        <pt x="318" y="77" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="a.color1" xMin="111" yMin="82" xMax="408" yMax="560">
+      <contour>
+        <pt x="260" y="82" on="1"/>
+        <pt x="219" y="82" on="0"/>
+        <pt x="151" y="146" on="0"/>
+        <pt x="111" y="255" on="0"/>
+        <pt x="111" y="321" on="1"/>
+        <pt x="111" y="387" on="0"/>
+        <pt x="151" y="495" on="0"/>
+        <pt x="219" y="560" on="0"/>
+        <pt x="260" y="560" on="1"/>
+        <pt x="301" y="560" on="0"/>
+        <pt x="368" y="495" on="0"/>
+        <pt x="408" y="387" on="0"/>
+        <pt x="408" y="321" on="1"/>
+        <pt x="408" y="255" on="0"/>
+        <pt x="368" y="146" on="0"/>
+        <pt x="301" y="82" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="a.color2" xMin="195" yMin="230" xMax="485" yMax="626">
+      <contour>
+        <pt x="195" y="230" on="1"/>
+        <pt x="195" y="626" on="1"/>
+        <pt x="485" y="626" on="1"/>
+        <pt x="485" y="230" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="273" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      uilabel simple a
+    </namerecord>
+    <namerecord nameID="274" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      tool tip simple a
+    </namerecord>
+    <namerecord nameID="275" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      sample text simple a
+    </namerecord>
+    <namerecord nameID="276" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      param1 text simple a
+    </namerecord>
+    <namerecord nameID="277" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      param2 text simple a
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Blu Bla
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      0.000;NONE;Blu-Bla
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Blu Bla
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 0.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      Blu-Bla
+    </namerecord>
+    <namerecord nameID="16" platformID="3" platEncID="1" langID="0x409">
+      Blu
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      Bla
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      CPAL paletteLabel A
+    </namerecord>
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
+      CPAL paletteEntryLabel C
+    </namerecord>
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
+      CPAL paletteEntryLabel D
+    </namerecord>
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
+      Weight
+    </namerecord>
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+      Italic
+    </namerecord>
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+      Light Regular
+    </namerecord>
+    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
+      Test-LightRegular
+    </namerecord>
+    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
+      Test-Regular
+    </namerecord>
+    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
+      Medium Regular
+    </namerecord>
+    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
+      Test-MediumRegular
+    </namerecord>
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+      Light Italic
+    </namerecord>
+    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
+      Test-LightItalic
+    </namerecord>
+    <namerecord nameID="268" platformID="3" platEncID="1" langID="0x409">
+      Test-Italic
+    </namerecord>
+    <namerecord nameID="269" platformID="3" platEncID="1" langID="0x409">
+      Medium Italic
+    </namerecord>
+    <namerecord nameID="270" platformID="3" platEncID="1" langID="0x409">
+      Test-MediumItalic
+    </namerecord>
+    <namerecord nameID="271" platformID="3" platEncID="1" langID="0x409">
+      Light
+    </namerecord>
+    <namerecord nameID="272" platformID="3" platEncID="1" langID="0x409">
+      Medium
+    </namerecord>
+    <namerecord nameID="273" platformID="3" platEncID="1" langID="0x409">
+      uilabel simple a
+    </namerecord>
+    <namerecord nameID="274" platformID="3" platEncID="1" langID="0x409">
+      tool tip simple a
+    </namerecord>
+    <namerecord nameID="275" platformID="3" platEncID="1" langID="0x409">
+      sample text simple a
+    </namerecord>
+    <namerecord nameID="276" platformID="3" platEncID="1" langID="0x409">
+      param1 text simple a
+    </namerecord>
+    <namerecord nameID="277" platformID="3" platEncID="1" langID="0x409">
+      param2 text simple a
+    </namerecord>
+    <namerecord nameID="278" platformID="3" platEncID="1" langID="0x409">
+      Feature description for MS Platform, script Unicode, language English
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-75"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="A.something"/>
+      <psName name="B.cv01"/>
+      <psName name="C.cv01"/>
+      <psName name="a.color1"/>
+      <psName name="a.color2"/>
+    </extraNames>
+  </post>
+
+  <COLR>
+    <Version value="1"/>
+    <!-- BaseGlyphRecordCount=0 -->
+    <!-- LayerRecordCount=0 -->
+    <BaseGlyphList>
+      <!-- BaseGlyphCount=1 -->
+      <BaseGlyphPaintRecord index="0">
+        <BaseGlyph value="a"/>
+        <Paint Format="1"><!-- PaintColrLayers -->
+          <NumLayers value="2"/>
+          <FirstLayerIndex value="0"/>
+        </Paint>
+      </BaseGlyphPaintRecord>
+    </BaseGlyphList>
+    <LayerList>
+      <!-- LayerCount=2 -->
+      <Paint index="0" Format="10"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <PaletteIndex value="0"/>
+          <Alpha value="1.0"/>
+        </Paint>
+        <Glyph value="a.color1"/>
+      </Paint>
+      <Paint index="1" Format="10"><!-- PaintGlyph -->
+        <Paint Format="2"><!-- PaintSolid -->
+          <PaletteIndex value="1"/>
+          <Alpha value="1.0"/>
+        </Paint>
+        <Glyph value="a.color2"/>
+      </Paint>
+    </LayerList>
+  </COLR>
+
+  <CPAL>
+    <version value="1"/>
+    <numPaletteEntries value="2"/>
+    <palette index="0" label="16">
+      <!-- CPAL paletteLabel A -->
+      <color index="0" value="#FF4C1AFF"/>
+      <color index="1" value="#0066CCFF"/>
+    </palette>
+    <paletteEntryLabels>
+      <label index="0" value="17"/><!-- CPAL paletteEntryLabel C -->
+      <label index="1" value="6"/><!-- CPAL paletteEntryLabel D -->
+    </paletteEntryLabels>
+  </CPAL>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=2 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=1 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="CAT "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=2 -->
+              <FeatureIndex index="0" value="0"/>
+              <FeatureIndex index="1" value="1"/>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="cv01"/>
+        <Feature>
+          <FeatureParamsCharacterVariants Format="0">
+            <Format value="0"/>
+            <FeatUILabelNameID value="1"/>  <!-- uilabel simple a -->
+            <FeatUITooltipTextNameID value="2"/>  <!-- tool tip simple a -->
+            <SampleTextNameID value="3"/>  <!-- sample text simple a -->
+            <NumNamedParameters value="2"/>
+            <FirstParamUILabelNameID value="4"/>  <!-- param1 text simple a -->
+            <!-- CharCount=2 -->
+            <Character index="0" value="66"/>
+            <Character index="1" value="67"/>
+          </FeatureParamsCharacterVariants>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="ss01"/>
+        <Feature>
+          <FeatureParamsStylisticSet>
+            <Version value="0"/>
+            <UINameID value="16"/>  <!-- Feature description for MS Platform, script Unicode, language English -->
+          </FeatureParamsStylisticSet>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="B" out="B.cv01"/>
+          <Substitution in="C" out="C.cv01"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="B" out="C"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=2 -->
+        <!-- RegionCount=0 -->
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=10 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=0 -->
+        <Item index="0" value="[]"/>
+        <Item index="1" value="[]"/>
+        <Item index="2" value="[]"/>
+        <Item index="3" value="[]"/>
+        <Item index="4" value="[]"/>
+        <Item index="5" value="[]"/>
+        <Item index="6" value="[]"/>
+        <Item index="7" value="[]"/>
+        <Item index="8" value="[]"/>
+        <Item index="9" value="[]"/>
+      </VarData>
+    </VarStore>
+  </HVAR>
+
+  <STAT>
+    <Version value="0x00010001"/>
+    <DesignAxisRecordSize value="8"/>
+    <!-- DesignAxisCount=2 -->
+    <DesignAxisRecord>
+      <Axis index="0">
+        <AxisTag value="wght"/>
+        <AxisNameID value="16"/>  <!-- Weight -->
+        <AxisOrdering value="0"/>
+      </Axis>
+      <Axis index="1">
+        <AxisTag value="ital"/>
+        <AxisNameID value="17"/>  <!-- Italic -->
+        <AxisOrdering value="1"/>
+      </Axis>
+    </DesignAxisRecord>
+    <!-- AxisValueCount=5 -->
+    <AxisValueArray>
+      <AxisValue index="0" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="1"/>  <!-- Light -->
+        <Value value="300.0"/>
+      </AxisValue>
+      <AxisValue index="1" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="2"/>  <!-- ElidableAxisValueName -->
+        <ValueNameID value="2"/>  <!-- Regular -->
+        <Value value="400.0"/>
+      </AxisValue>
+      <AxisValue index="2" Format="1">
+        <AxisIndex value="0"/>
+        <Flags value="0"/>
+        <ValueNameID value="3"/>  <!-- Medium -->
+        <Value value="500.0"/>
+      </AxisValue>
+      <AxisValue index="3" Format="1">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="4"/>  <!-- Regular -->
+        <Value value="0.0"/>
+      </AxisValue>
+      <AxisValue index="4" Format="1">
+        <AxisIndex value="1"/>
+        <Flags value="0"/>
+        <ValueNameID value="5"/>  <!-- Italic -->
+        <Value value="1.0"/>
+      </AxisValue>
+    </AxisValueArray>
+    <ElidedFallbackNameID value="6"/>  <!-- Italic -->
+  </STAT>
+
+  <fvar>
+
+    <!-- Weight -->
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>300.0</MinValue>
+      <DefaultValue>400.0</DefaultValue>
+      <MaxValue>500.0</MaxValue>
+      <AxisNameID>16</AxisNameID>
+    </Axis>
+
+    <!-- Italic -->
+    <Axis>
+      <AxisTag>ital</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>0.0</MinValue>
+      <DefaultValue>0.0</DefaultValue>
+      <MaxValue>1.0</MaxValue>
+      <AxisNameID>17</AxisNameID>
+    </Axis>
+
+    <!-- Light Regular -->
+    <!-- PostScript: Test-LightRegular -->
+    <NamedInstance flags="0x0" postscriptNameID="1" subfamilyNameID="2">
+      <coord axis="wght" value="300.0"/>
+      <coord axis="ital" value="0.0"/>
+    </NamedInstance>
+
+    <!-- Regular -->
+    <!-- PostScript: Test-Regular -->
+    <NamedInstance flags="0x0" postscriptNameID="3" subfamilyNameID="2">
+      <coord axis="wght" value="400.0"/>
+      <coord axis="ital" value="0.0"/>
+    </NamedInstance>
+
+    <!-- Medium Regular -->
+    <!-- PostScript: Test-MediumRegular -->
+    <NamedInstance flags="0x0" postscriptNameID="4" subfamilyNameID="5">
+      <coord axis="wght" value="500.0"/>
+      <coord axis="ital" value="0.0"/>
+    </NamedInstance>
+
+    <!-- Light Italic -->
+    <!-- PostScript: Test-LightItalic -->
+    <NamedInstance flags="0x0" postscriptNameID="6" subfamilyNameID="16">
+      <coord axis="wght" value="300.0"/>
+      <coord axis="ital" value="1.0"/>
+    </NamedInstance>
+
+    <!-- Italic -->
+    <!-- PostScript: Test-Italic -->
+    <NamedInstance flags="0x0" postscriptNameID="17" subfamilyNameID="1">
+      <coord axis="wght" value="400.0"/>
+      <coord axis="ital" value="1.0"/>
+    </NamedInstance>
+
+    <!-- Medium Italic -->
+    <!-- PostScript: Test-MediumItalic -->
+    <NamedInstance flags="0x0" postscriptNameID="2" subfamilyNameID="3">
+      <coord axis="wght" value="500.0"/>
+      <coord axis="ital" value="1.0"/>
+    </NamedInstance>
+  </fvar>
+
+  <gvar>
+    <version value="1"/>
+    <reserved value="0"/>
+  </gvar>
+
+</ttFont>

--- a/Tests/subset/data/PreserveSillyNamesTest.ttx
+++ b/Tests/subset/data/PreserveSillyNamesTest.ttx
@@ -10,24 +10,21 @@
     <GlyphID id="4" name="B.cv01"/>
     <GlyphID id="5" name="C"/>
     <GlyphID id="6" name="C.cv01"/>
-    <GlyphID id="7" name="a"/>
-    <GlyphID id="8" name="a.color1"/>
-    <GlyphID id="9" name="a.color2"/>
   </GlyphOrder>
 
   <head>
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="1.0"/>
     <fontRevision value="0.0"/>
-    <checkSumAdjustment value="0x27ccc17e"/>
+    <checkSumAdjustment value="0x4bcbcaf2"/>
     <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000011"/>
     <unitsPerEm value="1000"/>
-    <created value="Thu Jun  5 10:19:07 2025"/>
-    <modified value="Thu Jun  5 10:19:07 2025"/>
-    <xMin value="36"/>
+    <created value="Thu Jun  5 13:36:58 2025"/>
+    <modified value="Thu Jun  5 13:36:58 2025"/>
+    <xMin value="50"/>
     <yMin value="-200"/>
-    <xMax value="485"/>
+    <xMax value="450"/>
     <yMax value="800"/>
     <macStyle value="00000000 00000000"/>
     <lowestRecPPEM value="6"/>
@@ -42,9 +39,9 @@
     <descent value="-200"/>
     <lineGap value="0"/>
     <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="36"/>
-    <minRightSideBearing value="15"/>
-    <xMaxExtent value="485"/>
+    <minLeftSideBearing value="50"/>
+    <minRightSideBearing value="50"/>
+    <xMaxExtent value="450"/>
     <caretSlopeRise value="1000"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
@@ -53,14 +50,14 @@
     <reserved2 value="0"/>
     <reserved3 value="0"/>
     <metricDataFormat value="0"/>
-    <numberOfHMetrics value="8"/>
+    <numberOfHMetrics value="2"/>
   </hhea>
 
   <maxp>
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="0x10000"/>
-    <numGlyphs value="10"/>
-    <maxPoints value="16"/>
+    <numGlyphs value="7"/>
+    <maxPoints value="8"/>
     <maxContours value="2"/>
     <maxCompositePoints value="0"/>
     <maxCompositeContours value="0"/>
@@ -113,7 +110,7 @@
     <achVendID value="NONE"/>
     <fsSelection value="00000000 01000000"/>
     <usFirstCharIndex value="65"/>
-    <usLastCharIndex value="97"/>
+    <usLastCharIndex value="67"/>
     <sTypoAscender value="800"/>
     <sTypoDescender value="-200"/>
     <sTypoLineGap value="200"/>
@@ -136,9 +133,6 @@
     <mtx name="B.cv01" width="0" lsb="0"/>
     <mtx name="C" width="0" lsb="0"/>
     <mtx name="C.cv01" width="0" lsb="0"/>
-    <mtx name="a" width="500" lsb="36"/>
-    <mtx name="a.color1" width="500" lsb="111"/>
-    <mtx name="a.color2" width="500" lsb="195"/>
   </hmtx>
 
   <cmap>
@@ -147,13 +141,11 @@
       <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
       <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
       <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
-      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
     </cmap_format_4>
     <cmap_format_4 platformID="3" platEncID="1" language="0">
       <map code="0x41" name="A"/><!-- LATIN CAPITAL LETTER A -->
       <map code="0x42" name="B"/><!-- LATIN CAPITAL LETTER B -->
       <map code="0x43" name="C"/><!-- LATIN CAPITAL LETTER C -->
-      <map code="0x61" name="a"/><!-- LATIN SMALL LETTER A -->
     </cmap_format_4>
   </cmap>
 
@@ -194,64 +186,22 @@
 
     <TTGlyph name="C.cv01"/><!-- contains no outline data -->
 
-    <TTGlyph name="a" xMin="36" yMin="77" xMax="318" yMax="458">
-      <contour>
-        <pt x="36" y="77" on="1"/>
-        <pt x="36" y="458" on="1"/>
-        <pt x="318" y="458" on="1"/>
-        <pt x="318" y="77" on="1"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
-    <TTGlyph name="a.color1" xMin="111" yMin="82" xMax="408" yMax="560">
-      <contour>
-        <pt x="260" y="82" on="1"/>
-        <pt x="219" y="82" on="0"/>
-        <pt x="151" y="146" on="0"/>
-        <pt x="111" y="255" on="0"/>
-        <pt x="111" y="321" on="1"/>
-        <pt x="111" y="387" on="0"/>
-        <pt x="151" y="495" on="0"/>
-        <pt x="219" y="560" on="0"/>
-        <pt x="260" y="560" on="1"/>
-        <pt x="301" y="560" on="0"/>
-        <pt x="368" y="495" on="0"/>
-        <pt x="408" y="387" on="0"/>
-        <pt x="408" y="321" on="1"/>
-        <pt x="408" y="255" on="0"/>
-        <pt x="368" y="146" on="0"/>
-        <pt x="301" y="82" on="0"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
-    <TTGlyph name="a.color2" xMin="195" yMin="230" xMax="485" yMax="626">
-      <contour>
-        <pt x="195" y="230" on="1"/>
-        <pt x="195" y="626" on="1"/>
-        <pt x="485" y="626" on="1"/>
-        <pt x="485" y="230" on="1"/>
-      </contour>
-      <instructions/>
-    </TTGlyph>
-
   </glyf>
 
   <name>
-    <namerecord nameID="273" platformID="1" platEncID="0" langID="0x0" unicode="True">
+    <namerecord nameID="270" platformID="1" platEncID="0" langID="0x0" unicode="True">
       uilabel simple a
     </namerecord>
-    <namerecord nameID="274" platformID="1" platEncID="0" langID="0x0" unicode="True">
+    <namerecord nameID="271" platformID="1" platEncID="0" langID="0x0" unicode="True">
       tool tip simple a
     </namerecord>
-    <namerecord nameID="275" platformID="1" platEncID="0" langID="0x0" unicode="True">
+    <namerecord nameID="272" platformID="1" platEncID="0" langID="0x0" unicode="True">
       sample text simple a
     </namerecord>
-    <namerecord nameID="276" platformID="1" platEncID="0" langID="0x0" unicode="True">
+    <namerecord nameID="273" platformID="1" platEncID="0" langID="0x0" unicode="True">
       param1 text simple a
     </namerecord>
-    <namerecord nameID="277" platformID="1" platEncID="0" langID="0x0" unicode="True">
+    <namerecord nameID="274" platformID="1" platEncID="0" langID="0x0" unicode="True">
       param2 text simple a
     </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
@@ -279,72 +229,63 @@
       Bla
     </namerecord>
     <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
-      CPAL paletteLabel A
-    </namerecord>
-    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
-      CPAL paletteEntryLabel C
-    </namerecord>
-    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
-      CPAL paletteEntryLabel D
-    </namerecord>
-    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
       Weight
     </namerecord>
-    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
       Italic
     </namerecord>
-    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
       Light Regular
     </namerecord>
-    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
       Test-LightRegular
     </namerecord>
-    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
       Test-Regular
     </namerecord>
-    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="261" platformID="3" platEncID="1" langID="0x409">
       Medium Regular
     </namerecord>
-    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="262" platformID="3" platEncID="1" langID="0x409">
       Test-MediumRegular
     </namerecord>
-    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="263" platformID="3" platEncID="1" langID="0x409">
       Light Italic
     </namerecord>
-    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="264" platformID="3" platEncID="1" langID="0x409">
       Test-LightItalic
     </namerecord>
-    <namerecord nameID="268" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="265" platformID="3" platEncID="1" langID="0x409">
       Test-Italic
     </namerecord>
-    <namerecord nameID="269" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="266" platformID="3" platEncID="1" langID="0x409">
       Medium Italic
     </namerecord>
-    <namerecord nameID="270" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="267" platformID="3" platEncID="1" langID="0x409">
       Test-MediumItalic
     </namerecord>
-    <namerecord nameID="271" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="268" platformID="3" platEncID="1" langID="0x409">
       Light
     </namerecord>
-    <namerecord nameID="272" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="269" platformID="3" platEncID="1" langID="0x409">
       Medium
     </namerecord>
-    <namerecord nameID="273" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="270" platformID="3" platEncID="1" langID="0x409">
       uilabel simple a
     </namerecord>
-    <namerecord nameID="274" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="271" platformID="3" platEncID="1" langID="0x409">
       tool tip simple a
     </namerecord>
-    <namerecord nameID="275" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="272" platformID="3" platEncID="1" langID="0x409">
       sample text simple a
     </namerecord>
-    <namerecord nameID="276" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="273" platformID="3" platEncID="1" langID="0x409">
       param1 text simple a
     </namerecord>
-    <namerecord nameID="277" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="274" platformID="3" platEncID="1" langID="0x409">
       param2 text simple a
     </namerecord>
-    <namerecord nameID="278" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="275" platformID="3" platEncID="1" langID="0x409">
       Feature description for MS Platform, script Unicode, language English
     </namerecord>
   </name>
@@ -373,57 +314,8 @@
       <psName name="A.something"/>
       <psName name="B.cv01"/>
       <psName name="C.cv01"/>
-      <psName name="a.color1"/>
-      <psName name="a.color2"/>
     </extraNames>
   </post>
-
-  <COLR>
-    <Version value="1"/>
-    <!-- BaseGlyphRecordCount=0 -->
-    <!-- LayerRecordCount=0 -->
-    <BaseGlyphList>
-      <!-- BaseGlyphCount=1 -->
-      <BaseGlyphPaintRecord index="0">
-        <BaseGlyph value="a"/>
-        <Paint Format="1"><!-- PaintColrLayers -->
-          <NumLayers value="2"/>
-          <FirstLayerIndex value="0"/>
-        </Paint>
-      </BaseGlyphPaintRecord>
-    </BaseGlyphList>
-    <LayerList>
-      <!-- LayerCount=2 -->
-      <Paint index="0" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="0"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="a.color1"/>
-      </Paint>
-      <Paint index="1" Format="10"><!-- PaintGlyph -->
-        <Paint Format="2"><!-- PaintSolid -->
-          <PaletteIndex value="1"/>
-          <Alpha value="1.0"/>
-        </Paint>
-        <Glyph value="a.color2"/>
-      </Paint>
-    </LayerList>
-  </COLR>
-
-  <CPAL>
-    <version value="1"/>
-    <numPaletteEntries value="2"/>
-    <palette index="0" label="16">
-      <!-- CPAL paletteLabel A -->
-      <color index="0" value="#FF4C1AFF"/>
-      <color index="1" value="#0066CCFF"/>
-    </palette>
-    <paletteEntryLabels>
-      <label index="0" value="17"/><!-- CPAL paletteEntryLabel C -->
-      <label index="1" value="6"/><!-- CPAL paletteEntryLabel D -->
-    </paletteEntryLabels>
-  </CPAL>
 
   <GSUB>
     <Version value="0x00010000"/>
@@ -470,11 +362,11 @@
         <Feature>
           <FeatureParamsCharacterVariants Format="0">
             <Format value="0"/>
-            <FeatUILabelNameID value="1"/>  <!-- uilabel simple a -->
-            <FeatUITooltipTextNameID value="2"/>  <!-- tool tip simple a -->
-            <SampleTextNameID value="3"/>  <!-- sample text simple a -->
+            <FeatUILabelNameID value="270"/>  <!-- uilabel simple a -->
+            <FeatUITooltipTextNameID value="271"/>  <!-- tool tip simple a -->
+            <SampleTextNameID value="272"/>  <!-- sample text simple a -->
             <NumNamedParameters value="2"/>
-            <FirstParamUILabelNameID value="4"/>  <!-- param1 text simple a -->
+            <FirstParamUILabelNameID value="273"/>  <!-- param1 text simple a -->
             <!-- CharCount=2 -->
             <Character index="0" value="66"/>
             <Character index="1" value="67"/>
@@ -488,7 +380,7 @@
         <Feature>
           <FeatureParamsStylisticSet>
             <Version value="0"/>
-            <UINameID value="16"/>  <!-- Feature description for MS Platform, script Unicode, language English -->
+            <UINameID value="275"/>  <!-- Feature description for MS Platform, script Unicode, language English -->
           </FeatureParamsStylisticSet>
           <!-- LookupCount=1 -->
           <LookupListIndex index="0" value="1"/>
@@ -527,7 +419,7 @@
       </VarRegionList>
       <!-- VarDataCount=1 -->
       <VarData index="0">
-        <!-- ItemCount=10 -->
+        <!-- ItemCount=7 -->
         <NumShorts value="0"/>
         <!-- VarRegionCount=0 -->
         <Item index="0" value="[]"/>
@@ -537,9 +429,6 @@
         <Item index="4" value="[]"/>
         <Item index="5" value="[]"/>
         <Item index="6" value="[]"/>
-        <Item index="7" value="[]"/>
-        <Item index="8" value="[]"/>
-        <Item index="9" value="[]"/>
       </VarData>
     </VarStore>
   </HVAR>
@@ -627,35 +516,35 @@
 
     <!-- Regular -->
     <!-- PostScript: Test-Regular -->
-    <NamedInstance flags="0x0" postscriptNameID="3" subfamilyNameID="2">
+    <NamedInstance flags="0x0" postscriptNameID="3" subfamilyNameID="4">
       <coord axis="wght" value="400.0"/>
       <coord axis="ital" value="0.0"/>
     </NamedInstance>
 
     <!-- Medium Regular -->
     <!-- PostScript: Test-MediumRegular -->
-    <NamedInstance flags="0x0" postscriptNameID="4" subfamilyNameID="5">
+    <NamedInstance flags="0x0" postscriptNameID="5" subfamilyNameID="6">
       <coord axis="wght" value="500.0"/>
       <coord axis="ital" value="0.0"/>
     </NamedInstance>
 
     <!-- Light Italic -->
     <!-- PostScript: Test-LightItalic -->
-    <NamedInstance flags="0x0" postscriptNameID="6" subfamilyNameID="16">
+    <NamedInstance flags="0x0" postscriptNameID="16" subfamilyNameID="17">
       <coord axis="wght" value="300.0"/>
       <coord axis="ital" value="1.0"/>
     </NamedInstance>
 
     <!-- Italic -->
     <!-- PostScript: Test-Italic -->
-    <NamedInstance flags="0x0" postscriptNameID="17" subfamilyNameID="1">
+    <NamedInstance flags="0x0" postscriptNameID="1" subfamilyNameID="2">
       <coord axis="wght" value="400.0"/>
       <coord axis="ital" value="1.0"/>
     </NamedInstance>
 
     <!-- Medium Italic -->
     <!-- PostScript: Test-MediumItalic -->
-    <NamedInstance flags="0x0" postscriptNameID="2" subfamilyNameID="3">
+    <NamedInstance flags="0x0" postscriptNameID="3" subfamilyNameID="4">
       <coord axis="wght" value="500.0"/>
       <coord axis="ital" value="1.0"/>
     </NamedInstance>

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -487,7 +487,7 @@ class SubsetTest:
             self.getpath("TestTTF-Regular_non_BMP_char.ttx"), ".ttf"
         )
         subsetpath = self.temp_path(".ttf")
-        text = tostr("A\U0001F6D2", encoding="utf-8")
+        text = tostr("A\U0001f6d2", encoding="utf-8")
 
         subset.main([fontpath, "--text=%s" % text, "--output-file=%s" % subsetpath])
         subsetfont = TTFont(subsetpath)
@@ -500,7 +500,7 @@ class SubsetTest:
             self.getpath("TestTTF-Regular_non_BMP_char.ttx"), ".ttf"
         )
         subsetpath = self.temp_path(".ttf")
-        text = tobytes("A\U0001F6D2", encoding="utf-8")
+        text = tobytes("A\U0001f6d2", encoding="utf-8")
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             tmp.write(text)
 
@@ -2137,9 +2137,12 @@ def test_preserve_name_ids_when_used_elsewhere():
     subsetter.populate(glyphs=font.getGlyphOrder())
     subsetter.subset(font)
 
+    # After obfuscation, all names should use an id >= 256, except for id 5,
+    # which is not obfuscated.
     visitor = NameRecordVisitor()
+    visitor.TABLES = ("STAT", "fvar")
     visitor.visit(font)
-    assert not visitor.seen.intersection(subset.NAME_IDS_TO_OBFUSCATE)
+    assert all(id >= 256 or id == 5 for id in visitor.seen)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Preserve select nameIDs in `fvar` and `STAT` when obfuscating names, to avoid dangling name IDs in subset fonts.

Closes https://github.com/fonttools/fonttools/issues/3773.