### PR TITLE
[feaLib] Add shorthand for value at default location in variable scalar

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -2190,10 +2190,17 @@ class Parser(object):
     def expect_variable_scalar_(self):
         self.advance_lexer_()  # "("
         scalar = VariableScalar()
+        default_seen = False
         while True:
             if self.cur_token_type_ == Lexer.SYMBOL and self.cur_token_ == ")":
                 break
             if self.cur_token_type_ == Lexer.NUMBER:
+                if default_seen:
+                    raise FeatureLibError(
+                        "Duplicate value for the default location",
+                        self.cur_token_location_,
+                    )
+                default_seen = True
                 location, value = {}, self.cur_token_
                 self.advance_lexer_()
             else:

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -2193,7 +2193,11 @@ class Parser(object):
         while True:
             if self.cur_token_type_ == Lexer.SYMBOL and self.cur_token_ == ")":
                 break
-            location, value = self.expect_master_()
+            if self.cur_token_type_ == Lexer.NUMBER:
+                location, value = {}, self.cur_token_
+                self.advance_lexer_()
+            else:
+                location, value = self.expect_master_()
             scalar.add_value(location, value)
         return scalar
 

--- a/Lib/fontTools/feaLib/variableScalar.py
+++ b/Lib/fontTools/feaLib/variableScalar.py
@@ -46,13 +46,16 @@ class VariableScalar:
     def __repr__(self):
         items = []
         for location, value in self.values.items():
-            loc = ",".join(
-                [
-                    f"{ax}={int(coord) if float(coord).is_integer() else coord}"
-                    for ax, coord in location
-                ]
-            )
-            items.append("%s:%i" % (loc, value))
+            if location:
+                loc = ",".join(
+                    [
+                        f"{ax}={int(coord) if float(coord).is_integer() else coord}"
+                        for ax, coord in location
+                    ]
+                )
+                items.append("%s:%i" % (loc, value))
+            else:
+                items.append("%i" % value)
         return "(" + (" ".join(items)) + ")"
 
     @property

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -1344,6 +1344,28 @@ class BuilderTest(unittest.TestCase):
         ):
             addOpenTypeFeaturesFromString(font, features)
 
+    def test_variable_scalar_default(self):
+        """Test that missing axis name(s) in variable scalar means default location."""
+
+        features = """
+            feature kern {
+                pos two <0 (wght=900:22 12 wdth=150,wght=900:42) 0 0>;
+            } kern;
+        """
+
+        font = self.make_mock_vf()
+        addOpenTypeFeaturesFromString(font, features)
+
+        var_region_list = font.tables["GDEF"].table.VarStore.VarRegionList
+        var_region_axis_wght = var_region_list.Region[0].VarRegionAxis[0]
+        var_region_axis_wdth = var_region_list.Region[0].VarRegionAxis[1]
+        assert self.get_region(var_region_axis_wght) == (0.0, 0.875, 1.0)
+        assert self.get_region(var_region_axis_wdth) == (0.0, 0.0, 0.0)
+        var_region_axis_wght = var_region_list.Region[1].VarRegionAxis[0]
+        var_region_axis_wdth = var_region_list.Region[1].VarRegionAxis[1]
+        assert self.get_region(var_region_axis_wght) == (0.0, 0.875, 1.0)
+        assert self.get_region(var_region_axis_wdth) == (0.0, 0.5, 1.0)
+
     def test_ligatureCaretByPos_variable_scalar(self):
         """Test that the `avar` table is consulted when normalizing user-space
         values."""

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -2135,6 +2135,16 @@ class ParserTest(unittest.TestCase):
             'Ambiguous "ignore sub", there should be least one marked glyph'
         )
 
+    def test_variable_scalar_default(self):
+        doc = self.parse(
+            "feature test {valueRecordDef <0 (100 wght=200:-100 wght=900:-150 wdth=150,wght=900:-120) 0 0> foo;} test;"
+        )
+        value = doc.statements[0].statements[0].value
+        self.assertEqual(
+            value.asFea(),
+            "<0 (100 wght=200:-100 wght=900:-150 wdth=150,wght=900:-120) 0 0>",
+        )
+
     def parse(self, text, glyphNames=GLYPHNAMES, followIncludes=True):
         featurefile = StringIO(text)
         p = Parser(featurefile, glyphNames, followIncludes=followIncludes)

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -2145,6 +2145,14 @@ class ParserTest(unittest.TestCase):
             "<0 (100 wght=200:-100 wght=900:-150 wdth=150,wght=900:-120) 0 0>",
         )
 
+    def test_variable_scalar_duplicate_bare_value(self):
+        self.assertRaisesRegex(
+            FeatureLibError,
+            "Duplicate value for the default location",
+            self.parse,
+            "feature test {pos a (10 20 wght=900:30);} test",
+        )
+
     def parse(self, text, glyphNames=GLYPHNAMES, followIncludes=True):
         featurefile = StringIO(text)
         p = Parser(featurefile, glyphNames, followIncludes=followIncludes)

--- a/Tests/feaLib/variableScalar_test.py
+++ b/Tests/feaLib/variableScalar_test.py
@@ -14,11 +14,12 @@ from fontTools.varLib.models import VariationModel, normalizeValue
 
 def test_variable_scalar_repr():
     scalar = VariableScalar()
+    scalar.add_value({}, 20)
     scalar.add_value({"wght": 400}, 1)
     scalar.add_value({"wght": 500.5}, 4)
     scalar.add_value({"wght": 700}, 10)
 
-    assert str(scalar) == "(wght=400:1 wght=500.5:4 wght=700:10)"
+    assert str(scalar) == "(20 wght=400:1 wght=500.5:4 wght=700:10)"
 
 
 def test_variable_scalar_interpolation_with_avar():


### PR DESCRIPTION
Writing a number-only without an axis name and colon is used to mean this is the value for default location. For example, in a font whose `wght` default is 400:

```
(100 wght=900:120)
```

is shorthand for:

```
(wght=400:100 wght=900:120)
```