### PR TITLE
[fvar/trak] Remove `name` table dependency

### DIFF
--- a/Lib/fontTools/ttLib/tables/_f_v_a_r.py
+++ b/Lib/fontTools/ttLib/tables/_f_v_a_r.py
@@ -51,8 +51,6 @@ class table__f_v_a_r(DefaultTable.DefaultTable):
     See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6fvar.html
     """
 
-    dependencies = ["name"]
-
     def __init__(self, tag=None):
         DefaultTable.DefaultTable.__init__(self, tag)
         self.axes = []

--- a/Lib/fontTools/ttLib/tables/_t_r_a_k.py
+++ b/Lib/fontTools/ttLib/tables/_t_r_a_k.py
@@ -65,8 +65,6 @@ class table__t_r_a_k(DefaultTable.DefaultTable):
     See also https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6trak.html
     """
 
-    dependencies = ["name"]
-
     def compile(self, ttFont):
         dataList = []
         offset = TRAK_HEADER_FORMAT_SIZE


### PR DESCRIPTION
The dependency mechanism is only used when a table needs other tables to be compiled before it. It's not the case here. We just use `name` table in conversion to XML, and that works automatically.