### PR TITLE
[varLib] Clear inconsistent USE_MY_METRICS flags across masters

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -30,7 +30,11 @@ from fontTools.misc.fixedTools import floatToFixed as fl2fi
 from fontTools.misc.textTools import Tag, tostr
 from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables._f_v_a_r import Axis, NamedInstance
-from fontTools.ttLib.tables._g_l_y_f import GlyphCoordinates, dropImpliedOnCurvePoints
+from fontTools.ttLib.tables._g_l_y_f import (
+    GlyphCoordinates,
+    dropImpliedOnCurvePoints,
+    USE_MY_METRICS,
+)
 from fontTools.ttLib.tables.ttProgram import Program
 from fontTools.ttLib.tables.TupleVariation import TupleVariation
 from fontTools.ttLib.tables import otTables as ot
@@ -487,6 +491,77 @@ def _merge_TTHinting(font, masterModel, master_ttfs):
         cvar = font["cvar"] = newTable("cvar")
         cvar.version = 1
         cvar.variations = variations
+
+
+def _has_inconsistent_use_my_metrics_flag(
+    master_glyf, glyph_name, flagged_components, expected_num_components
+) -> bool:
+    master_glyph = master_glyf.get(glyph_name)
+    # 'sparse' glyph master doesn't contribute. Besides when components don't match
+    # the VF build is going to fail anyway, so be lenient here.
+    if (
+        master_glyph is not None
+        and master_glyph.isComposite()
+        and len(master_glyph.components) == expected_num_components
+    ):
+        for i, base_glyph in flagged_components:
+            comp = master_glyph.components[i]
+            if comp.glyphName != base_glyph:
+                break
+            if not (comp.flags & USE_MY_METRICS):
+                return True
+    return False
+
+
+def _unset_inconsistent_use_my_metrics_flags(vf, master_fonts):
+    """Clear USE_MY_METRICS on composite components if inconsistent across masters.
+
+    If a composite glyph's component has USE_MY_METRICS set differently among
+    the masters, the flag is removed from the variable font's glyf table so that
+    advance widths are not determined by that single component's phantom points.
+    """
+    glyf = vf["glyf"]
+    master_glyfs = [m["glyf"] for m in master_fonts if "glyf" in m]
+    if not master_glyfs:
+        # Should not happen: at least the base master (as copied into vf) has glyf
+        return
+
+    for glyph_name in glyf.keys():
+        glyph = glyf[glyph_name]
+        if not glyph.isComposite():
+            continue
+
+        # collect indices of component(s) that carry the USE_MY_METRICS flag.
+        # This is supposed to be 1 component per composite, but you never know.
+        flagged_components = [
+            (i, comp.glyphName)
+            for i, comp in enumerate(glyph.components)
+            if (comp.flags & USE_MY_METRICS)
+        ]
+        if not flagged_components:
+            # Nothing to fix
+            continue
+
+        # Verify that for all master glyf tables that contribute this glyph, the
+        # corresponding component (same glyphName and index) also carries USE_MY_METRICS
+        # and unset the flag if not.
+        expected_num_components = len(glyph.components)
+        if any(
+            _has_inconsistent_use_my_metrics_flag(
+                master_glyf, glyph_name, flagged_components, expected_num_components
+            )
+            for master_glyf in master_glyfs
+        ):
+            comp_names = [name for _, name in flagged_components]
+            log.info(
+                "Composite glyph '%s' has inconsistent USE_MY_METRICS flags across "
+                "masters; clearing the flag on component%s %s",
+                glyph_name,
+                "s" if len(comp_names) > 1 else "",
+                comp_names if len(comp_names) > 1 else comp_names[0],
+            )
+            for i, _ in flagged_components:
+                glyph.components[i].flags &= ~USE_MY_METRICS
 
 
 _MetricsFields = namedtuple(
@@ -1204,6 +1279,10 @@ def build(
 
     if "DSIG" in vf:
         del vf["DSIG"]
+
+    # Clear USE_MY_METRICS composite flags if set inconsistently across masters.
+    if "glyf" in vf:
+        _unset_inconsistent_use_my_metrics_flags(vf, master_fonts)
 
     # TODO append masters as named-instances as well; needs .designspace change.
     fvar = _add_fvar(vf, ds.axes, ds.instances)

--- a/Tests/varLib/data/InconsistentUseMyMetrics.designspace
+++ b/Tests/varLib/data/InconsistentUseMyMetrics.designspace
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <sources>
+    <source filename="master_ttx_interpolatable_ttf/InconsistentUseMyMetrics-Regular.ttx" name="Inconsistent Use My Metrics Regular" familyname="Inconsistent Use My Metrics" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="master_ttx_interpolatable_ttf/InconsistentUseMyMetrics-Bold.ttx" name="Inconsistent Use My Metrics Bold" familyname="Inconsistent Use My Metrics" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/InconsistentUseMyMetrics-Bold.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/InconsistentUseMyMetrics-Bold.ttx
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.59">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="zero"/>
+    <GlyphID id="2" name="zero.tf"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0xd39676ed"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Aug 22 17:34:57 2025"/>
+    <modified value="Fri Aug 22 17:41:00 2025"/>
+    <xMin value="44"/>
+    <yMin value="-200"/>
+    <xMax value="625"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000001"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="701"/>
+    <minLeftSideBearing value="44"/>
+    <minRightSideBearing value="50"/>
+    <xMaxExtent value="625"/>
+    <caretSlopeRise value="1000"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="3"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="3"/>
+    <maxPoints value="20"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="20"/>
+    <maxCompositeContours value="1"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="1"/>
+    <maxComponentDepth value="1"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="634"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 00100000"/>
+    <usFirstCharIndex value="48"/>
+    <usLastCharIndex value="48"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="zero" width="700" lsb="44"/>
+    <mtx name="zero.tf" width="701" lsb="44"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="zero" xMin="44" yMin="-8" xMax="625" yMax="729">
+      <contour>
+        <pt x="335" y="-8" on="1"/>
+        <pt x="275" y="-8" on="0"/>
+        <pt x="169" y="49" on="0"/>
+        <pt x="89" y="151" on="0"/>
+        <pt x="44" y="285" on="0"/>
+        <pt x="44" y="361" on="1"/>
+        <pt x="44" y="437" on="0"/>
+        <pt x="89" y="570" on="0"/>
+        <pt x="169" y="672" on="0"/>
+        <pt x="275" y="729" on="0"/>
+        <pt x="335" y="729" on="1"/>
+        <pt x="395" y="729" on="0"/>
+        <pt x="500" y="672" on="0"/>
+        <pt x="580" y="570" on="0"/>
+        <pt x="625" y="437" on="0"/>
+        <pt x="625" y="361" on="1"/>
+        <pt x="625" y="285" on="0"/>
+        <pt x="580" y="151" on="0"/>
+        <pt x="500" y="49" on="0"/>
+        <pt x="395" y="-8" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="zero.tf" xMin="44" yMin="-8" xMax="625" yMax="729">
+      <component glyphName="zero" x="0" y="0" flags="0x4"/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Inconsistent Use My Metrics
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Bold
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.000;NONE;InconsistentUseMyMetrics-Bold
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Inconsistent Use My Metrics Bold
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      InconsistentUseMyMetrics-Bold
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="zero.tf"/>
+    </extraNames>
+  </post>
+
+</ttFont>

--- a/Tests/varLib/data/master_ttx_interpolatable_ttf/InconsistentUseMyMetrics-Regular.ttx
+++ b/Tests/varLib/data/master_ttx_interpolatable_ttf/InconsistentUseMyMetrics-Regular.ttx
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.59">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="zero"/>
+    <GlyphID id="2" name="zero.tf"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0xf53d4e6f"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Aug 22 17:34:57 2025"/>
+    <modified value="Fri Aug 22 17:41:00 2025"/>
+    <xMin value="50"/>
+    <yMin value="-200"/>
+    <xMax value="521"/>
+    <yMax value="800"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="6"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="1000"/>
+    <descent value="-200"/>
+    <lineGap value="0"/>
+    <advanceWidthMax value="600"/>
+    <minLeftSideBearing value="50"/>
+    <minRightSideBearing value="50"/>
+    <xMaxExtent value="521"/>
+    <caretSlopeRise value="1000"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="2"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="3"/>
+    <maxPoints value="20"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="20"/>
+    <maxCompositeContours value="1"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="1"/>
+    <maxComponentDepth value="1"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="567"/>
+    <usWeightClass value="400"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00001000"/>
+    <ySubscriptXSize value="650"/>
+    <ySubscriptYSize value="600"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="75"/>
+    <ySuperscriptXSize value="650"/>
+    <ySuperscriptYSize value="600"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="350"/>
+    <yStrikeoutSize value="50"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="0"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="0"/>
+      <bWeight value="0"/>
+      <bProportion value="0"/>
+      <bContrast value="0"/>
+      <bStrokeVariation value="0"/>
+      <bArmStyle value="0"/>
+      <bLetterForm value="0"/>
+      <bMidline value="0"/>
+      <bXHeight value="0"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="NONE"/>
+    <fsSelection value="00000000 01000000"/>
+    <usFirstCharIndex value="48"/>
+    <usLastCharIndex value="48"/>
+    <sTypoAscender value="800"/>
+    <sTypoDescender value="-200"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="1000"/>
+    <usWinDescent value="200"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000001"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="700"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="0"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="zero" width="600" lsb="86"/>
+    <mtx name="zero.tf" width="600" lsb="86"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x30" name="zero"/><!-- DIGIT ZERO -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="zero" xMin="86" yMin="0" xMax="521" yMax="728">
+      <contour>
+        <pt x="304" y="0" on="1"/>
+        <pt x="259" y="0" on="0"/>
+        <pt x="180" y="57" on="0"/>
+        <pt x="120" y="157" on="0"/>
+        <pt x="86" y="289" on="0"/>
+        <pt x="86" y="364" on="1"/>
+        <pt x="86" y="439" on="0"/>
+        <pt x="120" y="571" on="0"/>
+        <pt x="180" y="671" on="0"/>
+        <pt x="259" y="728" on="0"/>
+        <pt x="304" y="728" on="1"/>
+        <pt x="349" y="728" on="0"/>
+        <pt x="428" y="671" on="0"/>
+        <pt x="487" y="571" on="0"/>
+        <pt x="521" y="439" on="0"/>
+        <pt x="521" y="364" on="1"/>
+        <pt x="521" y="289" on="0"/>
+        <pt x="487" y="157" on="0"/>
+        <pt x="428" y="57" on="0"/>
+        <pt x="349" y="0" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="zero.tf" xMin="86" yMin="0" xMax="521" yMax="728">
+      <component glyphName="zero" x="0" y="0" flags="0x204"/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Inconsistent Use My Metrics
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      1.000;NONE;InconsistentUseMyMetrics-Regular
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Inconsistent Use My Metrics Regular
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Version 1.000
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      InconsistentUseMyMetrics-Regular
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="0.0"/>
+    <underlinePosition value="-100"/>
+    <underlineThickness value="50"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="zero.tf"/>
+    </extraNames>
+  </post>
+
+</ttFont>

--- a/Tests/varLib/data/test_results/InconsistentUseMyMetrics-VF.ttx
+++ b/Tests/varLib/data/test_results/InconsistentUseMyMetrics-VF.ttx
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.59">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="zero"/>
+    <GlyphID id="2" name="zero.tf"/>
+  </GlyphOrder>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="zero" width="600" lsb="86"/>
+    <mtx name="zero.tf" width="600" lsb="86"/>
+  </hmtx>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="-200" xMax="450" yMax="800">
+      <contour>
+        <pt x="50" y="-200" on="1"/>
+        <pt x="50" y="800" on="1"/>
+        <pt x="450" y="800" on="1"/>
+        <pt x="450" y="-200" on="1"/>
+      </contour>
+      <contour>
+        <pt x="100" y="-150" on="1"/>
+        <pt x="400" y="-150" on="1"/>
+        <pt x="400" y="750" on="1"/>
+        <pt x="100" y="750" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="zero" xMin="86" yMin="0" xMax="521" yMax="728">
+      <contour>
+        <pt x="304" y="0" on="1"/>
+        <pt x="259" y="0" on="0"/>
+        <pt x="180" y="57" on="0"/>
+        <pt x="120" y="157" on="0"/>
+        <pt x="86" y="289" on="0"/>
+        <pt x="86" y="364" on="1"/>
+        <pt x="86" y="439" on="0"/>
+        <pt x="120" y="571" on="0"/>
+        <pt x="180" y="671" on="0"/>
+        <pt x="259" y="728" on="0"/>
+        <pt x="304" y="728" on="1"/>
+        <pt x="349" y="728" on="0"/>
+        <pt x="428" y="671" on="0"/>
+        <pt x="487" y="571" on="0"/>
+        <pt x="521" y="439" on="0"/>
+        <pt x="521" y="364" on="1"/>
+        <pt x="521" y="289" on="0"/>
+        <pt x="487" y="157" on="0"/>
+        <pt x="428" y="57" on="0"/>
+        <pt x="349" y="0" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="zero.tf" xMin="86" yMin="0" xMax="521" yMax="728">
+      <component glyphName="zero" x="0" y="0" flags="0x4"/>
+    </TTGlyph>
+
+  </glyf>
+
+  <fvar>
+
+    <!-- Weight -->
+    <Axis>
+      <AxisTag>wght</AxisTag>
+      <Flags>0x0</Flags>
+      <MinValue>400.0</MinValue>
+      <DefaultValue>400.0</DefaultValue>
+      <MaxValue>700.0</MaxValue>
+      <AxisNameID>256</AxisNameID>
+    </Axis>
+  </fvar>
+
+  <HVAR>
+    <Version value="0x00010000"/>
+    <VarStore Format="1">
+      <Format value="1"/>
+      <VarRegionList>
+        <!-- RegionAxisCount=1 -->
+        <!-- RegionCount=1 -->
+        <Region index="0">
+          <VarRegionAxis index="0">
+            <StartCoord value="0.0"/>
+            <PeakCoord value="1.0"/>
+            <EndCoord value="1.0"/>
+          </VarRegionAxis>
+        </Region>
+      </VarRegionList>
+      <!-- VarDataCount=1 -->
+      <VarData index="0">
+        <!-- ItemCount=3 -->
+        <NumShorts value="0"/>
+        <!-- VarRegionCount=1 -->
+        <VarRegionIndex index="0" value="0"/>
+        <Item index="0" value="[0]"/>
+        <Item index="1" value="[100]"/>
+        <Item index="2" value="[101]"/>
+      </VarData>
+    </VarStore>
+  </HVAR>
+
+</ttFont>

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -1076,6 +1076,15 @@ Expected to see .ScriptCount==1, instead saw 0""",
         self.expect_ttx(varfont, expected_ttx_path, tables)
         self.check_ttx_dump(varfont, expected_ttx_path, tables, ".ttf")
 
+    def test_varlib_build_inconsistent_use_my_metrics_flags(self):
+        self._run_varlib_build_test(
+            designspace_name="InconsistentUseMyMetrics",
+            font_name="InconsistentUseMyMetrics",
+            tables=["GlyphOrder", "hmtx", "glyf", "fvar", "HVAR"],
+            expected_ttx_name="InconsistentUseMyMetrics-VF",
+            save_before_dump=True,
+        )
+
 
 def test_load_masters_layerName_without_required_font():
     ds = DesignSpaceDocument()


### PR DESCRIPTION
A VF's glyf table is copied from the default master's glyf table. If a composite glyph's component has USE_MY_METRICS set in there (because the composite happens to have the same advance width as one of its components) but the flag is not set consistently among the other masters, that's probably because the composite and component metrics aren't meant to be the same throughout the variation space. Leaving the flag set, means ignoring variations of glyf/gvar phantom points of that composite glyph (as these gets simply copied from the component glyph with USE_MY_METRICS flag on).
The issue with composite glyph metrics doesn't arise normally unless the optional HVAR table (which provides deltas for the glyph metrics irrespective of the USE_MY_METRICS_FLAG) is removed from the VF. The absence of HVAR forces font renderers to use the glyf/gvar phantom points directly for the glyph metrics.

Our main provider or master ttf fonts (ufo2ft) should probably stop setting these flags by default when the intention is to build VF that aren't going to be hinted anyway (USE_MY_METRICS only make sense for hinted fonts).

From varLib's point of view, the safest approach is to check that the flags are set consistently on all the master glyf tables, and un-set them when that is not the case.