### PR TITLE
[cu2qu.ufo] skip processing empty glyphs to support sparse kerning masters

### DIFF
--- a/Lib/fontTools/cu2qu/ufo.py
+++ b/Lib/fontTools/cu2qu/ufo.py
@@ -165,8 +165,18 @@ def _glyphs_to_quadratic(glyphs, max_err, reverse_direction, stats, all_quadrati
     """Do the actual conversion of a set of compatible glyphs, after arguments
     have been set up.
 
+    Empty glyphs (without contours) are ignored and passed through unchanged.
+
     Return True if the glyphs were modified, else return False.
     """
+
+    # Skip empty glyphs (with zero contours)
+    non_empty_indices = [i for i, g in enumerate(glyphs) if len(g) > 0]
+    if not non_empty_indices:
+        return False
+
+    glyphs = [glyphs[i] for i in non_empty_indices]
+    max_err = [max_err[i] for i in non_empty_indices]
 
     try:
         segments_by_location = zip(*[_get_segments(g) for g in glyphs])
@@ -212,6 +222,8 @@ def glyphs_to_quadratic(
     compatibility. If this is not required, calling glyphs_to_quadratic with one
     glyph at a time may yield slightly more optimized results.
 
+    Empty glyphs (without contours) are ignored and passed through unchanged.
+
     Return True if glyphs were modified, else return False.
 
     Raises IncompatibleGlyphsError if glyphs have non-interpolatable outlines.
@@ -249,6 +261,8 @@ def fonts_to_quadratic(
     All curves will be converted to quadratic at once, ensuring interpolation
     compatibility. If this is not required, calling fonts_to_quadratic with one
     font at a time may yield slightly more optimized results.
+
+    Empty glyphs (without contours) are ignored and passed through unchanged.
 
     Return the set of modified glyph names if any, else return an empty set.
 

--- a/Tests/cu2qu/ufo_test.py
+++ b/Tests/cu2qu/ufo_test.py
@@ -292,3 +292,27 @@ class GlyphsToQuadraticTest(object):
             ],
             [(1, 651), (4, 651), (3, 101), (2, 101)],
         ]
+
+    def test_ignore_empty_glyphs(self):
+        non_empty = ufoLib2.objects.Glyph(name="sparse")
+        pen = non_empty.getPointPen()
+        pen.beginPath()
+        pen.addPoint((0, 0), segmentType="line")
+        pen.addPoint((0, 2))
+        pen.addPoint((1, 3))
+        pen.addPoint((3, 3), segmentType="curve")
+        pen.endPath()
+
+        empty = ufoLib2.objects.Glyph(name="sparse")
+
+        assert glyphs_to_quadratic([non_empty, empty])
+
+        # Verify non-empty glyph was converted to quadratic
+        assert [((p.x, p.y), p.segmentType) for p in non_empty[0]] == [
+            ((0, 0), "line"),
+            ((0.0, 3.0), None),
+            ((3.0, 3.0), "qcurve"),
+        ]
+
+        # Verify empty glyph remains empty
+        assert len(empty) == 0


### PR DESCRIPTION
This will help with the use case described at https://github.com/googlefonts/fontmake/issues/1158

varLib already treats empty glyphs in non-default 'sparse' masters as non participating in gvar interpolation. But if a designspace contains a UFO with such empty glyphs, cu2qu rejects them because it expects all input glyphs to have the same number of segments.