### PR TITLE
DecomposePointPen: add reverseFlipped="on_curve_first" to match fontc's flipped component decomposition

### DIFF
--- a/Lib/fontTools/misc/enumTools.py
+++ b/Lib/fontTools/misc/enumTools.py
@@ -1,0 +1,23 @@
+"""Enum-related utilities, including backports for older Python versions."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+__all__ = ["StrEnum"]
+
+# StrEnum is only available in Python 3.11+
+try:
+    from enum import StrEnum
+except ImportError:
+
+    class StrEnum(str, Enum):
+        """
+        Minimal backport of Python 3.11's StrEnum for older versions.
+
+        An Enum where all members are also strings.
+        """
+
+        def __str__(self) -> str:
+            return self.value

--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from fontTools.pens.basePen import AbstractPen, DecomposingPen
-from fontTools.pens.pointPen import AbstractPointPen, DecomposingPointPen
+from fontTools.pens.pointPen import (
+    AbstractPointPen,
+    DecomposingPointPen,
+    ReverseFlipped,
+)
 from fontTools.pens.recordingPen import RecordingPen
 
 
@@ -179,16 +183,37 @@ class FilterPointPen(_PassThruComponentsMixin, AbstractPointPen):
         self._outPen.addPoint(pt, segmentType, smooth, name, **kwargs)
 
 
-class _DecomposingFilterPenMixin:
-    """Mixin class that decomposes components as regular contours.
+class _DecomposingFilterMixinBase:
+    """Base mixin class with common `addComponent` logic for decomposing filter pens."""
 
-    Shared by both DecomposingFilterPen and DecomposingFilterPointPen.
+    def addComponent(self, baseGlyphName, transformation, **kwargs):
+        # only decompose the component if it's included in the set
+        if self.include is None or baseGlyphName in self.include:
+            # if we're decomposing nested components, temporarily set include to None
+            include_bak = self.include
+            if self.decomposeNested and self.include:
+                self.include = None
+            try:
+                super().addComponent(baseGlyphName, transformation, **kwargs)
+            finally:
+                if self.include != include_bak:
+                    self.include = include_bak
+        else:
+            _PassThruComponentsMixin.addComponent(
+                self, baseGlyphName, transformation, **kwargs
+            )
 
