### PR TITLE
[ci] add riscv64 wheel builds using RISE RISC-V native runners

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,6 +54,8 @@ jobs:
             arch: auto32
           - os: ubuntu-24.04-arm
             arch: aarch64
+          - os: ubuntu-24.04-riscv
+            arch: riscv64
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -61,11 +61,18 @@ jobs:
       with:
         submodules: recursive
     - name: Set up Python
+      # riscv64 not supported by actions/setup-python yet
+      # https://github.com/actions/setup-python/issues/1288
+      if: matrix.arch != 'riscv64'
       uses: actions/setup-python@v6
       with:
         python-version: "3.x"
+    - name: Setup Python for riscv64
+      if: matrix.arch == 'riscv64'
+      run: |
+        echo "/opt/python-3.12/bin" >> "$GITHUB_PATH"
     - name: Install dependencies
-      run: pip install cibuildwheel
+      run: python -m pip install cibuildwheel
 
     - name: Build Wheels
       run: python -m cibuildwheel --output-dir wheelhouse .


### PR DESCRIPTION
supersedes #4069

/cc @gounthar

https://github.com/apps/rise-risc-v-runners