### PR TITLE
Fix interpolation of variable scalars, and allow on pre-compiled fonts 

### DIFF
--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -962,6 +962,9 @@ class AxisDescriptor(AbstractAxisDescriptor):
         doc.addAxis(a1)
     """
 
+    name: str | None
+    map: list[tuple[float, float]] | None
+
     _attrs = [
         "tag",
         "name",

--- a/Lib/fontTools/feaLib/variableScalar.py
+++ b/Lib/fontTools/feaLib/variableScalar.py
@@ -1,18 +1,31 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Self
+
+from fontTools.designspaceLib import DesignSpaceDocument
+from fontTools.ttLib.ttFont import TTFont
 from fontTools.varLib.models import VariationModel, normalizeValue, piecewiseLinearMap
 
+LocationTuple = tuple[tuple[str, float], ...]
+"""A hashable location."""
 
-def Location(loc):
-    return tuple(sorted(loc.items()))
+
+def Location(location: Mapping[str, float]) -> LocationTuple:
+    """Create a hashable location from a dictionary-like location."""
+    return tuple(sorted(location.items()))
 
 
 class VariableScalar:
     """A scalar with different values at different points in the designspace."""
 
+    values: dict[LocationTuple, int]
+    """The values across various user-locations. Must always include the default
+    location by time of building."""
+
     def __init__(self, location_value={}):
-        self.values = {}
-        self.axes = {}
-        for location, value in location_value.items():
-            self.add_value(location, value)
+        self.values = {
+            Location(location): value for location, value in location_value.items()
+        }
 
     def __repr__(self):
         items = []
@@ -27,92 +40,186 @@ class VariableScalar:
         return "(" + (" ".join(items)) + ")"
 
     @property
-    def does_vary(self):
+    def does_vary(self) -> bool:
         values = list(self.values.values())
         return any(v != values[0] for v in values[1:])
 
-    @property
-    def axes_dict(self):
-        if not self.axes:
-            raise ValueError(
-                ".axes must be defined on variable scalar before interpolating"
-            )
-        return {ax.axisTag: ax for ax in self.axes}
-
-    def _normalized_location(self, location):
-        location = self.fix_location(location)
-        normalized_location = {}
-        for axtag in location.keys():
-            if axtag not in self.axes_dict:
-                raise ValueError("Unknown axis %s in %s" % (axtag, location))
-            axis = self.axes_dict[axtag]
-            normalized_location[axtag] = normalizeValue(
-                location[axtag], (axis.minValue, axis.defaultValue, axis.maxValue)
-            )
-
-        return Location(normalized_location)
-
-    def fix_location(self, location):
-        location = dict(location)
-        for tag, axis in self.axes_dict.items():
-            if tag not in location:
-                location[tag] = axis.defaultValue
-        return location
-
-    def add_value(self, location, value):
-        if self.axes:
-            location = self.fix_location(location)
-
+    def add_value(self, location: Mapping[str, float], value: int):
         self.values[Location(location)] = value
 
-    def fix_all_locations(self):
-        self.values = {
-            Location(self.fix_location(l)): v for l, v in self.values.items()
+
+@dataclass
+class VariableScalarBuilder:
+    """A helper class for building variable scalars, or otherwise interrogating
+    their variation model for interpolation or similar."""
+
+    axis_triples: dict[str, tuple[float, float, float]]
+    """Minimum, default, and maximum for each axis in user-coordinates."""
+    axis_mappings: dict[str, Mapping[float, float]]
+    """Optional mappings from normalized user-coordinates to normalized
+    design-coordinates."""
+
+    model_cache: dict[tuple[LocationTuple, ...], VariationModel]
+    """We often use the same exact locations (i.e. font sources) for a large
+    number of variable scalars. Instead of creating a model for each, cache
+    them. Cache by user-location to avoid repeated mapping computations."""
+
+    @classmethod
+    def from_ttf(cls, ttf: TTFont) -> Self:
+        return cls(
+            axis_triples={
+                axis.axisTag: (axis.minValue, axis.defaultValue, axis.maxValue)
+                for axis in ttf["fvar"].axes
+            },
+            axis_mappings=(
+                {}
+                if (avar := ttf.get("avar")) is None
+                else {axis: segments for axis, segments in avar.segments.items()}
+            ),
+            model_cache={},
+        )
+
+    @classmethod
+    def from_designspace(cls, doc: DesignSpaceDocument) -> Self:
+        return cls(
+            axis_triples={
+                axis.tag: (axis.minimum, axis.default, axis.maximum)
+                for axis in doc.axes
+            },
+            axis_mappings={
+                axis.tag: {
+                    normalizeValue(
+                        user, (axis.minimum, axis.default, axis.maximum)
+                    ): normalizeValue(
+                        design,
+                        (
+                            axis.map_forward(axis.minimum),
+                            axis.map_forward(axis.default),
+                            axis.map_forward(axis.maximum),
+                        ),
+                    )
+                    for user, design in axis.map.items()
+                }
+                for axis in doc.axes
+                if axis.map is not None
+            },
+            model_cache={},
+        )
+
+    def normalise_location(self, location: LocationTuple) -> LocationTuple:
+        """Fully-specify, validate, and normalize a user-location."""
+
+        full = {}
+
+        # Normalize explicit axes, and error for unrecognised ones.
+        for axtag, value in location:
+            axis = self.axis_triples.get(axtag)
+            if axis is None:
+                raise ValueError("Unknown axis %s in %s" % (axtag, location))
+
+            axis_min, axis_default, axis_max = axis
+            full[axtag] = normalizeValue(value, (axis_min, axis_default, axis_max))
+
+        # Populate implicit axes.
+        for axtag in self.axis_triples:
+            if axtag in full:
+                continue
+            full[axtag] = 0.0
+
+        return Location(full)
+
+    def normalised_values(self, scalar: VariableScalar) -> dict[LocationTuple, int]:
+        """Get the values of a variable scalar with fully-specified, normalized
+        and validated user-locations."""
+
+        return {
+            self.normalise_location(location): value
+            for location, value in scalar.values.items()
         }
 
-    @property
-    def default(self):
-        self.fix_all_locations()
-        key = Location({ax.axisTag: ax.defaultValue for ax in self.axes})
-        if key not in self.values:
+    def default_value(self, scalar: VariableScalar) -> int:
+        """Get the default value of a variable scalar."""
+
+        full_values = self.normalised_values(scalar)
+        default_loc = Location({tag: 0.0 for tag in self.axis_triples})
+
+        default_value = full_values.get(default_loc)
+        if default_value is None:
             raise ValueError("Default value could not be found")
-            # I *guess* we could interpolate one, but I don't know how.
-        return self.values[key]
 
-    def value_at_location(self, location, model_cache=None, avar=None):
-        loc = Location(location)
-        if loc in self.values.keys():
-            return self.values[loc]
-        values = list(self.values.values())
-        loc = dict(self._normalized_location(loc))
-        return self.model(model_cache, avar).interpolateFromMasters(loc, values)
+        return default_value
 
-    def model(self, model_cache=None, avar=None):
-        if model_cache is not None:
-            key = tuple(self.values.keys())
-            if key in model_cache:
-                return model_cache[key]
-        locations = [dict(self._normalized_location(k)) for k in self.values.keys()]
-        if avar is not None:
-            mapping = avar.segments
-            locations = [
-                {
-                    k: piecewiseLinearMap(v, mapping[k]) if k in mapping else v
-                    for k, v in location.items()
-                }
-                for location in locations
-            ]
-        m = VariationModel(locations)
-        if model_cache is not None:
-            model_cache[key] = m
-        return m
+    def value_at_location(
+        self, scalar: VariableScalar, location: LocationTuple
+    ) -> float:
+        """Interpolate the value of a scalar from a user-location."""
 
-    def get_deltas_and_supports(self, model_cache=None, avar=None):
-        values = list(self.values.values())
-        return self.model(model_cache, avar).getDeltasAndSupports(values)
+        location = self.normalise_location(location)
+        full_values = self.normalised_values(scalar)
 
-    def add_to_variation_store(self, store_builder, model_cache=None, avar=None):
-        deltas, supports = self.get_deltas_and_supports(model_cache, avar)
+        exact = full_values.get(location)
+        if exact is not None:
+            return exact
+
+        values = list(full_values.values())
+        design_location = {
+            axis_tag: (
+                value
+                if (mapping := self.axis_mappings.get(axis_tag)) is None
+                else piecewiseLinearMap(value, mapping)
+            )
+            for axis_tag, value in location
+        }
+
+        value = self.model(scalar).interpolateFromMasters(design_location, values)
+        if value is None:
+            raise ValueError("Insufficient number of values to interpolate")
+
+        return value
+
+    def model(self, scalar: VariableScalar) -> VariationModel:
+        """Return a variation model based on a scalar's values.
+
+        Variable scalars with the same fully-specified user-location will use
+        the same cached variation model."""
+
+        full_values = self.normalised_values(scalar)
+        cache_key = tuple(full_values.keys())
+
+        cached_model = self.model_cache.get(cache_key)
+        if cached_model is not None:
+            return cached_model
+
+        design_locations = [
+            {
+                axis_tag: (
+                    value
+                    if (mapping := self.axis_mappings.get(axis_tag)) is None
+                    else piecewiseLinearMap(value, mapping)
+                )
+                for axis_tag, value in location
+            }
+            for location in full_values.keys()
+        ]
+        model = self.model_cache[cache_key] = VariationModel(design_locations)
+
+        return model
+
+    def get_deltas_and_supports(self, scalar: VariableScalar):
+        """Calculate deltas and supports from this scalar's variation model."""
+        values = list(scalar.values.values())
+        return self.model(scalar).getDeltasAndSupports(values)
+
+    def add_to_variation_store(
+        self, scalar: VariableScalar, store_builder
+    ) -> tuple[int, int]:
+        """Serialise this scalar's variation model to a store, returning the
+        default value and variation index."""
+
+        deltas, supports = self.get_deltas_and_supports(scalar)
         store_builder.setSupports(supports)
         index = store_builder.storeDeltas(deltas)
