### PR TITLE
Offer separate extras for woff2, woff1-zopfli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,12 +101,25 @@ extras_require = {
     "lxml": [
         "lxml >= 4.0",
     ],
-    # for fontTools.sfnt and fontTools.woff2: to compress/uncompress
-    # WOFF 1.0 and WOFF 2.0 webfonts.
+    # for fontTools.sfnt and fontTools.woff2: to compress/uncompress WOFF 2.0 webfonts.
+    # WOFF 1.0 compression/decompression is supported without this. For better but
+    # slower WOFF 1.0 compression, this extra installs the zopfli library. To use zopfli
+    # instead of zlib, you also need to set fontTools.ttLib.sfnt.USE_ZOPFLI to True
+    # before compressing a WOFF 1.0 file.
     "woff": [
+        "fonttools[woff1-zopfli]",
+        "fonttools[woff2]",
+    ],
+    # for fontTools.sfnt: use zopfli for better WOFF 1.0 compression at the expense of
+    # compression speed. To use zopfli instead of zlib, you also need to set
+    # fontTools.ttLib.sfnt.USE_ZOPFLI to True before compressing a WOFF 1.0 file.
+    "woff1-zopfli": [
+        "zopfli >= 0.1.4",
+    ],
+    # for fontTools.sfnt and fontTools.woff2: to compress/uncompress WOFF 2.0 webfonts.
+    "woff2": [
         "brotli >= 1.0.1; platform_python_implementation == 'CPython'",
         "brotlicffi >= 0.8.0; platform_python_implementation != 'CPython'",
-        "zopfli >= 0.1.4",
     ],
     # for fontTools.unicode and fontTools.unicodedata: to use the latest version
     # of the Unicode Character Database instead of the built-in unicodedata


### PR DESCRIPTION
I've added two new extras:

- "woff1-zopfli": Add extra compression for WOFF v1 via zopfli
- "woff2": Support for WOFF v1 compression/decompression via brotli

and made the current "woff" extra depend on them so current behaviour doesn't change.

I've also edited the descriptions to hopefully make it clearer that WOFF v1 is fully supported without zopfli, and that you need to opt in to using zopfli compression even if the library is installed.

This will solve the issue described in #3960 when the consumers switch to the new "woff2" extra.