### PR TITLE
fix iterable check for Python 3.13.4 and newer

### DIFF
--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -719,8 +719,7 @@ class ChainContextPosStatement(Statement):
         for i, lookup in enumerate(lookups):
             if lookup:
                 try:
-                    for _ in lookup:
-                        break
+                    iter(lookup)
                 except TypeError:
                     self.lookups[i] = [lookup]
 
@@ -778,8 +777,7 @@ class ChainContextSubstStatement(Statement):
         for i, lookup in enumerate(lookups):
             if lookup:
                 try:
-                    for _ in lookup:
-                        break
+                    iter(lookup)
                 except TypeError:
                     self.lookups[i] = [lookup]
 


### PR DESCRIPTION
Fix the `feaLib/ast.py` snippet used to check whether a type is iterable to work correctly with Python 3.13.4.  The snippet wrongly assumed that a generator expression will raise immediately when the RHS of `in` is not iterable.  This is no longer the case with Python 3.13.4, and such a generator only raises when you actually start iterating. Use a plain `for` expression to start iterating and catch the problem more reliably.

Fixes #3854