-    Takes two required parameters, another (segment or point) pen 'outPen' to draw
+
+class _DecomposingFilterPenMixin(_DecomposingFilterMixinBase):
+    """Mixin class that decomposes components as regular contours for segment pens.
+
+    Used by DecomposingFilterPen.
+
+    Takes two required parameters, another segment pen 'outPen' to draw
     with, and a 'glyphSet' dict of drawable glyph objects to draw components from.
 
     The 'skipMissingComponents' and 'reverseFlipped' optional arguments work the
-    same as in the DecomposingPen/DecomposingPointPen. Both are False by default.
+    same as in the DecomposingPen. reverseFlipped is bool only (True/False).
 
     In addition, the decomposing filter pens also take the following two options:
 
@@ -210,35 +235,69 @@ class _DecomposingFilterPenMixin:
         outPen,
         glyphSet,
         skipMissingComponents=None,
-        reverseFlipped=False,
+        reverseFlipped: bool = False,
         include: set[str] | None = None,
         decomposeNested: bool = True,
+        **kwargs,
+    ):
+        assert isinstance(reverseFlipped, bool), (
+            f"Expected bool, got {type(reverseFlipped).__name__}"
+        )
+        super().__init__(
+            outPen=outPen,
+            glyphSet=glyphSet,
+            skipMissingComponents=skipMissingComponents,
+            reverseFlipped=reverseFlipped,
+            **kwargs,
+        )
+        self.include = include
+        self.decomposeNested = decomposeNested
+
+
+class _DecomposingFilterPointPenMixin(_DecomposingFilterMixinBase):
+    """Mixin class that decomposes components as regular contours for point pens.
+
+    Takes two required parameters, another point pen 'outPen' to draw
+    with, and a 'glyphSet' dict of drawable glyph objects to draw components from.
+
+    The 'skipMissingComponents' and 'reverseFlipped' optional arguments work the
+    same as in the DecomposingPointPen. reverseFlipped accepts bool | ReverseFlipped
+    (see DecomposingPointPen).
+
+    In addition, the decomposing filter pens also take the following two options:
+
+    'include' is an optional set of component base glyph names to consider for
+    decomposition; the default include=None means decompose all components no matter
+    the base glyph name).
+
+    'decomposeNested' (bool) controls whether to recurse decomposition into nested
+    components of components (this only matters when 'include' was also provided);
+    if False, only decompose top-level components included in the set, but not
+    also their children.
+    """
+
+    # raises MissingComponentError if base glyph is not found in glyphSet
+    skipMissingComponents = False
+
+    def __init__(
+        self,
+        outPen,
+        glyphSet,
+        skipMissingComponents=None,
+        reverseFlipped: bool | ReverseFlipped = False,
+        include: set[str] | None = None,
+        decomposeNested: bool = True,
+        **kwargs,
     ):
         super().__init__(
             outPen=outPen,
             glyphSet=glyphSet,
             skipMissingComponents=skipMissingComponents,
             reverseFlipped=reverseFlipped,
+            **kwargs,
         )
         self.include = include
         self.decomposeNested = decomposeNested
-
-    def addComponent(self, baseGlyphName, transformation, **kwargs):
-        # only decompose the component if it's included in the set
-        if self.include is None or baseGlyphName in self.include:
-            # if we're decomposing nested components, temporarily set include to None
-            include_bak = self.include
-            if self.decomposeNested and self.include:
-                self.include = None
-            try:
-                super().addComponent(baseGlyphName, transformation, **kwargs)
-            finally:
-                if self.include != include_bak:
-                    self.include = include_bak
-        else:
-            _PassThruComponentsMixin.addComponent(
-                self, baseGlyphName, transformation, **kwargs
-            )
 
 
 class DecomposingFilterPen(_DecomposingFilterPenMixin, DecomposingPen, FilterPen):
@@ -248,7 +307,7 @@ class DecomposingFilterPen(_DecomposingFilterPenMixin, DecomposingPen, FilterPen
 
 
 class DecomposingFilterPointPen(
-    _DecomposingFilterPenMixin, DecomposingPointPen, FilterPointPen
+    _DecomposingFilterPointPenMixin, DecomposingPointPen, FilterPointPen
 ):
     """Filter point pen that draws components as regular contours."""
 

--- a/Lib/fontTools/pens/filterPen.py
+++ b/Lib/fontTools/pens/filterPen.py
@@ -240,9 +240,9 @@ class _DecomposingFilterPenMixin(_DecomposingFilterMixinBase):
         decomposeNested: bool = True,
         **kwargs,
     ):
-        assert isinstance(reverseFlipped, bool), (
-            f"Expected bool, got {type(reverseFlipped).__name__}"
-        )
+        assert isinstance(
+            reverseFlipped, bool
+        ), f"Expected bool, got {type(reverseFlipped).__name__}"
         super().__init__(
             outPen=outPen,
             glyphSet=glyphSet,


### PR DESCRIPTION
Fixes the discrepancy in starting points when decomposing flipped components between fonttools and fontc (googlefonts/fontc#1633).

When decomposing composite glyphs with flipped components (negative determinant), fonttools and fontc handle the contour starting point differently:
  - fonttools (via ReverseContourPointPen): Reverses the contour but keeps the same starting point (even if it's off-curve)
  - fontc (via kurbo's `BezPath::reverse_subpaths()`: Reverses the contour and rotates it to start with the first on-curve point (BezPath being a collection of curve segments rather than a closed list of points; the rotation occurs well before `reverse_subpaths` while constructing the BezPaths from the UFO/Glyphs sources' outline points).

ufo2ft's uses fonttools' `DecomposingFilterPointPen` to decompose composite glyphs; when `reverseFlipped=True`, this uses the `ReverseContourPointPen` to reverse contour direction and compensate for the flip (negative determinant) in the component transformation.

This PR changes `reverseFlipped` parameter to take an enum (or StrEnum actually) to give users control over the behaviour when reversing contour direction of to-be-decomposed flipped components:

  - `ReverseFlipped.NO` - Don't reverse the contour (same as the current `False` default)
  - `ReverseFlipped.KEEP_START` - Reverse but keep original starting point (same as the current `True`)
  - `ReverseFlipped.ON_CURVE_FIRST` - Rotate to first on-curve point before reversing (new behavior, matching fontc).

The implementation includes:
  1. A new `OnCurveFirstPointPen` filter pen that ensures closed contours start with on-curve points.
  2. Integration in `DecomposingPointPen` (abstract base class of both `DecomposingFilterPointPen` and `DecomposingRecordingPointPen`)
  3.  Backward compatibility with the existing `reverseFlipped: bool` parameter, so exising code is unaffected.

For fontmake/ufo2ft to match fontc's output they will have to be modified to do something like

```python
pen = DecomposingFilterPointPen(outPen, glyphSet, reverseFlipped=ReverseFlipped.ON_CURVE_FIRST, ...)
```

