### PR TITLE
Add IFT table

### DIFF
--- a/Lib/fontTools/misc/iftSparseBitSet.py
+++ b/Lib/fontTools/misc/iftSparseBitSet.py
@@ -1,0 +1,299 @@
+"""Sparse Bit Set encoding/decoding for IFT (Incremental Font Transfer).
+
+Implements the sparse bit set format defined in the W3C IFT specification:
+https://w3c.github.io/IFT/Overview.html#sparse-bit-set-decoding
+"""
+
+# Reference: https://github.com/googlefonts/fontations/blob/main/read-fonts/src/collections/int_set/sparse_bit_set.rs
+
+
+import bisect
+from collections import deque
+from typing import Dict, Iterable, Optional, Set, Tuple
+
+# Maximum tree height that fits within a 32-bit leaf node for each branching factor.
+_BF_MAX_HEIGHT: Dict[int, int] = {2: 31, 4: 16, 8: 11, 32: 7}
+
+
+class SparseBitSetDecodeError(Exception):
+    pass
+
+
+def decode(data: bytes, bias: int = 0, maxValue: int = 0xFFFFFFFF) -> Tuple[Set[int], int]:
+    """Decode a sparse bit set from binary data.
+
+    Args:
+        data: bytes-like object containing the sparse bit set encoding.
+        bias: integer added to each decoded value.
+
+    Returns:
+        A tuple (values, bytesConsumed) where values is a set of integers
+        and bytesConsumed is the number of bytes read from data.
+    """
+    if not data:
+        raise SparseBitSetDecodeError("Empty data")
+
+    branchFactor, height = _decodeHeader(data[0])
+
+    maxHeight = _BF_MAX_HEIGHT[branchFactor]
+    if height > maxHeight:
+        raise SparseBitSetDecodeError(
+            f"Height {height} exceeds max {maxHeight} for branch factor {branchFactor}"
+        )
+
+    return _decodeImpl(data, branchFactor, height, bias, maxValue)
+
+def _decodeImpl(data: bytes, branchFactor: int, height: int, bias: int, maxValue: int) -> Tuple[Set[int], int]:
+    if height == 0:
+        # 1 byte was used for the header.
+        return (set(), 1)
+
+    bitStream = _InputBitStream(data, branchFactor)
+    result: Set[int] = set()
+    # Queue entries are (startValue, depth), where startValue is the first
+    # integer that could be covered by this node.
+    queue: deque[Tuple[int, int]] = deque()
+    queue.append((0, 1))
+
+    while queue:
+        start, depth = queue.popleft()
+        bits = bitStream.next()
+        if bits is None:
+            raise SparseBitSetDecodeError("Unexpected end of data")
+
+        # all bits were were zero which is a special command to completely fill
+        # in all integers covered by this node.
+        if bits == 0:
+            exp = height - depth + 1
+            nodeSize = branchFactor**exp
+            fillStart = start + bias
+            if fillStart > maxValue:
+                continue
+            fillEnd = min(maxValue, start + nodeSize - 1 + bias)
+            if fillStart < 0:
+                fillStart = 0
+            if fillStart <= fillEnd:
+                result.update(range(fillStart, fillEnd + 1))
+            continue
+
+        # Non-zero node: each set bit identifies a child/value.
+        exp = height - depth
+        nextNodeSize = branchFactor**exp
+        while True:
+            bitIndex = _trailingZeros(bits, 32)
+            if bitIndex == 32:
+                break
+            if depth == height:
+                val = start + bitIndex + bias
+                if val > maxValue:
+                    queue.clear()
+                    break
+                if val >= 0:
+                    result.add(val)
+            else:
+                startDelta = bitIndex * nextNodeSize
+                queue.append((start + startDelta, depth + 1))
+            bits &= ~(1 << bitIndex)
+
+    return (result, bitStream.bytesConsumed())
+
+
+def encode(values: Iterable[int]) -> bytes:
+    """Encode a set of integers as a sparse bit set.
+
+    Tries all branching factors and returns the shortest encoding.
+
+    Args:
+        values: iterable of non-negative integers.
+
+    Returns:
+        bytes containing the sparse bit set encoding.
+    """
+    valuesSorted = sorted(set(values))
+    if not valuesSorted:
+        return _encodeHeader(2, 0)
+
+    maxValue = valuesSorted[-1]
+    valueSet = set(valuesSorted)
+
+    best: Optional[bytes] = None
+    for branchFactor in (2, 4, 8, 32):
+        height = _treeHeight(branchFactor, maxValue)
+        if height > _BF_MAX_HEIGHT[branchFactor]:
+            continue
+        encoded = _encodeWithBf(valueSet, branchFactor, height)
+        if best is None or len(encoded) < len(best):
+            best = encoded
+
+    if best is None:
+        raise ValueError(f"Cannot encode max value {maxValue}")
+    return best
+
+
+def _encodeHeader(branchFactor: int, height: int) -> bytes:
+    branchFactorToId = {2: 0, 4: 1, 8: 2, 32: 3}
+    return bytes([(height << 2) | branchFactorToId[branchFactor]])
+
+
+def _decodeHeader(headerByte: int) -> Tuple[int, int]:
+    id = headerByte & 0x03
+    idToBranchFactor = {0: 2, 1: 4, 2: 8, 3: 32}
+    height = (headerByte >> 2) & 0x1F
+    return idToBranchFactor[id], height
+
+
+def _treeHeight(branchFactor: int, maxValue: int) -> int:
+    """Return the minimum tree height needed to represent maxValue."""
+    height = 1
+    capacity = branchFactor
+    while capacity <= maxValue:
+        capacity *= branchFactor
+        height += 1
+    return height
+
+
+def _encodeWithBf(valueSet: Set[int], branchFactor: int, height: int) -> bytes:
+    if height == 0:
+        return _encodeHeader(branchFactor, 0)
+
+    # Build layers bottom-up: layer 0 = leaves (individual values),
+    # each higher layer groups bf children into one parent bitmask.
+    layers: list[Dict[int, int]] = [{}]  # list of dicts: nodeIndex -> bitmask
+
+    for v in valueSet:
+        nodeIndex = v // branchFactor
+        bitPos = v % branchFactor
+        if nodeIndex not in layers[0]:
+            layers[0][nodeIndex] = 0
+        layers[0][nodeIndex] |= 1 << bitPos
+
+    for _ in range(1, height):
+        prevLayer = layers[-1]
+        newLayer: Dict[int, int] = {}
+        for nodeIndex, bitmask in prevLayer.items():
+            parentIndex = nodeIndex // branchFactor
+            bitPos = nodeIndex % branchFactor
+            if parentIndex not in newLayer:
+                newLayer[parentIndex] = 0
+            newLayer[parentIndex] |= 1 << bitPos
+        layers.append(newLayer)
+
+    # For zero-node optimization: track count of values in sorted list.
+    valuesSorted = sorted(valueSet)
+
+    def rangeCount(lo: int, hi: int) -> int:
+        return bisect.bisect_right(valuesSorted, hi) - bisect.bisect_left(valuesSorted, lo)
+
+    # Emit nodes BFS order (root to leaves).
+    # Queue entries: (nodeIndex, depthFromRoot, rangeStart, rangeEnd)
+    stream = _OutputBitStream(branchFactor)
+    subtreeSize = branchFactor**height
+    queue: deque[Tuple[int, int, int, int]] = deque([(0, 0, 0, subtreeSize - 1)])
+
+    while queue:
+        nodeIndex, depth, rangeStart, rangeEnd = queue.popleft()
+        layerIdx = height - 1 - depth  # layers[0]=leaves, layers[height-1]=root
+
+        bitmask = layers[layerIdx].get(nodeIndex, 0) if 0 <= layerIdx < len(layers) else 0
+
+        # Zero-node optimization: if entire range is filled on an INTERNAL node,
+        # write 0 and skip children.  At leaf level we always write the explicit
+        # bitmask so the encoding matches the reference.
+        if depth < height - 1 and rangeCount(rangeStart, rangeEnd) == rangeEnd - rangeStart + 1:
+            stream.write(0)
+            continue
+
+        stream.write(bitmask)
+
+        if bitmask != 0 and depth < height - 1:
+            childSize = (rangeEnd - rangeStart + 1) // branchFactor
+            bits = bitmask
+            while bits:
+                bitIndex = _trailingZeros(bits, 32)
+                childIndex = nodeIndex * branchFactor + bitIndex
+                childStart = rangeStart + bitIndex * childSize
+                childEnd = childStart + childSize - 1
+                queue.append((childIndex, depth + 1, childStart, childEnd))
+                bits &= ~(1 << bitIndex)
+
+    return _encodeHeader(branchFactor, height) + stream.toBytes()
+
+
+def _trailingZeros(val: int, maxBits: int) -> int:
+    if val == 0:
+        return maxBits
+    count = 0
+    while (val & 1) == 0:
+        val >>= 1
+        count += 1
+    return count
+
+
+class _InputBitStream:
+    """Reads bit nodes from a byte array, starting after the header byte."""
+
+    def __init__(self, data: bytes, branchFactor: int):
+        self.data = data
+        self.branchFactor = branchFactor
+        self.byteIndex = 1  # skip the header byte
+        self.subIndex = 0   # bit offset within current byte (for bf=2,4)
+
+    def next(self) -> Optional[int]:
+        if self.branchFactor in (2, 4):
+            if self.byteIndex >= len(self.data):
+                return None
+            mask = (1 << self.branchFactor) - 1
+            val = (self.data[self.byteIndex] >> self.subIndex) & mask
+            self.subIndex += self.branchFactor
+            if self.subIndex >= 8:
+                self.subIndex = 0
+                self.byteIndex += 1
+            return val
+        elif self.branchFactor == 8:
+            if self.byteIndex >= len(self.data):
+                return None
+            val = self.data[self.byteIndex]
+            self.byteIndex += 1
+            return val
+        elif self.branchFactor == 32:
+            if self.byteIndex + 3 >= len(self.data):
+                return None
+            b = self.data
+            i = self.byteIndex
+            val = b[i] | (b[i + 1] << 8) | (b[i + 2] << 16) | (b[i + 3] << 24)
+            self.byteIndex += 4
+            return val
+        return None
+
+    def bytesConsumed(self) -> int:
+        return self.byteIndex + (1 if self.subIndex > 0 else 0)
+
+
+class _OutputBitStream:
+    """Writes bit nodes into a byte array."""
+
+    def __init__(self, branchFactor: int):
+        self.branchFactor = branchFactor
+        self.data = bytearray()
+        self.subIndex = 0  # bit offset within current byte (for bf=2,4)
+
+    def write(self, value: int) -> None:
+        if self.branchFactor in (2, 4):
+            mask = (1 << self.branchFactor) - 1
+            value &= mask
+            if self.subIndex == 0:
+                self.data.append(0)
+            self.data[-1] |= value << self.subIndex
+            self.subIndex += self.branchFactor
+            if self.subIndex >= 8:
+                self.subIndex = 0
+        elif self.branchFactor == 8:
+            self.data.append(value & 0xFF)
+        elif self.branchFactor == 32:
+            self.data.append(value & 0xFF)
+            self.data.append((value >> 8) & 0xFF)
+            self.data.append((value >> 16) & 0xFF)
+            self.data.append((value >> 24) & 0xFF)
+
+    def toBytes(self) -> bytes:
+        return bytes(self.data)

