### PR TITLE
[designspaceLib] Adjust spec for `public.skipExportGlyphs`

### DIFF
--- a/Doc/source/designspaceLib/index.rst
+++ b/Doc/source/designspaceLib/index.rst
@@ -116,7 +116,9 @@ public.skipExportGlyphs
 This lib key works the same as the UFO lib key with the same name. The
 difference is that applications using a Designspace as the corner stone of the
 font compilation process should use the lib key in that Designspace instead of
-any of the UFOs, if the lib key is present in the Designspace.
+any of the UFOs, if the lib key is present in the Designspace. This should be
+true even if the lib key is present but empty in the Designspace, so that it is
+possible to use the Designspace lib key as an override to UFO-level lib keys.
 
 If the lib key is not present in the Designspace but it is present in the origin
 source of the Designspace, the font compiler should use the lib key from that

--- a/Doc/source/designspaceLib/index.rst
+++ b/Doc/source/designspaceLib/index.rst
@@ -116,9 +116,13 @@ public.skipExportGlyphs
 This lib key works the same as the UFO lib key with the same name. The
 difference is that applications using a Designspace as the corner stone of the
 font compilation process should use the lib key in that Designspace instead of
-any of the UFOs. If the lib key is empty or not present in the Designspace, all
-glyphs should be exported, regardless of what the same lib key in any of the
-UFOs says.
+any of the UFOs, if the lib key is present in the Designspace.
+
+If the lib key is not present in the Designspace but it is present in the origin
+source of the Designspace, the font compiler should use the lib key from that
+origin UFO, and it should apply that set of skipped glyphs to any fonts 
+compiled from the Designspace.
+
 
 public.fontInfo
 -----------------------


### PR DESCRIPTION
This proposal is described further at https://github.com/fonttools/fonttools/issues/3935, as well as the earlier issue thread at https://github.com/googlefonts/ufo2ft/issues/854.

In this PR, I am slightly more confident in the [first commit](https://github.com/fonttools/fonttools/commit/11c0a38b1c7d447103cd4d4434c3abb1608b3cc3) and slightly less confident about the [second commit](https://github.com/fonttools/fonttools/commit/481ce3d6ae9fd6a1bb91cba7baa9fa8c6fc35631), so I left them deliberately separate. However, I think this arrangement probably makes sense, assuming others agree that an empty lib key should be treated as significant data.

I am open to critique of language or formatting here, and direct edits from maintainers. I’m also happy to answer questions, if there are any that I can speak to.

Thank you for your consideration here!