### PR TITLE
Build abi3 wheels for Cython extensions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,8 @@ on:
 
 env:
   # skip binary wheels for pypy (preferable to use pure-python) and 32-bit Linux
-  CIBW_SKIP: pp* cp*linux_i686
+  # skip free-threaded CPython too: abi3 wheels are currently incompatible there
+  CIBW_SKIP: pp* cp*linux_i686 cp31?t-*
   CIBW_ENVIRONMENT: FONTTOOLS_WITH_CYTHON=1
   CIBW_TEST_REQUIRES: tox
   # only test core fonttools library without extras for now, stuff like lxml or scipy

--- a/Lib/fontTools/cu2qu/cu2qu.py
+++ b/Lib/fontTools/cu2qu/cu2qu.py
@@ -1,6 +1,4 @@
 # cython: language_level=3
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
-
 # Copyright 2015 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/Lib/fontTools/qu2cu/qu2cu.py
+++ b/Lib/fontTools/qu2cu/qu2cu.py
@@ -1,6 +1,4 @@
 # cython: language_level=3
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
-
 # Copyright 2023 Google Inc. All Rights Reserved.
 # Copyright 2023 Behdad Esfahbod. All Rights Reserved.
 #

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -41,3 +41,4 @@ recursive-include Tests *.xml *.designspace *.bin
 recursive-include Tests *.afm
 recursive-include Tests *.json
 recursive-include Tests *.ufoz
+global-exclude *.so *.pyd

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,9 @@ replace = version="{new_version}"
 [metadata]
 license_files = LICENSE
 
+[bdist_wheel]
+py_limited_api = cp310
+
 [tool:pytest]
 minversion = 7.0.0
 testpaths = 

--- a/setup.py
+++ b/setup.py
@@ -69,18 +69,24 @@ if with_cython and not has_cython:
 
 ext_modules = []
 if with_cython is True or (with_cython is None and has_cython):
+    py_limited_api = "0x030A0000"
     # On POSIX systems (Linux, macOS, etc.), math functions like sqrt, pow, fabs
     # may require explicit linkage to libm. This is particularly needed on some
     # Linux distributions (e.g., Amazon Linux with Clang) where libm is not
     # automatically linked. On Windows, math functions are in msvcrt.
     # See https://github.com/fonttools/fonttools/issues/4028
     libraries = ["m"] if os.name == "posix" else []
+    ext_kwargs = {
+        "define_macros": [("Py_LIMITED_API", py_limited_api)],
+        "py_limited_api": True,
+    }
 
     ext_modules.append(
         Extension(
             "fontTools.cu2qu.cu2qu",
             ["Lib/fontTools/cu2qu/cu2qu.py"],
             libraries=libraries,
+            **ext_kwargs,
         ),
     )
     ext_modules.append(
@@ -88,6 +94,7 @@ if with_cython is True or (with_cython is None and has_cython):
             "fontTools.qu2cu.qu2cu",
             ["Lib/fontTools/qu2cu/qu2cu.py"],
             libraries=libraries,
+            **ext_kwargs,
         ),
     )
     ext_modules.append(
@@ -95,6 +102,7 @@ if with_cython is True or (with_cython is None and has_cython):
             "fontTools.misc.bezierTools",
             ["Lib/fontTools/misc/bezierTools.py"],
             libraries=libraries,
+            **ext_kwargs,
         ),
     )
     ext_modules.append(
@@ -102,13 +110,18 @@ if with_cython is True or (with_cython is None and has_cython):
             "fontTools.pens.momentsPen",
             ["Lib/fontTools/pens/momentsPen.py"],
             libraries=libraries,
+            **ext_kwargs,
         ),
     )
     ext_modules.append(
-        Extension("fontTools.varLib.iup", ["Lib/fontTools/varLib/iup.py"]),
+        Extension(
+            "fontTools.varLib.iup", ["Lib/fontTools/varLib/iup.py"], **ext_kwargs
+        ),
     )
     ext_modules.append(
-        Extension("fontTools.feaLib.lexer", ["Lib/fontTools/feaLib/lexer.py"]),
+        Extension(
+            "fontTools.feaLib.lexer", ["Lib/fontTools/feaLib/lexer.py"], **ext_kwargs
+        ),
     )
 
 extras_require = {
@@ -535,6 +548,7 @@ setup_params = dict(
     package_dir={"": "Lib"},
     packages=find_packages("Lib"),
     include_package_data=True,
+    exclude_package_data={"": ["*.so", "*.pyd"]},
     data_files=find_data_files(),
     ext_modules=ext_modules,
     setup_requires=setup_requires,


### PR DESCRIPTION
Build the optional Cython extensions as cp310-abi3 wheels instead of per-CPython-version wheels.

This should substantially reduce the number of published binary wheels (49 currently!) while keeping support for Python 3.10+.

The free-threaded CPython 3.14t wheel builds are skipped since abi3 wheels are [currently incompatible](https://docs.python.org/3.14/howto/free-threading-extensions.html#limited-c-api-and-stable-abi) there, and we don't actually test those specifically either.
fontTools still publishes the pure-Python wheel, so unsupported environments can continue to install that one.