### PR TITLE
[roundingPen] Remove unreliable kwarg usage

### DIFF
--- a/Lib/fontTools/pens/roundingPen.py
+++ b/Lib/fontTools/pens/roundingPen.py
@@ -116,8 +116,8 @@ class RoundingPointPen(FilterPointPen):
     def addComponent(self, baseGlyphName, transformation, identifier=None, **kwargs):
         xx, xy, yx, yy, dx, dy = transformation
         self._outPen.addComponent(
-            baseGlyphName=baseGlyphName,
-            transformation=Transform(
+            baseGlyphName,
+            Transform(
                 self.transformRoundFunc(xx),
                 self.transformRoundFunc(xy),
                 self.transformRoundFunc(yx),


### PR DESCRIPTION
Argument names aren’t consistent among point pens’ .addComponent() implementation, in particular `baseGlyphName` vs `glyphName`. Even ufoLib is inconsistent with the base class:

https://github.com/fonttools/fonttools/blob/d48c962d6a15953669f2cb5656429a815a721ab0/Lib/fontTools/pens/pointPen.py#L65-L71

https://github.com/fonttools/fonttools/blob/d48c962d6a15953669f2cb5656429a815a721ab0/Lib/fontTools/ufoLib/glifLib.py#L2004

This fixes a regression introduced last year in https://github.com/fonttools/fonttools/commit/7cdac78423b259e77641fe3a1cf3a0b1cc5ec049#diff-cbf0ff73ca1c0029fb4905f0311f7be51b7c91c5f811d074e5c93cb20f4253e9.