--- a/Lib/fontTools/misc/iftSparseBitSet.py
+++ b/Lib/fontTools/misc/iftSparseBitSet.py
@@ -19,7 +19,9 @@ class SparseBitSetDecodeError(Exception):
     pass
 
 
-def decode(data: bytes, bias: int = 0, maxValue: int = 0xFFFFFFFF) -> Tuple[Set[int], int]:
+def decode(
+    data: bytes, bias: int = 0, maxValue: int = 0xFFFFFFFF
+) -> Tuple[Set[int], int]:
     """Decode a sparse bit set from binary data.
 
     Args:
@@ -43,7 +45,10 @@ def decode(data: bytes, bias: int = 0, maxValue: int = 0xFFFFFFFF) -> Tuple[Set[
 
     return _decodeImpl(data, branchFactor, height, bias, maxValue)
 
-def _decodeImpl(data: bytes, branchFactor: int, height: int, bias: int, maxValue: int) -> Tuple[Set[int], int]:
+
+def _decodeImpl(
+    data: bytes, branchFactor: int, height: int, bias: int, maxValue: int
+) -> Tuple[Set[int], int]:
     if height == 0:
         # 1 byte was used for the header.
         return (set(), 1)
@@ -182,7 +187,9 @@ def _encodeWithBf(valueSet: Set[int], branchFactor: int, height: int) -> bytes:
     valuesSorted = sorted(valueSet)
 
     def rangeCount(lo: int, hi: int) -> int:
-        return bisect.bisect_right(valuesSorted, hi) - bisect.bisect_left(valuesSorted, lo)
+        return bisect.bisect_right(valuesSorted, hi) - bisect.bisect_left(
+            valuesSorted, lo
+        )
 
     # Emit nodes BFS order (root to leaves).
     # Queue entries: (nodeIndex, depthFromRoot, rangeStart, rangeEnd)
@@ -194,12 +201,17 @@ def _encodeWithBf(valueSet: Set[int], branchFactor: int, height: int) -> bytes:
         nodeIndex, depth, rangeStart, rangeEnd = queue.popleft()
         layerIdx = height - 1 - depth  # layers[0]=leaves, layers[height-1]=root
 
-        bitmask = layers[layerIdx].get(nodeIndex, 0) if 0 <= layerIdx < len(layers) else 0
+        bitmask = (
+            layers[layerIdx].get(nodeIndex, 0) if 0 <= layerIdx < len(layers) else 0
+        )
 
         # Zero-node optimization: if entire range is filled on an INTERNAL node,
         # write 0 and skip children.  At leaf level we always write the explicit
         # bitmask so the encoding matches the reference.
-        if depth < height - 1 and rangeCount(rangeStart, rangeEnd) == rangeEnd - rangeStart + 1:
+        if (
+            depth < height - 1
+            and rangeCount(rangeStart, rangeEnd) == rangeEnd - rangeStart + 1
+        ):
             stream.write(0)
             continue
 
@@ -236,7 +248,7 @@ class _InputBitStream:
         self.data = data
         self.branchFactor = branchFactor
         self.byteIndex = 1  # skip the header byte
-        self.subIndex = 0   # bit offset within current byte (for bf=2,4)
+        self.subIndex = 0  # bit offset within current byte (for bf=2,4)
 
     def next(self) -> Optional[int]:
         if self.branchFactor in (2, 4):

--- a/Lib/fontTools/ttLib/tables/I_F_T_.py
+++ b/Lib/fontTools/ttLib/tables/I_F_T_.py
@@ -1,0 +1,12 @@
+"""IFT - Incremental Font Transfer table."""
+
+# Reference: https://github.com/googlefonts/fontations/blob/main/read-fonts/src/tables/ift.rs
+
+
+from .otBase import BaseTTXConverter
+
+
+class table_I_F_T_(BaseTTXConverter):
+    """Incremental Font Transfer table."""
+
+    pass

--- a/Lib/fontTools/ttLib/tables/I_F_T_X_.py
+++ b/Lib/fontTools/ttLib/tables/I_F_T_X_.py
@@ -1,0 +1,12 @@
+"""IFT - Incremental Font Transfer table."""
+
+# Reference: https://github.com/googlefonts/fontations/blob/main/read-fonts/src/tables/ift.rs
+
+
+from .otBase import BaseTTXConverter
+
+
+class table_I_F_T_X_(BaseTTXConverter):
+    """Incremental Font Transfer table."""
+
+    pass

--- a/Lib/fontTools/ttLib/tables/otBase.py
+++ b/Lib/fontTools/ttLib/tables/otBase.py
@@ -341,6 +341,15 @@ class OTTableReader(object):
         self.pos = newpos
         return value
 
+    def readInt24(self):
+        pos = self.pos
+        newpos = pos + 3
+        b = self.data[pos:newpos]
+        pad = b"\xff" if b[0] & 0x80 else b"\0"
+        (value,) = struct.unpack(">l", pad + b)
+        self.pos = newpos
+        return value
+
     def readUInt24Array(self, count):
         return [self.readUInt24() for _ in range(count)]
 

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -141,6 +141,11 @@ class BaseConverter(object):
             "BaseGlyphRecordCount",
             "LayerRecordCount",
             "AxisIndicesList",
+            # IFT - propagated to GlyphMap/FeatureMap/MappingEntries subtables
+            "NumGlyphs",
+            "MaxGlyphMapEntryIndex",
+            "MaxEntryIndex",
+            "NumEntries",
         ]
         self.description = description
 
@@ -2017,6 +2022,278 @@ class CompositeMode(_UInt8Enum):
     enumClass = _CompositeMode
 
 
+class MappingEntryFormat:
+    def __init__(self, value):
+        self.value = value
+
+    @property
+    def has_subset_def(self):
+        return bool(self.value & 0x01)
+
+    @property
+    def has_child_entries(self):
+        return bool(self.value & 0x02)
+
+    @property
+    def has_entry_id(self):
+        return bool(self.value & 0x04)
+
+    @property
+    def has_patch_format(self):
+        return bool(self.value & 0x08)
+
+    @property
+    def has_code_points(self):
+        return bool(self.value & 0x30)
+
+    @property
+    def bias_present_u16(self):
+        return (self.value & 0x30) == 0x20
+
+    @property
+    def bias_present_u24(self):
+        return (self.value & 0x30) == 0x30
+
+
+
+# Reference implementation:
+# https://github.com/googlefonts/fontations/blob/main/read-fonts/src/tables/ift.rs
+class MappingEntriesConverter(BaseConverter):
+    def read(self, reader, font, tableDict):
+        from fontTools.misc.fixedTools import fixedToFloat as fi2fl
+        from fontTools.misc.iftSparseBitSet import decode as sbsDecode
+
+        entryCount = reader["NumEntries"]
+        entries = []
+        lastEntryId = -1
+
+        for _ in range(entryCount):
+            entry = {}
+            formatFlags = MappingEntryFormat(reader.readUInt8())
+            entry["formatFlags"] = formatFlags
+
+            if formatFlags.has_subset_def:
+                featureCount = reader.readUInt8() 
+                features = []
+                for _ in range(featureCount):
+                    tag = reader.readTag() 
+                    features.append(tag)
+                entry["featureTags"] = features
+                designSpaceCount = reader.readUShort() 
+                segments = []
+                for _ in range(designSpaceCount):
+                    segTag = reader.readTag() 
+                    start = fi2fl(reader.readLong(), 16) 
+                    end = fi2fl(reader.readLong(), 16) 
+                    segments.append({"tag": segTag, "start": start, "end": end})
+                entry["designSpaceSegments"] = segments
+
+            if formatFlags.has_child_entries:
+                modeAndCount = reader.readUInt8() 
+                conjunctive = bool(modeAndCount & 0x80)
+                childCount = modeAndCount & 0x7F
+                entry["childEntryConjunctive"] = conjunctive
+                childIndices = []
+                for _ in range(childCount):
+                    idx = reader.readUInt24() 
+                    childIndices.append(idx)
+                entry["childEntryIndices"] = childIndices
+
+            if formatFlags.has_entry_id:
+                ids = []
+                while True:
+                    # Per IFT spec, Entry IDs are delta-encoded. The value is a
+                    # signed 24-bit integer. The least significant bit is a
+                    # continuation flag (1 if more IDs follow). The remaining
+                    # upper bits are a signed integer, representing the delta
+                    # from the previous ID.
+                    encodedVal = reader.readInt24()
+                    delta = encodedVal >> 1
+                    hasMore = encodedVal & 0x01
+                    currentEntryId = lastEntryId + 1 + delta
+                    ids.append(currentEntryId)
+                    lastEntryId = currentEntryId
+
+                    if not hasMore:
+                        break
+                entry["entryIds"] = ids
+            else:
+                entry["entryIds"] = [lastEntryId + 1]
+                lastEntryId = lastEntryId + 1
+
+            if formatFlags.has_patch_format:
+                entry["patchFormat"] = reader.readUInt8()
+
+            if formatFlags.has_code_points:
+                bias = 0
+                if formatFlags.bias_present_u24:
+                    bias = reader.readUInt24()
+                elif formatFlags.bias_present_u16:
+                    bias = reader.readUShort()
+                entry["codePointsBias"] = bias
+
+                codepoints, consumed = sbsDecode(
+                    reader.data[reader.pos :], bias=bias, maxValue=0x10FFFF
+                )
+                reader.advance(consumed)
+                entry["codePoints"] = sorted(codepoints)
+
+            entries.append(entry)
+        return entries
+
+    def write(self, writer, font, tableDict, value, repeatIndex=None):
+        from fontTools.misc.iftSparseBitSet import encode as sbsEncode
+        from fontTools.misc.fixedTools import floatToFixed as fl2fi
+
+        entries = value
+        lastId = -1
+
+        for entry in entries:
+            format_flags = entry.get("formatFlags", MappingEntryFormat(0))
+            writer.writeUInt8(format_flags.value)
+
+            if format_flags.has_subset_def:
+                features = entry.get("featureTags", [])
+                writer.writeUInt8(len(features))
+                for tag in features:
+                    writer.writeTag(tag)
+                segments = entry.get("designSpaceSegments", [])
+                writer.writeUShort(len(segments))
+                for seg in segments:
+                    writer.writeTag(seg["tag"])
+                    writer.writeLong(fl2fi(seg["start"], 16))
+                    writer.writeLong(fl2fi(seg["end"], 16))
+
+            if format_flags.has_child_entries:
+                childIndices = entry.get("childEntryIndices", [])
+                conjunctive = entry.get("childEntryConjunctive", False)
+                modeAndCount = (len(childIndices) & 0x7F) | (
+                    0x80 if conjunctive else 0
+                )
+                writer.writeUInt8(modeAndCount)
+                for idx in childIndices:
+                    writer.writeUInt24(idx)
+
+            if format_flags.has_entry_id:
+                ids = entry.get("entryIds", [])
+                for i, eid in enumerate(ids):
+                    # Recreate the delta-encoded Entry ID. The delta is shifted
+                    # left by one bit, and the least significant bit is set to 1
+                    # if more IDs follow in the list.
+                    delta = eid - lastId - 1
+                    has_more = 1 if i < len(ids) - 1 else 0
+                    encoded_value = (delta << 1) | has_more
+                    writer.writeUInt24(encoded_value & 0xFFFFFF)
+                    lastId = eid
+            else:
+                lastId += 1
+
+            if format_flags.has_patch_format:
+                writer.writeUInt8(entry.get("patchFormat", 0))
+
+            if format_flags.has_code_points:
+                bias = entry.get("codePointsBias", 0)
+                if format_flags.bias_present_u24:
+                    writer.writeUInt24(bias)
+                elif format_flags.bias_present_u16:
+                    writer.writeUShort(bias)
+                codepoints = entry.get("codePoints", [])
+                writer.writeData(
+                    sbsEncode([c - bias for c in codepoints if c >= bias])
+                )
+
+    def xmlWrite(self, xmlWriter, font, value, name, attrs):
+        for entry in value:
+            format_flags = entry.get("formatFlags", MappingEntryFormat(0))
+            xmlWriter.begintag("entry", formatFlags=format_flags.value)
+            xmlWriter.newline()
+            if "entryIds" in entry:
+                for eid in entry["entryIds"]:
+                    xmlWriter.simpletag("entryId", value=eid)
+                    xmlWriter.newline()
+            if "featureTags" in entry:
+                for tag in entry["featureTags"]:
+                    xmlWriter.simpletag("featureTag", value=tag)
+                    xmlWriter.newline()
+            if "designSpaceSegments" in entry:
+                for seg in entry["designSpaceSegments"]:
+                    xmlWriter.simpletag(
+                        "designSpaceSegment",
+                        tag=seg["tag"],
+                        start=seg["start"],
+                        end=seg["end"],
+                    )
+                    xmlWriter.newline()
+            if "childEntryIndices" in entry:
+                xmlWriter.simpletag(
+                    "childEntryConjunctive",
+                    value=int(entry.get("childEntryConjunctive", False)),
+                )
+                xmlWriter.newline()
+                for idx in entry["childEntryIndices"]:
+                    xmlWriter.simpletag("childEntry", index=idx)
+                    xmlWriter.newline()
+            if "patchFormat" in entry:
+                xmlWriter.simpletag("patchFormat", value=entry["patchFormat"])
+                xmlWriter.newline()
+            if "codePoints" in entry:
+                xmlWriter.simpletag(
+                    "codePointsBias", value=entry.get("codePointsBias", 0)
+                )
+                xmlWriter.newline()
+                codePointsStr = " ".join(str(c) for c in entry["codePoints"])
+                xmlWriter.simpletag("codePoints", value=codePointsStr)
+                xmlWriter.newline()
+            xmlWriter.endtag("entry")
+            xmlWriter.newline()
+
+    def xmlRead(self, attrs, content, font):
+        entries = []
+        for elem in content:
+            if not isinstance(elem, tuple):
+                continue
+            name, attrs, content = elem
+            if name == "entry":
+                format_flags_int = safeEval(attrs.get("formatFlags", "0"))
+                entry = {"formatFlags": MappingEntryFormat(format_flags_int)}
+                for e_elem in content:
+                    if not isinstance(e_elem, tuple):
+                        continue
+                    ename, eattrs, econtent = e_elem
+                    if ename == "entryId":
+                        entry.setdefault("entryIds", []).append(
+                            safeEval(eattrs["value"])
+                        )
+                    elif ename == "featureTag":
+                        entry.setdefault("featureTags", []).append(eattrs["value"])
+                    elif ename == "designSpaceSegment":
+                        entry.setdefault("designSpaceSegments", []).append(
+                            {
+                                "tag": eattrs["tag"],
+                                "start": float(eattrs["start"]),
+                                "end": float(eattrs["end"]),
+                            }
+                        )
+                    elif ename == "childEntryConjunctive":
+                        entry["childEntryConjunctive"] = bool(
+                            safeEval(eattrs["value"])
+                        )
+                    elif ename == "childEntry":
+                        entry.setdefault("childEntryIndices", []).append(
+                            safeEval(eattrs["index"])
+                        )
+                    elif ename == "patchFormat":
+                        entry["patchFormat"] = safeEval(eattrs["value"])
+                    elif ename == "codePointsBias":
+                        entry["codePointsBias"] = safeEval(eattrs["value"])
+                    elif ename == "codePoints":
+                        entry["codePoints"] = [
+                            int(c) for c in eattrs["value"].split() if c
+                        ]
+                entries.append(entry)
+        return entries
+
+
 converterMapping = {
     # type		class
     "int8": Int8,
@@ -2040,6 +2317,7 @@ converterMapping = {
     "Angle": Angle,
     "BiasedAngle": BiasedAngle,
     "struct": Struct,
+    "MappingEntries": MappingEntriesConverter,
     "Offset": Table,
     "LOffset": LTable,
     "Offset24": Table24,

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -39,6 +39,7 @@ import re
 import struct
 from typing import Optional
 import logging
+from enum import IntFlag
 
 
 log = logging.getLogger(__name__)
@@ -2022,37 +2023,21 @@ class CompositeMode(_UInt8Enum):
     enumClass = _CompositeMode
 
 
-class MappingEntryFormat:
-    def __init__(self, value):
-        self.value = value
-
-    @property
-    def has_subset_def(self):
-        return bool(self.value & 0x01)
-
-    @property
-    def has_child_entries(self):
-        return bool(self.value & 0x02)
-
-    @property
-    def has_entry_id(self):
-        return bool(self.value & 0x04)
-
-    @property
-    def has_patch_format(self):
-        return bool(self.value & 0x08)
-
-    @property
-    def has_code_points(self):
-        return bool(self.value & 0x30)
+class MappingEntryFormat(IntFlag):
+    HAS_SUBSET_DEF = 0x01
+    HAS_CHILD_ENTRIES = 0x02
+    HAS_ENTRY_ID = 0x04
+    HAS_PATCH_FORMAT = 0x08
+    # The code point bias is essentially a 2bit flag.
+    CODE_POINT_BIAS_BITS = 0x30
 
     @property
     def bias_present_u16(self):
-        return (self.value & 0x30) == 0x20
+        return (self & MappingEntryFormat.CODE_POINT_BIAS_BITS) == 0x20
 
     @property
     def bias_present_u24(self):
-        return (self.value & 0x30) == 0x30
+        return (self & MappingEntryFormat.CODE_POINT_BIAS_BITS) == 0x30
 
 
 
@@ -2072,7 +2057,7 @@ class MappingEntriesConverter(BaseConverter):
             formatFlags = MappingEntryFormat(reader.readUInt8())
             entry["formatFlags"] = formatFlags
 
-            if formatFlags.has_subset_def:
+            if formatFlags & MappingEntryFormat.HAS_SUBSET_DEF:
                 featureCount = reader.readUInt8() 
                 features = []
                 for _ in range(featureCount):
@@ -2088,7 +2073,7 @@ class MappingEntriesConverter(BaseConverter):
                     segments.append({"tag": segTag, "start": start, "end": end})
                 entry["designSpaceSegments"] = segments
 
-            if formatFlags.has_child_entries:
+            if formatFlags & MappingEntryFormat.HAS_CHILD_ENTRIES:
                 modeAndCount = reader.readUInt8() 
                 conjunctive = bool(modeAndCount & 0x80)
                 childCount = modeAndCount & 0x7F
@@ -2099,7 +2084,7 @@ class MappingEntriesConverter(BaseConverter):
                     childIndices.append(idx)
                 entry["childEntryIndices"] = childIndices
 
-            if formatFlags.has_entry_id:
+            if formatFlags & MappingEntryFormat.HAS_ENTRY_ID:
                 ids = []
                 while True:
                     # Per IFT spec, Entry IDs are delta-encoded. The value is a
@@ -2121,10 +2106,10 @@ class MappingEntriesConverter(BaseConverter):
                 entry["entryIds"] = [lastEntryId + 1]
                 lastEntryId = lastEntryId + 1
 
-            if formatFlags.has_patch_format:
+            if formatFlags & MappingEntryFormat.HAS_PATCH_FORMAT:
                 entry["patchFormat"] = reader.readUInt8()
 
-            if formatFlags.has_code_points:
+            if formatFlags & MappingEntryFormat.CODE_POINT_BIAS_BITS:
                 bias = 0
                 if formatFlags.bias_present_u24:
                     bias = reader.readUInt24()
@@ -2149,10 +2134,12 @@ class MappingEntriesConverter(BaseConverter):
         lastId = -1
 
         for entry in entries:
-            format_flags = entry.get("formatFlags", MappingEntryFormat(0))
-            writer.writeUInt8(format_flags.value)
+            # TODO: Automatically recompute formatFlags based on the contents of
+            # entry.
+            formatFlags = entry.get("formatFlags", MappingEntryFormat(0))
+            writer.writeUInt8(formatFlags.value)
 
-            if format_flags.has_subset_def:
+            if formatFlags & MappingEntryFormat.HAS_SUBSET_DEF:
                 features = entry.get("featureTags", [])
                 writer.writeUInt8(len(features))
                 for tag in features:
@@ -2164,7 +2151,7 @@ class MappingEntriesConverter(BaseConverter):
                     writer.writeLong(fl2fi(seg["start"], 16))
                     writer.writeLong(fl2fi(seg["end"], 16))
 
-            if format_flags.has_child_entries:
+            if formatFlags & MappingEntryFormat.HAS_CHILD_ENTRIES:
                 childIndices = entry.get("childEntryIndices", [])
                 conjunctive = entry.get("childEntryConjunctive", False)
                 modeAndCount = (len(childIndices) & 0x7F) | (
@@ -2174,7 +2161,7 @@ class MappingEntriesConverter(BaseConverter):
                 for idx in childIndices:
                     writer.writeUInt24(idx)
 
-            if format_flags.has_entry_id:
+            if formatFlags & MappingEntryFormat.HAS_ENTRY_ID:
                 ids = entry.get("entryIds", [])
                 for i, eid in enumerate(ids):
                     # Recreate the delta-encoded Entry ID. The delta is shifted
@@ -2188,14 +2175,14 @@ class MappingEntriesConverter(BaseConverter):
             else:
                 lastId += 1
 
-            if format_flags.has_patch_format:
+            if formatFlags & MappingEntryFormat.HAS_PATCH_FORMAT:
                 writer.writeUInt8(entry.get("patchFormat", 0))
 
-            if format_flags.has_code_points:
+            if formatFlags & MappingEntryFormat.CODE_POINT_BIAS_BITS:
                 bias = entry.get("codePointsBias", 0)
-                if format_flags.bias_present_u24:
+                if formatFlags.bias_present_u24:
                     writer.writeUInt24(bias)
-                elif format_flags.bias_present_u16:
+                elif formatFlags.bias_present_u16:
                     writer.writeUShort(bias)
                 codepoints = entry.get("codePoints", [])
                 writer.writeData(

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -41,7 +41,6 @@ from typing import Optional
 import logging
 from enum import IntFlag
 
-
 log = logging.getLogger(__name__)
 istuple = lambda t: isinstance(t, tuple)
 
@@ -1794,7 +1793,7 @@ class VarDataValue(BaseConverter):
         longWords = bool(wordCount & 0x8000)
         wordCount = wordCount & 0x7FFF
 
-        (writeBigArray, writeSmallArray) = {
+        writeBigArray, writeSmallArray = {
             False: (writer.writeShortArray, writer.writeInt8Array),
             True: (writer.writeLongArray, writer.writeShortArray),
         }[longWords]
@@ -2040,7 +2039,6 @@ class MappingEntryFormat(IntFlag):
         return (self & MappingEntryFormat.CODE_POINT_BIAS_BITS) == 0x30
 
 
-
 # Reference implementation:
 # https://github.com/googlefonts/fontations/blob/main/read-fonts/src/tables/ift.rs
 class MappingEntriesConverter(BaseConverter):
@@ -2058,29 +2056,29 @@ class MappingEntriesConverter(BaseConverter):
             entry["formatFlags"] = formatFlags
 
             if formatFlags & MappingEntryFormat.HAS_SUBSET_DEF:
-                featureCount = reader.readUInt8() 
+                featureCount = reader.readUInt8()
                 features = []
                 for _ in range(featureCount):
-                    tag = reader.readTag() 
+                    tag = reader.readTag()
                     features.append(tag)
                 entry["featureTags"] = features
-                designSpaceCount = reader.readUShort() 
+                designSpaceCount = reader.readUShort()
                 segments = []
                 for _ in range(designSpaceCount):
-                    segTag = reader.readTag() 
-                    start = fi2fl(reader.readLong(), 16) 
-                    end = fi2fl(reader.readLong(), 16) 
+                    segTag = reader.readTag()
+                    start = fi2fl(reader.readLong(), 16)
+                    end = fi2fl(reader.readLong(), 16)
                     segments.append({"tag": segTag, "start": start, "end": end})
                 entry["designSpaceSegments"] = segments
 
             if formatFlags & MappingEntryFormat.HAS_CHILD_ENTRIES:
-                modeAndCount = reader.readUInt8() 
+                modeAndCount = reader.readUInt8()
                 conjunctive = bool(modeAndCount & 0x80)
                 childCount = modeAndCount & 0x7F
                 entry["childEntryConjunctive"] = conjunctive
                 childIndices = []
                 for _ in range(childCount):
-                    idx = reader.readUInt24() 
+                    idx = reader.readUInt24()
                     childIndices.append(idx)
                 entry["childEntryIndices"] = childIndices
 
@@ -2154,9 +2152,7 @@ class MappingEntriesConverter(BaseConverter):
             if formatFlags & MappingEntryFormat.HAS_CHILD_ENTRIES:
                 childIndices = entry.get("childEntryIndices", [])
                 conjunctive = entry.get("childEntryConjunctive", False)
-                modeAndCount = (len(childIndices) & 0x7F) | (
-                    0x80 if conjunctive else 0
-                )
+                modeAndCount = (len(childIndices) & 0x7F) | (0x80 if conjunctive else 0)
                 writer.writeUInt8(modeAndCount)
                 for idx in childIndices:
                     writer.writeUInt24(idx)
@@ -2185,9 +2181,7 @@ class MappingEntriesConverter(BaseConverter):
                 elif formatFlags.bias_present_u16:
                     writer.writeUShort(bias)
                 codepoints = entry.get("codePoints", [])
-                writer.writeData(
-                    sbsEncode([c - bias for c in codepoints if c >= bias])
-                )
+                writer.writeData(sbsEncode([c - bias for c in codepoints if c >= bias]))
 
     def xmlWrite(self, xmlWriter, font, value, name, attrs):
         for entry in value:
@@ -2262,9 +2256,7 @@ class MappingEntriesConverter(BaseConverter):
                             }
                         )
                     elif ename == "childEntryConjunctive":
-                        entry["childEntryConjunctive"] = bool(
-                            safeEval(eattrs["value"])
-                        )
+                        entry["childEntryConjunctive"] = bool(safeEval(eattrs["value"]))
                     elif ename == "childEntry":
                         entry.setdefault("childEntryIndices", []).append(
                             safeEval(eattrs["index"])

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -6397,4 +6397,96 @@ otData = [
             ("LOffset", "VarStore", None, "Version >= 0x00020000", ""),
         ],
     ),
+    #
+    # IFT - Incremental Font Transfer tables
+    # https://w3c.github.io/IFT/Overview.html
+    # Reference: https://github.com/googlefonts/fontations/blob/main/read-fonts/src/tables/ift.rs
+    #
+    (
+        "PatchMapFormat2",
+        [
+            (
+                "uint8",
+                "Format",
+                None,
+                None,
+                "Set to 2, identifies this as format 2.",
+            ),
+            ("uint24", "Reserved", None, None, "Not used, set to 0."),
+            (
+                "uint8",
+                "Flags",
+                None,
+                None,
+                "Bit 0: CffCharStringsOffset present. Bit 1: Cff2CharStringsOffset present.",
+            ),
+            (
+                "uint32",
+                "CompatibilityId",
+                4,
+                0,
+                "Unique ID to identify compatible patches (16 bytes).",
+            ),
+            (
+                "uint8",
+                "DefaultPatchFormat",
+                None,
+                None,
+                "Default format of patches linked to by urlTemplate.",
+            ),
+            (
+                "uint24",
+                "NumEntries",
+                None,
+                None,
+                "Number of entries encoded in this table.",
+            ),
+            (
+                "LOffset",
+                "MappingEntries",
+                None,
+                None,
+                "Offset to a MappingEntries sub-table.",
+            ),
+            (
+                "LOffset",
+                "EntryIdStringData",
+                None,
+                None,
+                "Offset to entry ID string data block. May be null (0).",
+            ),
+            (
+                "uint16",
+                "UrlTemplateLength",
+                None,
+                None,
+                "Length of the urlTemplate byte array.",
+            ),
+            (
+                "uint8",
+                "UrlTemplate",
+                "UrlTemplateLength",
+                0,
+                "URL Template bytes used to produce URL strings for each entry.",
+            ),
+            (
+                "uint32",
+                "CffCharStringsOffset",
+                None,
+                "Flags & 0x01",
+                "Offset from start of CFF table to CharStrings INDEX.",
+            ),
+            (
+                "uint32",
+                "Cff2CharStringsOffset",
+                None,
+                "Flags & 0x02",
+                "Offset from start of CFF2 table to CharStrings INDEX.",
+            ),
+        ],
+    ),
+    # 'MappingEntries' contains stateful, delta-encoded entry IDs.  The custom
+    # 'MappingEntriesConverter' is used to do a stateful parsing of all records.
+    ("MappingEntries", [("MappingEntries", "entries", None, None, "Array of MappingEntry records.")]),
+    ("EntryIdStringData", []),
 ]

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -6487,6 +6487,9 @@ otData = [
     ),
     # 'MappingEntries' contains stateful, delta-encoded entry IDs.  The custom
     # 'MappingEntriesConverter' is used to do a stateful parsing of all records.
-    ("MappingEntries", [("MappingEntries", "entries", None, None, "Array of MappingEntry records.")]),
+    (
+        "MappingEntries",
+        [("MappingEntries", "entries", None, None, "Array of MappingEntry records.")],
+    ),
     ("EntryIdStringData", []),
 ]

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -2139,6 +2139,7 @@ class Paint(getFormatSwitchingBaseTableClass("uint8")):
 # subclass for each alternate field name.
 #
 _equivalents = {
+    "PatchMap": ("IFT ", "IFTX"),
     "MarkArray": ("Mark1Array",),
     "LangSys": ("DefaultLangSys",),
     "Coverage": (
@@ -2579,6 +2580,33 @@ def fixSubTableOverFlows(ttf, overflowRecord):
 
 
 # End of OverFlow logic
+
+
+# ---------------------------------------------------------------------------
+# IFT - Incremental Font Transfer tables
+# ---------------------------------------------------------------------------
+
+class EntryIdStringData(BaseTable):
+    """IFT entry ID string data block (raw bytes pool)."""
+
+    def decompile(self, reader, font):
+        # This subtable is reached via an LOffset, so the reader's data buffer
+        # is already scoped to the bytes starting at the subtable's offset within
+        # the IFT table blob.  Reading to the end of that buffer is correct; the
+        # actual bytes consumed are determined by the entryIdStringLength fields
+        # in the MappingEntries records.
+        self.data = bytes(reader.data[reader.pos :])
+
+    def compile(self, writer, font):
+        writer.writeData(self.data)
+
+    def toXML2(self, xmlWriter, font):
+        xmlWriter.simpletag("data", value=self.data.hex())
+        xmlWriter.newline()
+
+    def fromXML(self, name, attrs, content, font):
+        if name == "data":
+            self.data = bytes.fromhex(attrs["value"])
 
 
 def _buildClasses():

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -5,6 +5,7 @@ OpenType subtables.
 Most are constructed upon import from data in otData.py, all are populated with
 converter objects from otConverters.py.
 """
