### PR TITLE
ci: add riscv64 wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,10 +54,17 @@ jobs:
             arch: auto32
           - os: ubuntu-24.04-arm
             arch: aarch64
+          - os: ubuntu-latest
+            arch: riscv64
     steps:
     - uses: actions/checkout@v6
       with:
         submodules: recursive
+    - name: Set up QEMU
+      if: matrix.arch == 'riscv64'
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: riscv64
     - name: Set up Python
       uses: actions/setup-python@v6
       with:


### PR DESCRIPTION
## What does this change?

Add riscv64 to the cibuildwheel wheel build matrix using QEMU emulation on ubuntu-latest, so that riscv64 wheels are built alongside existing architectures.

## Changes

- Add `riscv64` matrix entry with QEMU setup step (conditional, only runs for riscv64)
- Add `CIBW_ARCHS_LINUX` override for riscv64

## Evidence

- Built successfully from source on native riscv64 hardware (BananaPi F3, SpacemiT K1, rv64gc)
- fonttools is pure C (Cython extensions), compiles cleanly on riscv64

---

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve Python ecosystem support on riscv64 platforms. Native riscv64 CI runners are available for free via [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners).