### PR TITLE
[feaLib] Sort BasLangSysRecords by tag

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -767,7 +767,7 @@ class Builder(object):
 
             for c in script[2]:
                 record.BaseScript.BaseValues.BaseCoord.append(self.buildBASECoord(c))
-            for language, min_coord, max_coord in minmax_for_script:
+            for language, min_coord, max_coord in sorted(minmax_for_script):
                 minmax_record = otTables.MinMax()
                 minmax_record.MinCoord = self.buildBASECoord(min_coord)
                 minmax_record.MaxCoord = self.buildBASECoord(max_coord)

--- a/Tests/feaLib/data/spec9a2.fea
+++ b/Tests/feaLib/data/spec9a2.fea
@@ -2,6 +2,8 @@ table BASE {
    HorizAxis.BaseTagList ideo romn;
    HorizAxis.BaseScriptList latn romn -120 0, cyrl romn -120 0, grek romn -120 0, hani ideo -120 0, kana ideo -120 0, hang ideo -120 0;
    HorizAxis.MinMax cyrl dflt -800, 1200;
-   # Some comment
+   # These should be sorted by script, so SRB after RUS (also this comment
+   # is part of the test, see https://github.com/fonttools/fonttools/pull/3783#discussion_r1973878772)
+   HorizAxis.MinMax cyrl SRB  -999, 999;
    HorizAxis.MinMax cyrl RUS  -1000, 1000;
 } BASE;

--- a/Tests/feaLib/data/spec9a2.ttx
+++ b/Tests/feaLib/data/spec9a2.ttx
@@ -33,7 +33,7 @@
               </MaxCoord>
               <!-- FeatMinMaxCount=0 -->
             </DefaultMinMax>
-            <!-- BaseLangSysCount=1 -->
+            <!-- BaseLangSysCount=2 -->
             <BaseLangSysRecord index="0">
               <BaseLangSysTag value="RUS "/>
               <MinMax>
@@ -42,6 +42,18 @@
                 </MinCoord>
                 <MaxCoord Format="1">
                   <Coordinate value="1000"/>
+                </MaxCoord>
+                <!-- FeatMinMaxCount=0 -->
+              </MinMax>
+            </BaseLangSysRecord>
+            <BaseLangSysRecord index="1">
+              <BaseLangSysTag value="SRB "/>
+              <MinMax>
+                <MinCoord Format="1">
+                  <Coordinate value="-999"/>
+                </MinCoord>
+                <MaxCoord Format="1">
+                  <Coordinate value="999"/>
                 </MaxCoord>
                 <!-- FeatMinMaxCount=0 -->
               </MinMax>


### PR DESCRIPTION
As required by the spec.


(@anthrotype pointed out in https://github.com/googlefonts/fontc/pull/1763/files#r2542066755, where I was also failing to sort these; fixing here so that I can reuse the test case)