### PR TITLE
Add support for Apple Color Emoji `bgcl` table

### DIFF
--- a/Doc/source/ttx.rst
+++ b/Doc/source/ttx.rst
@@ -36,13 +36,13 @@ The TTX file format
 The following tables are currently supported::
 
     BASE, CBDT, CBLC, CFF, CFF2, COLR, CPAL, DSIG, Debg, EBDT, EBLC,
-    FFTM, Feat, GDEF, GMAP, GPKG, GPOS, GSUB, GVAR, Glat, Gloc, HVAR,
-    JSTF, LTSH, MATH, META, MVAR, OS/2, SING, STAT, SVG, Silf, Sill,
-    TSI0, TSI1, TSI2, TSI3, TSI5, TSIB, TSIC, TSID, TSIJ, TSIP, TSIS,
-    TSIV, TTFA, VARC, VDMX, VORG, VVAR, ankr, avar, bsln, cidg, cmap,
-    cvar, cvt, feat, fpgm, fvar, gasp, gcid, glyf, gvar, hdmx, head,
-    hhea, hmtx, kern, lcar, loca, ltag, maxp, meta, mort, morx, name,
-    opbd, post, prep, prop, sbix, trak, vhea and vmtx
+    FFTM, Feat, GDEF, GPOS, GSUB, GVAR, Glat, Gloc, HVAR, JSTF, LTSH,
+    MATH, MVAR, OS/2, STAT, SVG, Silf, Sill, TSI0, TSI1, TSI2, TSI3,
+    TSI5, TSIB, TSIC, TSID, TSIJ, TSIP, TSIS, TSIV, TTFA, VARC, VDMX,
+    VORG, VVAR, ankr, avar, bgcl, bsln, cidg, cmap, cvar, cvt, feat,
+    fpgm, fvar, gasp, gcid, glyf, gvar, hdmx, head, hhea, hmtx, kern,
+    lcar, loca, ltag, maxp, meta, mort, morx, name, opbd, post, prep,
+    prop, sbix, trak, vhea and vmtx
 
 .. end table list
 

--- a/Lib/fontTools/ttLib/tables/__init__.py
+++ b/Lib/fontTools/ttLib/tables/__init__.py
@@ -53,6 +53,7 @@ def _moduleFinderHint():
     from . import V_V_A_R_
     from . import _a_n_k_r
     from . import _a_v_a_r
+    from . import _b_g_c_l
     from . import _b_s_l_n
     from . import _c_i_d_g
     from . import _c_m_a_p

--- a/Lib/fontTools/ttLib/tables/_b_g_c_l.py
+++ b/Lib/fontTools/ttLib/tables/_b_g_c_l.py
@@ -1,0 +1,97 @@
+"""Support for the `bgcl` (Apple Color Emoji background) table.
+
+This table stores a JSON blob. We decode it to a Python object on
+decompile and emit human readable JSON in the TTX via a <json> element.
+On compile we re-encode the JSON to UTF-8 bytes which is what Apple code
+reads via CTFontCopyTable then JSONDecoder.
+
+This is intentionally lightweight: it preserves the JSON structure and
+exposes convenience attributes `colors`, `emojicolors`, `indexmap` and
+`version` when available.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fontTools.misc.textTools import tostr, strjoin
+from . import DefaultTable
+import json
+
+if TYPE_CHECKING:
+    from fontTools.misc.xmlWriter import XMLWriter
+    from fontTools.ttLib import TTFont
+
+
+class table__b_g_c_l(DefaultTable.DefaultTable):
+    """bgcl table: stores a JSON blob describing background palettes.
+
+    The JSON structure typically contains the top-level keys:
+      - colors: [[R,G,B,A], ...]
+      - emojicolors: [[[dominant...],[accent...],[contextual...]], ...]
+      - indexmap: {"glyphIndex": emojicolors_index, ...}
+      - version: int
+    """
+
+    def decompile(self, data: bytes, ttFont: TTFont) -> None:
+        """Store raw bytes and attempt to parse JSON."""
+        self.data = data
+        try:
+            text = tostr(data, "utf_8")
+            self.json = json.loads(text)
+        except Exception as e:  # keep table decompilation robust
+            self.json = None
+            self.ERROR = f"bgcl JSON parse error: {e!r}"
+            return
+        # convenient attributes
+        self.colors = self.json.get("colors")
+        self.emojicolors = self.json.get("emojicolors")
+        self.indexmap = self.json.get("indexmap")
+        self.version = self.json.get("version")
+
+    def compile(self, ttFont: TTFont) -> bytes:
+        """Encode the JSON object to UTF-8 bytes for font binary storage."""
+        if getattr(self, "json", None) is None:
+            # fallback to raw bytes if parsing failed earlier
+            return getattr(self, "data", b"")
+        # use compact representation for binary table
+        return json.dumps(self.json, separators=(",", ":"), ensure_ascii=False).encode(
+            "utf_8"
+        )
+
+    def toXML(self, writer: XMLWriter, ttFont: TTFont) -> None:
+        """Emit pretty-printed JSON inside a <json> element for human inspection."""
+        if getattr(self, "json", None) is None:
+            # fallback to default hex output
+            DefaultTable.DefaultTable.toXML(self, writer, ttFont)
+            return
+        writer.begintag("json")
+        writer.newline()
+        pretty = json.dumps(self.json, indent=2, ensure_ascii=False)
+        writer.writecdata(pretty)
+        writer.newline()
+        writer.endtag("json")
+        writer.newline()
+
+    def fromXML(self, name: str, attrs: dict[str, str], content, ttFont: TTFont) -> None:
+        """Read JSON from the <json> element. `content` may be a list.
+
+        This mirrors SVG/other table `fromXML` handlers which accept a
+        list of content chunks.
+        """
+        if name != "json":
+            # fall back to DefaultTable behavior for unknown elements
+            return DefaultTable.DefaultTable.fromXML(self, name, attrs, content, ttFont)
+        text = strjoin(content).strip()
+        try:
+            self.json = json.loads(text)
+            # keep raw bytes in sync
+            self.data = text.encode("utf_8")
+            self.colors = self.json.get("colors")
+            self.emojicolors = self.json.get("emojicolors")
+            self.indexmap = self.json.get("indexmap")
+            self.version = self.json.get("version")
+        except Exception as e:
+            # store error and fall back to raw
+            self.json = None
+            self.ERROR = f"bgcl JSON parse error in fromXML: {e!r}"

--- a/Lib/fontTools/ttLib/tables/_b_g_c_l.py
+++ b/Lib/fontTools/ttLib/tables/_b_g_c_l.py
@@ -73,7 +73,9 @@ class table__b_g_c_l(DefaultTable.DefaultTable):
         writer.endtag("json")
         writer.newline()
 
-    def fromXML(self, name: str, attrs: dict[str, str], content, ttFont: TTFont) -> None:
+    def fromXML(
+        self, name: str, attrs: dict[str, str], content, ttFont: TTFont
+    ) -> None:
         """Read JSON from the <json> element. `content` may be a list.
 
         This mirrors SVG/other table `fromXML` handlers which accept a

