### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,9 +21,9 @@ jobs:
   build_pure:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v6
     - name: Build source distribution and pure-python wheel
       run: |
         uv build
@@ -55,11 +55,11 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: aarch64
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     - name: Install dependencies
@@ -83,13 +83,17 @@ jobs:
       - build_wheels
     # only run if the commit is tagged...
     if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: publish-to-pypi
+      url: https://pypi.org/p/fontTools
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         # so that all artifacts are downloaded in the same directory specified by 'path'
         merge-multiple: true
         path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.13.0
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.13.0


### PR DESCRIPTION
In light of the recent npm supply chain attacks and also https://blog.pypi.org/posts/2025-09-16-github-actions-token-exfiltration/, I'm combing through our font stack to see if all them Py projects are using the trusted publisher mechanism as recommended by PyPI. See https://docs.pypi.org/trusted-publishers/ and https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi.

Someone needs to do two things for this PR to work:

* Create an environment called "publish-to-pypi" in this GitHub repository under Settings -> Environments.
* Follow https://docs.pypi.org/trusted-publishers/adding-a-publisher/ to set up the other side on PyPI.