### PR TITLE
[instancer] bug fix in avar2 full instancing

### DIFF
--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -448,7 +448,7 @@ class AxisLimits(_BaseAxisLimits):
                 # Full instancing of avar2 font. Use avar table to normalize location and return.
                 location = self.pinnedLocation()
                 location = {
-                    tag: normalize(value, axes[tag], avarSegments.get(tag, None))
+                    tag: normalize(value, axes[tag], None)
                     for tag, value in location.items()
                 }
                 return NormalizedAxisLimits(


### PR DESCRIPTION
Avoid double piecewiseLinearMap:
in normalize() and avar renormalizeLocation()