--- a/Lib/fontTools/ttLib/tables/_b_g_c_l.py
+++ b/Lib/fontTools/ttLib/tables/_b_g_c_l.py
@@ -5,9 +5,12 @@ decompile and emit human readable JSON in the TTX via a <json> element.
 On compile we re-encode the JSON to UTF-8 bytes which is what Apple code
 reads via CTFontCopyTable then JSONDecoder.
 
-This is intentionally lightweight: it preserves the JSON structure and
-exposes convenience attributes `colors`, `emojicolors`, `indexmap` and
-`version` when available.
+On iOS 16 and later the `bgcl` payload is used as the wallpaper
+background color when the user selects an emoji wallpaper.
+
+This implementation is intentionally lightweight: it preserves the JSON
+structure and exposes convenience attributes `colors`, `emojicolors`,
+`indexmap` and `version` when available.
 """
 
 from __future__ import annotations
@@ -34,7 +37,12 @@ class table__b_g_c_l(DefaultTable.DefaultTable):
     """
 
     def decompile(self, data: bytes, ttFont: TTFont) -> None:
-        """Store raw bytes and attempt to parse JSON."""
+        """Store raw bytes and attempt to parse JSON.
+
+        The JSON commonly includes palette/lookup data used at runtime to
+        construct wallpaper/background colors for emoji wallpapers on
+        recent iOS releases.
+        """
         self.data = data
         try:
             text = tostr(data, "utf_8")

--- a/Lib/fontTools/ttLib/tables/_b_g_c_l.py
+++ b/Lib/fontTools/ttLib/tables/_b_g_c_l.py
@@ -8,7 +8,7 @@ reads via CTFontCopyTable then JSONDecoder.
 On iOS 16 and later the `bgcl` payload is used as the wallpaper
 background when the user selects an emoji wallpaper.
 
-Fields (expected structure and semantics):
+Fields:
 
 - ``colors``: list of palette entries. Each entry is an array of four
     integers ``[R, G, B, A]``. R/G/B are 0-255. A is 0-1.

--- a/Lib/fontTools/ttLib/tables/_b_g_c_l.py
+++ b/Lib/fontTools/ttLib/tables/_b_g_c_l.py
@@ -6,11 +6,40 @@ On compile we re-encode the JSON to UTF-8 bytes which is what Apple code
 reads via CTFontCopyTable then JSONDecoder.
 
 On iOS 16 and later the `bgcl` payload is used as the wallpaper
-background color when the user selects an emoji wallpaper.
+background when the user selects an emoji wallpaper.
 
