### PR TITLE
ttx_test: fix test for --no-recalc-timestamp option

### DIFF
--- a/Tests/ttx/ttx_test.py
+++ b/Tests/ttx/ttx_test.py
@@ -471,7 +471,7 @@ def test_options_recalc_timestamp():
     assert tto.recalcTimestamp is True
 
 
-def test_options_recalc_timestamp():
+def test_options_no_recalc_timestamp():
     tto = ttx.Options([("--no-recalc-timestamp", "")], 1)
     assert tto.recalcTimestamp is False
 


### PR DESCRIPTION
## PR Summary
The test for the `--no-recalc-timestamp` option in `ttx.Options` was incorrectly named `test_options_recalc_timestamp`. This small PR renames the test to `test_options_no_recalc_timestamp` to accurately reflect its purpose and makes sure no tests are silently ignored.
