### PR TITLE
Autoformat imports with isort

### DIFF
--- a/Lib/fontTools/__init__.py
+++ b/Lib/fontTools/__init__.py
@@ -1,4 +1,5 @@
 import logging
+
 from fontTools.misc.loggingTools import configLogger
 
 log = logging.getLogger(__name__)

--- a/Lib/fontTools/afmLib.py
+++ b/Lib/fontTools/afmLib.py
@@ -7,36 +7,36 @@ implement the whole Adobe AFM specification [#f1]_ but, it should read most
 
 Here is an example of using `afmLib` to read, modify and write an AFM file:
 
-	>>> from fontTools.afmLib import AFM
-	>>> f = AFM("Tests/afmLib/data/TestAFM.afm")
-	>>>
-	>>> # Accessing a pair gets you the kern value
-	>>> f[("V","A")]
-	-60
-	>>>
-	>>> # Accessing a glyph name gets you metrics
-	>>> f["A"]
-	(65, 668, (8, -25, 660, 666))
-	>>> # (charnum, width, bounding box)
-	>>>
-	>>> # Accessing an attribute gets you metadata
-	>>> f.FontName
-	'TestFont-Regular'
-	>>> f.FamilyName
-	'TestFont'
-	>>> f.Weight
-	'Regular'
-	>>> f.XHeight
-	500
-	>>> f.Ascender
-	750
-	>>>
-	>>> # Attributes and items can also be set
-	>>> f[("A","V")] = -150 # Tighten kerning
-	>>> f.FontName = "TestFont Squished"
-	>>>
-	>>> # And the font written out again (remove the # in front)
-	>>> #f.write("testfont-squished.afm")
+    >>> from fontTools.afmLib import AFM
+    >>> f = AFM("Tests/afmLib/data/TestAFM.afm")
+    >>>
+    >>> # Accessing a pair gets you the kern value
+    >>> f[("V","A")]
+    -60
+    >>>
+    >>> # Accessing a glyph name gets you metrics
+    >>> f["A"]
+    (65, 668, (8, -25, 660, 666))
+    >>> # (charnum, width, bounding box)
+    >>>
+    >>> # Accessing an attribute gets you metadata
+    >>> f.FontName
+    'TestFont-Regular'
+    >>> f.FamilyName
+    'TestFont'
+    >>> f.Weight
+    'Regular'
+    >>> f.XHeight
+    500
+    >>> f.Ascender
+    750
+    >>>
+    >>> # Attributes and items can also be set
+    >>> f[("A","V")] = -150 # Tighten kerning
+    >>> f.FontName = "TestFont Squished"
+    >>>
+    >>> # And the font written out again (remove the # in front)
+    >>> #f.write("testfont-squished.afm")
 
 .. rubric:: Footnotes
 

--- a/Lib/fontTools/agl.py
+++ b/Lib/fontTools/agl.py
@@ -9,26 +9,26 @@ Interface to the Adobe Glyph List
 This module exists to convert glyph names from the Adobe Glyph List
 to their Unicode equivalents. Example usage:
 
-	>>> from fontTools.agl import toUnicode
-	>>> toUnicode("nahiragana")
-	'な'
+    >>> from fontTools.agl import toUnicode
+    >>> toUnicode("nahiragana")
+    'な'
 
 It also contains two dictionaries, ``UV2AGL`` and ``AGL2UV``, which map from
 Unicode codepoints to AGL names and vice versa:
 
-	>>> import fontTools
-	>>> fontTools.agl.UV2AGL[ord("?")]
-	'question'
-	>>> fontTools.agl.AGL2UV["wcircumflex"]
-	373
+    >>> import fontTools
+    >>> fontTools.agl.UV2AGL[ord("?")]
+    'question'
+    >>> fontTools.agl.AGL2UV["wcircumflex"]
+    373
 
 This is used by fontTools when it has to construct glyph names for a font which
 doesn't include any (e.g. format 3.0 post tables).
 """
 
-from fontTools.misc.textTools import tostr
 import re
 
+from fontTools.misc.textTools import tostr
 
 _aglText = """\
 # -----------------------------------------------------------

--- a/Lib/fontTools/cffLib/CFF2ToCFF.py
+++ b/Lib/fontTools/cffLib/CFF2ToCFF.py
@@ -1,18 +1,19 @@
 """CFF2 to CFF converter."""
 
-from fontTools.ttLib import TTFont, newTable
-from fontTools.misc.cliTools import makeOutputFileName
+import logging
+from collections import defaultdict
+
 from fontTools.cffLib import (
     TopDictIndex,
-    buildOrder,
     buildDefaults,
-    topDictOperators,
+    buildOrder,
     privateDictOperators,
+    topDictOperators,
 )
-from .width import optimizeWidths
-from collections import defaultdict
-import logging
+from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.ttLib import TTFont, newTable
 
+from .width import optimizeWidths
 
 __all__ = ["convertCFF2ToCFF", "main"]
 

--- a/Lib/fontTools/cffLib/CFFToCFF2.py
+++ b/Lib/fontTools/cffLib/CFFToCFF2.py
@@ -1,20 +1,21 @@
 """CFF to CFF2 converter."""
 
-from fontTools.ttLib import TTFont, newTable
-from fontTools.misc.cliTools import makeOutputFileName
-from fontTools.misc.psCharStrings import T2WidthExtractor
+import logging
+from io import BytesIO
+
 from fontTools.cffLib import (
-    TopDictIndex,
     FDArrayIndex,
     FontDict,
+    TopDictIndex,
     buildOrder,
-    topDictOperators,
     privateDictOperators,
-    topDictOperators2,
     privateDictOperators2,
+    topDictOperators,
+    topDictOperators2,
 )
-from io import BytesIO
-import logging
+from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.misc.psCharStrings import T2WidthExtractor
+from fontTools.ttLib import TTFont, newTable
 
 __all__ = ["convertCFFToCFF2", "main"]
 

--- a/Lib/fontTools/cffLib/__init__.py
+++ b/Lib/fontTools/cffLib/__init__.py
@@ -11,25 +11,24 @@ the demands of variable fonts. This module parses both original CFF and CFF2.
 
 """
 
-from fontTools.misc import sstruct
-from fontTools.misc import psCharStrings
-from fontTools.misc.arrayTools import unionRect, intRect
+import logging
+import re
+import struct
+from io import BytesIO
+
+from fontTools.misc import psCharStrings, sstruct
+from fontTools.misc.arrayTools import intRect, unionRect
 from fontTools.misc.textTools import (
     bytechr,
     byteord,
     bytesjoin,
+    safeEval,
     tobytes,
     tostr,
-    safeEval,
 )
 from fontTools.ttLib import TTFont
-from fontTools.ttLib.tables.otBase import OTTableWriter
-from fontTools.ttLib.tables.otBase import OTTableReader
 from fontTools.ttLib.tables import otTables as ot
-from io import BytesIO
-import struct
-import logging
-import re
+from fontTools.ttLib.tables.otBase import OTTableReader, OTTableWriter
 
 # mute cffLib debug messages when running ttx in verbose mode
 DEBUG = logging.DEBUG - 1

--- a/Lib/fontTools/cffLib/width.py
+++ b/Lib/fontTools/cffLib/width.py
@@ -7,11 +7,11 @@ value do not need to specify their width in their charstring, saving bytes.
 This module determines the optimum ``defaultWidthX`` and ``nominalWidthX``
 values for a font, when provided with a list of glyph widths."""
 
-from fontTools.ttLib import TTFont
 from collections import defaultdict
-from operator import add
 from functools import reduce
+from operator import add
 
+from fontTools.ttLib import TTFont
 
 __all__ = ["optimizeWidths", "main"]
 

--- a/Lib/fontTools/colorLib/builder.py
+++ b/Lib/fontTools/colorLib/builder.py
@@ -22,18 +22,17 @@ from typing import (
     TypeVar,
     Union,
 )
+
 from fontTools.misc.arrayTools import intRect
 from fontTools.misc.fixedTools import fixedToFloat
 from fontTools.misc.treeTools import build_n_ary_tree
-from fontTools.ttLib.tables import C_O_L_R_
-from fontTools.ttLib.tables import C_P_A_L_
-from fontTools.ttLib.tables import _n_a_m_e
+from fontTools.ttLib.tables import C_O_L_R_, C_P_A_L_, _n_a_m_e
 from fontTools.ttLib.tables import otTables as ot
-from fontTools.ttLib.tables.otTables import ExtendMode, CompositeMode
+from fontTools.ttLib.tables.otTables import CompositeMode, ExtendMode
+
 from .errors import ColorLibError
 from .geometry import round_start_circle_stable_containment
 from .table_builder import BuildCallback, TableBuilder
-
 
 # TODO move type aliases to colorLib.types?
 T = TypeVar("T")

--- a/Lib/fontTools/colorLib/geometry.py
+++ b/Lib/fontTools/colorLib/geometry.py
@@ -1,6 +1,7 @@
 """Helpers for manipulating 2D points and vectors in COLR table."""
 
 from math import copysign, cos, hypot, isclose, pi
+
 from fontTools.misc.roundTools import otRound
 
 

--- a/Lib/fontTools/colorLib/table_builder.py
+++ b/Lib/fontTools/colorLib/table_builder.py
@@ -5,6 +5,8 @@ colorLib.table_builder: Generic helper for filling in BaseTable derivatives from
 
 import collections
 import enum
+
+from fontTools.misc.roundTools import otRound
 from fontTools.ttLib.tables.otBase import (
     BaseTable,
     FormatSwitchingBaseTable,
@@ -12,16 +14,15 @@ from fontTools.ttLib.tables.otBase import (
 )
 from fontTools.ttLib.tables.otConverters import (
     ComputedInt,
+    FloatValue,
+    IntValue,
+    OptionalValue,
+    Short,
     SimpleValue,
     Struct,
-    Short,
     UInt8,
     UShort,
-    IntValue,
-    FloatValue,
-    OptionalValue,
 )
-from fontTools.misc.roundTools import otRound
 
 
 class BuildCallback(enum.Enum):

--- a/Lib/fontTools/colorLib/unbuilder.py
+++ b/Lib/fontTools/colorLib/unbuilder.py
@@ -1,4 +1,5 @@
 from fontTools.ttLib.tables import otTables as ot
+
 from .table_builder import TableUnbuilder
 
 
@@ -59,8 +60,9 @@ class LayerListUnbuilder:
 
 
 if __name__ == "__main__":
-    from pprint import pprint
     import sys
+    from pprint import pprint
+
     from fontTools.ttLib import TTFont
 
     try:

--- a/Lib/fontTools/cu2qu/__main__.py
+++ b/Lib/fontTools/cu2qu/__main__.py
@@ -1,6 +1,6 @@
 import sys
-from .cli import _main as main
 
+from .cli import _main as main
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/Lib/fontTools/cu2qu/benchmark.py
+++ b/Lib/fontTools/cu2qu/benchmark.py
@@ -1,8 +1,9 @@
 """Benchmark the cu2qu algorithm performance."""
 
-from .cu2qu import *
 import random
 import timeit
+
+from .cu2qu import *
 
 MAX_ERR = 0.05
 

--- a/Lib/fontTools/cu2qu/cli.py
+++ b/Lib/fontTools/cu2qu/cli.py
@@ -1,12 +1,13 @@
-import os
 import argparse
 import logging
-import shutil
 import multiprocessing as mp
+import os
+import shutil
 from contextlib import closing
 from functools import partial
 
 import fontTools
+
 from .ufo import font_to_quadratic, fonts_to_quadratic
 
 ufo_module = None

--- a/Lib/fontTools/cu2qu/cu2qu.py
+++ b/Lib/fontTools/cu2qu/cu2qu.py
@@ -24,8 +24,8 @@ COMPILED = cython.compiled
 
 import math
 
-from .errors import Error as Cu2QuError, ApproxNotFoundError
-
+from .errors import ApproxNotFoundError
+from .errors import Error as Cu2QuError
 
 __all__ = ["curve_to_quadratic", "curves_to_quadratic"]
 

--- a/Lib/fontTools/cu2qu/ufo.py
+++ b/Lib/fontTools/cu2qu/ufo.py
@@ -24,19 +24,19 @@ the resulting splines are interpolation-compatible.
 """
 
 import logging
+
 from fontTools.pens.basePen import AbstractPen
 from fontTools.pens.pointPen import PointToSegmentPen
 from fontTools.pens.reverseContourPen import ReverseContourPen
 
 from . import curves_to_quadratic
 from .errors import (
-    UnequalZipLengthsError,
+    IncompatibleFontsError,
+    IncompatibleGlyphsError,
     IncompatibleSegmentNumberError,
     IncompatibleSegmentTypesError,
-    IncompatibleGlyphsError,
-    IncompatibleFontsError,
+    UnequalZipLengthsError,
 )
-
 
 __all__ = ["fonts_to_quadratic", "font_to_quadratic"]
 

--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1,7 +1,7 @@
 """
-    designSpaceDocument
+designSpaceDocument
 
-    - Read and write designspace files
+- Read and write designspace files
 """
 
 from __future__ import annotations
@@ -20,7 +20,6 @@ from fontTools.misc import etree as ET
 from fontTools.misc import plistlib
 from fontTools.misc.loggingTools import LogMixin
 from fontTools.misc.textTools import tobytes, tostr
-
 
 __all__ = [
     "AxisDescriptor",

--- a/Lib/fontTools/designspaceLib/__main__.py
+++ b/Lib/fontTools/designspaceLib/__main__.py
@@ -1,6 +1,6 @@
 import sys
-from fontTools.designspaceLib import main
 
+from fontTools.designspaceLib import main
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/Lib/fontTools/designspaceLib/statNames.py
+++ b/Lib/fontTools/designspaceLib/statNames.py
@@ -11,9 +11,9 @@ instance:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Dict, Literal, Optional, Tuple, Union
-import logging
 
 from fontTools.designspaceLib import (
     AxisDescriptor,

--- a/Lib/fontTools/encodings/codecs.py
+++ b/Lib/fontTools/encodings/codecs.py
@@ -1,5 +1,6 @@
 """Extend the Python codecs module with a few encodings that are used in OpenType (name table)
-but missing from Python.  See https://github.com/fonttools/fonttools/issues/236 for details."""
+but missing from Python.  See https://github.com/fonttools/fonttools/issues/236 for details.
+"""
 
 import codecs
 import encodings
@@ -60,23 +61,23 @@ _extended_encodings = {
     "x_mac_japanese_ttx": (
         "shift_jis",
         {
-            b"\xFC": chr(0x007C),
-            b"\x7E": chr(0x007E),
+            b"\xfc": chr(0x007C),
+            b"\x7e": chr(0x007E),
             b"\x80": chr(0x005C),
-            b"\xA0": chr(0x00A0),
-            b"\xFD": chr(0x00A9),
-            b"\xFE": chr(0x2122),
-            b"\xFF": chr(0x2026),
+            b"\xa0": chr(0x00A0),
+            b"\xfd": chr(0x00A9),
+            b"\xfe": chr(0x2122),
+            b"\xff": chr(0x2026),
         },
     ),
     "x_mac_trad_chinese_ttx": (
         "big5",
         {
             b"\x80": chr(0x005C),
-            b"\xA0": chr(0x00A0),
-            b"\xFD": chr(0x00A9),
-            b"\xFE": chr(0x2122),
-            b"\xFF": chr(0x2026),
+            b"\xa0": chr(0x00A0),
+            b"\xfd": chr(0x00A9),
+            b"\xfe": chr(0x2122),
+            b"\xff": chr(0x2026),
         },
     ),
     "x_mac_korean_ttx": (
@@ -86,18 +87,18 @@ _extended_encodings = {
             b"\x81": chr(0x20A9),
             b"\x82": chr(0x2014),
             b"\x83": chr(0x00A9),
-            b"\xFE": chr(0x2122),
-            b"\xFF": chr(0x2026),
+            b"\xfe": chr(0x2122),
+            b"\xff": chr(0x2026),
         },
     ),
     "x_mac_simp_chinese_ttx": (
         "gb2312",
         {
             b"\x80": chr(0x00FC),
-            b"\xA0": chr(0x00A0),
-            b"\xFD": chr(0x00A9),
-            b"\xFE": chr(0x2122),
-            b"\xFF": chr(0x2026),
+            b"\xa0": chr(0x00A0),
+            b"\xfd": chr(0x00A9),
+            b"\xfe": chr(0x2122),
+            b"\xff": chr(0x2026),
         },
     ),
 }

--- a/Lib/fontTools/feaLib/__main__.py
+++ b/Lib/fontTools/feaLib/__main__.py
@@ -1,12 +1,12 @@
-from fontTools.ttLib import TTFont
-from fontTools.feaLib.builder import addOpenTypeFeatures, Builder
-from fontTools.feaLib.error import FeatureLibError
-from fontTools import configLogger
-from fontTools.misc.cliTools import makeOutputFileName
-import sys
 import argparse
 import logging
+import sys
 
+from fontTools import configLogger
+from fontTools.feaLib.builder import Builder, addOpenTypeFeatures
+from fontTools.feaLib.error import FeatureLibError
+from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.ttLib import TTFont
 
 log = logging.getLogger("fontTools.feaLib")
 

--- a/Lib/fontTools/feaLib/ast.py
+++ b/Lib/fontTools/feaLib/ast.py
@@ -1,10 +1,11 @@
+import itertools
 import weakref
+from collections import OrderedDict
+
 from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.location import FeatureLibLocation
 from fontTools.misc.encodingTools import getEncoding
 from fontTools.misc.textTools import byteord, tobytes
-from collections import OrderedDict
-import itertools
 
 SHIFT = " " * 4
 

--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -1,49 +1,49 @@
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import Tag, tostr, binary2num, safeEval
+import copy
+import itertools
+import logging
+import os
+import warnings
+from collections import defaultdict
+from io import StringIO
+
+from fontTools.feaLib.ast import FeatureFile
 from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.lookupDebugInfo import (
-    LookupDebugInfo,
-    LOOKUP_DEBUG_INFO_KEY,
     LOOKUP_DEBUG_ENV_VAR,
+    LOOKUP_DEBUG_INFO_KEY,
+    LookupDebugInfo,
 )
 from fontTools.feaLib.parser import Parser
-from fontTools.feaLib.ast import FeatureFile
 from fontTools.feaLib.variableScalar import VariableScalar
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import Tag, binary2num, safeEval, tostr
 from fontTools.otlLib import builder as otl
-from fontTools.otlLib.maxContextCalc import maxCtxFont
-from fontTools.ttLib import newTable, getTableModule
-from fontTools.ttLib.tables import otBase, otTables
 from fontTools.otlLib.builder import (
     AlternateSubstBuilder,
+    AnySubstBuilder,
     ChainContextPosBuilder,
     ChainContextSubstBuilder,
-    LigatureSubstBuilder,
-    MultipleSubstBuilder,
+    ChainContextualRule,
+    ClassPairPosSubtableBuilder,
     CursivePosBuilder,
+    LigatureSubstBuilder,
     MarkBasePosBuilder,
     MarkLigPosBuilder,
     MarkMarkPosBuilder,
-    ReverseChainSingleSubstBuilder,
-    SingleSubstBuilder,
-    ClassPairPosSubtableBuilder,
+    MultipleSubstBuilder,
     PairPosBuilder,
+    ReverseChainSingleSubstBuilder,
     SinglePosBuilder,
-    ChainContextualRule,
-    AnySubstBuilder,
+    SingleSubstBuilder,
 )
 from fontTools.otlLib.error import OpenTypeLibError
-from fontTools.varLib.varStore import OnlineVarStoreBuilder
+from fontTools.otlLib.maxContextCalc import maxCtxFont
+from fontTools.ttLib import getTableModule, newTable
+from fontTools.ttLib.tables import otBase, otTables
 from fontTools.varLib.builder import buildVarDevTable
 from fontTools.varLib.featureVars import addFeatureVariationsRaw
 from fontTools.varLib.models import normalizeValue, piecewiseLinearMap
-from collections import defaultdict
-import copy
-import itertools
-from io import StringIO
-import logging
-import warnings
-import os
-
+from fontTools.varLib.varStore import OnlineVarStoreBuilder
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -1,7 +1,8 @@
+import os
+import re
+
 from fontTools.feaLib.error import FeatureLibError, IncludedFeaNotFound
 from fontTools.feaLib.location import FeatureLibLocation
-import re
-import os
 
 try:
     import cython

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1,13 +1,13 @@
-from fontTools.feaLib.error import FeatureLibError
-from fontTools.feaLib.lexer import Lexer, IncludingLexer, NonIncludingLexer
-from fontTools.feaLib.variableScalar import VariableScalar
-from fontTools.misc.encodingTools import getEncoding
-from fontTools.misc.textTools import bytechr, tobytes, tostr
-import fontTools.feaLib.ast as ast
 import logging
 import os
 import re
 
+import fontTools.feaLib.ast as ast
+from fontTools.feaLib.error import FeatureLibError
+from fontTools.feaLib.lexer import IncludingLexer, Lexer, NonIncludingLexer
+from fontTools.feaLib.variableScalar import VariableScalar
+from fontTools.misc.encodingTools import getEncoding
+from fontTools.misc.textTools import bytechr, tobytes, tostr
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/fontBuilder.py
+++ b/Lib/fontTools/fontBuilder.py
@@ -129,14 +129,14 @@ fb.save("test.otf")
 ```
 """
 
+import struct
+from collections import OrderedDict
+
+from .misc.timeTools import timestampNow
 from .ttLib import TTFont, newTable
 from .ttLib.tables._c_m_a_p import cmap_classes
 from .ttLib.tables._g_l_y_f import flagCubic
 from .ttLib.tables.O_S_2f_2 import Panose
-from .misc.timeTools import timestampNow
-import struct
-from collections import OrderedDict
-
 
 _headDefaults = dict(
     tableVersion=1.0,
@@ -513,11 +513,11 @@ class FontBuilder(object):
     def setupCFF(self, psName, fontInfo, charStringsDict, privateDict):
         from .cffLib import (
             CFFFontSet,
-            TopDictIndex,
-            TopDict,
             CharStrings,
             GlobalSubrsIndex,
             PrivateDict,
+            TopDict,
+            TopDictIndex,
         )
 
         assert not self.isTTF
@@ -564,13 +564,13 @@ class FontBuilder(object):
     def setupCFF2(self, charStringsDict, fdArrayList=None, regions=None):
         from .cffLib import (
             CFFFontSet,
-            TopDictIndex,
-            TopDict,
             CharStrings,
-            GlobalSubrsIndex,
-            PrivateDict,
             FDArrayIndex,
             FontDict,
+            GlobalSubrsIndex,
+            PrivateDict,
+            TopDict,
+            TopDictIndex,
         )
 
         assert not self.isTTF
@@ -623,8 +623,8 @@ class FontBuilder(object):
             self.setupCFF2Regions(regions)
 
     def setupCFF2Regions(self, regions):
-        from .varLib.builder import buildVarRegionList, buildVarData, buildVarStore
         from .cffLib import VarStoreData
+        from .varLib.builder import buildVarData, buildVarRegionList, buildVarStore
 
         assert "fvar" in self.font, "fvar must to be set up first"
         assert "CFF2" in self.font, "CFF2 must to be set up first"

--- a/Lib/fontTools/help.py
+++ b/Lib/fontTools/help.py
@@ -1,9 +1,10 @@
-import pkgutil
-import sys
-import fontTools
 import importlib
 import os
+import pkgutil
+import sys
 from pathlib import Path
+
+import fontTools
 
 
 def main():

--- a/Lib/fontTools/merge/__init__.py
+++ b/Lib/fontTools/merge/__init__.py
@@ -2,21 +2,21 @@
 #
 # Google Author(s): Behdad Esfahbod, Roozbeh Pournader
 
-from fontTools import ttLib
+import logging
+import sys
+from functools import reduce
+
 import fontTools.merge.base
+import fontTools.merge.tables
+from fontTools import ttLib
 from fontTools.merge.cmap import (
-    computeMegaGlyphOrder,
     computeMegaCmap,
+    computeMegaGlyphOrder,
     renameCFFCharStrings,
 )
-from fontTools.merge.layout import layoutPreMerge, layoutPostMerge
+from fontTools.merge.layout import layoutPostMerge, layoutPreMerge
 from fontTools.merge.options import Options
-import fontTools.merge.tables
 from fontTools.misc.loggingTools import Timer
-from functools import reduce
-import sys
-import logging
-
 
 log = logging.getLogger("fontTools.merge")
 timer = Timer(logger=logging.getLogger(__name__ + ".timer"), level=logging.INFO)

--- a/Lib/fontTools/merge/__main__.py
+++ b/Lib/fontTools/merge/__main__.py
@@ -1,6 +1,6 @@
 import sys
-from fontTools.merge import main
 
+from fontTools.merge import main
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/Lib/fontTools/merge/base.py
+++ b/Lib/fontTools/merge/base.py
@@ -2,9 +2,9 @@
 #
 # Google Author(s): Behdad Esfahbod, Roozbeh Pournader
 
-from fontTools.ttLib.tables.DefaultTable import DefaultTable
 import logging
 
+from fontTools.ttLib.tables.DefaultTable import DefaultTable
 
 log = logging.getLogger("fontTools.merge")
 

--- a/Lib/fontTools/merge/cmap.py
+++ b/Lib/fontTools/merge/cmap.py
@@ -2,10 +2,10 @@
 #
 # Google Author(s): Behdad Esfahbod, Roozbeh Pournader
 
-from fontTools.merge.unicode import is_Default_Ignorable
-from fontTools.pens.recordingPen import DecomposingRecordingPen
 import logging
 
+from fontTools.merge.unicode import is_Default_Ignorable
+from fontTools.pens.recordingPen import DecomposingRecordingPen
 
 log = logging.getLogger("fontTools.merge")
 

--- a/Lib/fontTools/merge/layout.py
+++ b/Lib/fontTools/merge/layout.py
@@ -2,13 +2,13 @@
 #
 # Google Author(s): Behdad Esfahbod, Roozbeh Pournader
 
-from fontTools import ttLib
-from fontTools.ttLib.tables.DefaultTable import DefaultTable
-from fontTools.ttLib.tables import otTables
-from fontTools.merge.base import add_method, mergeObjects
-from fontTools.merge.util import *
 import logging
 
+from fontTools import ttLib
+from fontTools.merge.base import add_method, mergeObjects
+from fontTools.merge.util import *
+from fontTools.ttLib.tables import otTables
+from fontTools.ttLib.tables.DefaultTable import DefaultTable
 
 log = logging.getLogger("fontTools.merge")
 

--- a/Lib/fontTools/merge/tables.py
+++ b/Lib/fontTools/merge/tables.py
@@ -2,14 +2,14 @@
 #
 # Google Author(s): Behdad Esfahbod, Roozbeh Pournader
 
-from fontTools import ttLib, cffLib
-from fontTools.misc.psCharStrings import T2WidthExtractor
-from fontTools.ttLib.tables.DefaultTable import DefaultTable
+import logging
+
+from fontTools import cffLib, ttLib
 from fontTools.merge.base import add_method, mergeObjects
 from fontTools.merge.cmap import computeMegaCmap
 from fontTools.merge.util import *
-import logging
-
+from fontTools.misc.psCharStrings import T2WidthExtractor
+from fontTools.ttLib.tables.DefaultTable import DefaultTable
 
 log = logging.getLogger("fontTools.merge")
 

--- a/Lib/fontTools/merge/util.py
+++ b/Lib/fontTools/merge/util.py
@@ -2,12 +2,12 @@
 #
 # Google Author(s): Behdad Esfahbod, Roozbeh Pournader
 
+import logging
+import operator
+from functools import reduce
+
 from fontTools.misc.timeTools import timestampNow
 from fontTools.ttLib.tables.DefaultTable import DefaultTable
-from functools import reduce
-import operator
-import logging
-
 
 log = logging.getLogger("fontTools.merge")
 

--- a/Lib/fontTools/misc/arrayTools.py
+++ b/Lib/fontTools/misc/arrayTools.py
@@ -2,10 +2,11 @@
 so on.
 """
 
-from fontTools.misc.roundTools import otRound
-from fontTools.misc.vector import Vector as _Vector
 import math
 import warnings
+
+from fontTools.misc.roundTools import otRound
+from fontTools.misc.vector import Vector as _Vector
 
 
 def calcBounds(array):
@@ -418,7 +419,7 @@ def _test():
 
 
 if __name__ == "__main__":
-    import sys
     import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/misc/bezierTools.py
+++ b/Lib/fontTools/misc/bezierTools.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-"""fontTools.misc.bezierTools.py -- tools for working with Bezier path segments.
-"""
+"""fontTools.misc.bezierTools.py -- tools for working with Bezier path segments."""
 
-from fontTools.misc.arrayTools import calcBounds, sectRect, rectArea
-from fontTools.misc.transform import Identity
 import math
 from collections import namedtuple
+
+from fontTools.misc.arrayTools import calcBounds, rectArea, sectRect
+from fontTools.misc.transform import Identity
 
 try:
     import cython
@@ -809,7 +809,7 @@ def _splitCubicAtTC(a, b, c, d, *ts):
 # Equation solvers.
 #
 
-from math import sqrt, acos, cos, pi
+from math import acos, cos, pi, sqrt
 
 
 def solveQuadratic(a, b, c, sqrt=sqrt):
@@ -1491,7 +1491,7 @@ def printSegments(segments):
 
 
 if __name__ == "__main__":
-    import sys
     import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/misc/classifyTools.py
+++ b/Lib/fontTools/misc/classifyTools.py
@@ -1,5 +1,4 @@
-""" fontTools.misc.classifyTools.py -- tools for classifying things.
-"""
+"""fontTools.misc.classifyTools.py -- tools for classifying things."""
 
 
 class Classifier(object):
@@ -165,6 +164,7 @@ def classify(list_of_sets, sort=True):
 
 
 if __name__ == "__main__":
-    import sys, doctest
+    import doctest
+    import sys
 
     sys.exit(doctest.testmod(optionflags=doctest.ELLIPSIS).failed)

--- a/Lib/fontTools/misc/cliTools.py
+++ b/Lib/fontTools/misc/cliTools.py
@@ -3,7 +3,6 @@
 import os
 import re
 
-
 numberAddedRE = re.compile(r"#\d+$")
 
 

--- a/Lib/fontTools/misc/configTools.py
+++ b/Lib/fontTools/misc/configTools.py
@@ -26,7 +26,6 @@ from typing import (
     Union,
 )
 
-
 log = logging.getLogger(__name__)
 
 __all__ = [

--- a/Lib/fontTools/misc/cython.py
+++ b/Lib/fontTools/misc/cython.py
@@ -1,4 +1,4 @@
-""" Exports a no-op 'cython' namespace similar to
+"""Exports a no-op 'cython' namespace similar to
 https://github.com/cython/cython/blob/master/Cython/Shadow.py
 
 This allows to optionally compile @cython decorated functions

--- a/Lib/fontTools/misc/eexec.py
+++ b/Lib/fontTools/misc/eexec.py
@@ -12,7 +12,7 @@ the new key at the end of the operation.
 
 """
 
-from fontTools.misc.textTools import bytechr, bytesjoin, byteord
+from fontTools.misc.textTools import bytechr, byteord, bytesjoin
 
 
 def _decryptChar(cipher, R):
@@ -113,7 +113,7 @@ def deHexString(h):
 
 
 if __name__ == "__main__":
-    import sys
     import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/misc/encodingTools.py
+++ b/Lib/fontTools/misc/encodingTools.py
@@ -1,5 +1,4 @@
-"""fontTools.misc.encodingTools.py -- tools for working with OpenType encodings.
-"""
+"""fontTools.misc.encodingTools.py -- tools for working with OpenType encodings."""
 
 import fontTools.encodings.codecs
 

--- a/Lib/fontTools/misc/etree.py
+++ b/Lib/fontTools/misc/etree.py
@@ -14,7 +14,6 @@ iterwalk.
 
 from fontTools.misc.textTools import tostr
 
-
 XML_DECLARATION = """<?xml version='1.0' encoding='%s'?>"""
 
 __all__ = [
@@ -208,7 +207,7 @@ except ImportError:
     #   Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
     # Here we reversed the pattern to match only the invalid characters.
     _invalid_xml_string = re.compile(
-        "[\u0000-\u0008\u000B-\u000C\u000E-\u001F\uD800-\uDFFF\uFFFE-\uFFFF]"
+        "[\u0000-\u0008\u000b-\u000c\u000e-\u001f\ud800-\udfff\ufffe-\uffff]"
     )
 
     def _tounicode(s):

--- a/Lib/fontTools/misc/fixedTools.py
+++ b/Lib/fontTools/misc/fixedTools.py
@@ -3,22 +3,23 @@ The `OpenType specification <https://docs.microsoft.com/en-us/typography/opentyp
 defines two fixed-point data types:
 
 ``Fixed``
-	A 32-bit signed fixed-point number with a 16 bit twos-complement
-	magnitude component and 16 fractional bits.
+    A 32-bit signed fixed-point number with a 16 bit twos-complement
+    magnitude component and 16 fractional bits.
 ``F2DOT14``
-	A 16-bit signed fixed-point number with a 2 bit twos-complement
-	magnitude component and 14 fractional bits.
+    A 16-bit signed fixed-point number with a 2 bit twos-complement
+    magnitude component and 14 fractional bits.
 
 To support reading and writing data with these data types, this module provides
 functions for converting between fixed-point, float and string representations.
 
 .. data:: MAX_F2DOT14
 
-	The maximum value that can still fit in an F2Dot14. (1.99993896484375)
+    The maximum value that can still fit in an F2Dot14. (1.99993896484375)
 """
 
-from .roundTools import otRound, nearestMultipleShortestRepr
 import logging
+
+from .roundTools import nearestMultipleShortestRepr, otRound
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/misc/loggingTools.py
+++ b/Lib/fontTools/misc/loggingTools.py
@@ -1,11 +1,10 @@
-import sys
 import logging
+import sys
 import timeit
-from functools import wraps
-from collections.abc import Mapping, Callable
 import warnings
+from collections.abc import Callable, Mapping
+from functools import wraps
 from logging import PercentStyle
-
 
 # default logging level used by Timer class
 TIME_LEVEL = logging.DEBUG

--- a/Lib/fontTools/misc/macRes.py
+++ b/Lib/fontTools/misc/macRes.py
@@ -1,9 +1,10 @@
-from io import BytesIO
 import struct
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import bytesjoin, tostr
 from collections import OrderedDict
 from collections.abc import MutableMapping
+from io import BytesIO
+
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import bytesjoin, tostr
 
 
 class ResourceError(Exception):

--- a/Lib/fontTools/misc/plistlib/__init__.py
+++ b/Lib/fontTools/misc/plistlib/__init__.py
@@ -1,6 +1,14 @@
 import collections.abc
 import re
+import warnings
+from base64 import b64decode, b64encode
+from datetime import datetime
+from functools import singledispatch
+from io import BytesIO
+from numbers import Integral
+from types import SimpleNamespace
 from typing import (
+    IO,
     Any,
     Callable,
     Dict,
@@ -11,20 +19,10 @@ from typing import (
     Sequence,
     Type,
     Union,
-    IO,
 )
-import warnings
-from io import BytesIO
-from datetime import datetime
-from base64 import b64encode, b64decode
-from numbers import Integral
-from types import SimpleNamespace
-from functools import singledispatch
 
 from fontTools.misc import etree
-
 from fontTools.misc.textTools import tostr
-
 
 # By default, we
 #  - deserialize <data> elements as bytes and

--- a/Lib/fontTools/misc/psCharStrings.py
+++ b/Lib/fontTools/misc/psCharStrings.py
@@ -2,6 +2,9 @@
 CFF dictionary data and Type1/Type2 CharStrings.
 """
 
+import logging
+import struct
+
 from fontTools.misc.fixedTools import (
     fixedToFloat,
     floatToFixed,
@@ -10,9 +13,6 @@ from fontTools.misc.fixedTools import (
 )
 from fontTools.misc.textTools import bytechr, byteord, bytesjoin, strjoin
 from fontTools.pens.boundsPen import BoundsPen
-import struct
-import logging
-
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/misc/psLib.py
+++ b/Lib/fontTools/misc/psLib.py
@@ -1,8 +1,13 @@
-from fontTools.misc.textTools import bytechr, byteord, bytesjoin, tobytes, tostr
+import logging
+import re
+from collections.abc import Callable
+from string import whitespace
+
 from fontTools.misc import eexec
+from fontTools.misc.textTools import bytechr, byteord, bytesjoin, tobytes, tostr
+
 from .psOperators import (
     PSOperators,
-    ps_StandardEncoding,
     ps_array,
     ps_boolean,
     ps_dict,
@@ -14,13 +19,9 @@ from .psOperators import (
     ps_procedure,
     ps_procmark,
     ps_real,
+    ps_StandardEncoding,
     ps_string,
 )
-import re
-from collections.abc import Callable
-from string import whitespace
-import logging
-
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/misc/roundTools.py
+++ b/Lib/fontTools/misc/roundTools.py
@@ -2,9 +2,9 @@
 Various round-to-integer helpers.
 """
 
-import math
 import functools
 import logging
+import math
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/misc/sstruct.py
+++ b/Lib/fontTools/misc/sstruct.py
@@ -23,33 +23,35 @@ the number of bits after the point. Fixed point numbers get
 converted to floats.
 
 pack(fmt, object):
-	'object' is either a dictionary or an instance (or actually
-	anything that has a __dict__ attribute). If it is a dictionary,
-	its keys are used for names. If it is an instance, it's
-	attributes are used to grab struct elements from. Returns
-	a string containing the data.
+    'object' is either a dictionary or an instance (or actually
+    anything that has a __dict__ attribute). If it is a dictionary,
+    its keys are used for names. If it is an instance, it's
+    attributes are used to grab struct elements from. Returns
+    a string containing the data.
 
 unpack(fmt, data, object=None)
-	If 'object' is omitted (or None), a new dictionary will be
-	returned. If 'object' is a dictionary, it will be used to add
-	struct elements to. If it is an instance (or in fact anything
-	that has a __dict__ attribute), an attribute will be added for
-	each struct element. In the latter two cases, 'object' itself
-	is returned.
+    If 'object' is omitted (or None), a new dictionary will be
+    returned. If 'object' is a dictionary, it will be used to add
+    struct elements to. If it is an instance (or in fact anything
+    that has a __dict__ attribute), an attribute will be added for
+    each struct element. In the latter two cases, 'object' itself
+    is returned.
 
 unpack2(fmt, data, object=None)
-	Convenience function. Same as unpack, except data may be longer
-	than needed. The returned value is a tuple: (object, leftoverdata).
+    Convenience function. Same as unpack, except data may be longer
+    than needed. The returned value is a tuple: (object, leftoverdata).
 
 calcsize(fmt)
-	like struct.calcsize(), but uses our own fmt strings:
-	it returns the size of the data in bytes.
+    like struct.calcsize(), but uses our own fmt strings:
+    it returns the size of the data in bytes.
 """
 
-from fontTools.misc.fixedTools import fixedToFloat as fi2fl, floatToFixed as fl2fi
-from fontTools.misc.textTools import tobytes, tostr
-import struct
 import re
+import struct
+
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
+from fontTools.misc.fixedTools import floatToFixed as fl2fi
+from fontTools.misc.textTools import tobytes, tostr
 
 __version__ = "1.2"
 __copyright__ = "Copyright 1998, Just van Rossum <just@letterror.com>"

--- a/Lib/fontTools/misc/symfont.py
+++ b/Lib/fontTools/misc/symfont.py
@@ -1,8 +1,10 @@
-from fontTools.pens.basePen import BasePen
+import sys
 from functools import partial
 from itertools import count
+
 import sympy as sp
-import sys
+
+from fontTools.pens.basePen import BasePen
 
 n = 3  # Max Bezier degree; 3 for cubic, 2 for quadratic
 

--- a/Lib/fontTools/misc/testTools.py
+++ b/Lib/fontTools/misc/testTools.py
@@ -1,13 +1,14 @@
 """Helpers for writing unit tests."""
 
-from collections.abc import Iterable
-from io import BytesIO
 import os
 import re
 import shutil
 import sys
 import tempfile
+from collections.abc import Iterable
+from io import BytesIO
 from unittest import TestCase as _TestCase
+
 from fontTools.config import Config
 from fontTools.misc.textTools import tobytes
 from fontTools.misc.xmlWriter import XMLWriter

--- a/Lib/fontTools/misc/textTools.py
+++ b/Lib/fontTools/misc/textTools.py
@@ -3,7 +3,6 @@
 import ast
 import string
 
-
 # alias kept for backward compatibility
 safeEval = ast.literal_eval
 
@@ -149,6 +148,7 @@ def bytesjoin(iterable, joiner=b""):
 
 
 if __name__ == "__main__":
-    import doctest, sys
+    import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/misc/timeTools.py
+++ b/Lib/fontTools/misc/timeTools.py
@@ -1,11 +1,9 @@
-"""fontTools.misc.timeTools.py -- tools for working with OpenType timestamps.
-"""
+"""fontTools.misc.timeTools.py -- tools for working with OpenType timestamps."""
 
+import calendar
 import os
 import time
 from datetime import datetime, timezone
-import calendar
-
 
 epoch_diff = calendar.timegm((1904, 1, 1, 0, 0, 0, 0, 0, 0))
 
@@ -82,7 +80,7 @@ def timestampSinceEpoch(value):
 
 
 if __name__ == "__main__":
-    import sys
     import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/misc/transform.py
+++ b/Lib/fontTools/misc/transform.py
@@ -11,53 +11,52 @@ used as dictionary keys.
 This module exports the following symbols:
 
 Transform
-	this is the main class
+    this is the main class
 Identity
-	Transform instance set to the identity transformation
+    Transform instance set to the identity transformation
 Offset
-	Convenience function that returns a translating transformation
+    Convenience function that returns a translating transformation
 Scale
-	Convenience function that returns a scaling transformation
+    Convenience function that returns a scaling transformation
 
 The DecomposedTransform class implements a transformation with separate
 translate, rotation, scale, skew, and transformation-center components.
 
 :Example:
 
-	>>> t = Transform(2, 0, 0, 3, 0, 0)
-	>>> t.transformPoint((100, 100))
-	(200, 300)
-	>>> t = Scale(2, 3)
-	>>> t.transformPoint((100, 100))
-	(200, 300)
-	>>> t.transformPoint((0, 0))
-	(0, 0)
-	>>> t = Offset(2, 3)
-	>>> t.transformPoint((100, 100))
-	(102, 103)
-	>>> t.transformPoint((0, 0))
-	(2, 3)
-	>>> t2 = t.scale(0.5)
-	>>> t2.transformPoint((100, 100))
-	(52.0, 53.0)
-	>>> import math
-	>>> t3 = t2.rotate(math.pi / 2)
-	>>> t3.transformPoint((0, 0))
-	(2.0, 3.0)
-	>>> t3.transformPoint((100, 100))
-	(-48.0, 53.0)
-	>>> t = Identity.scale(0.5).translate(100, 200).skew(0.1, 0.2)
-	>>> t.transformPoints([(0, 0), (1, 1), (100, 100)])
-	[(50.0, 100.0), (50.550167336042726, 100.60135501775433), (105.01673360427253, 160.13550177543362)]
-	>>>
+    >>> t = Transform(2, 0, 0, 3, 0, 0)
+    >>> t.transformPoint((100, 100))
+    (200, 300)
+    >>> t = Scale(2, 3)
+    >>> t.transformPoint((100, 100))
+    (200, 300)
+    >>> t.transformPoint((0, 0))
+    (0, 0)
+    >>> t = Offset(2, 3)
+    >>> t.transformPoint((100, 100))
+    (102, 103)
+    >>> t.transformPoint((0, 0))
+    (2, 3)
+    >>> t2 = t.scale(0.5)
+    >>> t2.transformPoint((100, 100))
+    (52.0, 53.0)
+    >>> import math
+    >>> t3 = t2.rotate(math.pi / 2)
+    >>> t3.transformPoint((0, 0))
+    (2.0, 3.0)
+    >>> t3.transformPoint((100, 100))
+    (-48.0, 53.0)
+    >>> t = Identity.scale(0.5).translate(100, 200).skew(0.1, 0.2)
+    >>> t.transformPoints([(0, 0), (1, 1), (100, 100)])
+    [(50.0, 100.0), (50.550167336042726, 100.60135501775433), (105.01673360427253, 160.13550177543362)]
+    >>>
 """
 
 from __future__ import annotations
 
 import math
-from typing import NamedTuple
 from dataclasses import dataclass
-
+from typing import NamedTuple
 
 __all__ = ["Transform", "Identity", "Offset", "Scale", "DecomposedTransform"]
 
@@ -510,7 +509,7 @@ class DecomposedTransform:
 
 
 if __name__ == "__main__":
-    import sys
     import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/misc/vector.py
+++ b/Lib/fontTools/misc/vector.py
@@ -1,8 +1,7 @@
-from numbers import Number
 import math
 import operator
 import warnings
-
+from numbers import Number
 
 __all__ = ["Vector"]
 

--- a/Lib/fontTools/misc/xmlReader.py
+++ b/Lib/fontTools/misc/xmlReader.py
@@ -1,10 +1,10 @@
+import logging
+import os
+import sys
+
 from fontTools import ttLib
 from fontTools.misc.textTools import safeEval
 from fontTools.ttLib.tables.DefaultTable import DefaultTable
-import sys
-import os
-import logging
-
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/misc/xmlWriter.py
+++ b/Lib/fontTools/misc/xmlWriter.py
@@ -1,9 +1,10 @@
 """xmlWriter.py -- Simple XML authoring class"""
 
-from fontTools.misc.textTools import byteord, strjoin, tobytes, tostr
-import sys
 import os
 import string
+import sys
+
+from fontTools.misc.textTools import byteord, strjoin, tobytes, tostr
 
 INDENT = "  "
 

--- a/Lib/fontTools/mtiLib/__init__.py
+++ b/Lib/fontTools/mtiLib/__init__.py
@@ -4,17 +4,18 @@
 # http://monotype.github.io/OpenType_Table_Source/otl_source.html
 # https://github.com/Monotype/OpenType_Table_Source/
 
-from fontTools import ttLib
-from fontTools.ttLib.tables._c_m_a_p import cmap_classes
-from fontTools.ttLib.tables import otTables as ot
-from fontTools.ttLib.tables.otBase import ValueRecord, valueRecordFormatDict
-from fontTools.otlLib import builder as otl
-from contextlib import contextmanager
-from fontTools.ttLib import newTable
-from fontTools.feaLib.lookupDebugInfo import LOOKUP_DEBUG_ENV_VAR, LOOKUP_DEBUG_INFO_KEY
-from operator import setitem
-import os
 import logging
+import os
+from contextlib import contextmanager
+from operator import setitem
+
+from fontTools import ttLib
+from fontTools.feaLib.lookupDebugInfo import LOOKUP_DEBUG_ENV_VAR, LOOKUP_DEBUG_INFO_KEY
+from fontTools.otlLib import builder as otl
+from fontTools.ttLib import newTable
+from fontTools.ttLib.tables import otTables as ot
+from fontTools.ttLib.tables._c_m_a_p import cmap_classes
+from fontTools.ttLib.tables.otBase import ValueRecord, valueRecordFormatDict
 
 
 class MtiLibError(Exception):
@@ -1329,6 +1330,7 @@ def main(args=None, font=None):
             args: Command line arguments (``--font``, ``--table``, input files).
     """
     import sys
+
     from fontTools import configLogger
     from fontTools.misc.testTools import MockFont
 

--- a/Lib/fontTools/mtiLib/__main__.py
+++ b/Lib/fontTools/mtiLib/__main__.py
@@ -1,4 +1,5 @@
 import sys
+
 from fontTools.mtiLib import main
 
 if __name__ == "__main__":

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -1,30 +1,27 @@
 from __future__ import annotations
 
-from collections import namedtuple, OrderedDict
+import copy
 import itertools
+import logging
+from collections import OrderedDict, namedtuple
+from functools import reduce
 from typing import Dict, Union
-from fontTools.misc.fixedTools import fixedToFloat
-from fontTools.misc.roundTools import otRound
+
 from fontTools import ttLib
+from fontTools.feaLib.ast import STATNameStatement
+from fontTools.misc.fixedTools import fixedToFloat
+from fontTools.misc.loggingTools import deprecateFunction
+from fontTools.misc.roundTools import otRound
+from fontTools.otlLib.error import OpenTypeLibError
+from fontTools.otlLib.optimize.gpos import _compression_level_from_env, compact_lookup
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.ttLib.tables.otBase import (
-    ValueRecord,
-    valueRecordFormatDict,
     OTLOffsetOverflowError,
     OTTableWriter,
+    ValueRecord,
+    valueRecordFormatDict,
 )
 from fontTools.ttLib.ttFont import TTFont
-from fontTools.feaLib.ast import STATNameStatement
-from fontTools.otlLib.optimize.gpos import (
-    _compression_level_from_env,
-    compact_lookup,
-)
-from fontTools.otlLib.error import OpenTypeLibError
-from fontTools.misc.loggingTools import deprecateFunction
-from functools import reduce
-import logging
-import copy
-
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/otlLib/optimize/__init__.py
+++ b/Lib/fontTools/otlLib/optimize/__init__.py
@@ -1,4 +1,5 @@
 from argparse import RawTextHelpFormatter
+
 from fontTools.otlLib.optimize.gpos import COMPRESSION_LEVEL, compact
 from fontTools.ttLib import TTFont
 

--- a/Lib/fontTools/otlLib/optimize/__main__.py
+++ b/Lib/fontTools/otlLib/optimize/__main__.py
@@ -1,6 +1,6 @@
 import sys
-from fontTools.otlLib.optimize import main
 
+from fontTools.otlLib.optimize import main
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/Lib/fontTools/pens/areaPen.py
+++ b/Lib/fontTools/pens/areaPen.py
@@ -2,7 +2,6 @@
 
 from fontTools.pens.basePen import BasePen
 
-
 __all__ = ["AreaPen"]
 
 

--- a/Lib/fontTools/pens/basePen.py
+++ b/Lib/fontTools/pens/basePen.py
@@ -10,7 +10,7 @@ that drawings don't need to know the details of how outlines are stored.
 
 The most basic pattern is this::
 
-	outline.draw(pen)  # 'outline' draws itself onto 'pen'
+    outline.draw(pen)  # 'outline' draws itself onto 'pen'
 
 Pens can be used to render outlines to the screen, but also to construct
 new outlines. Eg. an outline object can be both a drawable object (it has a
@@ -36,7 +36,7 @@ Coordinates are usually expressed as (x, y) tuples, but generally any
 sequence of length 2 will do.
 """
 
-from typing import Tuple, Dict
+from typing import Dict, Tuple
 
 from fontTools.misc.loggingTools import LogMixin
 from fontTools.misc.transform import DecomposedTransform, Identity

--- a/Lib/fontTools/pens/boundsPen.py
+++ b/Lib/fontTools/pens/boundsPen.py
@@ -1,7 +1,6 @@
-from fontTools.misc.arrayTools import updateBounds, pointInRect, unionRect
+from fontTools.misc.arrayTools import pointInRect, unionRect, updateBounds
 from fontTools.misc.bezierTools import calcCubicBounds, calcQuadraticBounds
 from fontTools.pens.basePen import BasePen
-
 
 __all__ = ["BoundsPen", "ControlBoundsPen"]
 

--- a/Lib/fontTools/pens/cairoPen.py
+++ b/Lib/fontTools/pens/cairoPen.py
@@ -2,7 +2,6 @@
 
 from fontTools.pens.basePen import BasePen
 
-
 __all__ = ["CairoPen"]
 
 

--- a/Lib/fontTools/pens/cocoaPen.py
+++ b/Lib/fontTools/pens/cocoaPen.py
@@ -1,6 +1,5 @@
 from fontTools.pens.basePen import BasePen
 
-
 __all__ = ["CocoaPen"]
 
 

--- a/Lib/fontTools/pens/cu2quPen.py
+++ b/Lib/fontTools/pens/cu2quPen.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import operator
+
 from fontTools.cu2qu import curve_to_quadratic, curves_to_quadratic
 from fontTools.pens.basePen import decomposeSuperBezierSegment
 from fontTools.pens.filterPen import FilterPen
+from fontTools.pens.pointPen import BasePointToSegmentPen, ReverseContourPointPen
 from fontTools.pens.reverseContourPen import ReverseContourPen
-from fontTools.pens.pointPen import BasePointToSegmentPen
-from fontTools.pens.pointPen import ReverseContourPointPen
 
 
 class Cu2QuPen(FilterPen):

--- a/Lib/fontTools/pens/freetypePen.py
+++ b/Lib/fontTools/pens/freetypePen.py
@@ -4,30 +4,30 @@
 
 __all__ = ["FreeTypePen"]
 
-import os
+import collections
 import ctypes
+import math
+import os
 import platform
 import subprocess
-import collections
-import math
 
 import freetype
-from freetype.raw import FT_Outline_Get_Bitmap, FT_Outline_Get_BBox, FT_Outline_Get_CBox
-from freetype.ft_types import FT_Pos
-from freetype.ft_structs import FT_Vector, FT_BBox, FT_Bitmap, FT_Outline
 from freetype.ft_enums import (
-    FT_OUTLINE_NONE,
-    FT_OUTLINE_EVEN_ODD_FILL,
-    FT_PIXEL_MODE_GRAY,
-    FT_CURVE_TAG_ON,
     FT_CURVE_TAG_CONIC,
     FT_CURVE_TAG_CUBIC,
+    FT_CURVE_TAG_ON,
+    FT_OUTLINE_EVEN_ODD_FILL,
+    FT_OUTLINE_NONE,
+    FT_PIXEL_MODE_GRAY,
 )
 from freetype.ft_errors import FT_Exception
+from freetype.ft_structs import FT_BBox, FT_Bitmap, FT_Outline, FT_Vector
+from freetype.ft_types import FT_Pos
+from freetype.raw import FT_Outline_Get_BBox, FT_Outline_Get_Bitmap, FT_Outline_Get_CBox
 
-from fontTools.pens.basePen import BasePen, PenError
 from fontTools.misc.roundTools import otRound
 from fontTools.misc.transform import Transform
+from fontTools.pens.basePen import BasePen, PenError
 
 Contour = collections.namedtuple("Contour", ("points", "tags"))
 

--- a/Lib/fontTools/pens/momentsPen.py
+++ b/Lib/fontTools/pens/momentsPen.py
@@ -864,7 +864,7 @@ class MomentsPen(BasePen):
 
 
 if __name__ == "__main__":
-    from fontTools.misc.symfont import x, y, printGreenPen
+    from fontTools.misc.symfont import printGreenPen, x, y
 
     printGreenPen(
         "MomentsPen",

--- a/Lib/fontTools/pens/perimeterPen.py
+++ b/Lib/fontTools/pens/perimeterPen.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 """Calculate the perimeter of a glyph."""
 
-from fontTools.pens.basePen import BasePen
-from fontTools.misc.bezierTools import (
-    approximateQuadraticArcLengthC,
-    calcQuadraticArcLengthC,
-    approximateCubicArcLengthC,
-    calcCubicArcLengthC,
-)
 import math
 
+from fontTools.misc.bezierTools import (
+    approximateCubicArcLengthC,
+    approximateQuadraticArcLengthC,
+    calcCubicArcLengthC,
+    calcQuadraticArcLengthC,
+)
+from fontTools.pens.basePen import BasePen
 
 __all__ = ["PerimeterPen"]
 

--- a/Lib/fontTools/pens/pointInsidePen.py
+++ b/Lib/fontTools/pens/pointInsidePen.py
@@ -2,9 +2,8 @@
 for shapes.
 """
 
+from fontTools.misc.bezierTools import solveCubic, solveQuadratic
 from fontTools.pens.basePen import BasePen
-from fontTools.misc.bezierTools import solveQuadratic, solveCubic
-
 
 __all__ = ["PointInsidePen"]
 

--- a/Lib/fontTools/pens/qtPen.py
+++ b/Lib/fontTools/pens/qtPen.py
@@ -1,6 +1,5 @@
 from fontTools.pens.basePen import BasePen
 
-
 __all__ = ["QtPen"]
 
 

--- a/Lib/fontTools/pens/qu2cuPen.py
+++ b/Lib/fontTools/pens/qu2cuPen.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from fontTools.qu2cu import quadratic_to_curves
+import math
+
 from fontTools.pens.filterPen import ContourFilterPen
 from fontTools.pens.reverseContourPen import ReverseContourPen
-import math
+from fontTools.qu2cu import quadratic_to_curves
 
 
 class Qu2CuPen(ContourFilterPen):

--- a/Lib/fontTools/pens/quartzPen.py
+++ b/Lib/fontTools/pens/quartzPen.py
@@ -1,9 +1,13 @@
+from Quartz.CoreGraphics import (
+    CGPathAddCurveToPoint,
+    CGPathAddLineToPoint,
+    CGPathAddQuadCurveToPoint,
+    CGPathCloseSubpath,
+    CGPathCreateMutable,
+    CGPathMoveToPoint,
+)
+
 from fontTools.pens.basePen import BasePen
-
-from Quartz.CoreGraphics import CGPathCreateMutable, CGPathMoveToPoint
-from Quartz.CoreGraphics import CGPathAddLineToPoint, CGPathAddCurveToPoint
-from Quartz.CoreGraphics import CGPathAddQuadCurveToPoint, CGPathCloseSubpath
-
 
 __all__ = ["QuartzPen"]
 

--- a/Lib/fontTools/pens/recordingPen.py
+++ b/Lib/fontTools/pens/recordingPen.py
@@ -3,7 +3,6 @@
 from fontTools.pens.basePen import AbstractPen, DecomposingPen
 from fontTools.pens.pointPen import AbstractPointPen, DecomposingPointPen
 
-
 __all__ = [
     "replayRecording",
     "RecordingPen",

--- a/Lib/fontTools/pens/reportLabPen.py
+++ b/Lib/fontTools/pens/reportLabPen.py
@@ -1,6 +1,6 @@
-from fontTools.pens.basePen import BasePen
 from reportlab.graphics.shapes import Path
 
+from fontTools.pens.basePen import BasePen
 
 __all__ = ["ReportLabPen"]
 
@@ -48,8 +48,9 @@ if __name__ == "__main__":
         )
         sys.exit(0)
 
-    from fontTools.ttLib import TTFont
     from reportlab.lib import colors
+
+    from fontTools.ttLib import TTFont
 
     path = sys.argv[1]
     glyphName = sys.argv[2]
@@ -66,7 +67,7 @@ if __name__ == "__main__":
 
     w, h = g.width, 1000
     from reportlab.graphics import renderPM
-    from reportlab.graphics.shapes import Group, Drawing, scale
+    from reportlab.graphics.shapes import Drawing, Group, scale
 
     # Everything is wrapped in a group to allow transformations.
     g = Group(pen.path)

--- a/Lib/fontTools/pens/reverseContourPen.py
+++ b/Lib/fontTools/pens/reverseContourPen.py
@@ -1,7 +1,6 @@
 from fontTools.misc.arrayTools import pairwise
 from fontTools.pens.filterPen import ContourFilterPen
 
-
 __all__ = ["reversedContour", "ReverseContourPen"]
 
 

--- a/Lib/fontTools/pens/roundingPen.py
+++ b/Lib/fontTools/pens/roundingPen.py
@@ -2,7 +2,6 @@ from fontTools.misc.roundTools import noRound, otRound
 from fontTools.misc.transform import Transform
 from fontTools.pens.filterPen import FilterPen, FilterPointPen
 
-
 __all__ = ["RoundingPen", "RoundingPointPen"]
 
 

--- a/Lib/fontTools/pens/statisticsPen.py
+++ b/Lib/fontTools/pens/statisticsPen.py
@@ -1,7 +1,8 @@
 """Pen calculating area, center of mass, variance and standard-deviation,
 covariance and correlation, and slant, of glyph shapes."""
 
-from math import sqrt, degrees, atan
+from math import atan, degrees, sqrt
+
 from fontTools.pens.basePen import BasePen, OpenContourError
 from fontTools.pens.momentsPen import MomentsPen
 
@@ -176,8 +177,8 @@ class StatisticsControlPen(StatisticsBase, BasePen):
 
 
 def _test(glyphset, upem, glyphs, quiet=False, *, control=False):
-    from fontTools.pens.transformPen import TransformPen
     from fontTools.misc.transform import Scale
+    from fontTools.pens.transformPen import TransformPen
 
     wght_sum = 0
     wght_sum_perceptual = 0

--- a/Lib/fontTools/pens/svgPathPen.py
+++ b/Lib/fontTools/pens/svgPathPen.py
@@ -1,4 +1,5 @@
 from typing import Callable
+
 from fontTools.pens.basePen import BasePen
 
 
@@ -216,8 +217,9 @@ def main(args=None):
 
         args = sys.argv[1:]
 
-    from fontTools.ttLib import TTFont
     import argparse
+
+    from fontTools.ttLib import TTFont
 
     parser = argparse.ArgumentParser(
         "fonttools pens.svgPathPen", description="Generate SVG from text"

--- a/Lib/fontTools/pens/teePen.py
+++ b/Lib/fontTools/pens/teePen.py
@@ -2,7 +2,6 @@
 
 from fontTools.pens.basePen import AbstractPen
 
-
 __all__ = ["TeePen"]
 
 

--- a/Lib/fontTools/pens/transformPen.py
+++ b/Lib/fontTools/pens/transformPen.py
@@ -1,6 +1,5 @@
 from fontTools.pens.filterPen import FilterPen, FilterPointPen
 
-
 __all__ = ["TransformPen", "TransformPointPen"]
 
 

--- a/Lib/fontTools/pens/ttGlyphPen.py
+++ b/Lib/fontTools/pens/ttGlyphPen.py
@@ -1,19 +1,22 @@
+import math
 from array import array
 from typing import Any, Callable, Dict, Optional, Tuple
+
 from fontTools.misc.fixedTools import MAX_F2DOT14, floatToFixedToFloat
 from fontTools.misc.loggingTools import LogMixin
-from fontTools.pens.pointPen import AbstractPointPen
 from fontTools.misc.roundTools import otRound
 from fontTools.pens.basePen import LoggingPen, PenError
+from fontTools.pens.pointPen import AbstractPointPen
 from fontTools.pens.transformPen import TransformPen, TransformPointPen
 from fontTools.ttLib.tables import ttProgram
-from fontTools.ttLib.tables._g_l_y_f import flagOnCurve, flagCubic
-from fontTools.ttLib.tables._g_l_y_f import Glyph
-from fontTools.ttLib.tables._g_l_y_f import GlyphComponent
-from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
-from fontTools.ttLib.tables._g_l_y_f import dropImpliedOnCurvePoints
-import math
-
+from fontTools.ttLib.tables._g_l_y_f import (
+    Glyph,
+    GlyphComponent,
+    GlyphCoordinates,
+    dropImpliedOnCurvePoints,
+    flagCubic,
+    flagOnCurve,
+)
 
 __all__ = ["TTGlyphPen", "TTGlyphPointPen"]
 

--- a/Lib/fontTools/pens/wxPen.py
+++ b/Lib/fontTools/pens/wxPen.py
@@ -1,6 +1,5 @@
 from fontTools.pens.basePen import BasePen
 
-
 __all__ = ["WxPen"]
 
 

--- a/Lib/fontTools/qu2cu/__main__.py
+++ b/Lib/fontTools/qu2cu/__main__.py
@@ -2,6 +2,5 @@ import sys
 
 from .cli import _main as main
 
-
 if __name__ == "__main__":
     sys.exit(main())

--- a/Lib/fontTools/qu2cu/benchmark.py
+++ b/Lib/fontTools/qu2cu/benchmark.py
@@ -1,9 +1,11 @@
 """Benchmark the qu2cu algorithm performance."""
 
-from .qu2cu import *
-from fontTools.cu2qu import curve_to_quadratic
 import random
 import timeit
+
+from fontTools.cu2qu import curve_to_quadratic
+
+from .qu2cu import *
 
 MAX_ERR = 0.5
 NUM_CURVES = 5

--- a/Lib/fontTools/qu2cu/cli.py
+++ b/Lib/fontTools/qu2cu/cli.py
@@ -1,12 +1,12 @@
-import os
 import argparse
 import logging
+import os
+
+import fontTools
 from fontTools.misc.cliTools import makeOutputFileName
-from fontTools.ttLib import TTFont
 from fontTools.pens.qu2cuPen import Qu2CuPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
-import fontTools
-
+from fontTools.ttLib import TTFont
 
 logger = logging.getLogger("fontTools.qu2cu")
 

--- a/Lib/fontTools/qu2cu/qu2cu.py
+++ b/Lib/fontTools/qu2cu/qu2cu.py
@@ -23,15 +23,11 @@ except (AttributeError, ImportError):
     from fontTools.misc import cython
 COMPILED = cython.compiled
 
-from fontTools.misc.bezierTools import splitCubicAtTC
-from collections import namedtuple
 import math
-from typing import (
-    List,
-    Tuple,
-    Union,
-)
+from collections import namedtuple
+from typing import List, Tuple, Union
 
+from fontTools.misc.bezierTools import splitCubicAtTC
 
 __all__ = ["quadratic_to_curves"]
 
@@ -384,8 +380,8 @@ def spline_to_curves(q, costs, tolerance=0.5, all_cubic=False):
 
 
 def main():
-    from fontTools.cu2qu.benchmark import generate_curve
     from fontTools.cu2qu import curve_to_quadratic
+    from fontTools.cu2qu.benchmark import generate_curve
 
     tolerance = 0.05
     reconstruct_tolerance = tolerance * 1

--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -4,28 +4,28 @@
 
 from __future__ import annotations
 
-from fontTools import config
-from fontTools.misc.roundTools import otRound
-from fontTools import ttLib
-from fontTools.ttLib.tables import otTables
-from fontTools.ttLib.tables.otBase import USE_HARFBUZZ_REPACKER
-from fontTools.otlLib.maxContextCalc import maxCtxFont
-from fontTools.pens.basePen import NullPen
-from fontTools.misc.loggingTools import Timer
-from fontTools.misc.cliTools import makeOutputFileName
-from fontTools.subset.util import _add_method, _uniq_sort
-from fontTools.subset.cff import *
-from fontTools.subset.svg import *
-from fontTools.varLib import varStore, multiVarStore  # For monkey-patching
-from fontTools.ttLib.tables._n_a_m_e import NameRecordVisitor, makeName
-from fontTools.unicodedata import mirrored
-import sys
-import struct
 import array
 import logging
+import struct
+import sys
 from collections import Counter, defaultdict
 from functools import reduce
 from types import MethodType
+
+from fontTools import config, ttLib
+from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.misc.loggingTools import Timer
+from fontTools.misc.roundTools import otRound
+from fontTools.otlLib.maxContextCalc import maxCtxFont
+from fontTools.pens.basePen import NullPen
+from fontTools.subset.cff import *
+from fontTools.subset.svg import *
+from fontTools.subset.util import _add_method, _uniq_sort
+from fontTools.ttLib.tables import otTables
+from fontTools.ttLib.tables._n_a_m_e import NameRecordVisitor, makeName
+from fontTools.ttLib.tables.otBase import USE_HARFBUZZ_REPACKER
+from fontTools.unicodedata import mirrored
+from fontTools.varLib import multiVarStore, varStore  # For monkey-patching
 
 __usage__ = "pyftsubset font-file [glyph...] [--option=value]..."
 
@@ -2494,8 +2494,8 @@ def closure_glyphs(self, s):
 
 @_add_method(ttLib.getTableClass("COLR"))
 def subset_glyphs(self, s):
-    from fontTools.colorLib.unbuilder import unbuildColrV1
     from fontTools.colorLib.builder import buildColrV1, populateCOLRv0
+    from fontTools.colorLib.unbuilder import unbuildColrV1
 
     # only include glyphs after COLR closure, which in turn comes after cmap and GSUB
     # closure, but importantly before glyf/CFF closures. COLR layers can refer to
@@ -3775,6 +3775,7 @@ def usage():
 def main(args=None):
     """OpenType font subsetter and optimizer"""
     from os.path import splitext
+
     from fontTools import configLogger
 
     if args is None:

--- a/Lib/fontTools/subset/__main__.py
+++ b/Lib/fontTools/subset/__main__.py
@@ -1,6 +1,6 @@
 import sys
-from fontTools.subset import main
 
+from fontTools.subset import main
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/Lib/fontTools/subset/cff.py
+++ b/Lib/fontTools/subset/cff.py
@@ -1,8 +1,8 @@
-from fontTools.misc import psCharStrings
 from fontTools import ttLib
-from fontTools.pens.basePen import NullPen
-from fontTools.misc.roundTools import otRound
+from fontTools.misc import psCharStrings
 from fontTools.misc.loggingTools import deprecateFunction
+from fontTools.misc.roundTools import otRound
+from fontTools.pens.basePen import NullPen
 from fontTools.subset.util import _add_method, _uniq_sort
 
 

--- a/Lib/fontTools/subset/svg.py
+++ b/Lib/fontTools/subset/svg.py
@@ -16,7 +16,6 @@ from fontTools import ttLib
 from fontTools.subset.util import _add_method
 from fontTools.ttLib.tables.S_V_G_ import SVGDocument
 
-
 __all__ = ["subset_glyphs"]
 
 

--- a/Lib/fontTools/svgLib/path/__init__.py
+++ b/Lib/fontTools/svgLib/path/__init__.py
@@ -1,9 +1,9 @@
-from fontTools.pens.transformPen import TransformPen
 from fontTools.misc import etree
 from fontTools.misc.textTools import tostr
+from fontTools.pens.transformPen import TransformPen
+
 from .parser import parse_path
 from .shapes import PathBuilder
-
 
 __all__ = [tostr(s) for s in ("SVGPath", "parse_path")]
 

--- a/Lib/fontTools/svgLib/path/arc.py
+++ b/Lib/fontTools/svgLib/path/arc.py
@@ -5,9 +5,9 @@ https://github.com/chromium/chromium/blob/93831f2/third_party/
 blink/renderer/core/svg/svg_path_parser.cc#L169-L278
 """
 
-from fontTools.misc.transform import Identity, Scale
 from math import atan2, ceil, cos, fabs, isfinite, pi, radians, sin, sqrt, tan
 
+from fontTools.misc.transform import Identity, Scale
 
 TWO_PI = 2 * pi
 PI_OVER_TWO = 0.5 * pi

--- a/Lib/fontTools/svgLib/path/parser.py
+++ b/Lib/fontTools/svgLib/path/parser.py
@@ -7,9 +7,9 @@
 # Copyright (c) 2013-2014 Lennart Regebro
 # License: MIT
 
-from .arc import EllipticalArc
 import re
 
+from .arc import EllipticalArc
 
 COMMANDS = set("MmZzLlHhVvCcSsQqTtAa")
 ARC_COMMANDS = set("Aa")

--- a/Lib/fontTools/t1Lib/__init__.py
+++ b/Lib/fontTools/t1Lib/__init__.py
@@ -3,31 +3,32 @@
 Functions for reading and writing raw Type 1 data:
 
 read(path)
-	reads any Type 1 font file, returns the raw data and a type indicator:
-	'LWFN', 'PFB' or 'OTHER', depending on the format of the file pointed
-	to by 'path'.
-	Raises an error when the file does not contain valid Type 1 data.
+    reads any Type 1 font file, returns the raw data and a type indicator:
+    'LWFN', 'PFB' or 'OTHER', depending on the format of the file pointed
+    to by 'path'.
+    Raises an error when the file does not contain valid Type 1 data.
 
 write(path, data, kind='OTHER', dohex=False)
-	writes raw Type 1 data to the file pointed to by 'path'.
-	'kind' can be one of 'LWFN', 'PFB' or 'OTHER'; it defaults to 'OTHER'.
-	'dohex' is a flag which determines whether the eexec encrypted
-	part should be written as hexadecimal or binary, but only if kind
-	is 'OTHER'.
+    writes raw Type 1 data to the file pointed to by 'path'.
+    'kind' can be one of 'LWFN', 'PFB' or 'OTHER'; it defaults to 'OTHER'.
+    'dohex' is a flag which determines whether the eexec encrypted
+    part should be written as hexadecimal or binary, but only if kind
+    is 'OTHER'.
 """
 
-import fontTools
-from fontTools.misc import eexec
-from fontTools.misc.macCreatorType import getMacCreatorAndType
-from fontTools.misc.textTools import bytechr, byteord, bytesjoin, tobytes
-from fontTools.misc.psOperators import (
-    _type1_pre_eexec_order,
-    _type1_fontinfo_order,
-    _type1_post_eexec_order,
-)
-from fontTools.encodings.StandardEncoding import StandardEncoding
 import os
 import re
+
+import fontTools
+from fontTools.encodings.StandardEncoding import StandardEncoding
+from fontTools.misc import eexec
+from fontTools.misc.macCreatorType import getMacCreatorAndType
+from fontTools.misc.psOperators import (
+    _type1_fontinfo_order,
+    _type1_post_eexec_order,
+    _type1_pre_eexec_order,
+)
+from fontTools.misc.textTools import bytechr, byteord, bytesjoin, tobytes
 
 __author__ = "jvr"
 __version__ = "1.0b3"
@@ -94,8 +95,7 @@ class T1Font(object):
         return self.font[key]
 
     def parse(self):
-        from fontTools.misc import psLib
-        from fontTools.misc import psCharStrings
+        from fontTools.misc import psCharStrings, psLib
 
         self.font = psLib.suckfont(self.data, self.encoding)
         charStrings = self.font["CharStrings"]

--- a/Lib/fontTools/tfmLib.py
+++ b/Lib/fontTools/tfmLib.py
@@ -3,36 +3,36 @@
 The TFM format is described in the TFtoPL WEB source code, whose typeset form
 can be found on `CTAN <http://mirrors.ctan.org/info/knuth-pdf/texware/tftopl.pdf>`_.
 
-	>>> from fontTools.tfmLib import TFM
-	>>> tfm = TFM("Tests/tfmLib/data/cmr10.tfm")
-	>>>
-	>>> # Accessing an attribute gets you metadata.
-	>>> tfm.checksum
-	1274110073
-	>>> tfm.designsize
-	10.0
-	>>> tfm.codingscheme
-	'TeX text'
-	>>> tfm.family
-	'CMR'
-	>>> tfm.seven_bit_safe_flag
-	False
-	>>> tfm.face
-	234
-	>>> tfm.extraheader
-	{}
-	>>> tfm.fontdimens
-	{'SLANT': 0.0, 'SPACE': 0.33333396911621094, 'STRETCH': 0.16666698455810547, 'SHRINK': 0.11111164093017578, 'XHEIGHT': 0.4305553436279297, 'QUAD': 1.0000028610229492, 'EXTRASPACE': 0.11111164093017578}
-	>>> # Accessing a character gets you its metrics.
-	>>> # “width” is always available, other metrics are available only when
-	>>> # applicable. All values are relative to “designsize”.
-	>>> tfm.chars[ord("g")]
-	{'width': 0.5000019073486328, 'height': 0.4305553436279297, 'depth': 0.1944446563720703, 'italic': 0.013888359069824219}
-	>>> # Kerning and ligature can be accessed as well.
-	>>> tfm.kerning[ord("c")]
-	{104: -0.02777862548828125, 107: -0.02777862548828125}
-	>>> tfm.ligatures[ord("f")]
-	{105: ('LIG', 12), 102: ('LIG', 11), 108: ('LIG', 13)}
+    >>> from fontTools.tfmLib import TFM
+    >>> tfm = TFM("Tests/tfmLib/data/cmr10.tfm")
+    >>>
+    >>> # Accessing an attribute gets you metadata.
+    >>> tfm.checksum
+    1274110073
+    >>> tfm.designsize
+    10.0
+    >>> tfm.codingscheme
+    'TeX text'
+    >>> tfm.family
+    'CMR'
+    >>> tfm.seven_bit_safe_flag
+    False
+    >>> tfm.face
+    234
+    >>> tfm.extraheader
+    {}
+    >>> tfm.fontdimens
+    {'SLANT': 0.0, 'SPACE': 0.33333396911621094, 'STRETCH': 0.16666698455810547, 'SHRINK': 0.11111164093017578, 'XHEIGHT': 0.4305553436279297, 'QUAD': 1.0000028610229492, 'EXTRASPACE': 0.11111164093017578}
+    >>> # Accessing a character gets you its metrics.
+    >>> # “width” is always available, other metrics are available only when
+    >>> # applicable. All values are relative to “designsize”.
+    >>> tfm.chars[ord("g")]
+    {'width': 0.5000019073486328, 'height': 0.4305553436279297, 'depth': 0.1944446563720703, 'italic': 0.013888359069824219}
+    >>> # Kerning and ligature can be accessed as well.
+    >>> tfm.kerning[ord("c")]
+    {104: -0.02777862548828125, 107: -0.02777862548828125}
+    >>> tfm.ligatures[ord("f")]
+    {105: ('LIG', 12), 102: ('LIG', 11), 108: ('LIG', 13)}
 """
 
 from types import SimpleNamespace

--- a/Lib/fontTools/ttLib/__init__.py
+++ b/Lib/fontTools/ttLib/__init__.py
@@ -1,9 +1,9 @@
 """fontTools.ttLib -- a package for dealing with TrueType fonts."""
 
-from fontTools.config import OPTIONS
-from fontTools.misc.loggingTools import deprecateFunction
 import logging
 
+from fontTools.config import OPTIONS
+from fontTools.misc.loggingTools import deprecateFunction
 
 log = logging.getLogger(__name__)
 
@@ -26,5 +26,5 @@ def debugmsg(msg):
     print(msg + time.strftime("  (%H:%M:%S)", time.localtime(time.time())))
 
 
-from fontTools.ttLib.ttFont import *
 from fontTools.ttLib.ttCollection import TTCollection
+from fontTools.ttLib.ttFont import *

--- a/Lib/fontTools/ttLib/__main__.py
+++ b/Lib/fontTools/ttLib/__main__.py
@@ -1,7 +1,8 @@
 import sys
+
 from fontTools.ttLib import OPTIMIZE_FONT_SPEED, TTLibError, TTLibFileIsCollectionError
-from fontTools.ttLib.ttFont import *
 from fontTools.ttLib.ttCollection import TTCollection
+from fontTools.ttLib.ttFont import *
 
 
 def main(args=None):

--- a/Lib/fontTools/ttLib/macUtils.py
+++ b/Lib/fontTools/ttLib/macUtils.py
@@ -1,7 +1,8 @@
 """ttLib.macUtils.py -- Various Mac-specific stuff."""
 
 from io import BytesIO
-from fontTools.misc.macRes import ResourceReader, ResourceError
+
+from fontTools.misc.macRes import ResourceError, ResourceReader
 
 
 def getSFNTResIndices(path):

--- a/Lib/fontTools/ttLib/removeOverlaps.py
+++ b/Lib/fontTools/ttLib/removeOverlaps.py
@@ -1,23 +1,21 @@
-""" Simplify TrueType glyphs by merging overlapping contours/components.
+"""Simplify TrueType glyphs by merging overlapping contours/components.
 
 Requires https://github.com/fonttools/skia-pathops
 """
 
 import itertools
 import logging
-from typing import Callable, Iterable, Optional, Mapping
-
-from fontTools.cffLib import CFFFontSet
-from fontTools.ttLib import ttFont
-from fontTools.ttLib.tables import _g_l_y_f
-from fontTools.ttLib.tables import _h_m_t_x
-from fontTools.misc.psCharStrings import T2CharString
-from fontTools.misc.roundTools import otRound, noRound
-from fontTools.pens.ttGlyphPen import TTGlyphPen
-from fontTools.pens.t2CharStringPen import T2CharStringPen
+from typing import Callable, Iterable, Mapping, Optional
 
 import pathops
 
+from fontTools.cffLib import CFFFontSet
+from fontTools.misc.psCharStrings import T2CharString
+from fontTools.misc.roundTools import noRound, otRound
+from fontTools.pens.t2CharStringPen import T2CharStringPen
+from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.ttLib import ttFont
+from fontTools.ttLib.tables import _g_l_y_f, _h_m_t_x
 
 __all__ = ["removeOverlaps"]
 

--- a/Lib/fontTools/ttLib/reorderGlyphs.py
+++ b/Lib/fontTools/ttLib/reorderGlyphs.py
@@ -6,22 +6,14 @@ __author__ = "Rod Sheeter"
 # for details.
 
 
+from abc import ABC, abstractmethod
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Callable, Deque, Iterable, List, Optional, Tuple
+
 from fontTools import ttLib
 from fontTools.ttLib.tables import otBase
 from fontTools.ttLib.tables import otTables as ot
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from collections import deque
-from typing import (
-    Optional,
-    Any,
-    Callable,
-    Deque,
-    Iterable,
-    List,
-    Tuple,
-)
-
 
 _COVERAGE_ATTR = "Coverage"  # tables that have one coverage use this name
 

--- a/Lib/fontTools/ttLib/scaleUpem.py
+++ b/Lib/fontTools/ttLib/scaleUpem.py
@@ -3,18 +3,17 @@
 AAT and Graphite tables are not supported. CFF/CFF2 fonts
 are de-subroutinized."""
 
-from fontTools.ttLib.ttVisitor import TTVisitor
+import fontTools.cffLib.specializer as cffSpecializer
 import fontTools.ttLib as ttLib
 import fontTools.ttLib.tables.otBase as otBase
 import fontTools.ttLib.tables.otTables as otTables
 from fontTools.cffLib import VarStoreData
-import fontTools.cffLib.specializer as cffSpecializer
-from fontTools.varLib import builder  # for VarData.calculateNumShorts
-from fontTools.varLib.multiVarStore import OnlineMultiVarStoreBuilder
-from fontTools.misc.vector import Vector
 from fontTools.misc.fixedTools import otRound
 from fontTools.misc.iterTools import batched
-
+from fontTools.misc.vector import Vector
+from fontTools.ttLib.ttVisitor import TTVisitor
+from fontTools.varLib import builder  # for VarData.calculateNumShorts
+from fontTools.varLib.multiVarStore import OnlineMultiVarStoreBuilder
 
 __all__ = ["scale_upem", "ScalerVisitor"]
 
@@ -399,9 +398,10 @@ def main(args=None):
 
         args = sys.argv[1:]
 
-    from fontTools.ttLib import TTFont
-    from fontTools.misc.cliTools import makeOutputFileName
     import argparse
+
+    from fontTools.misc.cliTools import makeOutputFileName
+    from fontTools.ttLib import TTFont
 
     parser = argparse.ArgumentParser(
         "fonttools ttLib.scaleUpem", description="Change the units-per-EM of fonts"

--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -13,15 +13,15 @@ classes, since whenever the number of tables changes or whenever
 a table's length changes you need to rewrite the whole file anyway.
 """
 
-from io import BytesIO
-from types import SimpleNamespace
-from fontTools.misc.textTools import Tag
-from fontTools.misc import sstruct
-from fontTools.ttLib import TTLibError, TTLibFileIsCollectionError
+import logging
 import struct
 from collections import OrderedDict
-import logging
+from io import BytesIO
+from types import SimpleNamespace
 
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import Tag
+from fontTools.ttLib import TTLibError, TTLibFileIsCollectionError
 
 log = logging.getLogger(__name__)
 
@@ -656,7 +656,7 @@ def writeTTCHeader(file, numFonts):
 
 
 if __name__ == "__main__":
-    import sys
     import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/ttLib/tables/BitmapGlyphMetrics.py
+++ b/Lib/fontTools/ttLib/tables/BitmapGlyphMetrics.py
@@ -1,9 +1,9 @@
 # Since bitmap glyph metrics are shared between EBLC and EBDT
 # this class gets its own python file.
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval
 import logging
 
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import safeEval
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/C_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/C_B_D_T_.py
@@ -3,21 +3,23 @@
 # Google Author(s): Matt Fontaine
 
 
-from fontTools.misc.textTools import bytesjoin
+import struct
+
 from fontTools.misc import sstruct
+from fontTools.misc.textTools import bytesjoin
+
 from . import E_B_D_T_
 from .BitmapGlyphMetrics import (
     BigGlyphMetrics,
-    bigGlyphMetricsFormat,
     SmallGlyphMetrics,
+    bigGlyphMetricsFormat,
     smallGlyphMetricsFormat,
 )
 from .E_B_D_T_ import (
     BitmapGlyph,
-    BitmapPlusSmallMetricsMixin,
     BitmapPlusBigMetricsMixin,
+    BitmapPlusSmallMetricsMixin,
 )
-import struct
 
 
 class table_C_B_D_T_(E_B_D_T_.table_E_B_D_T_):

--- a/Lib/fontTools/ttLib/tables/C_F_F_.py
+++ b/Lib/fontTools/ttLib/tables/C_F_F_.py
@@ -1,5 +1,7 @@
 from io import BytesIO
+
 from fontTools import cffLib
+
 from . import DefaultTable
 
 

--- a/Lib/fontTools/ttLib/tables/C_F_F__2.py
+++ b/Lib/fontTools/ttLib/tables/C_F_F__2.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+
 from fontTools.ttLib.tables.C_F_F_ import table_C_F_F_
 
 

--- a/Lib/fontTools/ttLib/tables/C_O_L_R_.py
+++ b/Lib/fontTools/ttLib/tables/C_O_L_R_.py
@@ -3,6 +3,7 @@
 # Google Author(s): Behdad Esfahbod
 
 from fontTools.misc.textTools import safeEval
+
 from . import DefaultTable
 
 
@@ -42,8 +43,9 @@ class table_C_O_L_R_(DefaultTable.DefaultTable):
         return colorLayerLists
 
     def _toOTTable(self, ttFont):
-        from . import otTables
         from fontTools.colorLib.builder import populateCOLRv0
+
+        from . import otTables
 
         tableClass = getattr(otTables, self.tableTag)
         table = tableClass()
@@ -60,8 +62,8 @@ class table_C_O_L_R_(DefaultTable.DefaultTable):
         return table
 
     def decompile(self, data, ttFont):
-        from .otBase import OTTableReader
         from . import otTables
+        from .otBase import OTTableReader
 
         # We use otData to decompile, but we adapt the decompiled otTables to the
         # existing COLR v0 API for backward compatibility.

--- a/Lib/fontTools/ttLib/tables/C_P_A_L_.py
+++ b/Lib/fontTools/ttLib/tables/C_P_A_L_.py
@@ -2,12 +2,14 @@
 #
 # Google Author(s): Behdad Esfahbod
 
-from fontTools.misc.textTools import bytesjoin, safeEval
-from . import DefaultTable
 import array
-from collections import namedtuple
 import struct
 import sys
+from collections import namedtuple
+
+from fontTools.misc.textTools import bytesjoin, safeEval
+
+from . import DefaultTable
 
 
 class table_C_P_A_L_(DefaultTable.DefaultTable):

--- a/Lib/fontTools/ttLib/tables/D_S_I_G_.py
+++ b/Lib/fontTools/ttLib/tables/D_S_I_G_.py
@@ -1,7 +1,9 @@
-from fontTools.misc.textTools import bytesjoin, strjoin, tobytes, tostr, safeEval
-from fontTools.misc import sstruct
-from . import DefaultTable
 import base64
+
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import bytesjoin, safeEval, strjoin, tobytes, tostr
+
+from . import DefaultTable
 
 DSIG_HeaderFormat = """
 	> # big endian

--- a/Lib/fontTools/ttLib/tables/D__e_b_g.py
+++ b/Lib/fontTools/ttLib/tables/D__e_b_g.py
@@ -1,8 +1,9 @@
 import json
 from textwrap import indent
 
-from . import DefaultTable
 from fontTools.misc.textTools import tostr
+
+from . import DefaultTable
 
 
 class table_D__e_b_g(DefaultTable.DefaultTable):

--- a/Lib/fontTools/ttLib/tables/DefaultTable.py
+++ b/Lib/fontTools/ttLib/tables/DefaultTable.py
@@ -29,8 +29,8 @@ class DefaultTable(object):
         writer.newline()
 
     def fromXML(self, name, attrs, content, ttFont):
-        from fontTools.misc.textTools import readHex
         from fontTools import ttLib
+        from fontTools.misc.textTools import readHex
 
         if name != "hexdata":
             raise ttLib.TTLibError("can't handle '%s' element" % name)

--- a/Lib/fontTools/ttLib/tables/E_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_D_T_.py
@@ -1,26 +1,27 @@
+import itertools
+import logging
+import os
+import struct
+
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import (
     bytechr,
     byteord,
     bytesjoin,
-    strjoin,
-    safeEval,
-    readHex,
-    hexStr,
     deHexStr,
+    hexStr,
+    readHex,
+    safeEval,
+    strjoin,
 )
+
+from . import DefaultTable
 from .BitmapGlyphMetrics import (
     BigGlyphMetrics,
-    bigGlyphMetricsFormat,
     SmallGlyphMetrics,
+    bigGlyphMetricsFormat,
     smallGlyphMetricsFormat,
 )
-from . import DefaultTable
-import itertools
-import os
-import struct
-import logging
-
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/E_B_L_C_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_L_C_.py
@@ -1,17 +1,18 @@
+import itertools
+import logging
+import struct
+from collections import deque
+
 from fontTools.misc import sstruct
-from . import DefaultTable
 from fontTools.misc.textTools import bytesjoin, safeEval
+
+from . import DefaultTable
 from .BitmapGlyphMetrics import (
     BigGlyphMetrics,
-    bigGlyphMetricsFormat,
     SmallGlyphMetrics,
+    bigGlyphMetricsFormat,
     smallGlyphMetricsFormat,
 )
-import struct
-import itertools
-from collections import deque
-import logging
-
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/F_F_T_M_.py
+++ b/Lib/fontTools/ttLib/tables/F_F_T_M_.py
@@ -1,6 +1,7 @@
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval
 from fontTools.misc.timeTools import timestampFromString, timestampToString
+
 from . import DefaultTable
 
 FFTMFormat = """

--- a/Lib/fontTools/ttLib/tables/F__e_a_t.py
+++ b/Lib/fontTools/ttLib/tables/F__e_a_t.py
@@ -1,9 +1,10 @@
+import struct
+
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import floatToFixedToStr
 from fontTools.misc.textTools import safeEval
-from . import DefaultTable
-from . import grUtils
-import struct
+
+from . import DefaultTable, grUtils
 
 Feat_hdr_format = """
     >

--- a/Lib/fontTools/ttLib/tables/G_M_A_P_.py
+++ b/Lib/fontTools/ttLib/tables/G_M_A_P_.py
@@ -1,5 +1,6 @@
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import tobytes, tostr, safeEval
+from fontTools.misc.textTools import safeEval, tobytes, tostr
+
 from . import DefaultTable
 
 GMAPFormat = """

--- a/Lib/fontTools/ttLib/tables/G_P_K_G_.py
+++ b/Lib/fontTools/ttLib/tables/G_P_K_G_.py
@@ -1,8 +1,10 @@
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import bytesjoin, safeEval, readHex
-from . import DefaultTable
-import sys
 import array
+import sys
+
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import bytesjoin, readHex, safeEval
+
+from . import DefaultTable
 
 GPKGFormat = """
 		>	# big endian

--- a/Lib/fontTools/ttLib/tables/G__l_a_t.py
+++ b/Lib/fontTools/ttLib/tables/G__l_a_t.py
@@ -1,13 +1,13 @@
+import struct
+
+# from itertools import *
+from functools import partial
+
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import floatToFixedToStr
 from fontTools.misc.textTools import safeEval
 
-# from itertools import *
-from functools import partial
-from . import DefaultTable
-from . import grUtils
-import struct
-
+from . import DefaultTable, grUtils
 
 Glat_format_0 = """
     >        # big endian

--- a/Lib/fontTools/ttLib/tables/G__l_o_c.py
+++ b/Lib/fontTools/ttLib/tables/G__l_o_c.py
@@ -1,9 +1,10 @@
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval
-from . import DefaultTable
 import array
 import sys
 
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import safeEval
+
+from . import DefaultTable
 
 Gloc_header = """
     >        # big endian

--- a/Lib/fontTools/ttLib/tables/L_T_S_H_.py
+++ b/Lib/fontTools/ttLib/tables/L_T_S_H_.py
@@ -1,7 +1,9 @@
-from fontTools.misc.textTools import safeEval
-from . import DefaultTable
-import struct
 import array
+import struct
+
+from fontTools.misc.textTools import safeEval
+
+from . import DefaultTable
 
 # XXX I've lowered the strictness, to make sure Apple's own Chicago
 # XXX gets through. They're looking into it, I hope to raise the standards

--- a/Lib/fontTools/ttLib/tables/M_E_T_A_.py
+++ b/Lib/fontTools/ttLib/tables/M_E_T_A_.py
@@ -1,9 +1,10 @@
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import byteord, safeEval
-from . import DefaultTable
 import pdb
 import struct
 
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import byteord, safeEval
+
+from . import DefaultTable
 
 METAHeaderFormat = """
 		>	# big endian

--- a/Lib/fontTools/ttLib/tables/O_S_2f_2.py
+++ b/Lib/fontTools/ttLib/tables/O_S_2f_2.py
@@ -1,10 +1,10 @@
-from fontTools.misc import sstruct
-from fontTools.misc.roundTools import otRound
-from fontTools.misc.textTools import safeEval, num2binary, binary2num
-from fontTools.ttLib.tables import DefaultTable
 import bisect
 import logging
 
+from fontTools.misc import sstruct
+from fontTools.misc.roundTools import otRound
+from fontTools.misc.textTools import binary2num, num2binary, safeEval
+from fontTools.ttLib.tables import DefaultTable
 
 log = logging.getLogger(__name__)
 
@@ -747,6 +747,7 @@ def calcCodePageRanges(unicodes):
 
 
 if __name__ == "__main__":
-    import doctest, sys
+    import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/ttLib/tables/S_I_N_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_I_N_G_.py
@@ -1,5 +1,6 @@
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import bytechr, byteord, tobytes, tostr, safeEval
+from fontTools.misc.textTools import bytechr, byteord, safeEval, tobytes, tostr
+
 from . import DefaultTable
 
 SINGFormat = """

--- a/Lib/fontTools/ttLib/tables/S_V_G_.py
+++ b/Lib/fontTools/ttLib/tables/S_V_G_.py
@@ -6,26 +6,27 @@ The XML format is:
 
 .. code-block:: xml
 
-	<SVG>
-		<svgDoc endGlyphID="1" startGlyphID="1">
-			<![CDATA[ <complete SVG doc> ]]
-		</svgDoc>
-	...
-		<svgDoc endGlyphID="n" startGlyphID="m">
-			<![CDATA[ <complete SVG doc> ]]
-		</svgDoc>
-	</SVG>
+    <SVG>
+            <svgDoc endGlyphID="1" startGlyphID="1">
+                    <![CDATA[ <complete SVG doc> ]]
+            </svgDoc>
+    ...
+            <svgDoc endGlyphID="n" startGlyphID="m">
+                    <![CDATA[ <complete SVG doc> ]]
+            </svgDoc>
+    </SVG>
 """
 
-from fontTools.misc.textTools import bytesjoin, safeEval, strjoin, tobytes, tostr
-from fontTools.misc import sstruct
-from . import DefaultTable
-from collections.abc import Sequence
-from dataclasses import dataclass, astuple
-from io import BytesIO
-import struct
 import logging
+import struct
+from collections.abc import Sequence
+from dataclasses import astuple, dataclass
+from io import BytesIO
 
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import bytesjoin, safeEval, strjoin, tobytes, tostr
+
+from . import DefaultTable
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/S__i_l_f.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_f.py
@@ -1,13 +1,15 @@
+import re
+import struct
+import sys
+from array import array
+from functools import reduce
+
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import floatToFixedToStr
 from fontTools.misc.textTools import byteord, safeEval
 
 # from itertools import *
-from . import DefaultTable
-from . import grUtils
-from array import array
-from functools import reduce
-import struct, re, sys
+from . import DefaultTable, grUtils
 
 Silf_hdr_format = """
     >

--- a/Lib/fontTools/ttLib/tables/S__i_l_l.py
+++ b/Lib/fontTools/ttLib/tables/S__i_l_l.py
@@ -1,9 +1,10 @@
+import struct
+
 from fontTools.misc import sstruct
 from fontTools.misc.fixedTools import floatToFixedToStr
 from fontTools.misc.textTools import safeEval
-from . import DefaultTable
-from . import grUtils
-import struct
+
+from . import DefaultTable, grUtils
 
 Sill_hdr = """
     >

--- a/Lib/fontTools/ttLib/tables/T_S_I_B_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_B_.py
@@ -1,4 +1,4 @@
-""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+"""TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
 tool to store its table source data.
 
 TSIB contains the source text for the ``BASE`` table.

--- a/Lib/fontTools/ttLib/tables/T_S_I_C_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_C_.py
@@ -1,4 +1,4 @@
-""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+"""TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
 tool to store its table source data.
 
 TSIC contains the source text for the Variation CVT window and data for

--- a/Lib/fontTools/ttLib/tables/T_S_I_D_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_D_.py
@@ -1,4 +1,4 @@
-""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+"""TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
 tool to store its table source data.
 
 TSID contains the source text for the ``GDEF`` table.

--- a/Lib/fontTools/ttLib/tables/T_S_I_J_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_J_.py
@@ -1,4 +1,4 @@
-""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+"""TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
 tool to store its table source data.
 
 TSIJ contains the source text for the ``JSTF`` table.

--- a/Lib/fontTools/ttLib/tables/T_S_I_P_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_P_.py
@@ -1,4 +1,4 @@
-""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+"""TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
 tool to store its table source data.
 
 TSIP contains the source text for the ``GPOS`` table.

--- a/Lib/fontTools/ttLib/tables/T_S_I_S_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_S_.py
@@ -1,4 +1,4 @@
-""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+"""TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
 tool to store its table source data.
 
 TSIS contains the source text for the ``GSUB`` table.

--- a/Lib/fontTools/ttLib/tables/T_S_I_V_.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I_V_.py
@@ -1,10 +1,11 @@
-""" TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
+"""TSI{B,C,D,J,P,S,V} are private tables used by Microsoft Visual TrueType (VTT)
 tool to store its table source data.
 
 See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
 """
 
 from fontTools.misc.textTools import strjoin, tobytes, tostr
+
 from . import asciiTable
 
 

--- a/Lib/fontTools/ttLib/tables/T_S_I__1.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__1.py
@@ -1,4 +1,4 @@
-""" TSI{0,1,2,3,5} are private tables used by Microsoft Visual TrueType (VTT)
+"""TSI{0,1,2,3,5} are private tables used by Microsoft Visual TrueType (VTT)
 tool to store its hinting source data.
 
 TSI1 contains the text of the glyph programs in the form of low-level assembly
@@ -7,9 +7,10 @@ code, as well as the 'extra' programs 'fpgm', 'ppgm' (i.e. 'prep'), and 'cvt'.
 See also https://learn.microsoft.com/en-us/typography/tools/vtt/tsi-tables
 """
 
-from . import DefaultTable
 from fontTools.misc.loggingTools import LogMixin
 from fontTools.misc.textTools import strjoin, tobytes, tostr
+
+from . import DefaultTable
 
 
 class table_T_S_I__1(LogMixin, DefaultTable.DefaultTable):

--- a/Lib/fontTools/ttLib/tables/T_S_I__2.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__2.py
@@ -1,4 +1,4 @@
-""" TSI{0,1,2,3,5} are private tables used by Microsoft Visual TrueType (VTT)
+"""TSI{0,1,2,3,5} are private tables used by Microsoft Visual TrueType (VTT)
 tool to store its hinting source data.
 
 TSI2 is the index table containing the lengths and offsets for the glyph

--- a/Lib/fontTools/ttLib/tables/T_S_I__3.py
+++ b/Lib/fontTools/ttLib/tables/T_S_I__3.py
@@ -1,4 +1,4 @@
-""" TSI{0,1,2,3,5} are private tables used by Microsoft Visual TrueType (VTT)
+"""TSI{0,1,2,3,5} are private tables used by Microsoft Visual TrueType (VTT)
 tool to store its hinting source data.
 
 TSI3 contains the text of the glyph programs in the form of 'VTTTalk' code.

--- a/Lib/fontTools/ttLib/tables/TupleVariation.py
+++ b/Lib/fontTools/ttLib/tables/TupleVariation.py
@@ -1,18 +1,16 @@
-from fontTools.misc.fixedTools import (
-    fixedToFloat as fi2fl,
-    floatToFixed as fl2fi,
-    floatToFixedToStr as fl2str,
-    strToFixedToFloat as str2fl,
-    otRound,
-)
-from fontTools.misc.textTools import safeEval
 import array
-from collections import Counter, defaultdict
 import io
 import logging
 import struct
 import sys
+from collections import Counter, defaultdict
 
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
+from fontTools.misc.fixedTools import floatToFixed as fl2fi
+from fontTools.misc.fixedTools import floatToFixedToStr as fl2str
+from fontTools.misc.fixedTools import otRound
+from fontTools.misc.fixedTools import strToFixedToFloat as str2fl
+from fontTools.misc.textTools import safeEval
 
 # https://www.microsoft.com/typography/otspec/otvarcommonformats.htm
 

--- a/Lib/fontTools/ttLib/tables/V_D_M_X_.py
+++ b/Lib/fontTools/ttLib/tables/V_D_M_X_.py
@@ -1,7 +1,9 @@
-from . import DefaultTable
+import struct
+
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval
-import struct
+
+from . import DefaultTable
 
 VDMX_HeaderFmt = """
 	>                 # big endian

--- a/Lib/fontTools/ttLib/tables/V_O_R_G_.py
+++ b/Lib/fontTools/ttLib/tables/V_O_R_G_.py
@@ -1,6 +1,8 @@
-from fontTools.misc.textTools import bytesjoin, safeEval
-from . import DefaultTable
 import struct
+
+from fontTools.misc.textTools import bytesjoin, safeEval
+
+from . import DefaultTable
 
 
 class table_V_O_R_G_(DefaultTable.DefaultTable):

--- a/Lib/fontTools/ttLib/tables/__init__.py
+++ b/Lib/fontTools/ttLib/tables/__init__.py
@@ -5,94 +5,97 @@ def _moduleFinderHint():
 
         >>> _moduleFinderHint()
     """
-    from . import B_A_S_E_
-    from . import C_B_D_T_
-    from . import C_B_L_C_
-    from . import C_F_F_
-    from . import C_F_F__2
-    from . import C_O_L_R_
-    from . import C_P_A_L_
-    from . import D_S_I_G_
-    from . import D__e_b_g
-    from . import E_B_D_T_
-    from . import E_B_L_C_
-    from . import F_F_T_M_
-    from . import F__e_a_t
-    from . import G_D_E_F_
-    from . import G_M_A_P_
-    from . import G_P_K_G_
-    from . import G_P_O_S_
-    from . import G_S_U_B_
-    from . import G_V_A_R_
-    from . import G__l_a_t
-    from . import G__l_o_c
-    from . import H_V_A_R_
-    from . import J_S_T_F_
-    from . import L_T_S_H_
-    from . import M_A_T_H_
-    from . import M_E_T_A_
-    from . import M_V_A_R_
-    from . import O_S_2f_2
-    from . import S_I_N_G_
-    from . import S_T_A_T_
-    from . import S_V_G_
-    from . import S__i_l_f
-    from . import S__i_l_l
-    from . import T_S_I_B_
-    from . import T_S_I_C_
-    from . import T_S_I_D_
-    from . import T_S_I_J_
-    from . import T_S_I_P_
-    from . import T_S_I_S_
-    from . import T_S_I_V_
-    from . import T_S_I__0
-    from . import T_S_I__1
-    from . import T_S_I__2
-    from . import T_S_I__3
-    from . import T_S_I__5
-    from . import T_T_F_A_
-    from . import V_A_R_C_
-    from . import V_D_M_X_
-    from . import V_O_R_G_
-    from . import V_V_A_R_
-    from . import _a_n_k_r
-    from . import _a_v_a_r
-    from . import _b_s_l_n
-    from . import _c_i_d_g
-    from . import _c_m_a_p
-    from . import _c_v_a_r
-    from . import _c_v_t
-    from . import _f_e_a_t
-    from . import _f_p_g_m
-    from . import _f_v_a_r
-    from . import _g_a_s_p
-    from . import _g_c_i_d
-    from . import _g_l_y_f
-    from . import _g_v_a_r
-    from . import _h_d_m_x
-    from . import _h_e_a_d
-    from . import _h_h_e_a
-    from . import _h_m_t_x
-    from . import _k_e_r_n
-    from . import _l_c_a_r
-    from . import _l_o_c_a
-    from . import _l_t_a_g
-    from . import _m_a_x_p
-    from . import _m_e_t_a
-    from . import _m_o_r_t
-    from . import _m_o_r_x
-    from . import _n_a_m_e
-    from . import _o_p_b_d
-    from . import _p_o_s_t
-    from . import _p_r_e_p
-    from . import _p_r_o_p
-    from . import _s_b_i_x
-    from . import _t_r_a_k
-    from . import _v_h_e_a
-    from . import _v_m_t_x
+    from . import (
+        B_A_S_E_,
+        C_B_D_T_,
+        C_B_L_C_,
+        C_F_F_,
+        C_F_F__2,
+        C_O_L_R_,
+        C_P_A_L_,
+        D_S_I_G_,
+        E_B_D_T_,
+        E_B_L_C_,
+        F_F_T_M_,
+        G_D_E_F_,
+        G_M_A_P_,
+        G_P_K_G_,
+        G_P_O_S_,
+        G_S_U_B_,
+        G_V_A_R_,
+        H_V_A_R_,
+        J_S_T_F_,
+        L_T_S_H_,
+        M_A_T_H_,
+        M_E_T_A_,
+        M_V_A_R_,
+        S_I_N_G_,
+        S_T_A_T_,
+        S_V_G_,
+        T_S_I__0,
+        T_S_I__1,
+        T_S_I__2,
+        T_S_I__3,
+        T_S_I__5,
+        T_S_I_B_,
+        T_S_I_C_,
+        T_S_I_D_,
+        T_S_I_J_,
+        T_S_I_P_,
+        T_S_I_S_,
+        T_S_I_V_,
+        T_T_F_A_,
+        V_A_R_C_,
+        V_D_M_X_,
+        V_O_R_G_,
+        V_V_A_R_,
+        D__e_b_g,
+        F__e_a_t,
+        G__l_a_t,
+        G__l_o_c,
+        O_S_2f_2,
+        S__i_l_f,
+        S__i_l_l,
+        _a_n_k_r,
+        _a_v_a_r,
+        _b_s_l_n,
+        _c_i_d_g,
+        _c_m_a_p,
+        _c_v_a_r,
+        _c_v_t,
+        _f_e_a_t,
+        _f_p_g_m,
+        _f_v_a_r,
+        _g_a_s_p,
+        _g_c_i_d,
+        _g_l_y_f,
+        _g_v_a_r,
+        _h_d_m_x,
+        _h_e_a_d,
+        _h_h_e_a,
+        _h_m_t_x,
+        _k_e_r_n,
+        _l_c_a_r,
+        _l_o_c_a,
+        _l_t_a_g,
+        _m_a_x_p,
+        _m_e_t_a,
+        _m_o_r_t,
+        _m_o_r_x,
+        _n_a_m_e,
+        _o_p_b_d,
+        _p_o_s_t,
+        _p_r_e_p,
+        _p_r_o_p,
+        _s_b_i_x,
+        _t_r_a_k,
+        _v_h_e_a,
+        _v_m_t_x,
+    )
 
 
 if __name__ == "__main__":
-    import doctest, sys
+    import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/ttLib/tables/_a_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_a_v_a_r.py
@@ -1,20 +1,18 @@
-from fontTools.misc import sstruct
-from fontTools.misc.fixedTools import (
-    fixedToFloat as fi2fl,
-    floatToFixed as fl2fi,
-    floatToFixedToStr as fl2str,
-    strToFixedToFloat as str2fl,
-)
-from fontTools.misc.textTools import bytesjoin, safeEval
-from fontTools.misc.roundTools import otRound
-from fontTools.varLib.models import piecewiseLinearMap
-from fontTools.varLib.varStore import VarStoreInstancer, NO_VARIATION_INDEX
-from fontTools.ttLib import TTLibError
-from . import DefaultTable
-from . import otTables
-import struct
 import logging
+import struct
 
+from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
+from fontTools.misc.fixedTools import floatToFixed as fl2fi
+from fontTools.misc.fixedTools import floatToFixedToStr as fl2str
+from fontTools.misc.fixedTools import strToFixedToFloat as str2fl
+from fontTools.misc.roundTools import otRound
+from fontTools.misc.textTools import bytesjoin, safeEval
+from fontTools.ttLib import TTLibError
+from fontTools.varLib.models import piecewiseLinearMap
+from fontTools.varLib.varStore import NO_VARIATION_INDEX, VarStoreInstancer
+
+from . import DefaultTable, otTables
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -1,13 +1,14 @@
-from fontTools.misc.textTools import bytesjoin, safeEval, readHex
-from fontTools.misc.encodingTools import getEncoding
-from fontTools.ttLib import getSearchRange
-from fontTools.unicode import Unicode
-from . import DefaultTable
-import sys
-import struct
 import array
 import logging
+import struct
+import sys
 
+from fontTools.misc.encodingTools import getEncoding
+from fontTools.misc.textTools import bytesjoin, readHex, safeEval
+from fontTools.ttLib import getSearchRange
+from fontTools.unicode import Unicode
+
+from . import DefaultTable
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/_c_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_c_v_a_r.py
@@ -1,12 +1,12 @@
-from . import DefaultTable
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import bytesjoin
 from fontTools.ttLib.tables.TupleVariation import (
+    TupleVariation,
     compileTupleVariationStore,
     decompileTupleVariationStore,
-    TupleVariation,
 )
 
+from . import DefaultTable
 
 # https://www.microsoft.com/typography/otspec/cvar.htm
 # https://www.microsoft.com/typography/otspec/otvarcommonformats.htm

--- a/Lib/fontTools/ttLib/tables/_c_v_t.py
+++ b/Lib/fontTools/ttLib/tables/_c_v_t.py
@@ -1,7 +1,9 @@
-from fontTools.misc.textTools import safeEval
-from . import DefaultTable
-import sys
 import array
+import sys
+
+from fontTools.misc.textTools import safeEval
+
+from . import DefaultTable
 
 
 class table__c_v_t(DefaultTable.DefaultTable):

--- a/Lib/fontTools/ttLib/tables/_f_p_g_m.py
+++ b/Lib/fontTools/ttLib/tables/_f_p_g_m.py
@@ -1,5 +1,4 @@
-from . import DefaultTable
-from . import ttProgram
+from . import DefaultTable, ttProgram
 
 
 class table__f_p_g_m(DefaultTable.DefaultTable):
@@ -56,7 +55,7 @@ class table__f_p_g_m(DefaultTable.DefaultTable):
 
 
 if __name__ == "__main__":
-    import sys
     import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/ttLib/tables/_f_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_f_v_a_r.py
@@ -1,15 +1,14 @@
-from fontTools.misc import sstruct
-from fontTools.misc.fixedTools import (
-    fixedToFloat as fi2fl,
-    floatToFixed as fl2fi,
-    floatToFixedToStr as fl2str,
-    strToFixedToFloat as str2fl,
-)
-from fontTools.misc.textTools import Tag, bytesjoin, safeEval
-from fontTools.ttLib import TTLibError
-from . import DefaultTable
 import struct
 
+from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
+from fontTools.misc.fixedTools import floatToFixed as fl2fi
+from fontTools.misc.fixedTools import floatToFixedToStr as fl2str
+from fontTools.misc.fixedTools import strToFixedToFloat as str2fl
+from fontTools.misc.textTools import Tag, bytesjoin, safeEval
+from fontTools.ttLib import TTLibError
+
+from . import DefaultTable
 
 # Apple's documentation of 'fvar':
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6fvar.html

--- a/Lib/fontTools/ttLib/tables/_g_a_s_p.py
+++ b/Lib/fontTools/ttLib/tables/_g_a_s_p.py
@@ -1,7 +1,8 @@
-from fontTools.misc.textTools import safeEval
-from . import DefaultTable
 import struct
 
+from fontTools.misc.textTools import safeEval
+
+from . import DefaultTable
 
 GASP_SYMMETRIC_GRIDFIT = 0x0004
 GASP_SYMMETRIC_SMOOTHING = 0x0008

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1,37 +1,34 @@
 """_g_l_y_f.py -- Converter classes for the 'glyf' table."""
 
-from collections import namedtuple
-from fontTools.misc import sstruct
-from fontTools import ttLib
-from fontTools import version
-from fontTools.misc.transform import DecomposedTransform
-from fontTools.misc.textTools import tostr, safeEval, pad
-from fontTools.misc.arrayTools import updateBounds, pointInRect
-from fontTools.misc.bezierTools import calcQuadraticBounds
-from fontTools.misc.fixedTools import (
-    fixedToFloat as fi2fl,
-    floatToFixed as fl2fi,
-    floatToFixedToStr as fl2str,
-    strToFixedToFloat as str2fl,
-)
-from fontTools.misc.roundTools import noRound, otRound
-from fontTools.misc.vector import Vector
-from numbers import Number
-from . import DefaultTable
-from . import ttProgram
-import sys
-import struct
 import array
 import logging
 import math
 import os
-from fontTools.misc import xmlWriter
-from fontTools.misc.filenames import userNameToFileName
-from fontTools.misc.loggingTools import deprecateFunction
+import struct
+import sys
+from collections import namedtuple
 from enum import IntFlag
 from functools import partial
+from numbers import Number
 from types import SimpleNamespace
 from typing import Set
+
+from fontTools import ttLib, version
+from fontTools.misc import sstruct, xmlWriter
+from fontTools.misc.arrayTools import pointInRect, updateBounds
+from fontTools.misc.bezierTools import calcQuadraticBounds
+from fontTools.misc.filenames import userNameToFileName
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
+from fontTools.misc.fixedTools import floatToFixed as fl2fi
+from fontTools.misc.fixedTools import floatToFixedToStr as fl2str
+from fontTools.misc.fixedTools import strToFixedToFloat as str2fl
+from fontTools.misc.loggingTools import deprecateFunction
+from fontTools.misc.roundTools import noRound, otRound
+from fontTools.misc.textTools import pad, safeEval, tostr
+from fontTools.misc.transform import DecomposedTransform
+from fontTools.misc.vector import Vector
+
+from . import DefaultTable, ttProgram
 
 log = logging.getLogger(__name__)
 
@@ -2307,6 +2304,7 @@ class GlyphCoordinates(object):
 
 
 if __name__ == "__main__":
-    import doctest, sys
+    import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/ttLib/tables/_g_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_g_v_a_r.py
@@ -1,17 +1,19 @@
-from collections import deque
-from functools import partial
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval
-from fontTools.misc.lazyTools import LazyDict
-from fontTools.ttLib import OPTIMIZE_FONT_SPEED
-from fontTools.ttLib.tables.TupleVariation import TupleVariation
-from . import DefaultTable
 import array
 import itertools
 import logging
 import struct
 import sys
+from collections import deque
+from functools import partial
+
 import fontTools.ttLib.tables.TupleVariation as tv
+from fontTools.misc import sstruct
+from fontTools.misc.lazyTools import LazyDict
+from fontTools.misc.textTools import safeEval
+from fontTools.ttLib import OPTIMIZE_FONT_SPEED
+from fontTools.ttLib.tables.TupleVariation import TupleVariation
+
+from . import DefaultTable
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/_h_d_m_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_d_m_x.py
@@ -1,8 +1,10 @@
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import bytechr, byteord, strjoin
-from . import DefaultTable
 import array
 from collections.abc import Mapping
+
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import bytechr, byteord, strjoin
+
+from . import DefaultTable
 
 hdmxHeaderFormat = """
 	>   # big endian!

--- a/Lib/fontTools/ttLib/tables/_h_e_a_d.py
+++ b/Lib/fontTools/ttLib/tables/_h_e_a_d.py
@@ -1,16 +1,17 @@
-from fontTools.misc import sstruct
-from fontTools.misc.fixedTools import floatToFixedToStr, strToFixedToFloat
-from fontTools.misc.textTools import safeEval, num2binary, binary2num
-from fontTools.misc.timeTools import (
-    timestampFromString,
-    timestampToString,
-    timestampNow,
-)
-from fontTools.misc.timeTools import epoch_diff as mac_epoch_diff  # For backward compat
-from fontTools.misc.arrayTools import intRect, unionRect
-from . import DefaultTable
 import logging
 
+from fontTools.misc import sstruct
+from fontTools.misc.arrayTools import intRect, unionRect
+from fontTools.misc.fixedTools import floatToFixedToStr, strToFixedToFloat
+from fontTools.misc.textTools import binary2num, num2binary, safeEval
+from fontTools.misc.timeTools import epoch_diff as mac_epoch_diff  # For backward compat
+from fontTools.misc.timeTools import (
+    timestampFromString,
+    timestampNow,
+    timestampToString,
+)
+
+from . import DefaultTable
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/_h_h_e_a.py
+++ b/Lib/fontTools/ttLib/tables/_h_h_e_a.py
@@ -1,12 +1,11 @@
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval
-from fontTools.misc.fixedTools import (
-    ensureVersionIsLong as fi2ve,
-    versionToFixed as ve2fi,
-)
-from . import DefaultTable
 import math
 
+from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import ensureVersionIsLong as fi2ve
+from fontTools.misc.fixedTools import versionToFixed as ve2fi
+from fontTools.misc.textTools import safeEval
+
+from . import DefaultTable
 
 hheaFormat = """
 		>  # big endian

--- a/Lib/fontTools/ttLib/tables/_h_m_t_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x.py
@@ -1,12 +1,13 @@
-from fontTools.misc.roundTools import otRound
-from fontTools import ttLib
-from fontTools.misc.textTools import safeEval
-from . import DefaultTable
-import sys
-import struct
 import array
 import logging
+import struct
+import sys
 
+from fontTools import ttLib
+from fontTools.misc.roundTools import otRound
+from fontTools.misc.textTools import safeEval
+
+from . import DefaultTable
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/_k_e_r_n.py
+++ b/Lib/fontTools/ttLib/tables/_k_e_r_n.py
@@ -1,12 +1,14 @@
-from fontTools.ttLib import getSearchRange
-from fontTools.misc.textTools import safeEval, readHex
-from fontTools.misc.fixedTools import fixedToFloat as fi2fl, floatToFixed as fl2fi
-from . import DefaultTable
-import struct
-import sys
 import array
 import logging
+import struct
+import sys
 
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
+from fontTools.misc.fixedTools import floatToFixed as fl2fi
+from fontTools.misc.textTools import readHex, safeEval
+from fontTools.ttLib import getSearchRange
+
+from . import DefaultTable
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/_l_o_c_a.py
+++ b/Lib/fontTools/ttLib/tables/_l_o_c_a.py
@@ -1,8 +1,8 @@
-from . import DefaultTable
-import sys
 import array
 import logging
+import sys
 
+from . import DefaultTable
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/_l_t_a_g.py
+++ b/Lib/fontTools/ttLib/tables/_l_t_a_g.py
@@ -1,6 +1,8 @@
-from fontTools.misc.textTools import bytesjoin, tobytes, safeEval
-from . import DefaultTable
 import struct
+
+from fontTools.misc.textTools import bytesjoin, safeEval, tobytes
+
+from . import DefaultTable
 
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6ltag.html
 

--- a/Lib/fontTools/ttLib/tables/_m_a_x_p.py
+++ b/Lib/fontTools/ttLib/tables/_m_a_x_p.py
@@ -1,5 +1,6 @@
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval
+
 from . import DefaultTable
 
 maxpFormat_0_5 = """

--- a/Lib/fontTools/ttLib/tables/_m_e_t_a.py
+++ b/Lib/fontTools/ttLib/tables/_m_e_t_a.py
@@ -1,6 +1,7 @@
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import bytesjoin, strjoin, readHex
+from fontTools.misc.textTools import bytesjoin, readHex, strjoin
 from fontTools.ttLib import TTLibError
+
 from . import DefaultTable
 
 # Apple's documentation of 'meta':

--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -1,24 +1,25 @@
 # -*- coding: utf-8 -*-
+import logging
+import struct
+
+import fontTools.ttLib.tables.otTables as otTables
+from fontTools import ttLib
 from fontTools.misc import sstruct
+from fontTools.misc.encodingTools import getEncoding
 from fontTools.misc.textTools import (
     bytechr,
     byteord,
     bytesjoin,
+    safeEval,
     strjoin,
     tobytes,
     tostr,
-    safeEval,
 )
-from fontTools.misc.encodingTools import getEncoding
 from fontTools.ttLib import newTable
-from fontTools.ttLib.ttVisitor import TTVisitor
-from fontTools import ttLib
-import fontTools.ttLib.tables.otTables as otTables
 from fontTools.ttLib.tables import C_P_A_L_
-from . import DefaultTable
-import struct
-import logging
+from fontTools.ttLib.ttVisitor import TTVisitor
 
+from . import DefaultTable
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/_p_o_s_t.py
+++ b/Lib/fontTools/ttLib/tables/_p_o_s_t.py
@@ -1,12 +1,14 @@
-from fontTools import ttLib
-from fontTools.ttLib.standardGlyphOrder import standardGlyphOrder
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import bytechr, byteord, tobytes, tostr, safeEval, readHex
-from . import DefaultTable
-import sys
-import struct
 import array
 import logging
+import struct
+import sys
+
+from fontTools import ttLib
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import bytechr, byteord, readHex, safeEval, tobytes, tostr
+from fontTools.ttLib.standardGlyphOrder import standardGlyphOrder
+
+from . import DefaultTable
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/_s_b_i_x.py
+++ b/Lib/fontTools/ttLib/tables/_s_b_i_x.py
@@ -1,8 +1,8 @@
 from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval, num2binary, binary2num
+from fontTools.misc.textTools import binary2num, num2binary, safeEval
+
 from . import DefaultTable
 from .sbixStrike import Strike
-
 
 sbixHeaderFormat = """
 	>

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k.py
@@ -1,16 +1,15 @@
-from fontTools.misc import sstruct
-from fontTools.misc.fixedTools import (
-    fixedToFloat as fi2fl,
-    floatToFixed as fl2fi,
-    floatToFixedToStr as fl2str,
-    strToFixedToFloat as str2fl,
-)
-from fontTools.misc.textTools import bytesjoin, safeEval
-from fontTools.ttLib import TTLibError
-from . import DefaultTable
 import struct
 from collections.abc import MutableMapping
 
+from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
+from fontTools.misc.fixedTools import floatToFixed as fl2fi
+from fontTools.misc.fixedTools import floatToFixedToStr as fl2str
+from fontTools.misc.fixedTools import strToFixedToFloat as str2fl
+from fontTools.misc.textTools import bytesjoin, safeEval
+from fontTools.ttLib import TTLibError
+
+from . import DefaultTable
 
 # Apple's documentation of 'trak':
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6trak.html

--- a/Lib/fontTools/ttLib/tables/_v_h_e_a.py
+++ b/Lib/fontTools/ttLib/tables/_v_h_e_a.py
@@ -1,12 +1,11 @@
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import safeEval
-from fontTools.misc.fixedTools import (
-    ensureVersionIsLong as fi2ve,
-    versionToFixed as ve2fi,
-)
-from . import DefaultTable
 import math
 
+from fontTools.misc import sstruct
+from fontTools.misc.fixedTools import ensureVersionIsLong as fi2ve
+from fontTools.misc.fixedTools import versionToFixed as ve2fi
+from fontTools.misc.textTools import safeEval
+
+from . import DefaultTable
 
 vheaFormat = """
 		>	# big endian

--- a/Lib/fontTools/ttLib/tables/asciiTable.py
+++ b/Lib/fontTools/ttLib/tables/asciiTable.py
@@ -1,4 +1,5 @@
 from fontTools.misc.textTools import strjoin, tobytes, tostr
+
 from . import DefaultTable
 
 

--- a/Lib/fontTools/ttLib/tables/grUtils.py
+++ b/Lib/fontTools/ttLib/tables/grUtils.py
@@ -1,4 +1,5 @@
-import struct, warnings
+import struct
+import warnings
 
 try:
     import lz4

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -1,13 +1,15 @@
-from fontTools.config import OPTIONS
-from fontTools.misc.textTools import Tag, bytesjoin
-from .DefaultTable import DefaultTable
-from enum import IntEnum
-import sys
 import array
-import struct
 import logging
+import struct
+import sys
+from enum import IntEnum
 from functools import lru_cache
 from typing import Iterator, NamedTuple, Optional, Tuple
+
+from fontTools.config import OPTIONS
+from fontTools.misc.textTools import Tag, bytesjoin
+
+from .DefaultTable import DefaultTable
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1,16 +1,23 @@
-from fontTools.misc.fixedTools import (
-    fixedToFloat as fi2fl,
-    floatToFixed as fl2fi,
-    floatToFixedToStr as fl2str,
-    strToFixedToFloat as str2fl,
-    ensureVersionIsLong as fi2ve,
-    versionToFixed as ve2fi,
-)
-from fontTools.ttLib.tables.TupleVariation import TupleVariation
-from fontTools.misc.roundTools import nearestMultipleShortestRepr, otRound
-from fontTools.misc.textTools import bytesjoin, tobytes, tostr, pad, safeEval
+import logging
+import re
+import struct
+from functools import partial
+from itertools import accumulate, zip_longest
+from types import SimpleNamespace
+from typing import Optional
+
+from fontTools.misc.fixedTools import ensureVersionIsLong as fi2ve
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
+from fontTools.misc.fixedTools import floatToFixed as fl2fi
+from fontTools.misc.fixedTools import floatToFixedToStr as fl2str
+from fontTools.misc.fixedTools import strToFixedToFloat as str2fl
+from fontTools.misc.fixedTools import versionToFixed as ve2fi
 from fontTools.misc.lazyTools import LazyList
+from fontTools.misc.roundTools import nearestMultipleShortestRepr, otRound
+from fontTools.misc.textTools import bytesjoin, pad, safeEval, tobytes, tostr
 from fontTools.ttLib import OPTIMIZE_FONT_SPEED, getSearchRange
+from fontTools.ttLib.tables.TupleVariation import TupleVariation
+
 from .otBase import (
     CountReference,
     FormatSwitchingBaseTable,
@@ -18,28 +25,17 @@ from .otBase import (
     OTTableWriter,
     ValueRecordFactory,
 )
+from .otTables import NO_VARIATION_INDEX, AATAction, AATState, AATStateTable
+from .otTables import CompositeMode as _CompositeMode
+from .otTables import ContextualMorphAction
+from .otTables import ExtendMode as _ExtendMode
 from .otTables import (
-    lookupTypes,
-    VarCompositeGlyph,
-    AATStateTable,
-    AATState,
-    AATAction,
-    ContextualMorphAction,
-    LigatureMorphAction,
     InsertionMorphAction,
+    LigatureMorphAction,
     MorxSubtable,
-    ExtendMode as _ExtendMode,
-    CompositeMode as _CompositeMode,
-    NO_VARIATION_INDEX,
+    VarCompositeGlyph,
+    lookupTypes,
 )
-from itertools import zip_longest, accumulate
-from functools import partial
-from types import SimpleNamespace
-import re
-import struct
-from typing import Optional
-import logging
-
 
 log = logging.getLogger(__name__)
 istuple = lambda t: isinstance(t, tuple)

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -5,42 +5,41 @@ OpenType subtables.
 Most are constructed upon import from data in otData.py, all are populated with
 converter objects from otConverters.py.
 """
+import array
 import copy
-from enum import IntEnum
+import itertools
+import logging
+import struct
+import sys
+from collections import defaultdict, namedtuple
+from enum import IntEnum, IntFlag
 from functools import reduce
 from math import radians
-import itertools
-from collections import defaultdict, namedtuple
-from fontTools.ttLib import OPTIMIZE_FONT_SPEED
-from fontTools.ttLib.tables.TupleVariation import TupleVariation
-from fontTools.ttLib.tables.otTraverse import dfs_base_table
+from typing import TYPE_CHECKING, Iterator, List, Optional, Set
+
+from fontTools.feaLib.lookupDebugInfo import LOOKUP_DEBUG_INFO_KEY, LookupDebugInfo
 from fontTools.misc.arrayTools import quantizeRect
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
+from fontTools.misc.fixedTools import floatToFixed as fl2fi
+from fontTools.misc.fixedTools import floatToFixedToStr as fl2str
+from fontTools.misc.fixedTools import strToFixedToFloat as str2fl
 from fontTools.misc.roundTools import otRound
-from fontTools.misc.transform import Transform, Identity, DecomposedTransform
 from fontTools.misc.textTools import bytesjoin, pad, safeEval
+from fontTools.misc.transform import DecomposedTransform, Identity, Transform
 from fontTools.misc.vector import Vector
 from fontTools.pens.boundsPen import ControlBoundsPen
 from fontTools.pens.transformPen import TransformPen
+from fontTools.ttLib import OPTIMIZE_FONT_SPEED
+from fontTools.ttLib.tables.otTraverse import dfs_base_table
+from fontTools.ttLib.tables.TupleVariation import TupleVariation
+
 from .otBase import (
     BaseTable,
+    CountReference,
     FormatSwitchingBaseTable,
     ValueRecord,
-    CountReference,
     getFormatSwitchingBaseTableClass,
 )
-from fontTools.misc.fixedTools import (
-    fixedToFloat as fi2fl,
-    floatToFixed as fl2fi,
-    floatToFixedToStr as fl2str,
-    strToFixedToFloat as str2fl,
-)
-from fontTools.feaLib.lookupDebugInfo import LookupDebugInfo, LOOKUP_DEBUG_INFO_KEY
-import logging
-import struct
-import array
-import sys
-from enum import IntFlag
-from typing import TYPE_CHECKING, Iterator, List, Optional, Set
 
 if TYPE_CHECKING:
     from fontTools.ttLib.ttGlyphSet import _TTGlyphSet
@@ -2588,6 +2587,7 @@ def fixSubTableOverFlows(ttf, overflowRecord):
 
 def _buildClasses():
     import re
+
     from .otData import otData
 
     formatPat = re.compile(r"([A-Za-z0-9]+)Format(\d+)$")

--- a/Lib/fontTools/ttLib/tables/otTraverse.py
+++ b/Lib/fontTools/ttLib/tables/otTraverse.py
@@ -2,8 +2,8 @@
 
 from collections import deque
 from typing import Callable, Deque, Iterable, List, Optional, Tuple
-from .otBase import BaseTable
 
+from .otBase import BaseTable
 
 __all__ = [
     "bfs_base_table",

--- a/Lib/fontTools/ttLib/tables/sbixGlyph.py
+++ b/Lib/fontTools/ttLib/tables/sbixGlyph.py
@@ -1,7 +1,7 @@
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import readHex, safeEval
 import struct
 
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import readHex, safeEval
 
 sbixGlyphHeaderFormat = """
 	>

--- a/Lib/fontTools/ttLib/tables/sbixStrike.py
+++ b/Lib/fontTools/ttLib/tables/sbixStrike.py
@@ -1,7 +1,9 @@
+import struct
+
 from fontTools.misc import sstruct
 from fontTools.misc.textTools import safeEval
+
 from .sbixGlyph import Glyph
-import struct
 
 sbixStrikeHeaderFormat = """
 	>

--- a/Lib/fontTools/ttLib/tables/ttProgram.py
+++ b/Lib/fontTools/ttLib/tables/ttProgram.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from fontTools.misc.textTools import num2binary, binary2num, readHex, strjoin
 import array
+import logging
+import re
 from io import StringIO
 from typing import List
-import re
-import logging
 
+from fontTools.misc.textTools import binary2num, num2binary, readHex, strjoin
 
 log = logging.getLogger(__name__)
 
@@ -588,7 +588,7 @@ def _test():
 
 
 if __name__ == "__main__":
-    import sys
     import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/ttLib/ttCollection.py
+++ b/Lib/fontTools/ttLib/ttCollection.py
@@ -1,8 +1,9 @@
-from fontTools.ttLib.ttFont import TTFont
-from fontTools.ttLib.sfnt import readTTCHeader, writeTTCHeader
-from io import BytesIO
-import struct
 import logging
+import struct
+from io import BytesIO
+
+from fontTools.ttLib.sfnt import readTTCHeader, writeTTCHeader
+from fontTools.ttLib.ttFont import TTFont
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -1,20 +1,21 @@
+import logging
+import os
+import traceback
+from io import BytesIO, StringIO, UnsupportedOperation
+
 from fontTools.config import Config
 from fontTools.misc import xmlWriter
 from fontTools.misc.configTools import AbstractConfig
-from fontTools.misc.textTools import Tag, byteord, tostr
 from fontTools.misc.loggingTools import deprecateArgument
+from fontTools.misc.textTools import Tag, byteord, tostr
 from fontTools.ttLib import TTLibError
+from fontTools.ttLib.sfnt import SFNTReader, SFNTWriter
 from fontTools.ttLib.ttGlyphSet import (
     _TTGlyph,
     _TTGlyphSetCFF,
     _TTGlyphSetGlyf,
     _TTGlyphSetVARC,
 )
-from fontTools.ttLib.sfnt import SFNTReader, SFNTWriter
-from io import BytesIO, StringIO, UnsupportedOperation
-import os
-import logging
-import traceback
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/ttLib/ttGlyphSet.py
+++ b/Lib/fontTools/ttLib/ttGlyphSet.py
@@ -5,16 +5,18 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from copy import copy, deepcopy
 from types import SimpleNamespace
-from fontTools.misc.vector import Vector
-from fontTools.misc.fixedTools import otRound, fixedToFloat as fi2fl
+
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
+from fontTools.misc.fixedTools import otRound
 from fontTools.misc.loggingTools import deprecateFunction
-from fontTools.misc.transform import Transform, DecomposedTransform
-from fontTools.pens.transformPen import TransformPen, TransformPointPen
+from fontTools.misc.transform import DecomposedTransform, Transform
+from fontTools.misc.vector import Vector
 from fontTools.pens.recordingPen import (
     DecomposingRecordingPen,
     lerpRecordings,
     replayRecording,
 )
+from fontTools.pens.transformPen import TransformPen, TransformPointPen
 
 
 class _TTGlyphSet(Mapping):
@@ -232,8 +234,8 @@ class _TTGlyphGlyf(_TTGlyph):
         return glyph, offset
 
     def _getGlyphInstance(self):
-        from fontTools.varLib.iup import iup_delta
         from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates
+        from fontTools.varLib.iup import iup_delta
         from fontTools.varLib.models import supportScalar
 
         glyphSet = self.glyphSet
@@ -323,8 +325,8 @@ class _TTGlyphVARC(_TTGlyph):
         how that works.
         """
         from fontTools.ttLib.tables.otTables import (
-            VarComponentFlags,
             NO_VARIATION_INDEX,
+            VarComponentFlags,
         )
 
         glyphSet = self.glyphSet

--- a/Lib/fontTools/ttLib/woff2.py
+++ b/Lib/fontTools/ttLib/woff2.py
@@ -1,32 +1,32 @@
-from io import BytesIO
-import sys
 import array
+import logging
 import struct
+import sys
 from collections import OrderedDict
+from io import BytesIO
+
 from fontTools.misc import sstruct
 from fontTools.misc.arrayTools import calcIntBounds
 from fontTools.misc.textTools import Tag, bytechr, byteord, bytesjoin, pad
 from fontTools.ttLib import (
     TTFont,
     TTLibError,
-    getTableModule,
-    getTableClass,
     getSearchRange,
+    getTableClass,
+    getTableModule,
 )
 from fontTools.ttLib.sfnt import (
+    DirectoryEntry,
+    SFNTDirectoryEntry,
     SFNTReader,
     SFNTWriter,
-    DirectoryEntry,
     WOFFFlavorData,
+    calcChecksum,
+    sfntDirectoryEntrySize,
     sfntDirectoryFormat,
     sfntDirectorySize,
-    SFNTDirectoryEntry,
-    sfntDirectoryEntrySize,
-    calcChecksum,
 )
-from fontTools.ttLib.tables import ttProgram, _g_l_y_f
-import logging
-
+from fontTools.ttLib.tables import _g_l_y_f, ttProgram
 
 log = logging.getLogger("fontTools.ttLib.woff2")
 
@@ -1544,6 +1544,7 @@ def decompress(input_file, output_file):
 def main(args=None):
     """Compress and decompress WOFF2 fonts"""
     import argparse
+
     from fontTools import configLogger
     from fontTools.ttx import makeOutputFileName
 

--- a/Lib/fontTools/ttx.py
+++ b/Lib/fontTools/ttx.py
@@ -109,19 +109,19 @@ Compile options
              layout engines.
 """
 
-from fontTools.ttLib import OPTIMIZE_FONT_SPEED, TTFont, TTLibError
+import getopt
+import logging
+import os
+import re
+import sys
+
+from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.misc.loggingTools import Timer
 from fontTools.misc.macCreatorType import getMacCreatorAndType
-from fontTools.unicode import setUnicodeData
 from fontTools.misc.textTools import Tag, tostr
 from fontTools.misc.timeTools import timestampSinceEpoch
-from fontTools.misc.loggingTools import Timer
-from fontTools.misc.cliTools import makeOutputFileName
-import os
-import sys
-import getopt
-import re
-import logging
-
+from fontTools.ttLib import OPTIMIZE_FONT_SPEED, TTFont, TTLibError
+from fontTools.unicode import setUnicodeData
 
 log = logging.getLogger("fontTools.ttx")
 

--- a/Lib/fontTools/ufoLib/__init__.py
+++ b/Lib/fontTools/ufoLib/__init__.py
@@ -32,28 +32,30 @@ Value conversion functions are available for converting
 - :func:`.convertFontInfoValueForAttributeFromVersion3ToVersion2`
 """
 
+import enum
+import logging
 import os
+import zipfile
+from collections import OrderedDict
 from copy import deepcopy
 from os import fsdecode
-import logging
-import zipfile
-import enum
-from collections import OrderedDict
+
 import fs
 import fs.base
-import fs.subfs
-import fs.errors
 import fs.copy
+import fs.errors
 import fs.osfs
-import fs.zipfs
+import fs.subfs
 import fs.tempfs
 import fs.tools
+import fs.zipfs
+
 from fontTools.misc import plistlib
-from fontTools.ufoLib.validators import *
-from fontTools.ufoLib.filenames import userNameToFileName
 from fontTools.ufoLib.converters import convertUFO1OrUFO2KerningToUFO3Kerning
 from fontTools.ufoLib.errors import UFOLibError
-from fontTools.ufoLib.utils import numberTypes, _VersionTupleEnumMixin
+from fontTools.ufoLib.filenames import userNameToFileName
+from fontTools.ufoLib.utils import _VersionTupleEnumMixin, numberTypes
+from fontTools.ufoLib.validators import *
 
 __all__ = [
     "makeUFOPath",

--- a/Lib/fontTools/ufoLib/glifLib.py
+++ b/Lib/fontTools/ufoLib/glifLib.py
@@ -3,7 +3,7 @@ Generic module for reading and writing the .glif format.
 
 More info about the .glif format (GLyphInterchangeFormat) can be found here:
 
-	http://unifiedfontobject.org
+        http://unifiedfontobject.org
 
 The main class in this module is :class:`GlyphSet`. It manages a set of .glif files
 in a folder. It offers two ways to read glyph data, and one way to write
@@ -12,33 +12,33 @@ glyph data. See the class doc string for details.
 
 from __future__ import annotations
 
-import logging
 import enum
-from warnings import warn
+import logging
 from collections import OrderedDict
+from warnings import warn
+
 import fs
 import fs.base
 import fs.errors
 import fs.osfs
 import fs.path
+
+from fontTools.misc import etree, plistlib
 from fontTools.misc.textTools import tobytes
-from fontTools.misc import plistlib
 from fontTools.pens.pointPen import AbstractPointPen, PointToSegmentPen
+from fontTools.ufoLib import UFOFormatVersion, _UFOBaseIO
 from fontTools.ufoLib.errors import GlifLibError
 from fontTools.ufoLib.filenames import userNameToFileName
+from fontTools.ufoLib.utils import _VersionTupleEnumMixin, numberTypes
 from fontTools.ufoLib.validators import (
-    genericTypeValidator,
-    colorValidator,
-    guidelinesValidator,
     anchorsValidator,
+    colorValidator,
+    genericTypeValidator,
+    glyphLibValidator,
+    guidelinesValidator,
     identifierValidator,
     imageValidator,
-    glyphLibValidator,
 )
-from fontTools.misc import etree
-from fontTools.ufoLib import _UFOBaseIO, UFOFormatVersion
-from fontTools.ufoLib.utils import numberTypes, _VersionTupleEnumMixin
-
 
 __all__ = [
     "GlyphSet",

--- a/Lib/fontTools/ufoLib/utils.py
+++ b/Lib/fontTools/ufoLib/utils.py
@@ -5,9 +5,8 @@ define the :py:obj:`.deprecated` decorator that is used elsewhere in
 the module.
 """
 
-import warnings
 import functools
-
+import warnings
 
 numberTypes = (int, float)
 

--- a/Lib/fontTools/ufoLib/validators.py
+++ b/Lib/fontTools/ufoLib/validators.py
@@ -1,13 +1,13 @@
 """Various low level data validators."""
 
 import calendar
+from collections.abc import Mapping
 from io import open
+
 import fs.base
 import fs.osfs
 
-from collections.abc import Mapping
 from fontTools.ufoLib.utils import numberTypes
-
 
 # -------
 # Generic

--- a/Lib/fontTools/unicodedata/__init__.py
+++ b/Lib/fontTools/unicodedata/__init__.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from fontTools.misc.textTools import byteord, tostr
-
 import re
 from bisect import bisect_right
 from typing import Literal, TypeVar, overload
 
+from fontTools.misc.textTools import byteord, tostr
 
 try:
     # use unicodedata backport compatible with python2:
@@ -15,7 +14,7 @@ except ImportError:  # pragma: no cover
     # fall back to built-in unicodedata (possibly outdated)
     from unicodedata import *
 
-from . import Blocks, Mirrored, Scripts, ScriptExtensions, OTTags
+from . import Blocks, Mirrored, OTTags, ScriptExtensions, Scripts
 
 __all__ = [
     # names from built-in unicodedata module

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -23,35 +23,37 @@ Then you can make a variable-font this way:
 API *will* change in near future.
 """
 
-from typing import List
-from fontTools.misc.vector import Vector
-from fontTools.misc.roundTools import noRound, otRound
-from fontTools.misc.fixedTools import floatToFixed as fl2fi
-from fontTools.misc.textTools import Tag, tostr
-from fontTools.ttLib import TTFont, newTable
-from fontTools.ttLib.tables._f_v_a_r import Axis, NamedInstance
-from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates, dropImpliedOnCurvePoints
-from fontTools.ttLib.tables.ttProgram import Program
-from fontTools.ttLib.tables.TupleVariation import TupleVariation
-from fontTools.ttLib.tables import otTables as ot
-from fontTools.ttLib.tables.otBase import OTTableWriter
-from fontTools.varLib import builder, models, varStore
-from fontTools.varLib.merger import VariationMerger, COLRVariationMerger
-from fontTools.varLib.mvar import MVAR_ENTRIES
-from fontTools.varLib.iup import iup_delta_optimize
-from fontTools.varLib.featureVars import addFeatureVariations
-from fontTools.designspaceLib import DesignSpaceDocument, InstanceDescriptor
-from fontTools.designspaceLib.split import splitInterpolable, splitVariableFonts
-from fontTools.varLib.stat import buildVFStatTable
-from fontTools.colorLib.builder import buildColrV1
-from fontTools.colorLib.unbuilder import unbuildColrV1
-from functools import partial
-from collections import OrderedDict, defaultdict, namedtuple
-import os.path
 import logging
+import os.path
+from collections import OrderedDict, defaultdict, namedtuple
 from copy import deepcopy
+from functools import partial
 from pprint import pformat
 from re import fullmatch
+from typing import List
+
+from fontTools.colorLib.builder import buildColrV1
+from fontTools.colorLib.unbuilder import unbuildColrV1
+from fontTools.designspaceLib import DesignSpaceDocument, InstanceDescriptor
+from fontTools.designspaceLib.split import splitInterpolable, splitVariableFonts
+from fontTools.misc.fixedTools import floatToFixed as fl2fi
+from fontTools.misc.roundTools import noRound, otRound
+from fontTools.misc.textTools import Tag, tostr
+from fontTools.misc.vector import Vector
+from fontTools.ttLib import TTFont, newTable
+from fontTools.ttLib.tables import otTables as ot
+from fontTools.ttLib.tables._f_v_a_r import Axis, NamedInstance
+from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates, dropImpliedOnCurvePoints
+from fontTools.ttLib.tables.otBase import OTTableWriter
+from fontTools.ttLib.tables.ttProgram import Program
+from fontTools.ttLib.tables.TupleVariation import TupleVariation
+from fontTools.varLib import builder, models, varStore
+from fontTools.varLib.featureVars import addFeatureVariations
+from fontTools.varLib.iup import iup_delta_optimize
+from fontTools.varLib.merger import COLRVariationMerger, VariationMerger
+from fontTools.varLib.mvar import MVAR_ENTRIES
+from fontTools.varLib.stat import buildVFStatTable
+
 from .errors import VarLibError, VarLibValidationError
 
 log = logging.getLogger("fontTools.varLib")
@@ -1367,6 +1369,7 @@ def addGSUBFeatureVariations(vf, designspace, featureTags=(), *, log_enabled=Fal
 def main(args=None):
     """Build variable fonts from a designspace file and masters"""
     from argparse import ArgumentParser
+
     from fontTools import configLogger
 
     parser = ArgumentParser(prog="varLib", description=main.__doc__)

--- a/Lib/fontTools/varLib/__main__.py
+++ b/Lib/fontTools/varLib/__main__.py
@@ -1,6 +1,6 @@
 import sys
-from fontTools.varLib import main
 
+from fontTools.varLib import main
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/Lib/fontTools/varLib/avar.py
+++ b/Lib/fontTools/varLib/avar.py
@@ -1,10 +1,11 @@
+import logging
+from itertools import product
+
+from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
 from fontTools.varLib import _add_avar, load_designspace
 from fontTools.varLib.models import VariationModel
 from fontTools.varLib.varStore import VarStoreInstancer
-from fontTools.misc.fixedTools import fixedToFloat as fi2fl
-from fontTools.misc.cliTools import makeOutputFileName
-from itertools import product
-import logging
 
 log = logging.getLogger("fontTools.varLib.avar")
 
@@ -190,10 +191,11 @@ def main(args=None):
 
         args = sys.argv[1:]
 
-    from fontTools import configLogger
-    from fontTools.ttLib import TTFont
-    from fontTools.designspaceLib import DesignSpaceDocument
     import argparse
+
+    from fontTools import configLogger
+    from fontTools.designspaceLib import DesignSpaceDocument
+    from fontTools.ttLib import TTFont
 
     parser = argparse.ArgumentParser(
         "fonttools varLib.avar",

--- a/Lib/fontTools/varLib/avarPlanner.py
+++ b/Lib/fontTools/varLib/avarPlanner.py
@@ -1,13 +1,14 @@
-from fontTools.ttLib import newTable
-from fontTools.ttLib.tables._f_v_a_r import Axis as fvarAxis
+import logging
+import math
+from pprint import pformat
+
+from fontTools.misc.cliTools import makeOutputFileName
 from fontTools.pens.areaPen import AreaPen
 from fontTools.pens.basePen import NullPen
 from fontTools.pens.statisticsPen import StatisticsPen
-from fontTools.varLib.models import piecewiseLinearMap, normalizeValue
-from fontTools.misc.cliTools import makeOutputFileName
-import math
-import logging
-from pprint import pformat
+from fontTools.ttLib import newTable
+from fontTools.ttLib.tables._f_v_a_r import Axis as fvarAxis
+from fontTools.varLib.models import normalizeValue, piecewiseLinearMap
 
 __all__ = [
     "planWeightAxis",
@@ -808,9 +809,10 @@ def main(args=None):
 
         args = sys.argv[1:]
 
+    import argparse
+
     from fontTools import configLogger
     from fontTools.ttLib import TTFont
-    import argparse
 
     parser = argparse.ArgumentParser(
         "fonttools varLib.avarPlanner",

--- a/Lib/fontTools/varLib/cff.py
+++ b/Lib/fontTools/varLib/cff.py
@@ -1,34 +1,34 @@
 from collections import namedtuple
+from functools import partial
+from io import BytesIO
+
+from fontTools import varLib
 from fontTools.cffLib import (
-    maxStackLimit,
-    TopDictIndex,
-    buildOrder,
-    topDictOperators,
-    topDictOperators2,
-    privateDictOperators,
-    privateDictOperators2,
     FDArrayIndex,
     FontDict,
+    TopDictIndex,
     VarStoreData,
+    buildOrder,
+    maxStackLimit,
+    privateDictOperators,
+    privateDictOperators2,
+    topDictOperators,
+    topDictOperators2,
 )
-from io import BytesIO
-from fontTools.cffLib.specializer import specializeCommands, commandsToProgram
-from fontTools.ttLib import newTable
-from fontTools import varLib
-from fontTools.varLib.models import allEqual
+from fontTools.cffLib.specializer import commandsToProgram, specializeCommands
 from fontTools.misc.loggingTools import deprecateFunction
-from fontTools.misc.roundTools import roundFunc
 from fontTools.misc.psCharStrings import T2CharString, T2OutlineExtractor
+from fontTools.misc.roundTools import roundFunc
 from fontTools.pens.t2CharStringPen import T2CharStringPen
-from functools import partial
+from fontTools.ttLib import newTable
+from fontTools.varLib.models import allEqual
 
 from .errors import (
     VarLibCFFDictMergeError,
-    VarLibCFFPointTypeMergeError,
     VarLibCFFHintTypeMergeError,
+    VarLibCFFPointTypeMergeError,
     VarLibMergeError,
 )
-
 
 # Backwards compatibility
 MergeDictError = VarLibCFFDictMergeError

--- a/Lib/fontTools/varLib/featureVars.py
+++ b/Lib/fontTools/varLib/featureVars.py
@@ -4,13 +4,14 @@ https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featurevariat
 NOTE: The API is experimental and subject to change.
 """
 
+from collections import OrderedDict
+
 from fontTools.misc.dictTools import hashdict
 from fontTools.misc.intTools import bit_count
+from fontTools.otlLib.builder import buildLookup, buildSingleSubstSubtable
 from fontTools.ttLib import newTable
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.ttLib.ttVisitor import TTVisitor
-from fontTools.otlLib.builder import buildLookup, buildSingleSubstSubtable
-from collections import OrderedDict
 
 from .errors import VarLibError, VarLibValidationError
 
@@ -690,6 +691,7 @@ def _remapLangSys(langSys, featureRemap):
 
 
 if __name__ == "__main__":
-    import doctest, sys
+    import doctest
+    import sys
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/fontTools/varLib/hvar.py
+++ b/Lib/fontTools/varLib/hvar.py
@@ -1,13 +1,20 @@
+import logging
+from functools import partial
+
+from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.misc.fixedTools import fixedToFloat as fi2fl
 from fontTools.misc.roundTools import noRound
 from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.ttLib.tables.otBase import OTTableWriter
-from fontTools.varLib import HVAR_FIELDS, VVAR_FIELDS, _add_VHVAR
-from fontTools.varLib import builder, models, varStore
-from fontTools.misc.fixedTools import fixedToFloat as fi2fl
-from fontTools.misc.cliTools import makeOutputFileName
-from functools import partial
-import logging
+from fontTools.varLib import (
+    HVAR_FIELDS,
+    VVAR_FIELDS,
+    _add_VHVAR,
+    builder,
+    models,
+    varStore,
+)
 
 log = logging.getLogger("fontTools.varLib.avar")
 
@@ -69,9 +76,10 @@ def main(args=None):
 
         args = sys.argv[1:]
 
+    import argparse
+
     from fontTools import configLogger
     from fontTools.designspaceLib import DesignSpaceDocument
-    import argparse
 
     parser = argparse.ArgumentParser(
         "fonttools varLib.hvar",

--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -1,4 +1,4 @@
-""" Partially instantiate a variable font.
+"""Partially instantiate a variable font.
 
 The module exports an `instantiateVariableFont` function and CLI that allow to
 create full instances (i.e. static fonts) from variable fonts, as well as "partial"
@@ -36,7 +36,7 @@ If the input location specifies all the axes, the resulting instance is no longe
 'variable' (same as using fontools varLib.mutator):
 .. code-block:: pycon
 
-    >>>    
+    >>>
     >> instance = instancer.instantiateVariableFont(
     ...     varfont, {"wght": 700, "wdth": 67.5}
     ... )
@@ -72,7 +72,7 @@ L1
 L2
     dropping one or more axes while pinning them at non-default locations;
     .. code-block:: pycon
-    
+
         >>>
         >> font = instancer.instantiateVariableFont(varfont, {"wght": 700})
 
@@ -81,14 +81,14 @@ L3
     a new minimum or maximum, potentially -- though not necessarily -- dropping
     entire regions of variations that fall completely outside this new range.
     .. code-block:: pycon
-    
+
         >>>
         >> font = instancer.instantiateVariableFont(varfont, {"wght": (100, 300)})
 
 L4
     moving the default location of an axis, by specifying (min,defalt,max) values:
     .. code-block:: pycon
-    
+
         >>>
         >> font = instancer.instantiateVariableFont(varfont, {"wght": (100, 300, 700)})
 
@@ -99,46 +99,41 @@ The discussion and implementation of these features are tracked at
 https://github.com/fonttools/fonttools/issues/1537
 """
 
-from fontTools.misc.fixedTools import (
-    floatToFixedToFloat,
-    strToFixedToFloat,
-    otRound,
-)
-from fontTools.varLib.models import normalizeValue, piecewiseLinearMap
-from fontTools.ttLib import TTFont, newTable
-from fontTools.ttLib.tables.TupleVariation import TupleVariation
-from fontTools.ttLib.tables import _g_l_y_f
-from fontTools import varLib
+import collections
+import dataclasses
+import logging
+import os
+import re
+import warnings
+from contextlib import contextmanager
+from copy import deepcopy
+from enum import IntEnum
+from typing import Dict, Iterable, Mapping, Optional, Sequence, Tuple, Union
 
 # we import the `subset` module because we use the `prune_lookups` method on the GSUB
 # table class, and that method is only defined dynamically upon importing `subset`
 from fontTools import subset  # noqa: F401
+from fontTools import varLib
 from fontTools.cffLib import privateDictOperators2
 from fontTools.cffLib.specializer import (
-    programToCommands,
     commandsToProgram,
-    specializeCommands,
     generalizeCommands,
+    programToCommands,
+    specializeCommands,
 )
-from fontTools.varLib import builder
-from fontTools.varLib.mvar import MVAR_ENTRIES
-from fontTools.varLib.merger import MutatorMerger
-from fontTools.varLib.instancer import names
-from .featureVars import instantiateFeatureVariations
 from fontTools.misc.cliTools import makeOutputFileName
-from fontTools.varLib.instancer import solver
+from fontTools.misc.fixedTools import floatToFixedToFloat, otRound, strToFixedToFloat
+from fontTools.ttLib import TTFont, newTable
+from fontTools.ttLib.tables import _g_l_y_f
 from fontTools.ttLib.tables.otTables import VarComponentFlags
-import collections
-import dataclasses
-from contextlib import contextmanager
-from copy import deepcopy
-from enum import IntEnum
-import logging
-import os
-import re
-from typing import Dict, Iterable, Mapping, Optional, Sequence, Tuple, Union
-import warnings
+from fontTools.ttLib.tables.TupleVariation import TupleVariation
+from fontTools.varLib import builder
+from fontTools.varLib.instancer import names, solver
+from fontTools.varLib.merger import MutatorMerger
+from fontTools.varLib.models import normalizeValue, piecewiseLinearMap
+from fontTools.varLib.mvar import MVAR_ENTRIES
 
+from .featureVars import instantiateFeatureVariations
 
 log = logging.getLogger("fontTools.varLib.instancer")
 
@@ -1800,8 +1795,9 @@ def parseArgs(args):
         axis to min/max range.
         Axes locations are in user-space coordinates, as defined in the "fvar" table.
     """
-    from fontTools import configLogger
     import argparse
+
+    from fontTools import configLogger
 
     parser = argparse.ArgumentParser(
         "fonttools varLib.instancer",

--- a/Lib/fontTools/varLib/instancer/__main__.py
+++ b/Lib/fontTools/varLib/instancer/__main__.py
@@ -1,4 +1,5 @@
 import sys
+
 from fontTools.varLib.instancer import main
 
 if __name__ == "__main__":

--- a/Lib/fontTools/varLib/instancer/featureVars.py
+++ b/Lib/fontTools/varLib/instancer/featureVars.py
@@ -1,7 +1,7 @@
-from fontTools.ttLib.tables import otTables as ot
-from copy import deepcopy
 import logging
+from copy import deepcopy
 
+from fontTools.ttLib.tables import otTables as ot
 
 log = logging.getLogger("fontTools.varLib.instancer")
 

--- a/Lib/fontTools/varLib/instancer/names.py
+++ b/Lib/fontTools/varLib/instancer/names.py
@@ -1,9 +1,9 @@
 """Helpers for instantiating name table records."""
 
+import re
 from contextlib import contextmanager
 from copy import deepcopy
 from enum import IntEnum
-import re
 
 
 class NameID(IntEnum):

--- a/Lib/fontTools/varLib/instancer/solver.py
+++ b/Lib/fontTools/varLib/instancer/solver.py
@@ -1,6 +1,7 @@
-from fontTools.varLib.models import supportScalar
-from fontTools.misc.fixedTools import MAX_F2DOT14
 from functools import lru_cache
+
+from fontTools.misc.fixedTools import MAX_F2DOT14
+from fontTools.varLib.models import supportScalar
 
 __all__ = ["rebaseTent"]
 

--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -6,27 +6,29 @@ Call as:
 $ fonttools varLib.interpolatable font1 font2 ...
 """
 
+import logging
+import os
+from collections import defaultdict
+from functools import wraps
+from math import atan2, pi, sqrt
+from pprint import pformat
+from types import SimpleNamespace
+
+from fontTools.misc.fixedTools import floatToFixedToStr
+from fontTools.misc.transform import Transform
+from fontTools.pens.momentsPen import OpenContourError
+from fontTools.pens.recordingPen import (
+    DecomposingRecordingPen,
+    RecordingPen,
+    lerpRecordings,
+)
+from fontTools.pens.statisticsPen import StatisticsControlPen, StatisticsPen
+from fontTools.pens.transformPen import TransformPen
+from fontTools.varLib.models import normalizeLocation, piecewiseLinearMap
+
 from .interpolatableHelpers import *
 from .interpolatableTestContourOrder import test_contour_order
 from .interpolatableTestStartingPoint import test_starting_point
-from fontTools.pens.recordingPen import (
-    RecordingPen,
-    DecomposingRecordingPen,
-    lerpRecordings,
-)
-from fontTools.pens.transformPen import TransformPen
-from fontTools.pens.statisticsPen import StatisticsPen, StatisticsControlPen
-from fontTools.pens.momentsPen import OpenContourError
-from fontTools.varLib.models import piecewiseLinearMap, normalizeLocation
-from fontTools.misc.fixedTools import floatToFixedToStr
-from fontTools.misc.transform import Transform
-from collections import defaultdict
-from types import SimpleNamespace
-from functools import wraps
-from pprint import pformat
-from math import sqrt, atan2, pi
-import logging
-import os
 
 log = logging.getLogger("fontTools.varLib.interpolatable")
 
@@ -1134,7 +1136,7 @@ def main(args=None):
             if arg is None:
                 continue
             log.info("Writing %s to %s", p.upper(), arg)
-            from .interpolatablePlot import InterpolatablePS, InterpolatablePDF
+            from .interpolatablePlot import InterpolatablePDF, InterpolatablePS
 
             PlotterClass = InterpolatablePS if p == "ps" else InterpolatablePDF
 

--- a/Lib/fontTools/varLib/interpolatableHelpers.py
+++ b/Lib/fontTools/varLib/interpolatableHelpers.py
@@ -1,14 +1,14 @@
-from fontTools.ttLib.ttGlyphSet import LerpGlyphSet
+import itertools
+import logging
+from collections import defaultdict, deque
+from enum import Enum
+from math import atan2, copysign, pi, sqrt
+
+from fontTools.misc.transform import Transform
 from fontTools.pens.basePen import AbstractPen, BasePen, DecomposingPen
 from fontTools.pens.pointPen import AbstractPointPen, SegmentToPointPen
-from fontTools.pens.recordingPen import RecordingPen, DecomposingRecordingPen
-from fontTools.misc.transform import Transform
-from collections import defaultdict, deque
-from math import sqrt, copysign, atan2, pi
-from enum import Enum
-import itertools
-
-import logging
+from fontTools.pens.recordingPen import DecomposingRecordingPen, RecordingPen
+from fontTools.ttLib.ttGlyphSet import LerpGlyphSet
 
 log = logging.getLogger("fontTools.varLib.interpolatable")
 

--- a/Lib/fontTools/varLib/interpolatablePlot.py
+++ b/Lib/fontTools/varLib/interpolatablePlot.py
@@ -1,29 +1,32 @@
-from .interpolatableHelpers import *
-from fontTools.ttLib import TTFont
-from fontTools.ttLib.ttGlyphSet import LerpGlyphSet
-from fontTools.pens.recordingPen import (
-    RecordingPen,
-    DecomposingRecordingPen,
-    RecordingPointPen,
-)
+import logging
+import math
+import os
+from functools import wraps
+from io import BytesIO
+from itertools import cycle
+
+import cairo
+
 from fontTools.pens.boundsPen import ControlBoundsPen
 from fontTools.pens.cairoPen import CairoPen
 from fontTools.pens.pointPen import (
-    SegmentToPointPen,
     PointToSegmentPen,
     ReverseContourPointPen,
+    SegmentToPointPen,
 )
+from fontTools.pens.recordingPen import (
+    DecomposingRecordingPen,
+    RecordingPen,
+    RecordingPointPen,
+)
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.ttGlyphSet import LerpGlyphSet
 from fontTools.varLib.interpolatableHelpers import (
     PerContourOrComponentPen,
     SimpleRecordingPointPen,
 )
-from itertools import cycle
-from functools import wraps
-from io import BytesIO
-import cairo
-import math
-import os
-import logging
+
+from .interpolatableHelpers import *
 
 log = logging.getLogger("fontTools.varLib.interpolatable")
 

--- a/Lib/fontTools/varLib/interpolatableTestContourOrder.py
+++ b/Lib/fontTools/varLib/interpolatableTestContourOrder.py
@@ -1,5 +1,6 @@
-from .interpolatableHelpers import *
 import logging
+
+from .interpolatableHelpers import *
 
 log = logging.getLogger("fontTools.varLib.interpolatable")
 

--- a/Lib/fontTools/varLib/interpolate_layout.py
+++ b/Lib/fontTools/varLib/interpolate_layout.py
@@ -2,13 +2,14 @@
 Interpolate OpenType Layout tables (GDEF / GPOS / GSUB).
 """
 
-from fontTools.ttLib import TTFont
-from fontTools.varLib import models, VarLibError, load_designspace, load_masters
-from fontTools.varLib.merger import InstancerMerger
-import os.path
 import logging
+import os.path
 from copy import deepcopy
 from pprint import pformat
+
+from fontTools.ttLib import TTFont
+from fontTools.varLib import VarLibError, load_designspace, load_masters, models
+from fontTools.varLib.merger import InstancerMerger
 
 log = logging.getLogger("fontTools.varLib.interpolate_layout")
 
@@ -61,9 +62,10 @@ def interpolate_layout(designspace, loc, master_finder=lambda s: s, mapped=False
 
 def main(args=None):
     """Interpolate GDEF/GPOS/GSUB tables for a point on a designspace"""
-    from fontTools import configLogger
     import argparse
     import sys
+
+    from fontTools import configLogger
 
     parser = argparse.ArgumentParser(
         "fonttools varLib.interpolate_layout",

--- a/Lib/fontTools/varLib/iup.py
+++ b/Lib/fontTools/varLib/iup.py
@@ -5,13 +5,8 @@ except (AttributeError, ImportError):
     from fontTools.misc import cython
 COMPILED = cython.compiled
 
-from typing import (
-    Sequence,
-    Tuple,
-    Union,
-)
 from numbers import Integral, Real
-
+from typing import Sequence, Tuple, Union
 
 _Point = Tuple[Real, Real]
 _Delta = Tuple[Real, Real]

--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -2,42 +2,40 @@
 Merge OpenType Layout tables (GDEF / GPOS / GSUB).
 """
 
-import os
 import copy
 import enum
-from operator import ior
 import logging
+import os
+from functools import reduce
+from operator import ior
+
 from fontTools.colorLib.builder import MAX_PAINT_COLR_LAYER_COUNT, LayerReuseCache
 from fontTools.misc import classifyTools
 from fontTools.misc.roundTools import otRound
 from fontTools.misc.treeTools import build_n_ary_tree
-from fontTools.ttLib.tables import otTables as ot
+from fontTools.otlLib.builder import buildSinglePos
+from fontTools.otlLib.optimize.gpos import _compression_level_from_env, compact_pair_pos
 from fontTools.ttLib.tables import otBase as otBase
+from fontTools.ttLib.tables import otTables as ot
+from fontTools.ttLib.tables.DefaultTable import DefaultTable
 from fontTools.ttLib.tables.otConverters import BaseFixedValue
 from fontTools.ttLib.tables.otTraverse import dfs_base_table
-from fontTools.ttLib.tables.DefaultTable import DefaultTable
 from fontTools.varLib import builder, models, varStore
-from fontTools.varLib.models import nonNone, allNone, allEqual, allEqualTo, subList
+from fontTools.varLib.models import allEqual, allEqualTo, allNone, nonNone, subList
 from fontTools.varLib.varStore import VarStoreInstancer
-from functools import reduce
-from fontTools.otlLib.builder import buildSinglePos
-from fontTools.otlLib.optimize.gpos import (
-    _compression_level_from_env,
-    compact_pair_pos,
-)
 
 log = logging.getLogger("fontTools.varLib.merger")
 
 from .errors import (
-    ShouldBeConstant,
     FoundANone,
-    MismatchedTypes,
-    NotANone,
-    LengthsDiffer,
-    KeysDiffer,
-    InconsistentGlyphOrder,
     InconsistentExtensions,
     InconsistentFormats,
+    InconsistentGlyphOrder,
+    KeysDiffer,
+    LengthsDiffer,
+    MismatchedTypes,
+    NotANone,
+    ShouldBeConstant,
     UnsupportedFormat,
     VarLibMergeError,
 )

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -9,6 +9,7 @@ __all__ = [
 ]
 
 from fontTools.misc.roundTools import noRound
+
 from .errors import VariationModelError
 
 
@@ -579,8 +580,9 @@ def piecewiseLinearMap(v, mapping):
 
 def main(args=None):
     """Normalize locations on a given designspace"""
-    from fontTools import configLogger
     import argparse
+
+    from fontTools import configLogger
 
     parser = argparse.ArgumentParser(
         "fonttools varLib.models",
@@ -634,7 +636,8 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    import doctest, sys
+    import doctest
+    import sys
 
     if len(sys.argv) > 1:
         sys.exit(main())

--- a/Lib/fontTools/varLib/multiVarStore.py
+++ b/Lib/fontTools/varLib/multiVarStore.py
@@ -1,21 +1,21 @@
-from fontTools.misc.roundTools import noRound, otRound
+from collections import defaultdict
+from functools import partial
+from heapq import heappop, heappush
+
+import fontTools.varLib.varStore  # For monkey-patching
 from fontTools.misc.intTools import bit_count
+from fontTools.misc.iterTools import batched
+from fontTools.misc.roundTools import noRound, otRound
 from fontTools.misc.vector import Vector
 from fontTools.ttLib.tables import otTables as ot
-from fontTools.varLib.models import supportScalar
-import fontTools.varLib.varStore  # For monkey-patching
 from fontTools.varLib.builder import (
-    buildVarRegionList,
-    buildSparseVarRegionList,
-    buildSparseVarRegion,
-    buildMultiVarStore,
     buildMultiVarData,
+    buildMultiVarStore,
+    buildSparseVarRegion,
+    buildSparseVarRegionList,
+    buildVarRegionList,
 )
-from fontTools.misc.iterTools import batched
-from functools import partial
-from collections import defaultdict
-from heapq import heappush, heappop
-
+from fontTools.varLib.models import supportScalar
 
 NO_VARIATION_INDEX = ot.NO_VARIATION_INDEX
 ot.MultiVarStore.NO_VARIATION_INDEX = NO_VARIATION_INDEX

--- a/Lib/fontTools/varLib/mutator.py
+++ b/Lib/fontTools/varLib/mutator.py
@@ -6,30 +6,26 @@ Instantiate a variation font.  Run, eg:
     $ fonttools varLib.mutator ./NotoSansArabic-VF.ttf wght=140 wdth=85
 """
 
-from fontTools.misc.fixedTools import floatToFixedToFloat, floatToFixed
+import logging
+import os.path
+from io import BytesIO
+
+import fontTools.subset.cff
+from fontTools.misc.fixedTools import floatToFixed, floatToFixedToFloat
 from fontTools.misc.roundTools import otRound
 from fontTools.pens.boundsPen import BoundsPen
 from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables import ttProgram
 from fontTools.ttLib.tables._g_l_y_f import (
+    OVERLAP_COMPOUND,
     GlyphCoordinates,
     flagOverlapSimple,
-    OVERLAP_COMPOUND,
 )
-from fontTools.varLib.models import (
-    supportScalar,
-    normalizeLocation,
-    piecewiseLinearMap,
-)
-from fontTools.varLib.merger import MutatorMerger
-from fontTools.varLib.varStore import VarStoreInstancer
-from fontTools.varLib.mvar import MVAR_ENTRIES
 from fontTools.varLib.iup import iup_delta
-import fontTools.subset.cff
-import os.path
-import logging
-from io import BytesIO
-
+from fontTools.varLib.merger import MutatorMerger
+from fontTools.varLib.models import normalizeLocation, piecewiseLinearMap, supportScalar
+from fontTools.varLib.mvar import MVAR_ENTRIES
+from fontTools.varLib.varStore import VarStoreInstancer
 
 log = logging.getLogger("fontTools.varlib.mutator")
 
@@ -436,8 +432,9 @@ def instantiateVariableFont(varfont, location, inplace=False, overlap=True):
 
 def main(args=None):
     """Instantiate a variation font"""
-    from fontTools import configLogger
     import argparse
+
+    from fontTools import configLogger
 
     parser = argparse.ArgumentParser(
         "fonttools varLib.mutator", description="Instantiate a variable font"

--- a/Lib/fontTools/varLib/plot.py
+++ b/Lib/fontTools/varLib/plot.py
@@ -1,13 +1,15 @@
 """Visualize DesignSpaceDocument and resulting VariationModel."""
 
-from fontTools.varLib.models import VariationModel, supportScalar
-from fontTools.designspaceLib import DesignSpaceDocument
+import logging
+import math
+import sys
+from itertools import cycle
+
 from matplotlib import pyplot
 from mpl_toolkits.mplot3d import axes3d
-from itertools import cycle
-import math
-import logging
-import sys
+
+from fontTools.designspaceLib import DesignSpaceDocument
+from fontTools.varLib.models import VariationModel, supportScalar
 
 log = logging.getLogger(__name__)
 

--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -1,17 +1,17 @@
-from fontTools.misc.roundTools import noRound, otRound
+from collections import defaultdict
+from functools import partial
+from heapq import heappop, heappush
+
 from fontTools.misc.intTools import bit_count
+from fontTools.misc.roundTools import noRound, otRound
 from fontTools.ttLib.tables import otTables as ot
-from fontTools.varLib.models import supportScalar
 from fontTools.varLib.builder import (
+    buildVarData,
+    buildVarRegion,
     buildVarRegionList,
     buildVarStore,
-    buildVarRegion,
-    buildVarData,
 )
-from functools import partial
-from collections import defaultdict
-from heapq import heappush, heappop
-
+from fontTools.varLib.models import supportScalar
 
 NO_VARIATION_INDEX = ot.NO_VARIATION_INDEX
 ot.VarStore.NO_VARIATION_INDEX = NO_VARIATION_INDEX
@@ -688,6 +688,7 @@ ot.VarStore.optimize = VarStore_optimize
 def main(args=None):
     """Optimize a font's GDEF variation store"""
     from argparse import ArgumentParser
+
     from fontTools import configLogger
     from fontTools.ttLib import TTFont
     from fontTools.ttLib.tables.otBase import OTTableWriter

--- a/Lib/fontTools/voltLib/ast.py
+++ b/Lib/fontTools/voltLib/ast.py
@@ -1,5 +1,6 @@
-from fontTools.voltLib.error import VoltLibError
 from typing import NamedTuple
+
+from fontTools.voltLib.error import VoltLibError
 
 
 class Pos(NamedTuple):

--- a/Lib/fontTools/voltLib/parser.py
+++ b/Lib/fontTools/voltLib/parser.py
@@ -1,7 +1,8 @@
-import fontTools.voltLib.ast as ast
-from fontTools.voltLib.lexer import Lexer
-from fontTools.voltLib.error import VoltLibError
 from io import open
+
+import fontTools.voltLib.ast as ast
+from fontTools.voltLib.error import VoltLibError
+from fontTools.voltLib.lexer import Lexer
 
 PARSE_FUNCS = {
     "DEF_GLYPH": "parse_def_glyph_",

--- a/Lib/fontTools/voltLib/voltToFea.py
+++ b/Lib/fontTools/voltLib/voltToFea.py
@@ -45,8 +45,8 @@ Limitations
 
 import logging
 import re
-from io import StringIO
 from graphlib import TopologicalSorter
+from io import StringIO
 
 from fontTools.feaLib import ast
 from fontTools.ttLib import TTFont, TTLibError

--- a/MetaTools/buildTableList.py
+++ b/MetaTools/buildTableList.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python3
 
-import sys
-import os
 import glob
-from fontTools.ttLib import identifierToTag
+import os
+import sys
 import textwrap
 
+from fontTools.ttLib import identifierToTag
 
 fontToolsDir = os.path.dirname(os.path.dirname(os.path.join(os.getcwd(), sys.argv[0])))
 fontToolsDir = os.path.normpath(fontToolsDir)

--- a/MetaTools/buildUCD.py
+++ b/MetaTools/buildUCD.py
@@ -4,13 +4,14 @@ Tools to parse data files from the Unicode Character Database.
 """
 
 
-from urllib.request import urlopen
-import re
 import logging
 import os
-from os.path import abspath, dirname, join as pjoin, pardir, sep
+import re
+from os.path import abspath, dirname
+from os.path import join as pjoin
+from os.path import pardir, sep
 from typing import List
-
+from urllib.request import urlopen
 
 UNIDATA_URL = "https://unicode.org/Public/UNIDATA/"
 UNIDATA_LICENSE_URL = "http://unicode.org/copyright.html#License"

--- a/MetaTools/roundTrip.py
+++ b/MetaTools/roundTrip.py
@@ -2,23 +2,24 @@
 
 """usage: ttroundtrip [options] font1 ... fontN
 
-    Dump each TT/OT font as a TTX file, compile again to TTF or OTF
-    and dump again. Then do a diff on the two TTX files. Append problems
-    and diffs to a file called "report.txt" in the current directory.
-    This is only for testing FontTools/TTX, the resulting files are
-    deleted afterwards.
+Dump each TT/OT font as a TTX file, compile again to TTF or OTF
+and dump again. Then do a diff on the two TTX files. Append problems
+and diffs to a file called "report.txt" in the current directory.
+This is only for testing FontTools/TTX, the resulting files are
+deleted afterwards.
 
-    This tool supports some of ttx's command line options (-i, -t
-    and -x). Specifying -t or -x implies ttx -m <originalfile> on
-    the way back.
+This tool supports some of ttx's command line options (-i, -t
+and -x). Specifying -t or -x implies ttx -m <originalfile> on
+the way back.
 """
 
 
-import sys
-import os
-import tempfile
 import getopt
+import os
+import sys
+import tempfile
 import traceback
+
 from fontTools import ttx
 
 

--- a/Snippets/checksum.py
+++ b/Snippets/checksum.py
@@ -5,7 +5,6 @@ import argparse
 import hashlib
 import os
 import sys
-
 from os.path import basename
 
 from fontTools.ttLib import TTFont

--- a/Snippets/cmap-format.py
+++ b/Snippets/cmap-format.py
@@ -10,9 +10,10 @@
 # getEncoding() of subtable and use that encoding to map the
 # characters to Unicode...  TODO: Extend this script to do that.
 
+import sys
+
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables._c_m_a_p import CmapSubtable
-import sys
 
 if len(sys.argv) != 3:
     print("usage: cmap-format.py fontfile.ttf outfile.ttf")

--- a/Snippets/compact_gpos.py
+++ b/Snippets/compact_gpos.py
@@ -19,15 +19,15 @@ python Snippets/compact_gpos.py MyFont.ttf > results.csv
 """
 
 import argparse
-from collections import defaultdict
 import csv
-import time
 import sys
+import time
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, Iterable, List, Optional, Sequence, Tuple
 
-from fontTools.ttLib import TTFont
 from fontTools.otlLib.optimize import compact
+from fontTools.ttLib import TTFont
 
 MODES = [str(c) for c in range(1, 10)]
 
@@ -110,7 +110,7 @@ def woff_size(font: TTFont, path: Path) -> int:
 
 def write_csv(rows: List[Tuple[Any]]) -> None:
     sys.stdout.reconfigure(encoding="utf-8")
-    sys.stdout.write("\uFEFF")
+    sys.stdout.write("\ufeff")
     writer = csv.writer(sys.stdout, lineterminator="\n")
     writer.writerow(
         [

--- a/Snippets/decompose-ttf.py
+++ b/Snippets/decompose-ttf.py
@@ -5,9 +5,10 @@
 
 
 import sys
-from fontTools.ttLib import TTFont
+
 from fontTools.pens.recordingPen import DecomposingRecordingPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.ttLib import TTFont
 
 try:
     import pathops

--- a/Snippets/dump_woff_metadata.py
+++ b/Snippets/dump_woff_metadata.py
@@ -1,6 +1,7 @@
 import sys
-from fontTools.ttx import makeOutputFileName
+
 from fontTools.ttLib import TTFont
+from fontTools.ttx import makeOutputFileName
 
 
 def main(args=None):

--- a/Snippets/interpolate.py
+++ b/Snippets/interpolate.py
@@ -21,11 +21,12 @@
 # $ ./interpolate.py && open Roboto.ttf
 
 
-from fontTools.ttLib import TTFont
-from fontTools.ttLib.tables._n_a_m_e import NameRecord
-from fontTools.ttLib.tables._f_v_a_r import table__f_v_a_r, Axis, NamedInstance
-from fontTools.ttLib.tables._g_v_a_r import table__g_v_a_r, TupleVariation
 import logging
+
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables._f_v_a_r import Axis, NamedInstance, table__f_v_a_r
+from fontTools.ttLib.tables._g_v_a_r import TupleVariation, table__g_v_a_r
+from fontTools.ttLib.tables._n_a_m_e import NameRecord
 
 
 def AddFontVariations(font):

--- a/Snippets/layout-features.py
+++ b/Snippets/layout-features.py
@@ -1,8 +1,9 @@
 #! /usr/bin/env python3
 
+import sys
+
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables import otTables
-import sys
 
 if len(sys.argv) != 2:
     print("usage: layout-features.py fontfile.ttf")

--- a/Snippets/merge_woff_metadata.py
+++ b/Snippets/merge_woff_metadata.py
@@ -1,7 +1,8 @@
-import sys
 import os
-from fontTools.ttx import makeOutputFileName
+import sys
+
 from fontTools.ttLib import TTFont
+from fontTools.ttx import makeOutputFileName
 
 
 def main(args=None):

--- a/Snippets/otf2ttf.py
+++ b/Snippets/otf2ttf.py
@@ -5,12 +5,11 @@ import logging
 import os
 import sys
 
-from fontTools.pens.cu2quPen import Cu2QuPen
 from fontTools import configLogger
 from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.pens.cu2quPen import Cu2QuPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib import TTFont, newTable
-
 
 log = logging.getLogger()
 

--- a/Snippets/print-json.py
+++ b/Snippets/print-json.py
@@ -1,7 +1,8 @@
-import fontTools.ttLib as ttLib
-from fontTools.ttLib.ttVisitor import TTVisitor
-from fontTools.misc.textTools import Tag
 from array import array
+
+import fontTools.ttLib as ttLib
+from fontTools.misc.textTools import Tag
+from fontTools.ttLib.ttVisitor import TTVisitor
 
 
 class JsonVisitor(TTVisitor):
@@ -139,8 +140,9 @@ def visit(self, obj):
 
 
 if __name__ == "__main__":
-    from fontTools.ttLib import TTFont
     import sys
+
+    from fontTools.ttLib import TTFont
 
     if len(sys.argv) != 2:
         print("usage: print-json.py font")

--- a/Snippets/rename-fonts.py
+++ b/Snippets/rename-fonts.py
@@ -6,12 +6,12 @@ The current family name substring is searched in the nameIDs 1, 3, 4, 6, 16,
 and 21, and if found the suffix is inserted after it; or else the suffix is
 appended at the end.
 """
-import os
 import argparse
 import logging
-from fontTools.ttLib import TTFont
-from fontTools.misc.cliTools import makeOutputFileName
+import os
 
+from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.ttLib import TTFont
 
 logger = logging.getLogger()
 

--- a/Snippets/statShape.py
+++ b/Snippets/statShape.py
@@ -1,13 +1,13 @@
 """Draw statistical shape of a glyph as an ellipse."""
 
-from fontTools.ttLib import TTFont
-from fontTools.pens.recordingPen import RecordingPen
-from fontTools.pens.cairoPen import CairoPen
-from fontTools.pens.statisticsPen import StatisticsPen
-import cairo
 import math
 import sys
 
+import cairo
+from fontTools.pens.cairoPen import CairoPen
+from fontTools.pens.recordingPen import RecordingPen
+from fontTools.pens.statisticsPen import StatisticsPen
+from fontTools.ttLib import TTFont
 
 font = TTFont(sys.argv[1])
 unicode = sys.argv[2]

--- a/Snippets/subset-fpgm.py
+++ b/Snippets/subset-fpgm.py
@@ -1,7 +1,8 @@
 #! /usr/bin/env python3
 
-from fontTools.ttLib import TTFont
 import sys
+
+from fontTools.ttLib import TTFont
 
 if len(sys.argv) < 2:
     print("usage: subset-fpgm.py fontfile.ttf func-number...")

--- a/Snippets/svg2glif.py
+++ b/Snippets/svg2glif.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
-""" Convert SVG paths to UFO glyphs. """
+"""Convert SVG paths to UFO glyphs."""
 
 
 __requires__ = ["fontTools"]
 
 from types import SimpleNamespace
-from fontTools.svgLib import SVGPath
 
 from fontTools.pens.pointPen import SegmentToPointPen
+from fontTools.svgLib import SVGPath
 from fontTools.ufoLib.glifLib import writeGlyphToString
-
 
 __all__ = ["svg2glif"]
 

--- a/Tests/afmLib/afmLib_test.py
+++ b/Tests/afmLib/afmLib_test.py
@@ -1,7 +1,7 @@
-import unittest
 import os
-from fontTools import afmLib
+import unittest
 
+from fontTools import afmLib
 
 CWD = os.path.abspath(os.path.dirname(__file__))
 DATADIR = os.path.join(CWD, "data")

--- a/Tests/agl_test.py
+++ b/Tests/agl_test.py
@@ -1,18 +1,19 @@
-from fontTools import agl
 import unittest
+
+from fontTools import agl
 
 
 class AglToUnicodeTest(unittest.TestCase):
     def test_spec_examples(self):
         # https://github.com/adobe-type-tools/agl-specification#3-examples
         self.assertEqual(agl.toUnicode("Lcommaaccent"), "Ļ")
-        self.assertEqual(agl.toUnicode("uni20AC0308"), "\u20AC\u0308")
-        self.assertEqual(agl.toUnicode("u1040C"), "\U0001040C")
+        self.assertEqual(agl.toUnicode("uni20AC0308"), "\u20ac\u0308")
+        self.assertEqual(agl.toUnicode("u1040C"), "\U0001040c")
         self.assertEqual(agl.toUnicode("uniD801DC0C"), "")
         self.assertEqual(agl.toUnicode("uni20ac"), "")
         self.assertEqual(
             agl.toUnicode("Lcommaaccent_uni20AC0308_u1040C.alternate"),
-            "\u013B\u20AC\u0308\U0001040C",
+            "\u013b\u20ac\u0308\U0001040c",
         )
         self.assertEqual(agl.toUnicode("Lcommaaccent_uni013B_u013B"), "ĻĻĻ")
         self.assertEqual(agl.toUnicode("foo"), "")
@@ -42,7 +43,7 @@ class AglToUnicodeTest(unittest.TestCase):
         # Interesting test case because "uni" is a prefix of "union".
         self.assertEqual(agl.toUnicode("union"), "∪")
         # U+222A U+FE00 is a Standardized Variant for UNION WITH SERIFS.
-        self.assertEqual(agl.toUnicode("union_uniFE00"), "\u222A\uFE00")
+        self.assertEqual(agl.toUnicode("union_uniFE00"), "\u222a\ufe00")
 
     def test_dingbats(self):
         self.assertEqual(agl.toUnicode("a20", isZapfDingbats=True), "✔")

--- a/Tests/cffLib/cffLib_test.py
+++ b/Tests/cffLib/cffLib_test.py
@@ -6,12 +6,13 @@ libdir = os.path.join(
 )
 sys.path.insert(0, libdir)
 
-from fontTools.cffLib import TopDict, PrivateDict, CharStrings, CFFFontSet
-from fontTools.misc.testTools import parseXML, DataFilesHandler
-from fontTools.ttLib import TTFont
 import copy
 import unittest
 from io import BytesIO
+
+from fontTools.cffLib import CFFFontSet, CharStrings, PrivateDict, TopDict
+from fontTools.misc.testTools import DataFilesHandler, parseXML
+from fontTools.ttLib import TTFont
 
 
 class CffLibTest(DataFilesHandler):

--- a/Tests/cffLib/specializer_test.py
+++ b/Tests/cffLib/specializer_test.py
@@ -1,18 +1,19 @@
+import os
+
+import pytest
 from fontTools.cffLib import maxStackLimit as maxStack
 from fontTools.cffLib.specializer import (
-    programToString,
-    stringToProgram,
-    generalizeProgram,
-    specializeProgram,
-    programToCommands,
     commandsToProgram,
     generalizeCommands,
+    generalizeProgram,
+    programToCommands,
+    programToString,
     specializeCommands,
+    specializeProgram,
+    stringToProgram,
 )
+from fontTools.misc.testTools import DataFilesHandler, parseXML
 from fontTools.ttLib import TTFont
-import os
-import pytest
-from fontTools.misc.testTools import parseXML, DataFilesHandler
 
 
 def charstr_generalize(charstr, **kwargs):

--- a/Tests/colorLib/builder_test.py
+++ b/Tests/colorLib/builder_test.py
@@ -1,13 +1,14 @@
 from copy import deepcopy
+from typing import List
+
+import pytest
+from fontTools.colorLib import builder
+from fontTools.colorLib.builder import LayerListBuilder
+from fontTools.colorLib.errors import ColorLibError
+from fontTools.colorLib.geometry import Circle, round_start_circle_stable_containment
+from fontTools.colorLib.table_builder import TableBuilder
 from fontTools.ttLib import newTable
 from fontTools.ttLib.tables import otTables as ot
-from fontTools.colorLib import builder
-from fontTools.colorLib.geometry import round_start_circle_stable_containment, Circle
-from fontTools.colorLib.builder import LayerListBuilder
-from fontTools.colorLib.table_builder import TableBuilder
-from fontTools.colorLib.errors import ColorLibError
-import pytest
-from typing import List
 
 
 def _build(cls, source):

--- a/Tests/colorLib/table_builder_test.py
+++ b/Tests/colorLib/table_builder_test.py
@@ -1,7 +1,7 @@
+import pytest
+from fontTools.colorLib.table_builder import TableBuilder
 from fontTools.ttLib.tables import otTables  # trigger setup to occur
 from fontTools.ttLib.tables.otConverters import UShort
-from fontTools.colorLib.table_builder import TableBuilder
-import pytest
 
 
 class WriteMe:

--- a/Tests/colorLib/unbuilder_test.py
+++ b/Tests/colorLib/unbuilder_test.py
@@ -1,8 +1,7 @@
-from fontTools.ttLib.tables import otTables as ot
+import pytest
 from fontTools.colorLib.builder import buildColrV1
 from fontTools.colorLib.unbuilder import unbuildColrV1
-import pytest
-
+from fontTools.ttLib.tables import otTables as ot
 
 TEST_COLOR_GLYPHS = {
     "glyph00010": {

--- a/Tests/config_test.py
+++ b/Tests/config_test.py
@@ -1,4 +1,3 @@
-from fontTools.misc.configTools import AbstractConfig, Options
 import pytest
 from fontTools.config import (
     OPTIONS,
@@ -7,6 +6,7 @@ from fontTools.config import (
     ConfigValueParsingError,
     ConfigValueValidationError,
 )
+from fontTools.misc.configTools import AbstractConfig, Options
 from fontTools.ttLib import TTFont
 
 

--- a/Tests/cu2qu/cli_test.py
+++ b/Tests/cu2qu/cli_test.py
@@ -1,13 +1,12 @@
 import os
 
-import pytest
 import py
+import pytest
 
 ufoLib2 = pytest.importorskip("ufoLib2")
 
-from fontTools.cu2qu.ufo import CURVE_TYPE_LIB_KEY
 from fontTools.cu2qu.cli import _main as main
-
+from fontTools.cu2qu.ufo import CURVE_TYPE_LIB_KEY
 
 DATADIR = os.path.join(os.path.dirname(__file__), "data")
 

--- a/Tests/cu2qu/cu2qu_test.py
+++ b/Tests/cu2qu/cu2qu_test.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 import collections
-import math
-import unittest
-import os
 import json
+import math
+import os
+import unittest
 
 from fontTools.cu2qu import curve_to_quadratic, curves_to_quadratic
-
 
 DATADIR = os.path.join(os.path.dirname(__file__), "data")
 

--- a/Tests/cu2qu/ufo_test.py
+++ b/Tests/cu2qu/ufo_test.py
@@ -1,22 +1,20 @@
 import os
 
-from fontTools.misc.loggingTools import CapturingLogHandler
-from fontTools.cu2qu.ufo import (
-    fonts_to_quadratic,
-    font_to_quadratic,
-    glyphs_to_quadratic,
-    glyph_to_quadratic,
-    logger,
-    CURVE_TYPE_LIB_KEY,
-)
+import pytest
 from fontTools.cu2qu.errors import (
+    IncompatibleFontsError,
     IncompatibleSegmentNumberError,
     IncompatibleSegmentTypesError,
-    IncompatibleFontsError,
 )
-
-import pytest
-
+from fontTools.cu2qu.ufo import (
+    CURVE_TYPE_LIB_KEY,
+    font_to_quadratic,
+    fonts_to_quadratic,
+    glyph_to_quadratic,
+    glyphs_to_quadratic,
+    logger,
+)
+from fontTools.misc.loggingTools import CapturingLogHandler
 
 ufoLib2 = pytest.importorskip("ufoLib2")
 

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -1,16 +1,16 @@
 # coding=utf-8
 
 import os
-from pathlib import Path
 import re
 import shutil
+from pathlib import Path
 
 import pytest
 from fontTools import ttLib
 from fontTools.designspaceLib import (
     AxisDescriptor,
-    AxisMappingDescriptor,
     AxisLabelDescriptor,
+    AxisMappingDescriptor,
     DesignSpaceDocument,
     DesignSpaceDocumentError,
     DiscreteAxisDescriptor,

--- a/Tests/encodings/codecs_test.py
+++ b/Tests/encodings/codecs_test.py
@@ -1,4 +1,5 @@
 import unittest
+
 import fontTools.encodings.codecs  # Not to be confused with "import codecs"
 
 

--- a/Tests/feaLib/ast_test.py
+++ b/Tests/feaLib/ast_test.py
@@ -1,5 +1,6 @@
-from fontTools.feaLib import ast
 import unittest
+
+from fontTools.feaLib import ast
 
 
 class AstTest(unittest.TestCase):

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -1,26 +1,27 @@
-from fontTools.misc.loggingTools import CapturingLogHandler
+import difflib
+import logging
+import os
+import re
+import shutil
+import sys
+import tempfile
+import unittest
+import warnings
+from io import StringIO
+from textwrap import dedent
+
+from fontTools.feaLib import ast
 from fontTools.feaLib.builder import (
     Builder,
     addOpenTypeFeatures,
     addOpenTypeFeaturesFromString,
 )
 from fontTools.feaLib.error import FeatureLibError
-from fontTools.ttLib import TTFont, newTable
-from fontTools.feaLib.parser import Parser
-from fontTools.feaLib import ast
 from fontTools.feaLib.lexer import Lexer
+from fontTools.feaLib.parser import Parser
 from fontTools.fontBuilder import addFvar
-import difflib
-from io import StringIO
-from textwrap import dedent
-import os
-import re
-import shutil
-import sys
-import tempfile
-import logging
-import unittest
-import warnings
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.ttLib import TTFont, newTable
 
 
 def makeTTFont():

--- a/Tests/feaLib/error_test.py
+++ b/Tests/feaLib/error_test.py
@@ -1,6 +1,7 @@
+import unittest
+
 from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.location import FeatureLibLocation
-import unittest
 
 
 class FeatureLibErrorTest(unittest.TestCase):

--- a/Tests/feaLib/lexer_test.py
+++ b/Tests/feaLib/lexer_test.py
@@ -1,11 +1,12 @@
-from fontTools.feaLib.error import FeatureLibError, IncludedFeaNotFound
-from fontTools.feaLib.lexer import IncludingLexer, Lexer
-from fontTools.misc.textTools import tobytes
-from io import StringIO
 import os
 import shutil
 import tempfile
 import unittest
+from io import StringIO
+
+from fontTools.feaLib.error import FeatureLibError, IncludedFeaNotFound
+from fontTools.feaLib.lexer import IncludingLexer, Lexer
+from fontTools.misc.textTools import tobytes
 
 
 def lex(s):

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-from fontTools.misc.loggingTools import CapturingLogHandler
-from fontTools.feaLib.error import FeatureLibError
-from fontTools.feaLib.parser import Parser, SymbolTable
-from io import StringIO
-import warnings
-import fontTools.feaLib.ast as ast
 import os
 import unittest
+import warnings
+from io import StringIO
+
+import fontTools.feaLib.ast as ast
+from fontTools.feaLib.error import FeatureLibError
+from fontTools.feaLib.parser import Parser, SymbolTable
+from fontTools.misc.loggingTools import CapturingLogHandler
 
 
 def glyphstr(glyphs):

--- a/Tests/fontBuilder/fontBuilder_test.py
+++ b/Tests/fontBuilder/fontBuilder_test.py
@@ -1,13 +1,14 @@
 import os
+
 import pytest
 from fontTools.designspaceLib import AxisDescriptor
-from fontTools.ttLib import TTFont
-from fontTools.pens.ttGlyphPen import TTGlyphPen
-from fontTools.pens.t2CharStringPen import T2CharStringPen
 from fontTools.fontBuilder import FontBuilder
-from fontTools.ttLib.tables.TupleVariation import TupleVariation
 from fontTools.misc.psCharStrings import T2CharString
 from fontTools.misc.testTools import stripVariableItemsFromTTX
+from fontTools.pens.t2CharStringPen import T2CharStringPen
+from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables.TupleVariation import TupleVariation
 
 
 def getTestData(fileName, mode="r"):

--- a/Tests/merge/merge_test.py
+++ b/Tests/merge/merge_test.py
@@ -1,18 +1,20 @@
+import difflib
 import io
 import itertools
-from fontTools import ttLib
-from fontTools.ttLib.tables._g_l_y_f import Glyph
-from fontTools.fontBuilder import FontBuilder
-from fontTools.merge import Merger, main as merge_main
-import difflib
 import os
+import pathlib
 import re
 import shutil
 import sys
 import tempfile
 import unittest
-import pathlib
+
 import pytest
+from fontTools import ttLib
+from fontTools.fontBuilder import FontBuilder
+from fontTools.merge import Merger
+from fontTools.merge import main as merge_main
+from fontTools.ttLib.tables._g_l_y_f import Glyph
 
 
 class MergeIntegrationTest(unittest.TestCase):

--- a/Tests/misc/arrayTools_test.py
+++ b/Tests/misc/arrayTools_test.py
@@ -1,21 +1,22 @@
+import math
+
 from fontTools.misc.arrayTools import (
+    asInt16,
     calcBounds,
     calcIntBounds,
-    updateBounds,
+    insetRect,
+    intRect,
+    normRect,
+    offsetRect,
     pointInRect,
     pointsInRect,
-    vectorLength,
-    asInt16,
-    normRect,
+    rectCenter,
     scaleRect,
-    offsetRect,
-    insetRect,
     sectRect,
     unionRect,
-    rectCenter,
-    intRect,
+    updateBounds,
+    vectorLength,
 )
-import math
 
 
 def test_calcBounds():

--- a/Tests/misc/bezierTools_test.py
+++ b/Tests/misc/bezierTools_test.py
@@ -1,20 +1,20 @@
 import fontTools.misc.bezierTools as bezierTools
+import pytest
 from fontTools.misc.bezierTools import (
-    calcQuadraticBounds,
-    calcQuadraticArcLength,
-    calcCubicBounds,
     calcCubicArcLength,
-    curveLineIntersections,
+    calcCubicBounds,
+    calcQuadraticArcLength,
+    calcQuadraticBounds,
     curveCurveIntersections,
+    curveLineIntersections,
     segmentPointAtT,
+    solveCubic,
+    splitCubic,
+    splitCubicAtT,
     splitLine,
     splitQuadratic,
-    splitCubic,
     splitQuadraticAtT,
-    splitCubicAtT,
-    solveCubic,
 )
-import pytest
 
 
 def test_calcQuadraticBounds():

--- a/Tests/misc/configTools_test.py
+++ b/Tests/misc/configTools_test.py
@@ -1,11 +1,11 @@
 import dataclasses
-import pytest
 
+import pytest
 from fontTools.misc.configTools import (
     AbstractConfig,
+    ConfigUnknownOptionError,
     Option,
     Options,
-    ConfigUnknownOptionError,
 )
 
 

--- a/Tests/misc/encodingTools_test.py
+++ b/Tests/misc/encodingTools_test.py
@@ -1,4 +1,5 @@
 import unittest
+
 from fontTools.misc.encodingTools import getEncoding
 
 

--- a/Tests/misc/etree_test.py
+++ b/Tests/misc/etree_test.py
@@ -1,8 +1,9 @@
 # coding: utf-8
-from fontTools.misc import etree
-from collections import OrderedDict
 import io
+from collections import OrderedDict
+
 import pytest
+from fontTools.misc import etree
 
 
 @pytest.mark.parametrize(

--- a/Tests/misc/filenames_test.py
+++ b/Tests/misc/filenames_test.py
@@ -1,5 +1,6 @@
 import unittest
-from fontTools.misc.filenames import userNameToFileName, handleClash1, handleClash2
+
+from fontTools.misc.filenames import handleClash1, handleClash2, userNameToFileName
 
 
 class UserNameToFilenameTest(unittest.TestCase):

--- a/Tests/misc/fixedTools_test.py
+++ b/Tests/misc/fixedTools_test.py
@@ -1,12 +1,13 @@
+import unittest
+
 from fontTools.misc.fixedTools import (
     fixedToFloat,
+    fixedToStr,
     floatToFixed,
     floatToFixedToStr,
-    fixedToStr,
     strToFixed,
     strToFixedToFloat,
 )
-import unittest
 
 
 class FixedToolsTest(unittest.TestCase):

--- a/Tests/misc/loggingTools_test.py
+++ b/Tests/misc/loggingTools_test.py
@@ -1,16 +1,17 @@
-from fontTools.misc.loggingTools import (
-    LevelFormatter,
-    Timer,
-    configLogger,
-    ChannelsFilter,
-    LogMixin,
-)
-from io import StringIO
 import logging
+import re
 import textwrap
 import time
-import re
+from io import StringIO
+
 import pytest
+from fontTools.misc.loggingTools import (
+    ChannelsFilter,
+    LevelFormatter,
+    LogMixin,
+    Timer,
+    configLogger,
+)
 
 
 def logger_name_generator():

--- a/Tests/misc/macRes_test.py
+++ b/Tests/misc/macRes_test.py
@@ -1,11 +1,11 @@
-from io import BytesIO
-import sys
 import os
+import sys
 import tempfile
 import unittest
-from fontTools.misc.textTools import deHexStr
-from fontTools.misc.macRes import ResourceReader
+from io import BytesIO
 
+from fontTools.misc.macRes import ResourceReader
+from fontTools.misc.textTools import deHexStr
 
 # test resource data in DeRez notation
 """

--- a/Tests/misc/plistlib_test.py
+++ b/Tests/misc/plistlib_test.py
@@ -1,16 +1,15 @@
-import sys
-import os
-import datetime
 import codecs
 import collections
+import datetime
+import os
+import sys
+from collections.abc import Mapping
 from io import BytesIO
 from numbers import Integral
-from fontTools.misc import etree
-from fontTools.misc import plistlib
-from fontTools.misc.textTools import tostr
-import pytest
-from collections.abc import Mapping
 
+import pytest
+from fontTools.misc import etree, plistlib
+from fontTools.misc.textTools import tostr
 
 # The testdata is generated using https://github.com/python/cpython/...
 # Mac/Tools/plistlib_generate_testdata.py

--- a/Tests/misc/psCharStrings_test.py
+++ b/Tests/misc/psCharStrings_test.py
@@ -1,15 +1,16 @@
+import unittest
+
 from fontTools.cffLib import PrivateDict
 from fontTools.cffLib.specializer import stringToProgram
-from fontTools.misc.testTools import getXML, parseXML
 from fontTools.misc.psCharStrings import (
     T2CharString,
-    encodeFloat,
     encodeFixed,
+    encodeFloat,
     read_fixed1616,
     read_realNumber,
 )
+from fontTools.misc.testTools import getXML, parseXML
 from fontTools.pens.recordingPen import RecordingPen
-import unittest
 
 
 def hexenc(s):

--- a/Tests/misc/py23_test.py
+++ b/Tests/misc/py23_test.py
@@ -1,21 +1,20 @@
-from fontTools.misc.py23 import tobytes
-from fontTools.misc.textTools import deHexStr
 import filecmp
-from io import StringIO
-import tempfile
-from subprocess import check_call
-import sys
 import os
+import sys
+import tempfile
 import unittest
+from io import StringIO
+from subprocess import check_call
 
 from fontTools.misc.py23 import (
+    isclose,
+    redirect_stderr,
+    redirect_stdout,
     round2,
     round3,
-    isclose,
-    redirect_stdout,
-    redirect_stderr,
+    tobytes,
 )
-
+from fontTools.misc.textTools import deHexStr
 
 PIPE_SCRIPT = """\
 import sys

--- a/Tests/misc/symfont_test.py
+++ b/Tests/misc/symfont_test.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     AreaPen = None
 import unittest
+
 import pytest
 
 precision = 6

--- a/Tests/misc/testTools_test.py
+++ b/Tests/misc/testTools_test.py
@@ -1,5 +1,6 @@
-import fontTools.misc.testTools as testTools
 import unittest
+
+import fontTools.misc.testTools as testTools
 
 
 class TestToolsTest(unittest.TestCase):

--- a/Tests/misc/timeTools_test.py
+++ b/Tests/misc/timeTools_test.py
@@ -1,14 +1,15 @@
-from fontTools.misc.timeTools import (
-    asctime,
-    timestampNow,
-    timestampToString,
-    timestampFromString,
-    epoch_diff,
-)
+import locale
 import os
 import time
-import locale
+
 import pytest
+from fontTools.misc.timeTools import (
+    asctime,
+    epoch_diff,
+    timestampFromString,
+    timestampNow,
+    timestampToString,
+)
 
 
 def test_asctime():

--- a/Tests/misc/transform_test.py
+++ b/Tests/misc/transform_test.py
@@ -1,12 +1,13 @@
+import math
+
+import pytest
 from fontTools.misc.transform import (
-    Transform,
+    DecomposedTransform,
     Identity,
     Offset,
     Scale,
-    DecomposedTransform,
+    Transform,
 )
-import math
-import pytest
 
 
 class TransformTest(object):

--- a/Tests/misc/treeTools_test.py
+++ b/Tests/misc/treeTools_test.py
@@ -1,5 +1,5 @@
-from fontTools.misc.treeTools import build_n_ary_tree
 import pytest
+from fontTools.misc.treeTools import build_n_ary_tree
 
 
 @pytest.mark.parametrize(

--- a/Tests/misc/vector_test.py
+++ b/Tests/misc/vector_test.py
@@ -1,4 +1,5 @@
 import math
+
 import pytest
 from fontTools.misc.arrayTools import Vector as ArrayVector
 from fontTools.misc.vector import Vector

--- a/Tests/misc/visitor_test.py
+++ b/Tests/misc/visitor_test.py
@@ -1,6 +1,7 @@
-from fontTools.misc.visitor import Visitor
 import enum
+
 import pytest
+from fontTools.misc.visitor import Visitor
 
 
 class E(enum.Enum):

--- a/Tests/misc/xmlReader_test.py
+++ b/Tests/misc/xmlReader_test.py
@@ -1,10 +1,11 @@
-from io import BytesIO
 import os
-import unittest
-from fontTools.ttLib import TTFont
-from fontTools.misc.textTools import strjoin
-from fontTools.misc.xmlReader import XMLReader, ProgressPrinter, BUFSIZE
 import tempfile
+import unittest
+from io import BytesIO
+
+from fontTools.misc.textTools import strjoin
+from fontTools.misc.xmlReader import BUFSIZE, ProgressPrinter, XMLReader
+from fontTools.ttLib import TTFont
 
 
 class TestXMLReader(unittest.TestCase):

--- a/Tests/misc/xmlWriter_test.py
+++ b/Tests/misc/xmlWriter_test.py
@@ -1,6 +1,7 @@
-from io import BytesIO
 import os
 import unittest
+from io import BytesIO
+
 from fontTools.misc.textTools import bytesjoin, tobytes
 from fontTools.misc.xmlWriter import XMLWriter
 

--- a/Tests/mtiLib/mti_test.py
+++ b/Tests/mtiLib/mti_test.py
@@ -1,12 +1,13 @@
-from fontTools.misc.xmlWriter import XMLWriter
-from fontTools.ttLib import TTFont
-from fontTools.feaLib.lookupDebugInfo import LOOKUP_DEBUG_ENV_VAR
-from fontTools import mtiLib
 import difflib
-from io import StringIO
 import os
 import sys
+from io import StringIO
+
 import pytest
+from fontTools import mtiLib
+from fontTools.feaLib.lookupDebugInfo import LOOKUP_DEBUG_ENV_VAR
+from fontTools.misc.xmlWriter import XMLWriter
+from fontTools.ttLib import TTFont
 
 
 @pytest.fixture(autouse=True)

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1,11 +1,12 @@
 import io
 import struct
-from fontTools.misc.fixedTools import floatToFixed, fixedToFloat
+
+import pytest
+from fontTools import ttLib
+from fontTools.misc.fixedTools import fixedToFloat, floatToFixed
 from fontTools.misc.testTools import getXML
 from fontTools.otlLib import builder, error
-from fontTools import ttLib
 from fontTools.ttLib.tables import otTables
-import pytest
 
 
 class BuilderTest(object):

--- a/Tests/otlLib/maxContextCalc_test.py
+++ b/Tests/otlLib/maxContextCalc_test.py
@@ -1,8 +1,9 @@
 import os
+
 import pytest
-from fontTools.ttLib import TTFont
-from fontTools.otlLib.maxContextCalc import maxCtxFont
 from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
+from fontTools.otlLib.maxContextCalc import maxCtxFont
+from fontTools.ttLib import TTFont
 
 
 def test_max_ctx_calc_no_features():

--- a/Tests/otlLib/mock_builder_test.py
+++ b/Tests/otlLib/mock_builder_test.py
@@ -1,25 +1,26 @@
+import logging
+
+import pytest
+from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.otlLib.builder import (
     AlternateSubstBuilder,
     ChainContextPosBuilder,
     ChainContextSubstBuilder,
-    LigatureSubstBuilder,
-    MultipleSubstBuilder,
+    ChainContextualRule,
+    ClassPairPosSubtableBuilder,
     CursivePosBuilder,
+    LigatureSubstBuilder,
     MarkBasePosBuilder,
     MarkLigPosBuilder,
     MarkMarkPosBuilder,
-    ReverseChainSingleSubstBuilder,
-    SingleSubstBuilder,
-    ClassPairPosSubtableBuilder,
+    MultipleSubstBuilder,
     PairPosBuilder,
+    ReverseChainSingleSubstBuilder,
     SinglePosBuilder,
-    ChainContextualRule,
+    SingleSubstBuilder,
 )
 from fontTools.otlLib.error import OpenTypeLibError
 from fontTools.ttLib import TTFont
-from fontTools.misc.loggingTools import CapturingLogHandler
-import logging
-import pytest
 
 
 @pytest.fixture

--- a/Tests/pens/areaPen_test.py
+++ b/Tests/pens/areaPen_test.py
@@ -1,5 +1,6 @@
-from fontTools.pens.areaPen import AreaPen
 import unittest
+
+from fontTools.pens.areaPen import AreaPen
 
 precision = 6
 

--- a/Tests/pens/basePen_test.py
+++ b/Tests/pens/basePen_test.py
@@ -1,12 +1,13 @@
+import unittest
+
+from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.pens.basePen import (
     AbstractPen,
     BasePen,
-    decomposeSuperBezierSegment,
     decomposeQuadraticSegment,
+    decomposeSuperBezierSegment,
 )
 from fontTools.pens.pointPen import AbstractPointPen
-from fontTools.misc.loggingTools import CapturingLogHandler
-import unittest
 
 
 class _TestPen(BasePen):

--- a/Tests/pens/boundsPen_test.py
+++ b/Tests/pens/boundsPen_test.py
@@ -1,5 +1,6 @@
-from fontTools.pens.boundsPen import BoundsPen, ControlBoundsPen
 import unittest
+
+from fontTools.pens.boundsPen import BoundsPen, ControlBoundsPen
 
 
 def draw_(pen):

--- a/Tests/pens/cocoaPen_test.py
+++ b/Tests/pens/cocoaPen_test.py
@@ -1,9 +1,13 @@
 import unittest
 
 try:
+    from AppKit import (
+        NSBezierPathElementClosePath,
+        NSBezierPathElementCurveTo,
+        NSBezierPathElementLineTo,
+        NSBezierPathElementMoveTo,
+    )
     from fontTools.pens.cocoaPen import CocoaPen
-    from AppKit import NSBezierPathElementMoveTo, NSBezierPathElementLineTo
-    from AppKit import NSBezierPathElementCurveTo, NSBezierPathElementClosePath
 
     PATH_ELEMENTS = {
         # NSBezierPathElement key      desc

--- a/Tests/pens/cu2quPen_test.py
+++ b/Tests/pens/cu2quPen_test.py
@@ -12,20 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import sys
 import unittest
-
-from fontTools.pens.cu2quPen import Cu2QuPen, Cu2QuPointPen, Cu2QuMultiPen
-from fontTools.pens.recordingPen import RecordingPen, RecordingPointPen
-from fontTools.misc.loggingTools import CapturingLogHandler
 from textwrap import dedent
-import logging
+
 import pytest
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.pens.cu2quPen import Cu2QuMultiPen, Cu2QuPen, Cu2QuPointPen
+from fontTools.pens.recordingPen import RecordingPen, RecordingPointPen
 
 try:
-    from .utils import CUBIC_GLYPHS, QUAD_GLYPHS
-    from .utils import DummyGlyph, DummyPointGlyph
-    from .utils import DummyPen, DummyPointPen
+    from .utils import (
+        CUBIC_GLYPHS,
+        QUAD_GLYPHS,
+        DummyGlyph,
+        DummyPen,
+        DummyPointGlyph,
+        DummyPointPen,
+    )
 except ImportError as e:
     pytest.skip(str(e), allow_module_level=True)
 

--- a/Tests/pens/filterPen_test.py
+++ b/Tests/pens/filterPen_test.py
@@ -1,12 +1,11 @@
 import logging
 from types import MappingProxyType
 
+import pytest
 from fontTools.pens.basePen import MissingComponentError
 from fontTools.pens.filterPen import DecomposingFilterPen, DecomposingFilterPointPen
 from fontTools.pens.pointPen import PointToSegmentPen
 from fontTools.pens.recordingPen import RecordingPen, RecordingPointPen
-
-import pytest
 
 
 class SimpleGlyph:

--- a/Tests/pens/freetypePen_test.py
+++ b/Tests/pens/freetypePen_test.py
@@ -1,6 +1,6 @@
-import unittest
-import os
 import math
+import os
+import unittest
 
 try:
     from fontTools.pens.freetypePen import FreeTypePen
@@ -9,7 +9,7 @@ try:
 except ImportError:
     FREETYPE_PY_AVAILABLE = False
 
-from fontTools.misc.transform import Scale, Offset
+from fontTools.misc.transform import Offset, Scale
 
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
 

--- a/Tests/pens/hashPointPen_test.py
+++ b/Tests/pens/hashPointPen_test.py
@@ -1,6 +1,6 @@
+import pytest
 from fontTools.misc.transform import Identity
 from fontTools.pens.hashPointPen import HashPointPen
-import pytest
 
 
 class _TestGlyph(object):

--- a/Tests/pens/perimeterPen_test.py
+++ b/Tests/pens/perimeterPen_test.py
@@ -1,5 +1,6 @@
-from fontTools.pens.perimeterPen import PerimeterPen
 import unittest
+
+from fontTools.pens.perimeterPen import PerimeterPen
 
 
 def draw1_(pen):

--- a/Tests/pens/pointInsidePen_test.py
+++ b/Tests/pens/pointInsidePen_test.py
@@ -1,6 +1,7 @@
-from io import StringIO
-from fontTools.pens.pointInsidePen import PointInsidePen
 import unittest
+from io import StringIO
+
+from fontTools.pens.pointInsidePen import PointInsidePen
 
 
 class PointInsidePenTest(unittest.TestCase):

--- a/Tests/pens/pointPen_test.py
+++ b/Tests/pens/pointPen_test.py
@@ -3,10 +3,10 @@ import unittest
 from fontTools.pens.basePen import AbstractPen
 from fontTools.pens.pointPen import (
     AbstractPointPen,
-    PointToSegmentPen,
-    SegmentToPointPen,
     GuessSmoothPointPen,
+    PointToSegmentPen,
     ReverseContourPointPen,
+    SegmentToPointPen,
 )
 
 

--- a/Tests/pens/qu2cuPen_test.py
+++ b/Tests/pens/qu2cuPen_test.py
@@ -14,16 +14,14 @@
 
 import sys
 import unittest
+from textwrap import dedent
 
+import pytest
 from fontTools.pens.qu2cuPen import Qu2CuPen
 from fontTools.pens.recordingPen import RecordingPen
-from textwrap import dedent
-import pytest
 
 try:
-    from .utils import CUBIC_GLYPHS, QUAD_GLYPHS
-    from .utils import DummyGlyph
-    from .utils import DummyPen
+    from .utils import CUBIC_GLYPHS, QUAD_GLYPHS, DummyGlyph, DummyPen
 except ImportError as e:
     pytest.skip(str(e), allow_module_level=True)
 

--- a/Tests/pens/quartzPen_test.py
+++ b/Tests/pens/quartzPen_test.py
@@ -2,13 +2,14 @@ import unittest
 
 try:
     from fontTools.pens.quartzPen import QuartzPen
-
-    from Quartz.CoreGraphics import CGPathApply
-    from Quartz.CoreGraphics import kCGPathElementMoveToPoint
-    from Quartz.CoreGraphics import kCGPathElementAddLineToPoint
-    from Quartz.CoreGraphics import kCGPathElementAddQuadCurveToPoint
-    from Quartz.CoreGraphics import kCGPathElementAddCurveToPoint
-    from Quartz.CoreGraphics import kCGPathElementCloseSubpath
+    from Quartz.CoreGraphics import (
+        CGPathApply,
+        kCGPathElementAddCurveToPoint,
+        kCGPathElementAddLineToPoint,
+        kCGPathElementAddQuadCurveToPoint,
+        kCGPathElementCloseSubpath,
+        kCGPathElementMoveToPoint,
+    )
 
     PATH_ELEMENTS = {
         # CG constant key                    desc       num_points

--- a/Tests/pens/recordingPen_test.py
+++ b/Tests/pens/recordingPen_test.py
@@ -1,9 +1,9 @@
+import pytest
 from fontTools.pens.recordingPen import (
-    RecordingPen,
     DecomposingRecordingPen,
+    RecordingPen,
     RecordingPointPen,
 )
-import pytest
 
 
 class _TestGlyph(object):

--- a/Tests/pens/reverseContourPen_test.py
+++ b/Tests/pens/reverseContourPen_test.py
@@ -1,7 +1,6 @@
+import pytest
 from fontTools.pens.recordingPen import RecordingPen
 from fontTools.pens.reverseContourPen import ReverseContourPen
-import pytest
-
 
 TEST_DATA = [
     (
@@ -502,8 +501,8 @@ def test_reverse_pen_outputImpliedClosingLine():
 @pytest.mark.parametrize("contour, outputImpliedClosingLine, expected", TEST_DATA)
 def test_reverse_point_pen(contour, outputImpliedClosingLine, expected):
     from fontTools.pens.pointPen import (
-        ReverseContourPointPen,
         PointToSegmentPen,
+        ReverseContourPointPen,
         SegmentToPointPen,
     )
 

--- a/Tests/pens/roundingPen_test.py
+++ b/Tests/pens/roundingPen_test.py
@@ -1,8 +1,8 @@
+from functools import partial
+
 from fontTools.misc.fixedTools import floatToFixedToFloat
 from fontTools.pens.recordingPen import RecordingPen, RecordingPointPen
 from fontTools.pens.roundingPen import RoundingPen, RoundingPointPen
-from functools import partial
-
 
 tt_scale_round = partial(floatToFixedToFloat, precisionBits=14)
 

--- a/Tests/pens/t2CharStringPen_test.py
+++ b/Tests/pens/t2CharStringPen_test.py
@@ -1,5 +1,6 @@
-from fontTools.pens.t2CharStringPen import T2CharStringPen
 import unittest
+
+from fontTools.pens.t2CharStringPen import T2CharStringPen
 
 
 class T2CharStringPenTest(unittest.TestCase):

--- a/Tests/pens/ttGlyphPen_test.py
+++ b/Tests/pens/ttGlyphPen_test.py
@@ -1,12 +1,12 @@
 import os
-import pytest
 import struct
 
+import pytest
 from fontTools import ttLib
 from fontTools.misc.roundTools import noRound
 from fontTools.pens.basePen import PenError
 from fontTools.pens.recordingPen import RecordingPen, RecordingPointPen
-from fontTools.pens.ttGlyphPen import TTGlyphPen, TTGlyphPointPen, MAX_F2DOT14
+from fontTools.pens.ttGlyphPen import MAX_F2DOT14, TTGlyphPen, TTGlyphPointPen
 
 
 class TTGlyphPenTestBase:

--- a/Tests/pens/utils.py
+++ b/Tests/pens/utils.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from fontTools.pens.pointPen import PointToSegmentPen, SegmentToPointPen
-from fontTools.ufoLib.glifLib import GlyphSet
-from math import isclose
 import os
 import unittest
+from math import isclose
 
+from fontTools.pens.pointPen import PointToSegmentPen, SegmentToPointPen
+from fontTools.ufoLib.glifLib import GlyphSet
 
 DATADIR = os.path.join(os.path.dirname(__file__), "data")
 CUBIC_GLYPHS = GlyphSet(os.path.join(DATADIR, "cubic"))

--- a/Tests/qu2cu/qu2cu_cli_test.py
+++ b/Tests/qu2cu/qu2cu_cli_test.py
@@ -1,11 +1,9 @@
 import os
 
-import pytest
 import py
-
+import pytest
 from fontTools.qu2cu.cli import _main as main
 from fontTools.ttLib import TTFont
-
 
 DATADIR = os.path.join(os.path.dirname(__file__), "data")
 

--- a/Tests/qu2cu/qu2cu_test.py
+++ b/Tests/qu2cu/qu2cu_test.py
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import pytest
-
-from fontTools.qu2cu import quadratic_to_curves
-from fontTools.qu2cu.qu2cu import main as qu2cu_main
-from fontTools.qu2cu.benchmark import main as benchmark_main
-
-import os
 import json
+import os
+import unittest
+
+import pytest
 from fontTools.cu2qu import curve_to_quadratic
+from fontTools.qu2cu import quadratic_to_curves
+from fontTools.qu2cu.benchmark import main as benchmark_main
+from fontTools.qu2cu.qu2cu import main as qu2cu_main
 
 
 class Qu2CuTest:

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -1,24 +1,25 @@
-import io
-from fontTools.ttLib.tables._n_a_m_e import NameRecordVisitor
-import fontTools.ttLib.tables.otBase
-from fontTools.misc.testTools import getXML, stripVariableItemsFromTTX
-from fontTools.misc.textTools import tobytes, tostr
-from fontTools import subset
-from fontTools.fontBuilder import FontBuilder
-from fontTools.pens.ttGlyphPen import TTGlyphPen
-from fontTools.ttLib import TTFont, newTable
-from fontTools.ttLib.tables import otTables as ot
-from fontTools.misc.loggingTools import CapturingLogHandler
-from fontTools.subset.svg import etree
 import difflib
+import io
 import logging
 import os
+import pathlib
 import shutil
 import sys
 import tempfile
 import unittest
-import pathlib
+
+import fontTools.ttLib.tables.otBase
 import pytest
+from fontTools import subset
+from fontTools.fontBuilder import FontBuilder
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.misc.testTools import getXML, stripVariableItemsFromTTX
+from fontTools.misc.textTools import tobytes, tostr
+from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.subset.svg import etree
+from fontTools.ttLib import TTFont, newTable
+from fontTools.ttLib.tables import otTables as ot
+from fontTools.ttLib.tables._n_a_m_e import NameRecordVisitor
 
 
 class SubsetTest:

--- a/Tests/subset/svg_test.py
+++ b/Tests/subset/svg_test.py
@@ -1,14 +1,13 @@
-from string import ascii_letters
 import textwrap
-
-from fontTools.misc.testTools import getXML
-from fontTools import subset
-from fontTools.fontBuilder import FontBuilder
-from fontTools.pens.ttGlyphPen import TTGlyphPen
-from fontTools.ttLib import TTFont, newTable
-from fontTools.subset.svg import NAMESPACES, ranges
+from string import ascii_letters
 
 import pytest
+from fontTools import subset
+from fontTools.fontBuilder import FontBuilder
+from fontTools.misc.testTools import getXML
+from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.subset.svg import NAMESPACES, ranges
+from fontTools.ttLib import TTFont, newTable
 
 etree = pytest.importorskip("lxml.etree")
 

--- a/Tests/svgLib/path/parser_test.py
+++ b/Tests/svgLib/path/parser_test.py
@@ -1,7 +1,6 @@
+import pytest
 from fontTools.pens.recordingPen import RecordingPen
 from fontTools.svgLib import parse_path
-
-import pytest
 
 
 @pytest.mark.parametrize(

--- a/Tests/svgLib/path/path_test.py
+++ b/Tests/svgLib/path/path_test.py
@@ -1,10 +1,9 @@
-from fontTools.misc.textTools import tobytes
-from fontTools.pens.recordingPen import RecordingPen
-from fontTools.svgLib import SVGPath
-
 import os
 from tempfile import NamedTemporaryFile
 
+from fontTools.misc.textTools import tobytes
+from fontTools.pens.recordingPen import RecordingPen
+from fontTools.svgLib import SVGPath
 
 SVG_DATA = """\
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>

--- a/Tests/svgLib/path/shapes_test.py
+++ b/Tests/svgLib/path/shapes_test.py
@@ -1,6 +1,6 @@
-from fontTools.svgLib.path import shapes
-from fontTools.misc import etree
 import pytest
+from fontTools.misc import etree
+from fontTools.svgLib.path import shapes
 
 
 @pytest.mark.parametrize(

--- a/Tests/t1Lib/t1Lib_test.py
+++ b/Tests/t1Lib/t1Lib_test.py
@@ -1,11 +1,11 @@
-import unittest
 import os
-import sys
-from fontTools import t1Lib
-from fontTools.pens.basePen import NullPen
-from fontTools.misc.psCharStrings import T1CharString
 import random
+import sys
+import unittest
 
+from fontTools import t1Lib
+from fontTools.misc.psCharStrings import T1CharString
+from fontTools.pens.basePen import NullPen
 
 CWD = os.path.abspath(os.path.dirname(__file__))
 DATADIR = os.path.join(CWD, "data")

--- a/Tests/tfmLib/tfmLib_test.py
+++ b/Tests/tfmLib/tfmLib_test.py
@@ -2,7 +2,6 @@ import glob
 import os
 
 import pytest
-
 from fontTools import tfmLib
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")

--- a/Tests/ttLib/main_test.py
+++ b/Tests/ttLib/main_test.py
@@ -3,10 +3,8 @@ import sys
 import tempfile
 from pathlib import Path
 
-from fontTools.ttLib import __main__, TTFont, TTCollection
-
 import pytest
-
+from fontTools.ttLib import TTCollection, TTFont, __main__
 
 TEST_DATA = Path(__file__).parent / "data"
 

--- a/Tests/ttLib/removeOverlaps_test.py
+++ b/Tests/ttLib/removeOverlaps_test.py
@@ -1,11 +1,12 @@
 import logging
-import pytest
 from pathlib import Path
+
+import pytest
 
 pathops = pytest.importorskip("pathops")
 
 from fontTools.ttLib import TTFont
-from fontTools.ttLib.removeOverlaps import removeOverlaps, _simplify, _round_path
+from fontTools.ttLib.removeOverlaps import _round_path, _simplify, removeOverlaps
 
 DATA_DIR = Path(__file__).parent / "data"
 

--- a/Tests/ttLib/reorderGlyphs_test.py
+++ b/Tests/ttLib/reorderGlyphs_test.py
@@ -1,6 +1,6 @@
-import pytest
-
 from pathlib import Path
+
+import pytest
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.reorderGlyphs import reorderGlyphs
 

--- a/Tests/ttLib/scaleUpem_test.py
+++ b/Tests/ttLib/scaleUpem_test.py
@@ -1,13 +1,14 @@
-from fontTools.ttLib import TTFont
-from fontTools.ttLib.scaleUpem import scale_upem
-from io import BytesIO
 import difflib
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+from io import BytesIO
+
 import pytest
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.scaleUpem import scale_upem
 
 
 class ScaleUpemTest(unittest.TestCase):

--- a/Tests/ttLib/sfnt_test.py
+++ b/Tests/ttLib/sfnt_test.py
@@ -1,11 +1,12 @@
-import io
 import copy
+import io
 import pickle
 import tempfile
-from fontTools.ttLib import TTFont
-from fontTools.ttLib.sfnt import calcChecksum, SFNTReader, WOFFFlavorData
 from pathlib import Path
+
 import pytest
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.sfnt import SFNTReader, WOFFFlavorData, calcChecksum
 
 TEST_DATA = Path(__file__).parent / "data"
 

--- a/Tests/ttLib/tables/C_B_L_C_test.py
+++ b/Tests/ttLib/tables/C_B_L_C_test.py
@@ -5,7 +5,6 @@ import os
 from fontTools.misc.testTools import getXML
 from fontTools.ttLib import TTFont
 
-
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
 
 # This is a subset from NotoColorEmoji.ttf which contains an IndexTable format=3

--- a/Tests/ttLib/tables/C_F_F__2_test.py
+++ b/Tests/ttLib/tables/C_F_F__2_test.py
@@ -1,11 +1,11 @@
 """cff2Lib_test.py -- unit test for Adobe CFF fonts."""
 
-from fontTools.ttLib import TTFont
-from io import StringIO
-import re
 import os
+import re
 import unittest
+from io import StringIO
 
+from fontTools.ttLib import TTFont
 
 CURR_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 DATA_DIR = os.path.join(CURR_DIR, "data")

--- a/Tests/ttLib/tables/C_F_F_test.py
+++ b/Tests/ttLib/tables/C_F_F_test.py
@@ -1,11 +1,11 @@
 """cffLib_test.py -- unit test for Adobe CFF fonts."""
 
-from fontTools.ttLib import TTFont, newTable
-from io import StringIO
-import re
 import os
+import re
 import unittest
+from io import StringIO
 
+from fontTools.ttLib import TTFont, newTable
 
 CURR_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 DATA_DIR = os.path.join(CURR_DIR, "data")

--- a/Tests/ttLib/tables/C_O_L_R_test.py
+++ b/Tests/ttLib/tables/C_O_L_R_test.py
@@ -1,12 +1,11 @@
+import binascii
+from pathlib import Path
+
+import pytest
 from fontTools import ttLib
 from fontTools.misc.testTools import getXML, parseXML
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables.C_O_L_R_ import table_C_O_L_R_
-
-from pathlib import Path
-import binascii
-import pytest
-
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 

--- a/Tests/ttLib/tables/C_P_A_L_test.py
+++ b/Tests/ttLib/tables/C_P_A_L_test.py
@@ -1,8 +1,8 @@
+import unittest
+
 from fontTools.misc.testTools import getXML, parseXML
 from fontTools.misc.textTools import deHexStr
 from fontTools.ttLib import getTableModule, newTable
-import unittest
-
 
 CPAL_DATA_V0 = deHexStr(
     "0000 0002 "  # version=0, numPaletteEntries=2

--- a/Tests/ttLib/tables/D__e_b_g_test.py
+++ b/Tests/ttLib/tables/D__e_b_g_test.py
@@ -1,6 +1,5 @@
-from fontTools.misc.testTools import parseXmlInto, getXML
+from fontTools.misc.testTools import getXML, parseXmlInto
 from fontTools.ttLib.tables.D__e_b_g import table_D__e_b_g
-
 
 DEBG_DATA = {
     "com.github.fonttools.feaLib": {

--- a/Tests/ttLib/tables/M_V_A_R_test.py
+++ b/Tests/ttLib/tables/M_V_A_R_test.py
@@ -1,9 +1,9 @@
-from fontTools.misc.testTools import FakeFont, getXML, parseXML
-from fontTools.misc.textTools import deHexStr, hexStr
-from fontTools.ttLib.tables._f_v_a_r import Axis
-from fontTools.ttLib import newTable, TTFont
 import unittest
 
+from fontTools.misc.testTools import FakeFont, getXML, parseXML
+from fontTools.misc.textTools import deHexStr, hexStr
+from fontTools.ttLib import TTFont, newTable
+from fontTools.ttLib.tables._f_v_a_r import Axis
 
 MVAR_DATA = deHexStr(
     "0001 0000 "  # 0:   version=1.0

--- a/Tests/ttLib/tables/O_S_2f_2_test.py
+++ b/Tests/ttLib/tables/O_S_2f_2_test.py
@@ -1,6 +1,7 @@
-from fontTools.ttLib import TTFont, newTable, getTableModule
-from fontTools.ttLib.tables.O_S_2f_2 import *
 import unittest
+
+from fontTools.ttLib import TTFont, getTableModule, newTable
+from fontTools.ttLib.tables.O_S_2f_2 import *
 
 
 class OS2TableTest(unittest.TestCase):

--- a/Tests/ttLib/tables/S_T_A_T_test.py
+++ b/Tests/ttLib/tables/S_T_A_T_test.py
@@ -1,8 +1,8 @@
+import unittest
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr
 from fontTools.ttLib import newTable
-import unittest
-
 
 STAT_DATA = deHexStr(
     "0001 0000 "  #   0: Version=1.0

--- a/Tests/ttLib/tables/S_V_G__test.py
+++ b/Tests/ttLib/tables/S_V_G__test.py
@@ -2,12 +2,11 @@ import gzip
 import io
 import struct
 
+import pytest
 from fontTools.misc import etree
 from fontTools.misc.testTools import getXML, parseXML
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables.S_V_G_ import table_S_V_G_
-
-import pytest
 
 
 def dump(table, ttFont=None):

--- a/Tests/ttLib/tables/T_S_I__1_test.py
+++ b/Tests/ttLib/tables/T_S_I__1_test.py
@@ -1,10 +1,9 @@
+import pytest
 from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.misc.textTools import tobytes
 from fontTools.ttLib import TTFont, TTLibError
 from fontTools.ttLib.tables.T_S_I__0 import table_T_S_I__0
 from fontTools.ttLib.tables.T_S_I__1 import table_T_S_I__1
-import pytest
-
 
 TSI1_DATA = b"""abcdefghijklmnopqrstuvxywz0123456789"""
 TSI1_UTF8_DATA = b"""abcd\xc3\xa9ghijklmnopqrstuvxywz0123456789"""

--- a/Tests/ttLib/tables/TupleVariation_test.py
+++ b/Tests/ttLib/tables/TupleVariation_test.py
@@ -1,19 +1,20 @@
+import random
+import unittest
+from io import BytesIO
+
 from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.misc.testTools import parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.misc.xmlWriter import XMLWriter
 from fontTools.ttLib.tables.TupleVariation import (
-    log,
     TupleVariation,
     compileSharedTuples,
-    decompileSharedTuples,
     compileTupleVariationStore,
+    decompileSharedTuples,
     decompileTupleVariationStore,
     inferRegion_,
+    log,
 )
-from io import BytesIO
-import random
-import unittest
 
 
 def hexencode(s):

--- a/Tests/ttLib/tables/V_A_R_C_test.py
+++ b/Tests/ttLib/tables/V_A_R_C_test.py
@@ -1,8 +1,9 @@
-from fontTools.ttLib import TTFont
-from io import StringIO, BytesIO
-import pytest
 import os
 import unittest
+from io import BytesIO, StringIO
+
+import pytest
+from fontTools.ttLib import TTFont
 
 CURR_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 DATA_DIR = os.path.join(CURR_DIR, "data")

--- a/Tests/ttLib/tables/_a_n_k_r_test.py
+++ b/Tests/ttLib/tables/_a_n_k_r_test.py
@@ -1,9 +1,9 @@
 # coding: utf-8
+import unittest
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import newTable
-import unittest
-
 
 # This is the anchor points table of the first font file in
 # “/Library/Fonts/Devanagari Sangam MN.ttc” on macOS 10.12.6.

--- a/Tests/ttLib/tables/_a_v_a_r_test.py
+++ b/Tests/ttLib/tables/_a_v_a_r_test.py
@@ -1,18 +1,18 @@
+import os
+import unittest
+from io import BytesIO
+
+import fontTools.ttLib.tables.otTables as otTables
+import fontTools.varLib.models as models
+import fontTools.varLib.varStore as varStore
+from fontTools.misc.fixedTools import floatToFixed as fl2fi
 from fontTools.misc.testTools import parseXML
 from fontTools.misc.textTools import deHexStr
 from fontTools.misc.xmlWriter import XMLWriter
-from fontTools.misc.fixedTools import floatToFixed as fl2fi
 from fontTools.pens.statisticsPen import StatisticsPen
 from fontTools.ttLib import TTFont, TTLibError
-import fontTools.ttLib.tables.otTables as otTables
 from fontTools.ttLib.tables._a_v_a_r import table__a_v_a_r
-from fontTools.ttLib.tables._f_v_a_r import table__f_v_a_r, Axis
-import fontTools.varLib.models as models
-import fontTools.varLib.varStore as varStore
-from io import BytesIO
-import os
-import unittest
-
+from fontTools.ttLib.tables._f_v_a_r import Axis, table__f_v_a_r
 
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
 

--- a/Tests/ttLib/tables/_b_s_l_n_test.py
+++ b/Tests/ttLib/tables/_b_s_l_n_test.py
@@ -1,8 +1,8 @@
+import unittest
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import newTable
-import unittest
-
 
 # Apple's spec of the baseline table gives no example for 'bsln' format 0,
 # but the Apple Chancery font contains the following data.

--- a/Tests/ttLib/tables/_c_i_d_g_test.py
+++ b/Tests/ttLib/tables/_c_i_d_g_test.py
@@ -1,8 +1,8 @@
+import unittest
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import newTable
-import unittest
-
 
 # On macOS X 10.12.6, the first font in /System/Library/Fonts/PingFang.ttc
 # has a ‘cidg’ table with a similar structure as this test data, just larger.

--- a/Tests/ttLib/tables/_c_m_a_p_test.py
+++ b/Tests/ttLib/tables/_c_m_a_p_test.py
@@ -1,9 +1,10 @@
 import io
 import os
 import re
+import unittest
+
 from fontTools import ttLib
 from fontTools.fontBuilder import FontBuilder
-import unittest
 from fontTools.ttLib.tables._c_m_a_p import CmapSubtable, table__c_m_a_p
 
 CURR_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))

--- a/Tests/ttLib/tables/_c_v_a_r_test.py
+++ b/Tests/ttLib/tables/_c_v_a_r_test.py
@@ -1,10 +1,9 @@
+import unittest
+
 from fontTools.misc.testTools import getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import TTLibError, getTableModule, newTable
 from fontTools.ttLib.tables.TupleVariation import TupleVariation
-
-import unittest
-
 
 CVAR_DATA = deHexStr(
     "0001 0000 "  #  0: majorVersion=1 minorVersion=0

--- a/Tests/ttLib/tables/_f_v_a_r_test.py
+++ b/Tests/ttLib/tables/_f_v_a_r_test.py
@@ -1,12 +1,12 @@
+import unittest
+from io import BytesIO
+
 from fontTools.misc.testTools import parseXML
 from fontTools.misc.textTools import deHexStr
 from fontTools.misc.xmlWriter import XMLWriter
 from fontTools.ttLib import TTLibError
-from fontTools.ttLib.tables._f_v_a_r import table__f_v_a_r, Axis, NamedInstance
-from fontTools.ttLib.tables._n_a_m_e import table__n_a_m_e, NameRecord
-from io import BytesIO
-import unittest
-
+from fontTools.ttLib.tables._f_v_a_r import Axis, NamedInstance, table__f_v_a_r
+from fontTools.ttLib.tables._n_a_m_e import NameRecord, table__n_a_m_e
 
 FVAR_DATA = deHexStr(
     "00 01 00 00 00 10 00 02 00 02 00 14 00 02 00 0C "

--- a/Tests/ttLib/tables/_g_c_i_d_test.py
+++ b/Tests/ttLib/tables/_g_c_i_d_test.py
@@ -1,8 +1,8 @@
+import unittest
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import newTable
-import unittest
-
 
 # On macOS X 10.12.3, the font /Library/Fonts/AppleGothic.ttf has a ‘gcid’
 # table with a similar structure as this test data, just more CIDs.

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -1,35 +1,36 @@
+import array
+import itertools
+import os
+import re
+import sys
+import unittest
+from copy import deepcopy
+from io import BytesIO, StringIO
+
+import pytest
 from fontTools.misc.fixedTools import otRound
 from fontTools.misc.roundTools import noRound
 from fontTools.misc.testTools import getXML, parseXML
 from fontTools.misc.transform import Transform
-from fontTools.pens.ttGlyphPen import TTGlyphPen
-from fontTools.pens.recordingPen import RecordingPen, RecordingPointPen
 from fontTools.pens.pointPen import PointToSegmentPen
-from fontTools.ttLib import TTFont, newTable, TTLibError
+from fontTools.pens.recordingPen import RecordingPen, RecordingPointPen
+from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.ttLib import TTFont, TTLibError, newTable
+from fontTools.ttLib.tables import ttProgram
 from fontTools.ttLib.tables._g_l_y_f import (
-    Glyph,
-    GlyphCoordinates,
-    GlyphComponent,
-    dropImpliedOnCurvePoints,
-    flagOnCurve,
-    flagCubic,
     ARGS_ARE_XY_VALUES,
     SCALED_COMPONENT_OFFSET,
     UNSCALED_COMPONENT_OFFSET,
     WE_HAVE_A_SCALE,
     WE_HAVE_A_TWO_BY_TWO,
     WE_HAVE_AN_X_AND_Y_SCALE,
+    Glyph,
+    GlyphComponent,
+    GlyphCoordinates,
+    dropImpliedOnCurvePoints,
+    flagCubic,
+    flagOnCurve,
 )
-from fontTools.ttLib.tables import ttProgram
-import sys
-import array
-from copy import deepcopy
-from io import StringIO, BytesIO
-import itertools
-import pytest
-import re
-import os
-import unittest
 
 
 class GlyphCoordinatesTest(object):

--- a/Tests/ttLib/tables/_g_v_a_r_test.py
+++ b/Tests/ttLib/tables/_g_v_a_r_test.py
@@ -1,9 +1,9 @@
+import unittest
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import TTLibError, getTableClass, getTableModule, newTable
-import unittest
 from fontTools.ttLib.tables.TupleVariation import TupleVariation
-
 
 gvarClass = getTableClass("gvar")
 

--- a/Tests/ttLib/tables/_h_h_e_a_test.py
+++ b/Tests/ttLib/tables/_h_h_e_a_test.py
@@ -1,11 +1,11 @@
-from fontTools.misc.loggingTools import CapturingLogHandler
-from fontTools.misc.testTools import parseXML, getXML
-from fontTools.misc.textTools import deHexStr
-from fontTools.ttLib import TTFont, newTable
-from fontTools.misc.fixedTools import log
 import os
 import unittest
 
+from fontTools.misc.fixedTools import log
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.misc.testTools import getXML, parseXML
+from fontTools.misc.textTools import deHexStr
+from fontTools.ttLib import TTFont, newTable
 
 CURR_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 DATA_DIR = os.path.join(CURR_DIR, "data")

--- a/Tests/ttLib/tables/_h_m_t_x_test.py
+++ b/Tests/ttLib/tables/_h_m_t_x_test.py
@@ -1,10 +1,11 @@
-from fontTools.misc.testTools import parseXML, getXML
-from fontTools.misc.textTools import deHexStr
-from fontTools.ttLib import TTFont, newTable, TTLibError
-from fontTools.misc.loggingTools import CapturingLogHandler
-from fontTools.ttLib.tables._h_m_t_x import table__h_m_t_x, log
 import struct
 import unittest
+
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.misc.testTools import getXML, parseXML
+from fontTools.misc.textTools import deHexStr
+from fontTools.ttLib import TTFont, TTLibError, newTable
+from fontTools.ttLib.tables._h_m_t_x import log, table__h_m_t_x
 
 
 class HmtxTableTest(unittest.TestCase):

--- a/Tests/ttLib/tables/_k_e_r_n_test.py
+++ b/Tests/ttLib/tables/_k_e_r_n_test.py
@@ -1,10 +1,10 @@
+import itertools
+
+import pytest
+from fontTools.misc.testTools import FakeFont, getXML, parseXML
+from fontTools.misc.textTools import deHexStr
 from fontTools.ttLib import newTable
 from fontTools.ttLib.tables._k_e_r_n import KernTable_format_0, KernTable_format_unkown
-from fontTools.misc.textTools import deHexStr
-from fontTools.misc.testTools import FakeFont, getXML, parseXML
-import itertools
-import pytest
-
 
 KERN_VER_0_FMT_0_DATA = deHexStr(
     "0000 "  #  0: version=0
@@ -375,8 +375,8 @@ class KernTable_format_0_Test(object):
             + b"\x01"
             + b"\x00"
             + b"\x01"
-            + b"\xFF"
-            + b"\xFF"
+            + b"\xff"
+            + b"\xff"
             + b"\x00"
             + b"\x02",
             font,

--- a/Tests/ttLib/tables/_l_c_a_r_test.py
+++ b/Tests/ttLib/tables/_l_c_a_r_test.py
@@ -1,8 +1,8 @@
+import unittest
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import newTable
-import unittest
-
 
 # Example: Format 0 Ligature Caret Table
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6lcar.html

--- a/Tests/ttLib/tables/_l_t_a_g_test.py
+++ b/Tests/ttLib/tables/_l_t_a_g_test.py
@@ -1,8 +1,9 @@
-from fontTools.misc.testTools import parseXML
-from fontTools.misc.xmlWriter import XMLWriter
-from io import BytesIO
 import struct
 import unittest
+from io import BytesIO
+
+from fontTools.misc.testTools import parseXML
+from fontTools.misc.xmlWriter import XMLWriter
 from fontTools.ttLib import newTable
 
 

--- a/Tests/ttLib/tables/_m_e_t_a_test.py
+++ b/Tests/ttLib/tables/_m_e_t_a_test.py
@@ -1,11 +1,11 @@
+import unittest
+from io import BytesIO
+
 from fontTools.misc.testTools import parseXML
 from fontTools.misc.textTools import deHexStr
 from fontTools.misc.xmlWriter import XMLWriter
 from fontTools.ttLib import TTLibError
 from fontTools.ttLib.tables._m_e_t_a import table__m_e_t_a
-from io import BytesIO
-import unittest
-
 
 # From a real font on MacOS X, but substituted 'bild' tag by 'TEST',
 # and shortened the payload.
@@ -30,11 +30,11 @@ class MetaTableTest(unittest.TestCase):
     def test_decompile(self):
         table = table__m_e_t_a()
         table.decompile(META_DATA, ttFont={"meta": table})
-        self.assertEqual({"TEST": b"\xCA\xFE\xBE\xEF"}, table.data)
+        self.assertEqual({"TEST": b"\xca\xfe\xbe\xef"}, table.data)
 
     def test_compile(self):
         table = table__m_e_t_a()
-        table.data["TEST"] = b"\xCA\xFE\xBE\xEF"
+        table.data["TEST"] = b"\xca\xfe\xbe\xef"
         self.assertEqual(META_DATA, table.compile(ttFont={"meta": table}))
 
     def test_decompile_text(self):
@@ -52,7 +52,7 @@ class MetaTableTest(unittest.TestCase):
 
     def test_toXML(self):
         table = table__m_e_t_a()
-        table.data["TEST"] = b"\xCA\xFE\xBE\xEF"
+        table.data["TEST"] = b"\xca\xfe\xbe\xef"
         writer = XMLWriter(BytesIO())
         table.toXML(writer, {"meta": table})
         xml = writer.file.getvalue().decode("utf-8")
@@ -83,7 +83,7 @@ class MetaTableTest(unittest.TestCase):
             '<hexdata tag="TEST">' "    cafebeef" "</hexdata>"
         ):
             table.fromXML(name, attrs, content, ttFont=None)
-        self.assertEqual({"TEST": b"\xCA\xFE\xBE\xEF"}, table.data)
+        self.assertEqual({"TEST": b"\xca\xfe\xbe\xef"}, table.data)
 
     def test_toXML_text(self):
         table = table__m_e_t_a()

--- a/Tests/ttLib/tables/_m_o_r_t_test.py
+++ b/Tests/ttLib/tables/_m_o_r_t_test.py
@@ -1,8 +1,8 @@
+import unittest
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import newTable
-import unittest
-
 
 # Glyph Metamorphosis Table Examples
 # Example 1: Non-contextual Glyph Substitution

--- a/Tests/ttLib/tables/_m_o_r_x_test.py
+++ b/Tests/ttLib/tables/_m_o_r_x_test.py
@@ -1,8 +1,8 @@
+import unittest
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import bytechr, bytesjoin, deHexStr, hexStr
 from fontTools.ttLib import newTable
-import unittest
-
 
 # A simple 'morx' table with non-contextual glyph substitution.
 # Unfortunately, the Apple spec for 'morx' does not contain a complete example.

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -1,19 +1,20 @@
+import struct
+import unittest
+from io import BytesIO
+
 from fontTools.misc import sstruct
 from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.misc.testTools import FakeFont
-from fontTools.misc.textTools import bytesjoin, tostr, Tag
+from fontTools.misc.textTools import Tag, bytesjoin, tostr
 from fontTools.misc.xmlWriter import XMLWriter
-from io import BytesIO
-import struct
-import unittest
 from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables._n_a_m_e import (
-    table__n_a_m_e,
     NameRecord,
+    log,
+    makeName,
     nameRecordFormat,
     nameRecordSize,
-    makeName,
-    log,
+    table__n_a_m_e,
 )
 
 

--- a/Tests/ttLib/tables/_o_p_b_d_test.py
+++ b/Tests/ttLib/tables/_o_p_b_d_test.py
@@ -1,8 +1,8 @@
+import unittest
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import newTable
-import unittest
-
 
 # Example: Format 0 Optical Bounds Table
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6opbd.html

--- a/Tests/ttLib/tables/_p_r_o_p_test.py
+++ b/Tests/ttLib/tables/_p_r_o_p_test.py
@@ -1,8 +1,8 @@
+import unittest
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import newTable
-import unittest
-
 
 PROP_FORMAT_0_DATA = deHexStr(
     "0001 0000 0000 "  #  0: Version=1.0, Format=0

--- a/Tests/ttLib/tables/_t_r_a_k_test.py
+++ b/Tests/ttLib/tables/_t_r_a_k_test.py
@@ -1,10 +1,10 @@
-from fontTools.misc.testTools import parseXML, getXML
-from fontTools.misc.textTools import deHexStr
-from fontTools.ttLib import TTFont, TTLibError
-from fontTools.ttLib.tables._t_r_a_k import *
-from fontTools.ttLib.tables._n_a_m_e import table__n_a_m_e, NameRecord
 import unittest
 
+from fontTools.misc.testTools import getXML, parseXML
+from fontTools.misc.textTools import deHexStr
+from fontTools.ttLib import TTFont, TTLibError
+from fontTools.ttLib.tables._n_a_m_e import NameRecord, table__n_a_m_e
+from fontTools.ttLib.tables._t_r_a_k import *
 
 # /Library/Fonts/Osaka.ttf from OSX has trak table with both horiz and vertData
 OSAKA_TRAK_TABLE_DATA = deHexStr(

--- a/Tests/ttLib/tables/_v_h_e_a_test.py
+++ b/Tests/ttLib/tables/_v_h_e_a_test.py
@@ -1,11 +1,11 @@
-from fontTools.misc.loggingTools import CapturingLogHandler
-from fontTools.misc.testTools import parseXML, getXML
-from fontTools.misc.textTools import deHexStr
-from fontTools.ttLib import TTFont, newTable
-from fontTools.misc.fixedTools import log
 import os
 import unittest
 
+from fontTools.misc.fixedTools import log
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.misc.testTools import getXML, parseXML
+from fontTools.misc.textTools import deHexStr
+from fontTools.ttLib import TTFont, newTable
 
 CURR_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 DATA_DIR = os.path.join(CURR_DIR, "data")

--- a/Tests/ttLib/tables/_v_m_t_x_test.py
+++ b/Tests/ttLib/tables/_v_m_t_x_test.py
@@ -1,6 +1,7 @@
-from fontTools.ttLib.tables._v_m_t_x import table__v_m_t_x
-import _h_m_t_x_test
 import unittest
+
+import _h_m_t_x_test
+from fontTools.ttLib.tables._v_m_t_x import table__v_m_t_x
 
 
 class VmtxTableTest(_h_m_t_x_test.HmtxTableTest):

--- a/Tests/ttLib/tables/otBase_test.py
+++ b/Tests/ttLib/tables/otBase_test.py
@@ -1,6 +1,7 @@
+import unittest
+
 from fontTools.misc.textTools import deHexStr
 from fontTools.ttLib.tables.otBase import OTTableReader, OTTableWriter
-import unittest
 
 
 class OTTableReaderTest(unittest.TestCase):

--- a/Tests/ttLib/tables/otConverters_test.py
+++ b/Tests/ttLib/tables/otConverters_test.py
@@ -1,10 +1,11 @@
+import unittest
+
+import fontTools.ttLib.tables.otConverters as otConverters
 from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.misc.testTools import FakeFont, makeXMLWriter
 from fontTools.misc.textTools import deHexStr
-import fontTools.ttLib.tables.otConverters as otConverters
 from fontTools.ttLib import newTable
 from fontTools.ttLib.tables.otBase import OTTableReader, OTTableWriter
-import unittest
 
 
 class Char64Test(unittest.TestCase):
@@ -17,7 +18,7 @@ class Char64Test(unittest.TestCase):
         self.assertEqual(reader.pos, 64)
 
     def test_read_replace_not_ascii(self):
-        reader = OTTableReader(b"Hello \xE4 world" + 100 * b"\0")
+        reader = OTTableReader(b"Hello \xe4 world" + 100 * b"\0")
         with CapturingLogHandler(otConverters.log, "WARNING") as captor:
             data = self.converter.read(reader, self.font, {})
         self.assertEqual(data, "Hello � world")

--- a/Tests/ttLib/tables/otTables_test.py
+++ b/Tests/ttLib/tables/otTables_test.py
@@ -1,11 +1,12 @@
-from fontTools.misc.testTools import getXML, parseXML, parseXmlInto, FakeFont
+import unittest
+from io import StringIO
+from textwrap import dedent
+
+import fontTools.ttLib.tables.otTables as otTables
+from fontTools.misc.testTools import FakeFont, getXML, parseXML, parseXmlInto
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.misc.xmlWriter import XMLWriter
 from fontTools.ttLib.tables.otBase import OTTableReader, OTTableWriter
-import fontTools.ttLib.tables.otTables as otTables
-from io import StringIO
-from textwrap import dedent
-import unittest
 
 
 def makeCoverage(glyphs):

--- a/Tests/ttLib/tables/tables_test.py
+++ b/Tests/ttLib/tables/tables_test.py
@@ -1,10 +1,11 @@
-from fontTools.ttLib import TTFont, tagToXML
-from io import StringIO
-import os
-import sys
-import re
 import contextlib
+import os
+import re
+import sys
+from io import StringIO
+
 import pytest
+from fontTools.ttLib import TTFont, tagToXML
 
 try:
     import unicodedata2

--- a/Tests/ttLib/tables/ttProgram_test.py
+++ b/Tests/ttLib/tables/ttProgram_test.py
@@ -1,10 +1,11 @@
-from fontTools.misc.xmlWriter import XMLWriter
-from fontTools.ttLib.tables.ttProgram import Program
-from fontTools.misc.textTools import deHexStr
 import array
-from io import StringIO
 import os
 import unittest
+from io import StringIO
+
+from fontTools.misc.textTools import deHexStr
+from fontTools.misc.xmlWriter import XMLWriter
+from fontTools.ttLib.tables.ttProgram import Program
 
 CURR_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 DATA_DIR = os.path.join(CURR_DIR, "data")

--- a/Tests/ttLib/ttCollection_test.py
+++ b/Tests/ttLib/ttCollection_test.py
@@ -1,7 +1,8 @@
 import os
 from pathlib import Path
-from fontTools.ttLib import TTCollection
+
 import pytest
+from fontTools.ttLib import TTCollection
 
 TTX_DATA_DIR = Path(__file__).parent.parent / "ttx" / "data"
 

--- a/Tests/ttLib/ttFont_test.py
+++ b/Tests/ttLib/ttFont_test.py
@@ -1,8 +1,10 @@
 import io
 import os
-import re
 import random
+import re
 import tempfile
+
+import pytest
 from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
 from fontTools.ttLib import (
     TTFont,
@@ -12,10 +14,8 @@ from fontTools.ttLib import (
     unregisterCustomTableClass,
 )
 from fontTools.ttLib.standardGlyphOrder import standardGlyphOrder
-from fontTools.ttLib.tables.DefaultTable import DefaultTable
 from fontTools.ttLib.tables._c_m_a_p import CmapSubtable
-import pytest
-
+from fontTools.ttLib.tables.DefaultTable import DefaultTable
 
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
 

--- a/Tests/ttLib/ttGlyphSet_test.py
+++ b/Tests/ttLib/ttGlyphSet_test.py
@@ -1,15 +1,15 @@
-from fontTools.ttLib import TTFont
-from fontTools.ttLib import ttGlyphSet
-from fontTools.ttLib.ttGlyphSet import LerpGlyphSet
-from fontTools.pens.recordingPen import (
-    RecordingPen,
-    RecordingPointPen,
-    DecomposingRecordingPen,
-)
+import os
+
+import pytest
 from fontTools.misc.roundTools import otRound
 from fontTools.misc.transform import DecomposedTransform
-import os
-import pytest
+from fontTools.pens.recordingPen import (
+    DecomposingRecordingPen,
+    RecordingPen,
+    RecordingPointPen,
+)
+from fontTools.ttLib import TTFont, ttGlyphSet
+from fontTools.ttLib.ttGlyphSet import LerpGlyphSet
 
 
 class TTGlyphSetTest(object):

--- a/Tests/ttLib/ttVisitor_test.py
+++ b/Tests/ttLib/ttVisitor_test.py
@@ -1,7 +1,8 @@
+import os
+
+import pytest
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.ttVisitor import TTVisitor
-import os
-import pytest
 
 
 class TestVisitor(TTVisitor):

--- a/Tests/ttLib/woff2_test.py
+++ b/Tests/ttLib/woff2_test.py
@@ -1,42 +1,42 @@
-from fontTools import ttLib
+import copy
+import os
+import random
+import struct
+import unittest
+from collections import OrderedDict
+from functools import partial
+from io import BytesIO
+
+import pytest
+from fontTools import fontBuilder, ttLib
+from fontTools.misc import sstruct
+from fontTools.misc.textTools import Tag, bytechr, byteord
+from fontTools.pens.recordingPen import RecordingPen
+from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib import woff2
 from fontTools.ttLib.tables import _g_l_y_f
 from fontTools.ttLib.woff2 import (
-    WOFF2Reader,
-    woff2DirectorySize,
-    woff2DirectoryFormat,
-    woff2FlagsSize,
-    woff2UnknownTagSize,
-    woff2Base128MaxSize,
     WOFF2DirectoryEntry,
-    getKnownTagIndex,
-    packBase128,
-    base128Size,
-    woff2UnknownTagIndex,
     WOFF2FlavorData,
-    woff2TransformedTableTags,
     WOFF2GlyfTable,
-    WOFF2LocaTable,
     WOFF2HmtxTable,
+    WOFF2LocaTable,
+    WOFF2Reader,
     WOFF2Writer,
-    unpackBase128,
-    unpack255UShort,
+    base128Size,
+    getKnownTagIndex,
     pack255UShort,
+    packBase128,
+    unpack255UShort,
+    unpackBase128,
+    woff2Base128MaxSize,
+    woff2DirectoryFormat,
+    woff2DirectorySize,
+    woff2FlagsSize,
+    woff2TransformedTableTags,
+    woff2UnknownTagIndex,
+    woff2UnknownTagSize,
 )
-import unittest
-from fontTools.misc import sstruct
-from fontTools.misc.textTools import Tag, bytechr, byteord
-from fontTools import fontBuilder
-from fontTools.pens.ttGlyphPen import TTGlyphPen
-from fontTools.pens.recordingPen import RecordingPen
-from io import BytesIO
-import struct
-import os
-import random
-import copy
-from collections import OrderedDict
-from functools import partial
-import pytest
 
 haveBrotli = False
 try:
@@ -1167,7 +1167,7 @@ class WOFF2HmtxTableTest(object):
         with pytest.raises(
             ttLib.TTLibError, match="Bits 2-7 of 'hmtx' flags are reserved"
         ):
-            hmtxTable.reconstruct(b"\xFF", ttFont=None)
+            hmtxTable.reconstruct(b"\xff", ttFont=None)
 
     def test_reconstruct_flags_required_bits(self):
         hmtxTable = WOFF2HmtxTable()

--- a/Tests/ttx/ttx_test.py
+++ b/Tests/ttx/ttx_test.py
@@ -1,8 +1,3 @@
-from fontTools.misc.testTools import parseXML
-from fontTools.misc.timeTools import timestampSinceEpoch
-from fontTools.ttLib import TTFont, TTLibError
-from fontTools.ttLib.tables.DefaultTable import DefaultTable
-from fontTools import ttx
 import base64
 import getopt
 import logging
@@ -15,6 +10,11 @@ import unittest
 from pathlib import Path
 
 import pytest
+from fontTools import ttx
+from fontTools.misc.testTools import parseXML
+from fontTools.misc.timeTools import timestampSinceEpoch
+from fontTools.ttLib import TTFont, TTLibError
+from fontTools.ttLib.tables.DefaultTable import DefaultTable
 
 try:
     import zopfli

--- a/Tests/ufoLib/GLIF1_test.py
+++ b/Tests/ufoLib/GLIF1_test.py
@@ -1,11 +1,13 @@
 import unittest
+from itertools import islice
+
 from fontTools.ufoLib.glifLib import (
     GlifLibError,
     readGlyphFromString,
     writeGlyphToString,
 )
+
 from .testSupport import Glyph, stripText
-from itertools import islice
 
 # ----------
 # Test Cases
@@ -320,7 +322,7 @@ class TestGLIF1(unittest.TestCase):
         glif = """
 		<glyph name="a" format="1">
 			<note>
-				\U0001F4A9
+				\U0001f4a9
 			</note>
 			<outline>
 			</outline>

--- a/Tests/ufoLib/GLIF2_test.py
+++ b/Tests/ufoLib/GLIF2_test.py
@@ -1,11 +1,13 @@
 import unittest
+from itertools import islice
+
 from fontTools.ufoLib.glifLib import (
     GlifLibError,
     readGlyphFromString,
     writeGlyphToString,
 )
+
 from .testSupport import Glyph, stripText
-from itertools import islice
 
 # ----------
 # Test Cases

--- a/Tests/ufoLib/UFO1_test.py
+++ b/Tests/ufoLib/UFO1_test.py
@@ -1,10 +1,11 @@
 import os
 import shutil
-import unittest
 import tempfile
+import unittest
 from io import open
-from fontTools.ufoLib import UFOReader, UFOWriter, UFOLibError
-from fontTools.ufoLib import plistlib
+
+from fontTools.ufoLib import UFOLibError, UFOReader, UFOWriter, plistlib
+
 from .testSupport import fontInfoVersion1, fontInfoVersion2
 
 

--- a/Tests/ufoLib/UFO2_test.py
+++ b/Tests/ufoLib/UFO2_test.py
@@ -1,10 +1,11 @@
 import os
 import shutil
-import unittest
 import tempfile
+import unittest
 from io import open
-from fontTools.ufoLib import UFOReader, UFOWriter, UFOLibError
-from fontTools.ufoLib import plistlib
+
+from fontTools.ufoLib import UFOLibError, UFOReader, UFOWriter, plistlib
+
 from .testSupport import fontInfoVersion2
 
 

--- a/Tests/ufoLib/UFO3_test.py
+++ b/Tests/ufoLib/UFO3_test.py
@@ -1,11 +1,13 @@
 import os
 import shutil
-import unittest
 import tempfile
+import unittest
 from io import open
-from fontTools.ufoLib import UFOReader, UFOWriter, UFOLibError
-from fontTools.ufoLib.glifLib import GlifLibError
+
 from fontTools.misc import plistlib
+from fontTools.ufoLib import UFOLibError, UFOReader, UFOWriter
+from fontTools.ufoLib.glifLib import GlifLibError
+
 from .testSupport import fontInfoVersion3
 
 

--- a/Tests/ufoLib/UFOConversion_test.py
+++ b/Tests/ufoLib/UFOConversion_test.py
@@ -1,12 +1,12 @@
 import os
 import shutil
-import unittest
 import tempfile
+import unittest
 from io import open
-from fontTools.ufoLib import UFOReader, UFOWriter
-from fontTools.ufoLib import plistlib
-from .testSupport import expectedFontInfo1To2Conversion, expectedFontInfo2To1Conversion
 
+from fontTools.ufoLib import UFOReader, UFOWriter, plistlib
+
+from .testSupport import expectedFontInfo1To2Conversion, expectedFontInfo2To1Conversion
 
 # the format version 1 lib.plist contains some data
 # that these tests shouldn't be concerned about.

--- a/Tests/ufoLib/UFOZ_test.py
+++ b/Tests/ufoLib/UFOZ_test.py
@@ -1,16 +1,16 @@
-from fontTools.ufoLib import UFOReader, UFOWriter, UFOFileStructure
-from fontTools.ufoLib.errors import UFOLibError, GlifLibError
-from fontTools.misc import plistlib
-from fontTools.misc.textTools import tostr
-import sys
 import os
-import fs.osfs
-import fs.tempfs
-import fs.memoryfs
-import fs.copy
-import pytest
+import sys
 import warnings
 
+import fs.copy
+import fs.memoryfs
+import fs.osfs
+import fs.tempfs
+import pytest
+from fontTools.misc import plistlib
+from fontTools.misc.textTools import tostr
+from fontTools.ufoLib import UFOFileStructure, UFOReader, UFOWriter
+from fontTools.ufoLib.errors import GlifLibError, UFOLibError
 
 TESTDATA = fs.osfs.OSFS(os.path.join(os.path.dirname(__file__), "testdata"))
 TEST_UFO3 = "TestFont1 (UFO3).ufo"

--- a/Tests/ufoLib/filenames_test.py
+++ b/Tests/ufoLib/filenames_test.py
@@ -1,5 +1,6 @@
 import unittest
-from fontTools.ufoLib.filenames import userNameToFileName, handleClash1, handleClash2
+
+from fontTools.ufoLib.filenames import handleClash1, handleClash2, userNameToFileName
 
 
 class TestFilenames(unittest.TestCase):

--- a/Tests/ufoLib/glifLib_test.py
+++ b/Tests/ufoLib/glifLib_test.py
@@ -1,25 +1,27 @@
 import logging
 import os
-import tempfile
 import shutil
+import tempfile
 import unittest
-from pathlib import Path
 from io import open
-from .testSupport import getDemoFontGlyphSetPath
+from pathlib import Path
+
+import pytest
+from fontTools.misc.etree import XML_DECLARATION
+from fontTools.pens.recordingPen import RecordingPointPen
+from fontTools.ufoLib.errors import (
+    GlifLibError,
+    UnsupportedGLIFFormat,
+    UnsupportedUFOFormat,
+)
 from fontTools.ufoLib.glifLib import (
     GlyphSet,
     glyphNameToFileName,
     readGlyphFromString,
     writeGlyphToString,
 )
-from fontTools.ufoLib.errors import (
-    GlifLibError,
-    UnsupportedGLIFFormat,
-    UnsupportedUFOFormat,
-)
-from fontTools.misc.etree import XML_DECLARATION
-from fontTools.pens.recordingPen import RecordingPointPen
-import pytest
+
+from .testSupport import getDemoFontGlyphSetPath
 
 GLYPHSETDIR = getDemoFontGlyphSetPath()
 

--- a/Tests/ufoLib/testSupport.py
+++ b/Tests/ufoLib/testSupport.py
@@ -1,6 +1,7 @@
 """Miscellaneous helpers for our test suite."""
 
 import os
+
 from fontTools.ufoLib.utils import numberTypes
 
 
@@ -543,7 +544,7 @@ fontInfoVersion3 = {
         dict(x=100, y=200, angle=45, identifier="guide1"),
         dict(x=100, y=200, angle=45, identifier="guide2"),
         dict(x=100, y=200, angle=45, identifier="\x20"),
-        dict(x=100, y=200, angle=45, identifier="\x7E"),
+        dict(x=100, y=200, angle=45, identifier="\x7e"),
         # colors
         dict(x=100, y=200, angle=45, color="0,0,0,0"),
         dict(x=100, y=200, angle=45, color="1,0,0,0"),

--- a/Tests/ufoLib/ufoLib_test.py
+++ b/Tests/ufoLib/ufoLib_test.py
@@ -1,10 +1,10 @@
 import logging
 import shutil
 
-from fontTools.misc import plistlib
-from fontTools.ufoLib import UFOReader, UFOWriter, UFOFormatVersion
-from fontTools.ufoLib.errors import UFOLibError, UnsupportedUFOFormat
 import pytest
+from fontTools.misc import plistlib
+from fontTools.ufoLib import UFOFormatVersion, UFOReader, UFOWriter
+from fontTools.ufoLib.errors import UFOLibError, UnsupportedUFOFormat
 
 
 @pytest.fixture

--- a/Tests/unicodedata_test.py
+++ b/Tests/unicodedata_test.py
@@ -1,6 +1,5 @@
-from fontTools import unicodedata
-
 import pytest
+from fontTools import unicodedata
 
 
 def test_script():
@@ -155,7 +154,7 @@ def test_script():
 
 
 def test_script_extension():
-    assert unicodedata.script_extension("\u00B7") == {
+    assert unicodedata.script_extension("\u00b7") == {
         "Avst",
         "Cari",
         "Copt",
@@ -173,7 +172,7 @@ def test_script_extension():
         "Perm",
         "Shaw",
     }
-    assert unicodedata.script_extension("\u02BC") == {
+    assert unicodedata.script_extension("\u02bc") == {
         "Beng",
         "Cyrl",
         "Deva",
@@ -242,11 +241,11 @@ def test_script_code():
 
 def test_block():
     assert unicodedata.block("\x00") == "Basic Latin"
-    assert unicodedata.block("\x7F") == "Basic Latin"
+    assert unicodedata.block("\x7f") == "Basic Latin"
     assert unicodedata.block("\x80") == "Latin-1 Supplement"
     assert unicodedata.block("\u1c90") == "Georgian Extended"
     assert unicodedata.block("\u0870") == "Arabic Extended-B"
-    assert unicodedata.block("\U00011B00") == "Devanagari Extended-A"
+    assert unicodedata.block("\U00011b00") == "Devanagari Extended-A"
 
 
 def test_ot_tags_from_script():

--- a/Tests/varLib/avar_test.py
+++ b/Tests/varLib/avar_test.py
@@ -1,9 +1,10 @@
-from fontTools.ttLib import TTFont
-from fontTools.varLib.models import VariationModel
-from fontTools.varLib.avar import _pruneLocations, mappings_from_avar
 import os
 import unittest
+
 import pytest
+from fontTools.ttLib import TTFont
+from fontTools.varLib.avar import _pruneLocations, mappings_from_avar
+from fontTools.varLib.models import VariationModel
 
 TESTS = [
     (

--- a/Tests/varLib/builder_test.py
+++ b/Tests/varLib/builder_test.py
@@ -1,4 +1,6 @@
 from io import StringIO
+
+import pytest
 from fontTools.designspaceLib import (
     AxisDescriptor,
     DesignSpaceDocument,
@@ -9,7 +11,6 @@ from fontTools.misc.xmlWriter import XMLWriter
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.varLib import build
 from fontTools.varLib.builder import buildVarData
-import pytest
 
 
 @pytest.mark.parametrize(

--- a/Tests/varLib/featureVars_test.py
+++ b/Tests/varLib/featureVars_test.py
@@ -1,13 +1,14 @@
 from collections import OrderedDict
+
+import pytest
+from fontTools import varLib
 from fontTools.designspaceLib import AxisDescriptor
 from fontTools.ttLib import TTFont, newTable
-from fontTools import varLib
 from fontTools.varLib.featureVars import (
     addFeatureVariations,
-    overlayFeatureVariations,
     overlayBox,
+    overlayFeatureVariations,
 )
-import pytest
 
 
 def makeVariableFont(glyphOrder, axes):

--- a/Tests/varLib/hvar_test.py
+++ b/Tests/varLib/hvar_test.py
@@ -1,9 +1,10 @@
-from fontTools.ttLib import TTFont
-from fontTools.varLib.hvar import add_HVAR
-from io import StringIO
 import os
 import unittest
+from io import StringIO
+
 import pytest
+from fontTools.ttLib import TTFont
+from fontTools.varLib.hvar import add_HVAR
 
 
 def test_roundtrip():

--- a/Tests/varLib/instancer/conftest.py
+++ b/Tests/varLib/instancer/conftest.py
@@ -1,7 +1,7 @@
 import os
-from fontTools import ttLib
-import pytest
 
+import pytest
+from fontTools import ttLib
 
 TESTDATA = os.path.join(os.path.dirname(__file__), "data")
 

--- a/Tests/varLib/instancer/instancer_test.py
+++ b/Tests/varLib/instancer/instancer_test.py
@@ -1,28 +1,22 @@
+import collections
+import logging
+import os
+import re
+from copy import deepcopy
+from io import BytesIO, StringIO
+from types import SimpleNamespace
+
+import pytest
+from fontTools import designspaceLib, ttLib, varLib
+from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
 from fontTools.misc.fixedTools import floatToFixedToFloat
 from fontTools.misc.roundTools import noRound
 from fontTools.misc.testTools import stripVariableItemsFromTTX
 from fontTools.misc.textTools import Tag
-from fontTools import ttLib
-from fontTools import designspaceLib
-from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
-from fontTools.ttLib.tables import _f_v_a_r, _g_l_y_f
-from fontTools.ttLib.tables import otTables
+from fontTools.ttLib.tables import _f_v_a_r, _g_l_y_f, otTables
 from fontTools.ttLib.tables.TupleVariation import TupleVariation
-from fontTools import varLib
-from fontTools.varLib import instancer
+from fontTools.varLib import builder, featureVars, instancer, models
 from fontTools.varLib.mvar import MVAR_ENTRIES
-from fontTools.varLib import builder
-from fontTools.varLib import featureVars
-from fontTools.varLib import models
-import collections
-from copy import deepcopy
-from io import BytesIO, StringIO
-import logging
-import os
-import re
-from types import SimpleNamespace
-import pytest
-
 
 # see Tests/varLib/instancer/conftest.py for "varfont" fixture definition
 

--- a/Tests/varLib/instancer/names_test.py
+++ b/Tests/varLib/instancer/names_test.py
@@ -1,8 +1,7 @@
-from fontTools.ttLib.tables import otTables
-from fontTools.otlLib.builder import buildStatTable
-from fontTools.varLib import instancer
-
 import pytest
+from fontTools.otlLib.builder import buildStatTable
+from fontTools.ttLib.tables import otTables
+from fontTools.varLib import instancer
 
 
 def test_pruningUnusedNames(varfont):

--- a/Tests/varLib/instancer/solver_test.py
+++ b/Tests/varLib/instancer/solver_test.py
@@ -1,6 +1,5 @@
-from fontTools.varLib.instancer import solver
-from fontTools.varLib.instancer import NormalizedAxisTripleAndDistances
 import pytest
+from fontTools.varLib.instancer import NormalizedAxisTripleAndDistances, solver
 
 
 class RebaseTentTest(object):

--- a/Tests/varLib/interpolatable_test.py
+++ b/Tests/varLib/interpolatable_test.py
@@ -1,11 +1,12 @@
-from fontTools.ttLib import TTFont
-from fontTools.varLib.interpolatable import main as interpolatable_main
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+
 import pytest
+from fontTools.ttLib import TTFont
+from fontTools.varLib.interpolatable import main as interpolatable_main
 
 try:
     import scipy

--- a/Tests/varLib/interpolate_layout_test.py
+++ b/Tests/varLib/interpolate_layout_test.py
@@ -1,15 +1,16 @@
-from fontTools.ttLib import TTFont
-from fontTools.varLib import build
-from fontTools.varLib.interpolate_layout import interpolate_layout
-from fontTools.varLib.interpolate_layout import main as interpolate_layout_main
-from fontTools.designspaceLib import DesignSpaceDocument, DesignSpaceDocumentError
-from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
 import difflib
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+
+from fontTools.designspaceLib import DesignSpaceDocument, DesignSpaceDocumentError
+from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
+from fontTools.ttLib import TTFont
+from fontTools.varLib import build
+from fontTools.varLib.interpolate_layout import interpolate_layout
+from fontTools.varLib.interpolate_layout import main as interpolate_layout_main
 
 
 class InterpolateLayoutTest(unittest.TestCase):

--- a/Tests/varLib/iup_test.py
+++ b/Tests/varLib/iup_test.py
@@ -1,5 +1,6 @@
-import fontTools.varLib.iup as iup
 import sys
+
+import fontTools.varLib.iup as iup
 import pytest
 
 

--- a/Tests/varLib/merger_test.py
+++ b/Tests/varLib/merger_test.py
@@ -1,15 +1,15 @@
-from copy import deepcopy
 import string
-from fontTools.colorLib.builder import LayerListBuilder, buildCOLR, buildClipList
+from copy import deepcopy
+from io import BytesIO
+
+import pytest
+from fontTools.colorLib.builder import LayerListBuilder, buildClipList, buildCOLR
 from fontTools.misc.testTools import getXML
-from fontTools.varLib.merger import COLRVariationMerger
-from fontTools.varLib.models import VariationModel
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.ttLib.tables.otBase import OTTableReader, OTTableWriter
-from io import BytesIO
-import pytest
-
+from fontTools.varLib.merger import COLRVariationMerger
+from fontTools.varLib.models import VariationModel
 
 NO_VARIATION_INDEX = ot.NO_VARIATION_INDEX
 

--- a/Tests/varLib/models_test.py
+++ b/Tests/varLib/models_test.py
@@ -1,10 +1,10 @@
+import pytest
 from fontTools.varLib.models import (
-    normalizeLocation,
-    supportScalar,
     VariationModel,
     VariationModelError,
+    normalizeLocation,
+    supportScalar,
 )
-import pytest
 
 
 def test_normalizeLocation():

--- a/Tests/varLib/mutator_test.py
+++ b/Tests/varLib/mutator_test.py
@@ -1,13 +1,14 @@
-from fontTools.ttLib import TTFont
-from fontTools.varLib import build
-from fontTools.varLib.mutator import main as mutator
-from fontTools.varLib.mutator import instantiateVariableFont as make_instance
 import difflib
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+
+from fontTools.ttLib import TTFont
+from fontTools.varLib import build
+from fontTools.varLib.mutator import instantiateVariableFont as make_instance
+from fontTools.varLib.mutator import main as mutator
 
 
 class MutatorTest(unittest.TestCase):

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -1,34 +1,36 @@
-from fontTools.colorLib.builder import buildCOLR
-from fontTools.ttLib import TTFont, newTable
-from fontTools.ttLib.tables import otTables as ot
-from fontTools.varLib import (
-    build,
-    build_many,
-    load_designspace,
-    _add_COLR,
-    addGSUBFeatureVariations,
-)
-from fontTools.varLib.errors import VarLibValidationError
-import fontTools.varLib.errors as varLibErrors
-from fontTools.varLib.models import VariationModel
-from fontTools.varLib.mutator import instantiateVariableFont
-from fontTools.varLib import main as varLib_main, load_masters
-from fontTools.varLib import set_default_weight_width_slant
-from fontTools.designspaceLib import (
-    DesignSpaceDocumentError,
-    DesignSpaceDocument,
-    SourceDescriptor,
-)
-from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
 import difflib
-from copy import deepcopy
-from io import BytesIO
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+from copy import deepcopy
+from io import BytesIO
+
+import fontTools.varLib.errors as varLibErrors
 import pytest
+from fontTools.colorLib.builder import buildCOLR
+from fontTools.designspaceLib import (
+    DesignSpaceDocument,
+    DesignSpaceDocumentError,
+    SourceDescriptor,
+)
+from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
+from fontTools.ttLib import TTFont, newTable
+from fontTools.ttLib.tables import otTables as ot
+from fontTools.varLib import (
+    _add_COLR,
+    addGSUBFeatureVariations,
+    build,
+    build_many,
+    load_designspace,
+    load_masters,
+)
+from fontTools.varLib import main as varLib_main
+from fontTools.varLib import set_default_weight_width_slant
+from fontTools.varLib.errors import VarLibValidationError
+from fontTools.varLib.models import VariationModel
+from fontTools.varLib.mutator import instantiateVariableFont
 
 
 def reload_font(font):

--- a/Tests/varLib/varStore_test.py
+++ b/Tests/varLib/varStore_test.py
@@ -1,14 +1,15 @@
-import pytest
 import random
 from io import StringIO
-from fontTools.misc.xmlWriter import XMLWriter
+
+import pytest
 from fontTools.misc.roundTools import noRound
-from fontTools.varLib.models import VariationModel
-from fontTools.varLib.varStore import OnlineVarStoreBuilder, VarStoreInstancer
+from fontTools.misc.xmlWriter import XMLWriter
 from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables._f_v_a_r import Axis
 from fontTools.ttLib.tables.otBase import OTTableReader, OTTableWriter
 from fontTools.ttLib.tables.otTables import VarStore
+from fontTools.varLib.models import VariationModel
+from fontTools.varLib.varStore import OnlineVarStoreBuilder, VarStoreInstancer
 
 
 @pytest.mark.parametrize(

--- a/Tests/voltLib/lexer_test.py
+++ b/Tests/voltLib/lexer_test.py
@@ -1,6 +1,7 @@
+import unittest
+
 from fontTools.voltLib.error import VoltLibError
 from fontTools.voltLib.lexer import Lexer
-import unittest
 
 
 def lex(s):

--- a/Tests/voltLib/parser_test.py
+++ b/Tests/voltLib/parser_test.py
@@ -1,8 +1,9 @@
+import unittest
+from io import StringIO
+
 from fontTools.voltLib import ast
 from fontTools.voltLib.error import VoltLibError
 from fontTools.voltLib.parser import Parser
-from io import StringIO
-import unittest
 
 
 class ParserTest(unittest.TestCase):


### PR DESCRIPTION
Automatic application of coding styles makes my life easier a lot.

Split out from #3879, this applies import sorting for everything. After that I've run black again to iron out any formatting differences (we run black already).

I've applied both tools with their default settings:

```sh
$ isort .
$ black .
```