+
 import copy
 from enum import IntEnum
 from functools import reduce
@@ -2585,6 +2586,7 @@ def fixSubTableOverFlows(ttf, overflowRecord):
 # ---------------------------------------------------------------------------
 # IFT - Incremental Font Transfer tables
 # ---------------------------------------------------------------------------
+
 
 class EntryIdStringData(BaseTable):
     """IFT entry ID string data block (raw bytes pool)."""

--- a/Tests/misc/iftSparseBitSet_test.py
+++ b/Tests/misc/iftSparseBitSet_test.py
@@ -1,6 +1,7 @@
 import unittest
 from fontTools.misc.iftSparseBitSet import encode, decode, SparseBitSetDecodeError
 
+
 class IftSparseBitSetTest(unittest.TestCase):
     def test_roundtrip_empty_success(self):
         values = set()
@@ -119,6 +120,7 @@ class IftSparseBitSetTest(unittest.TestCase):
         decoded, consumed = decode(encoded)
         self.assertEqual(decoded, values)
         self.assertEqual(consumed, len(encoded))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tests/misc/iftSparseBitSet_test.py
+++ b/Tests/misc/iftSparseBitSet_test.py
@@ -1,0 +1,124 @@
+import unittest
+from fontTools.misc.iftSparseBitSet import encode, decode, SparseBitSetDecodeError
+
+class IftSparseBitSetTest(unittest.TestCase):
+    def test_roundtrip_empty_success(self):
+        values = set()
+        encoded = encode(values)
+        decoded, consumed = decode(encoded)
+        self.assertEqual(decoded, values)
+        self.assertEqual(consumed, len(encoded))
+
+    def test_roundtrip_singleValue_success(self):
+        values = {42}
+        encoded = encode(values)
+        decoded, consumed = decode(encoded)
+        self.assertEqual(decoded, values)
+        self.assertEqual(consumed, len(encoded))
+
+    def test_roundtrip_multipleValues_success(self):
+        values = {1, 10, 100, 1000}
+        encoded = encode(values)
+        decoded, consumed = decode(encoded)
+        self.assertEqual(decoded, values)
+        self.assertEqual(consumed, len(encoded))
+
+    def test_roundtrip_largeRange_success(self):
+        # Test zero-node optimization (filling subtrees).
+        # A range of 1000 values should be very compact.
+        values = set(range(100, 1100))
+        encoded = encode(values)
+        decoded, consumed = decode(encoded)
+        self.assertEqual(decoded, values)
+        self.assertEqual(consumed, len(encoded))
+        # 1000 values would take ~125 bytes if 1 bit per value.
+        # With zero-node optimization, it should be much smaller.
+        self.assertLess(len(encoded), 50)
+
+    def test_roundtrip_sparseValues_success(self):
+        values = {1, 1000000}
+        encoded = encode(values)
+        decoded, consumed = decode(encoded)
+        self.assertEqual(decoded, values)
+        self.assertEqual(consumed, len(encoded))
+
+    def test_decode_positiveBias_shiftsValues(self):
+        # b"\x04\x01" is {0} with BF=2, height=1.
+        decoded, consumed = decode(b"\x04\x01", bias=100)
+        self.assertEqual(decoded, {100})
+        self.assertEqual(consumed, 2)
+
+    def test_decode_negativeBias_clipsToZero(self):
+        # b"\x04\x01" is {0}. With bias -1, it becomes -1 and should be ignored.
+        decoded, consumed = decode(b"\x04\x01", bias=-1)
+        self.assertEqual(decoded, set())
+        self.assertEqual(consumed, 2)
+
+    def test_decode_headerOnlyHeight0_success(self):
+        # Height 0 always means empty set.
+        self.assertEqual(decode(b"\x00"), (set(), 1))
+
+    def test_decode_emptyData_raisesError(self):
+        with self.assertRaisesRegex(SparseBitSetDecodeError, "Empty data"):
+            decode(b"")
+
+    def test_decode_truncatedData_raisesError(self):
+        # Encoded {0} is b"\x04\x01". Truncate to b"\x04".
+        with self.assertRaisesRegex(SparseBitSetDecodeError, "Unexpected end of data"):
+            decode(b"\x04")
+
+    def test_decode_invalidHeight_raisesError(self):
+        # BF=32 (id 3), Max Height=7. Try height 8.
+        header = (8 << 2) | 3
+        with self.assertRaisesRegex(SparseBitSetDecodeError, "exceeds max 7"):
+            decode(bytes([header]))
+
+    def test_encode_valueOutOfRange_raisesError(self):
+        # BF=32, Max Height=7, Max Capacity=32^7 = 2^35.
+        # Value 2^35 requires height 8, which is not supported.
+        with self.assertRaisesRegex(ValueError, "Cannot encode max value"):
+            encode([2**35])
+
+    def test_decode_maxValue_truncates_output(self):
+        values = {1, 2, 10, 20}
+        encoded = encode(values)
+        decoded, consumed = decode(encoded, maxValue=15)
+        self.assertEqual(decoded, {1, 2, 10})
+        self.assertEqual(consumed, len(encoded))
+
+    def test_decode_maxValue_with_zero_node(self):
+        # A dense range from 0 to 99 will use the zero-node optimization.
+        values = set(range(100))
+        encoded = encode(values)
+        # maxValue should truncate this dense range.
+        decoded, consumed = decode(encoded, maxValue=49)
+        self.assertEqual(decoded, set(range(50)))
+        self.assertEqual(consumed, len(encoded))
+
+    def test_decode_maxValue_leaves_empty_set(self):
+        values = {100, 200, 300}
+        encoded = encode(values)
+        decoded, consumed = decode(encoded, maxValue=50)
+        self.assertEqual(decoded, set())
+        self.assertEqual(consumed, len(encoded))
+
+    def test_roundtrip_almost_full_range(self):
+        # A range of 64 with one value missing should NOT use zero-node optimization
+        values = set(range(64))
+        values.remove(32)
+        encoded = encode(values)
+        decoded, consumed = decode(encoded)
+        self.assertEqual(decoded, values)
+        self.assertEqual(consumed, len(encoded))
+
+    def test_roundtrip_full_child_sparse_parent(self):
+        # This set fills one child node completely (e.g., 8-15 for bf=8),
+        # but the parent node is sparse.
+        values = set(range(8, 16))
+        encoded = encode(values)
+        decoded, consumed = decode(encoded)
+        self.assertEqual(decoded, values)
+        self.assertEqual(consumed, len(encoded))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/ttLib/tables/otBase_test.py
+++ b/Tests/ttLib/tables/otBase_test.py
@@ -29,6 +29,16 @@ class OTTableReaderTest(unittest.TestCase):
         self.assertEqual(list(reader.readUShortArray(3)), [0xDEAD, 0xBEEF, 0xCAFE])
         self.assertEqual(reader.pos, 6)
 
+    def test_readInt24(self):
+        # Positive
+        reader = OTTableReader(deHexStr("3C 13 37"))
+        self.assertEqual(reader.readInt24(), 3937079)
+        self.assertEqual(reader.pos, 3)
+        # Negative
+        reader = OTTableReader(deHexStr("C3 13 37"))
+        self.assertEqual(reader.readInt24(), -3992777)
+        self.assertEqual(reader.pos, 3)
+
     def test_readUInt24(self):
         reader = OTTableReader(deHexStr("C3 13 37"))
         self.assertEqual(reader.readUInt24(), 0xC31337)


### PR DESCRIPTION
For #4070 

- Will help us debug the upcoming IFT format
  - Introduces the "IFT " and "IFTX" tables which use the PatchMapFormat2 schema.
- Only Format2 was implemented as it is the only format we have implemented
- Verified across all the fonts in https://github.com/garretrieger/ift-demo/tree/main/docs/fonts
- MappingEntriesConverter uses custom code since it has a lot of custom logic