-        return int(self.default), index
+
+        # NOTE: Default value should be an exact integer by construction of
+        #       VariableScalar.
+        return int(self.default_value(scalar)), index

--- a/Lib/fontTools/varLib/models.py
+++ b/Lib/fontTools/varLib/models.py
@@ -8,6 +8,7 @@ __all__ = [
     "VariationModel",
 ]
 
+from collections.abc import Mapping
 from fontTools.misc.roundTools import noRound
 from .errors import VariationModelError
 
@@ -557,7 +558,7 @@ class VariationModel(object):
         return self.interpolateFromDeltasAndScalars(deltas, scalars)
 
 
-def piecewiseLinearMap(v, mapping):
+def piecewiseLinearMap(v: float, mapping: Mapping[float, float]) -> float:
     keys = mapping.keys()
     if not keys:
         return v


### PR DESCRIPTION
(aims to facilitate https://github.com/googlefonts/ufo2ft/issues/945)

Previously, calculating an individual interpolated value did not account
 for avar mapping. This commit fixes this, as well as allowing for
 interpolation and other common operations to be performed on fonts prior
 to compilation by decoupling from the exact ttLib representations of
 axes.

Some refactoring has been undergone to assist with this, including
 adding some more types and docs, and splitting the builder into a
 separate class to limit the amount of state in the VariableScalar class
 itself.

The fonttools and ufo2ft test suites pass with these changes, although
 there is no coverage for the designspace-based interpolation yet. This
 should be introduced before merging.

## TODOs

- [ ] Improve test coverage