### PR TITLE
Improve {v,h}mtx error when not enough data to decompile sidebearings

### DIFF
--- a/Lib/fontTools/ttLib/tables/_h_m_t_x.py
+++ b/Lib/fontTools/ttLib/tables/_h_m_t_x.py
@@ -40,15 +40,19 @@ class table__h_m_t_x(DefaultTable.DefaultTable):
                 % (self.headerTag, self.numberOfMetricsName)
             )
             numberOfMetrics = numGlyphs
-        if len(data) < 4 * numberOfMetrics:
-            raise ttLib.TTLibError("not enough '%s' table data" % self.tableTag)
+        numberOfSideBearings = numGlyphs - numberOfMetrics
+        tableSize = 4 * numberOfMetrics + 2 * numberOfSideBearings
+        if len(data) < tableSize:
+            raise ttLib.TTLibError(
+                f"not enough '{self.tableTag}' table data: "
+                f"expected {tableSize} bytes, got {len(data)}"
+            )
         # Note: advanceWidth is unsigned, but some font editors might
         # read/write as signed. We can't be sure whether it was a mistake
         # or not, so we read as unsigned but also issue a warning...
         metricsFmt = ">" + self.longMetricFormat * numberOfMetrics
         metrics = struct.unpack(metricsFmt, data[: 4 * numberOfMetrics])
         data = data[4 * numberOfMetrics :]
-        numberOfSideBearings = numGlyphs - numberOfMetrics
         sideBearings = array.array("h", data[: 2 * numberOfSideBearings])
         data = data[2 * numberOfSideBearings :]
 

--- a/Tests/ttLib/tables/_h_m_t_x_test.py
+++ b/Tests/ttLib/tables/_h_m_t_x_test.py
@@ -58,13 +58,23 @@ class HmtxTableTest(unittest.TestCase):
         self.assertEqual(mtxTable["C"], (632, 54))
         self.assertEqual(mtxTable["D"], (632, -4))
 
-    def test_decompile_not_enough_data(self):
+    def test_decompile_not_enough_data_for_long_metrics(self):
         font = self.makeFont(numGlyphs=1, numberOfMetrics=1)
         mtxTable = newTable(self.tag)
         msg = "not enough '%s' table data" % self.tag
 
         with self.assertRaisesRegex(TTLibError, msg):
             mtxTable.decompile(b"\0\0\0", font)
+
+    def test_decompile_not_enough_data_for_sidebearings(self):
+        # we expect 1 long metric (advance + sidebearing) and 1 short metric
+        # (sb-only): 4 + 2 = 6 bytes total
+        font = self.makeFont(numGlyphs=2, numberOfMetrics=1)
+        mtxTable = newTable(self.tag)
+        msg = "not enough '%s' table data: expected 6 bytes, got 4" % self.tag
+
+        with self.assertRaisesRegex(TTLibError, msg):
+            mtxTable.decompile(b"\0\0\0\0", font)
 
     def test_decompile_too_much_data(self):
         font = self.makeFont(numGlyphs=1, numberOfMetrics=1)


### PR DESCRIPTION
Fixes #3843 

Sometimes hmtx or vmtx may appear truncated with not enough data to decompile the list of sidebearings at the end of the table. Currently an IndexError would be thrown which is confusing.

```
ERROR: An exception occurred during the decompilation of the 'vmtx' table
Traceback (most recent call last):
  File "fontTools/ttLib/ttFont.py", line 468, in _readTable
    table.decompile(data, self)
  File "fontTools/ttLib/tables/_h_m_t_x.py", line 67, in decompile
    self.metrics[glyphName] = (lastAdvance, sideBearings[i])
                                            ~~~~~~~~~~~~^^^
IndexError: array index out of range
Dumping 'vmtx' table...
```

This PR makes it so we raise the same TTLibError(f"not enough {tableTag} data") that we already raise when we don't have enough table data to decompile the "long" metrics.