### PR TITLE
[feaLib] Raise an error for rsub with NULL target

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -887,6 +887,11 @@ class Parser(object):
 
         is_deletion = False
         if len(new) == 1 and isinstance(new[0], ast.NullGlyph):
+            if reverse:
+                raise FeatureLibError(
+                    "Reverse chaining substitutions do not support glyph deletion",
+                    location,
+                )
             new = []  # Deletion
             is_deletion = True
 

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1440,6 +1440,14 @@ class ParserTest(unittest.TestCase):
             "feature test {rsub f_i by f i;} test;",
         )
 
+    def test_rsub_deletion(self):
+        self.assertRaisesRegex(
+            FeatureLibError,
+            "Reverse chaining substitutions do not support glyph deletion",
+            self.parse,
+            "lookup test { rsub a b c' e by NULL; } test;",
+        )
+
     def test_script(self):
         doc = self.parse("feature test {script cyrl;} test;")
         s = doc.statements[0].statements[0]


### PR DESCRIPTION
Glyph deletion can’t be supported with reverse chaining substitution and we were silently converting it to chaining substitution.

See discussion in https://github.com/fonttools/fonttools/issues/2952.

* Fixes https://github.com/fonttools/fonttools/issues/2952