-This implementation is intentionally lightweight: it preserves the JSON
-structure and exposes convenience attributes `colors`, `emojicolors`,
-`indexmap` and `version` when available.
+Fields (expected structure and semantics):
+
+- ``colors``: list of palette entries. Each entry is an array of four
+    integers ``[R, G, B, A]``. R/G/B are 0-255. A is 0-1.
+
+- ``emojicolors``: list of per-emoji palettes. Each item is an array of
+    three sublists: primary/dominant, accent, contextual
+    (names inferred). Each sublist contains integer indexes referencing
+    entries in ``colors``; the runtime uses these to assemble layered
+    background tints for an emoji.
+
+- ``indexmap``: mapping (glyph identifier → palette index). The map
+    maps a glyph identity to an integer index selecting an entry in
+    ``emojicolors``. The font/UI uses this to pick the correct palette
+    for a glyph when rendering wallpaper backgrounds.
+
+- ``version``: integer table version used for parsing/compatibility.
+
+Runtime usage summary:
+
+- The system fetches the table bytes with ``CTFontCopyTable('bgcl')``,
+    decodes the bytes as UTF‑8 JSON and runs the JSON through the app's
+    decoder into an internal ``BgclTable`` structure. The app looks up a
+    glyph's entry in ``indexmap``, retrieves the corresponding
+    ``emojicolors`` palette, then converts the referenced ``colors``
+    entries into color objects (normalizing channels/alpha as needed).
+    This resulting color(s) drive the wallpaper background appearance for
+    emoji wallpapers on supported iOS versions.
+
+This implementation preserves the JSON payload and exposes convenience
+attributes ``colors``, ``emojicolors``, ``indexmap`` and ``version``
+when available.
 """
 
 from __future__ import annotations

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -1486,6 +1486,12 @@ def newTable(tag: str | bytes) -> DefaultTable:
     return tableClass(tag)
 
 
+try:
+    registerCustomTableClass("BGCL", "fontTools.ttLib.tables.B_G_C_L_", "table_B_G_C_L_")
+except Exception:
+    pass
+
+
 def _escapechar(c: str) -> str:
     """Helper function for tagToIdentifier()"""
     import re

--- a/Lib/fontTools/ttLib/ttFont.py
+++ b/Lib/fontTools/ttLib/ttFont.py
@@ -1486,12 +1486,6 @@ def newTable(tag: str | bytes) -> DefaultTable:
     return tableClass(tag)
 
 
-try:
-    registerCustomTableClass("BGCL", "fontTools.ttLib.tables.B_G_C_L_", "table_B_G_C_L_")
-except Exception:
-    pass
-
-
 def _escapechar(c: str) -> str:
     """Helper function for tagToIdentifier()"""
     import re

--- a/Tests/ttLib/tables/_b_g_c_l_test.py
+++ b/Tests/ttLib/tables/_b_g_c_l_test.py
@@ -1,0 +1,27 @@
+import importlib
+import unittest
+
+
+class Test_b_g_c_l(unittest.TestCase):
+    """Unit tests for the `bgcl` table implementation."""
+
+    def test_compile_decompile_roundtrip(self):
+        mod = importlib.import_module("fontTools.ttLib.tables._b_g_c_l")
+        cls = getattr(mod, "table__b_g_c_l")
+
+        sample = {
+            "colors": [[255, 0, 0, 1], [0, 255, 0, 1]],
+            "emojicolors": [[[0], [1], []]],
+            "indexmap": {"10": 0},
+            "version": 1,
+        }
+
+        t1 = cls("bgcl")
+        t1.json = sample
+        data = t1.compile(None)
+
+        t2 = cls("bgcl")
+        t2.decompile(data, None)
+
+        self.assertEqual(getattr(t2, "json", None), sample)
+

--- a/Tests/ttLib/tables/_b_g_c_l_test.py
+++ b/Tests/ttLib/tables/_b_g_c_l_test.py
@@ -1,13 +1,13 @@
-import importlib
 import unittest
+
+from fontTools.ttLib import getTableClass
 
 
 class Test_b_g_c_l(unittest.TestCase):
     """Unit tests for the `bgcl` table implementation."""
 
     def test_compile_decompile_roundtrip(self):
-        mod = importlib.import_module("fontTools.ttLib.tables._b_g_c_l")
-        cls = getattr(mod, "table__b_g_c_l")
+        cls = getTableClass("bgcl")
 
         sample = {
             "colors": [[255, 0, 0, 1], [0, 255, 0, 1]],

--- a/Tests/ttLib/tables/_b_g_c_l_test.py
+++ b/Tests/ttLib/tables/_b_g_c_l_test.py
@@ -24,4 +24,3 @@ class Test_b_g_c_l(unittest.TestCase):
         t2.decompile(data, None)
 
         self.assertEqual(getattr(t2, "json", None), sample)
-


### PR DESCRIPTION
Add support for Apple Color Emoji `bgcl` table (JSON payload).

Purpose: stores Apple Color Emoji background palettes as a UTF‑8 JSON blob (palette colors + per‑emoji palette indices). The system font reads it at runtime to style emoji backgrounds. It is used in iOS 16+ lock screen emoji wallpaper.