### PR TITLE
Clarify linear_sum_assignment backend options and minimal dependency usage

### DIFF
--- a/Lib/fontTools/varLib/interpolatableHelpers.py
+++ b/Lib/fontTools/varLib/interpolatableHelpers.py
@@ -174,6 +174,9 @@ def min_cost_perfect_bipartite_matching_bruteforce(G):
     return best, best_cost
 
 
+# Prefer `scipy.optimize.linear_sum_assignment` for performance.
+# `Munkres` is also supported as a fallback for minimalistic systems
+# where installing SciPy is not feasible.
 try:
     from scipy.optimize import linear_sum_assignment
 

--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,11 @@ are required to unlock the extra features named "ufo", etc.
     for Python, which internally uses `NumPy <https://pypi.python.org/pypi/numpy>`__
     arrays and hence is very fast;
   * `munkres <https://pypi.python.org/pypi/munkres>`__: a pure-Python
-    module that implements the Hungarian or Kuhn-Munkres algorithm.
+    module that implements the Hungarian or Kuhn-Munkres algorithm. Slower than
+    SciPy, but useful for minimalistic systems where adding SciPy is undesirable.
+
+  This ensures both performance (via SciPy) and minimal footprint (via Munkres)
+  are possible.
 
   To plot the results to a PDF or HTML format, you also need to install:
 


### PR DESCRIPTION
While working on GlobaLeaks, we install python3-fonttools as a dependency for python3-fpd2. Our system initially pulled in python3-scipy, which significantly increased the size of our setups and of Docker releases. To reduce the footprint, we preferred installing the pure-Python Munkres implementation and prioritize reduced footprint over performance.

We appreciate that FontTools maintains both options for solving the Assignment problem:

- scipy.optimize.linear_sum_assignment for performance, and

- Munkres as a fallback for minimalistic systems.

The aim of this pull request is to extend documentation to make this duplicity clear and ensure it is maintained in future versions. This possibility is in fact considered by maintainers of the Debian and Ubuntu package python3-fonttools that have scipy and munkres as alternative requirements.

Finally, we note that the current requirements.txt installs both libraries. It could be considered to make Munkres the default for PyPI installations, allowing users to start from a smaller set of dependencies, while still retaining the option to install SciPy for performance.