### PR TITLE
Create explicit schema/type for otData.py

### DIFF
--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -18,6 +18,7 @@ from .otBase import (
     OTTableWriter,
     ValueRecordFactory,
 )
+from .otDataSchema import FieldSpec
 from .otTables import (
     lookupTypes,
     VarCompositeGlyph,
@@ -45,67 +46,67 @@ log = logging.getLogger(__name__)
 istuple = lambda t: isinstance(t, tuple)
 
 
-def buildConverters(tableSpec, tableNamespace):
+def buildConverters(tableSpec: list[FieldSpec], tableNamespace):
     """Given a table spec from otData.py, build a converter object for each
     field of the table. This is called for each table in otData.py, and
     the results are assigned to the corresponding class in otTables.py."""
     converters = []
     convertersByName = {}
-    for tp, name, repeat, aux, descr in tableSpec:
-        tableName = name
-        if name.startswith("ValueFormat"):
-            assert tp == "uint16"
+    for spec in tableSpec:
+        tableName = spec.name
+        if spec.name.startswith("ValueFormat"):
+            assert spec.type == "uint16"
             converterClass = ValueFormat
-        elif name.endswith("Count") or name in ("StructLength", "MorphType"):
+        elif spec.name.endswith("Count") or spec.name in ("StructLength", "MorphType"):
             converterClass = {
                 "uint8": ComputedUInt8,
                 "uint16": ComputedUShort,
                 "uint32": ComputedULong,
-            }[tp]
-        elif name == "SubTable":
+            }[spec.type]
+        elif spec.name == "SubTable":
             converterClass = SubTable
-        elif name == "ExtSubTable":
+        elif spec.name == "ExtSubTable":
             converterClass = ExtSubTable
-        elif name == "SubStruct":
+        elif spec.name == "SubStruct":
             converterClass = SubStruct
-        elif name == "FeatureParams":
+        elif spec.name == "FeatureParams":
             converterClass = FeatureParams
-        elif name in ("CIDGlyphMapping", "GlyphCIDMapping"):
+        elif spec.name in ("CIDGlyphMapping", "GlyphCIDMapping"):
             converterClass = StructWithLength
         else:
-            if not tp in converterMapping and "(" not in tp:
-                tableName = tp
+            if not spec.type in converterMapping and "(" not in spec.type:
+                tableName = spec.type
                 converterClass = Struct
             else:
-                converterClass = eval(tp, tableNamespace, converterMapping)
+                converterClass = eval(spec.type, tableNamespace, converterMapping)
 
-        conv = converterClass(name, repeat, aux, description=descr)
+        conv = converterClass(spec.name, spec.repeat, spec.aux, description=spec.description)
 
         if conv.tableClass:
             # A "template" such as OffsetTo(AType) knows the table class already
             tableClass = conv.tableClass
-        elif tp in ("MortChain", "MortSubtable", "MorxChain"):
-            tableClass = tableNamespace.get(tp)
+        elif spec.type in ("MortChain", "MortSubtable", "MorxChain"):
+            tableClass = tableNamespace.get(spec.type)
         else:
             tableClass = tableNamespace.get(tableName)
 
         if not conv.tableClass:
             conv.tableClass = tableClass
 
-        if name in ["SubTable", "ExtSubTable", "SubStruct"]:
+        if spec.name in ["SubTable", "ExtSubTable", "SubStruct"]:
             conv.lookupTypes = tableNamespace["lookupTypes"]
             # also create reverse mapping
             for t in conv.lookupTypes.values():
                 for cls in t.values():
-                    convertersByName[cls.__name__] = Table(name, repeat, aux, cls)
-        if name == "FeatureParams":
+                    convertersByName[cls.__name__] = Table(spec.name, spec.repeat, spec.aux, cls)
+        if spec.name == "FeatureParams":
             conv.featureParamTypes = tableNamespace["featureParamTypes"]
             conv.defaultFeatureParams = tableNamespace["FeatureParams"]
             for cls in conv.featureParamTypes.values():
-                convertersByName[cls.__name__] = Table(name, repeat, aux, cls)
+                convertersByName[cls.__name__] = Table(spec.name, spec.repeat, spec.aux, cls)
         converters.append(conv)
-        assert name not in convertersByName, name
-        convertersByName[name] = conv
+        assert spec.name not in convertersByName, spec.name
+        convertersByName[spec.name] = conv
     return converters, convertersByName
 
 

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -80,7 +80,9 @@ def buildConverters(tableSpec: list[FieldSpec], tableNamespace):
             else:
                 converterClass = eval(spec.type, tableNamespace, converterMapping)
 
-        conv = converterClass(spec.name, spec.repeat, spec.aux, description=spec.description)
+        conv = converterClass(
+            spec.name, spec.repeat, spec.aux, description=spec.description
+        )
 
         if conv.tableClass:
             # A "template" such as OffsetTo(AType) knows the table class already
@@ -98,12 +100,16 @@ def buildConverters(tableSpec: list[FieldSpec], tableNamespace):
             # also create reverse mapping
             for t in conv.lookupTypes.values():
                 for cls in t.values():
-                    convertersByName[cls.__name__] = Table(spec.name, spec.repeat, spec.aux, cls)
+                    convertersByName[cls.__name__] = Table(
+                        spec.name, spec.repeat, spec.aux, cls
+                    )
         if spec.name == "FeatureParams":
             conv.featureParamTypes = tableNamespace["featureParamTypes"]
             conv.defaultFeatureParams = tableNamespace["FeatureParams"]
             for cls in conv.featureParamTypes.values():
-                convertersByName[cls.__name__] = Table(spec.name, spec.repeat, spec.aux, cls)
+                convertersByName[cls.__name__] = Table(
+                    spec.name, spec.repeat, spec.aux, cls
+                )
         converters.append(conv)
         assert spec.name not in convertersByName, spec.name
         convertersByName[spec.name] = conv

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -3147,6 +3147,7 @@ otData = [
             FieldSpec(
                 "VarIdxMapValue",
                 "mapping",
+                repeat="",
                 aux=0,
                 description="Array of compressed data",
             ),
@@ -3163,6 +3164,7 @@ otData = [
             FieldSpec(
                 "VarIdxMapValue",
                 "mapping",
+                repeat="",
                 aux=0,
                 description="Array of compressed data",
             ),
@@ -3179,6 +3181,7 @@ otData = [
             FieldSpec(
                 "VarIdxMapValue",
                 "mapping",
+                repeat="",
                 aux=0,
                 description="Array of compressed data",
             ),
@@ -3218,7 +3221,7 @@ otData = [
             FieldSpec("uint8", "Format", description="Set to 1."),
             FieldSpec("uint16", "VarRegionCount"),
             FieldSpec("uint16", "VarRegionIndex", repeat="VarRegionCount", aux=0),
-            FieldSpec("TupleList", "Item", aux=0),
+            FieldSpec("TupleList", "Item", repeat="", aux=0),
         ],
     ),
     (
@@ -3249,13 +3252,13 @@ otData = [
     (
         "AxisIndicesList",
         [
-            FieldSpec("TupleList", "Item", aux=0),
+            FieldSpec("TupleList", "Item", repeat="", aux=0),
         ],
     ),
     (
         "VarCompositeGlyphs",
         [
-            FieldSpec("VarCompositeGlyphList", "VarCompositeGlyph"),
+            FieldSpec("VarCompositeGlyphList", "VarCompositeGlyph", repeat=""),
         ],
     ),
     # Glyph advance variations

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -1,3 +1,5 @@
+from .otDataSchema import FieldSpec
+
 otData = [
     #
     # common
@@ -6,156 +8,138 @@ otData = [
     (
         "ScriptList",
         [
-            ("uint16", "ScriptCount", None, None, "Number of ScriptRecords"),
-            (
+            FieldSpec("uint16", "ScriptCount", description="Number of ScriptRecords"),
+            FieldSpec(
                 "struct",
                 "ScriptRecord",
-                "ScriptCount",
-                0,
-                "Array of ScriptRecords -listed alphabetically by ScriptTag",
+                repeat="ScriptCount",
+                aux=0,
+                description="Array of ScriptRecords -listed alphabetically by ScriptTag",
             ),
         ],
     ),
     (
         "ScriptRecord",
         [
-            ("Tag", "ScriptTag", None, None, "4-byte ScriptTag identifier"),
-            (
+            FieldSpec("Tag", "ScriptTag", description="4-byte ScriptTag identifier"),
+            FieldSpec(
                 "Offset",
                 "Script",
-                None,
-                None,
-                "Offset to Script table-from beginning of ScriptList",
+                description="Offset to Script table-from beginning of ScriptList",
             ),
         ],
     ),
     (
         "Script",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "DefaultLangSys",
-                None,
-                None,
-                "Offset to DefaultLangSys table-from beginning of Script table-may be NULL",
+                description="Offset to DefaultLangSys table-from beginning of Script table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LangSysCount",
-                None,
-                None,
-                "Number of LangSysRecords for this script-excluding the DefaultLangSys",
+                description="Number of LangSysRecords for this script-excluding the DefaultLangSys",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "LangSysRecord",
-                "LangSysCount",
-                0,
-                "Array of LangSysRecords-listed alphabetically by LangSysTag",
+                repeat="LangSysCount",
+                aux=0,
+                description="Array of LangSysRecords-listed alphabetically by LangSysTag",
             ),
         ],
     ),
     (
         "LangSysRecord",
         [
-            ("Tag", "LangSysTag", None, None, "4-byte LangSysTag identifier"),
-            (
+            FieldSpec(
+                "Tag", "LangSysTag", description="4-byte LangSysTag identifier"
+            ),
+            FieldSpec(
                 "Offset",
                 "LangSys",
-                None,
-                None,
-                "Offset to LangSys table-from beginning of Script table",
+                description="Offset to LangSys table-from beginning of Script table",
             ),
         ],
     ),
     (
         "LangSys",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "LookupOrder",
-                None,
-                None,
-                "= NULL (reserved for an offset to a reordering table)",
+                description="= NULL (reserved for an offset to a reordering table)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ReqFeatureIndex",
-                None,
-                None,
-                "Index of a feature required for this language system- if no required features = 0xFFFF",
+                description="Index of a feature required for this language system- if no required features = 0xFFFF",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "FeatureCount",
-                None,
-                None,
-                "Number of FeatureIndex values for this language system-excludes the required feature",
+                description="Number of FeatureIndex values for this language system-excludes the required feature",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "FeatureIndex",
-                "FeatureCount",
-                0,
-                "Array of indices into the FeatureList-in arbitrary order",
+                repeat="FeatureCount",
+                aux=0,
+                description="Array of indices into the FeatureList-in arbitrary order",
             ),
         ],
     ),
     (
         "FeatureList",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "FeatureCount",
-                None,
-                None,
-                "Number of FeatureRecords in this table",
+                description="Number of FeatureRecords in this table",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "FeatureRecord",
-                "FeatureCount",
-                0,
-                "Array of FeatureRecords-zero-based (first feature has FeatureIndex = 0)-listed alphabetically by FeatureTag",
+                repeat="FeatureCount",
+                aux=0,
+                description="Array of FeatureRecords-zero-based (first feature has FeatureIndex = 0)-listed alphabetically by FeatureTag",
             ),
         ],
     ),
     (
         "FeatureRecord",
         [
-            ("Tag", "FeatureTag", None, None, "4-byte feature identification tag"),
-            (
+            FieldSpec(
+                "Tag", "FeatureTag", description="4-byte feature identification tag"
+            ),
+            FieldSpec(
                 "Offset",
                 "Feature",
-                None,
-                None,
-                "Offset to Feature table-from beginning of FeatureList",
+                description="Offset to Feature table-from beginning of FeatureList",
             ),
         ],
     ),
     (
         "Feature",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "FeatureParams",
-                None,
-                None,
-                "= NULL (reserved for offset to FeatureParams)",
+                description="= NULL (reserved for offset to FeatureParams)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookupCount",
-                None,
-                None,
-                "Number of LookupList indices for this feature",
+                description="Number of LookupList indices for this feature",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookupListIndex",
-                "LookupCount",
-                0,
-                "Array of LookupList indices for this feature -zero-based (first lookup is LookupListIndex = 0)",
+                repeat="LookupCount",
+                aux=0,
+                description="Array of LookupList indices for this feature -zero-based (first lookup is LookupListIndex = 0)",
             ),
         ],
     ),
@@ -163,231 +147,235 @@ otData = [
     (
         "FeatureParamsSize",
         [
-            (
+            FieldSpec(
                 "DeciPoints",
                 "DesignSize",
-                None,
-                None,
-                "The design size in 720/inch units (decipoints).",
+                description="The design size in 720/inch units (decipoints).",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "SubfamilyID",
-                None,
-                None,
-                "Serves as an identifier that associates fonts in a subfamily.",
+                description="Serves as an identifier that associates fonts in a subfamily.",
             ),
-            ("NameID", "SubfamilyNameID", None, None, "Subfamily NameID."),
-            (
+            FieldSpec("NameID", "SubfamilyNameID", description="Subfamily NameID."),
+            FieldSpec(
                 "DeciPoints",
                 "RangeStart",
-                None,
-                None,
-                "Small end of recommended usage range (exclusive) in 720/inch units.",
+                description="Small end of recommended usage range (exclusive) in 720/inch units.",
             ),
-            (
+            FieldSpec(
                 "DeciPoints",
                 "RangeEnd",
-                None,
-                None,
-                "Large end of recommended usage range (inclusive) in 720/inch units.",
+                description="Large end of recommended usage range (inclusive) in 720/inch units.",
             ),
         ],
     ),
     (
         "FeatureParamsStylisticSet",
         [
-            ("uint16", "Version", None, None, "Set to 0."),
-            ("NameID", "UINameID", None, None, "UI NameID."),
+            FieldSpec("uint16", "Version", description="Set to 0."),
+            FieldSpec("NameID", "UINameID", description="UI NameID."),
         ],
     ),
     (
         "FeatureParamsCharacterVariants",
         [
-            ("uint16", "Format", None, None, "Set to 0."),
-            ("NameID", "FeatUILabelNameID", None, None, "Feature UI label NameID."),
-            (
+            FieldSpec("uint16", "Format", description="Set to 0."),
+            FieldSpec(
+                "NameID", "FeatUILabelNameID", description="Feature UI label NameID."
+            ),
+            FieldSpec(
                 "NameID",
                 "FeatUITooltipTextNameID",
-                None,
-                None,
-                "Feature UI tooltip text NameID.",
+                description="Feature UI tooltip text NameID.",
             ),
-            ("NameID", "SampleTextNameID", None, None, "Sample text NameID."),
-            ("uint16", "NumNamedParameters", None, None, "Number of named parameters."),
-            (
+            FieldSpec(
+                "NameID", "SampleTextNameID", description="Sample text NameID."
+            ),
+            FieldSpec(
+                "uint16",
+                "NumNamedParameters",
+                description="Number of named parameters.",
+            ),
+            FieldSpec(
                 "NameID",
                 "FirstParamUILabelNameID",
-                None,
-                None,
-                "First NameID of UI feature parameters.",
+                description="First NameID of UI feature parameters.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "CharCount",
-                None,
-                None,
-                "Count of characters this feature provides glyph variants for.",
+                description="Count of characters this feature provides glyph variants for.",
             ),
-            (
+            FieldSpec(
                 "uint24",
                 "Character",
-                "CharCount",
-                0,
-                "Unicode characters for which this feature provides glyph variants.",
+                repeat="CharCount",
+                aux=0,
+                description="Unicode characters for which this feature provides glyph variants.",
             ),
         ],
     ),
     (
         "LookupList",
         [
-            ("uint16", "LookupCount", None, None, "Number of lookups in this table"),
-            (
+            FieldSpec(
+                "uint16", "LookupCount", description="Number of lookups in this table"
+            ),
+            FieldSpec(
                 "Offset",
                 "Lookup",
-                "LookupCount",
-                0,
-                "Array of offsets to Lookup tables-from beginning of LookupList -zero based (first lookup is Lookup index = 0)",
+                repeat="LookupCount",
+                aux=0,
+                description="Array of offsets to Lookup tables-from beginning of LookupList -zero based (first lookup is Lookup index = 0)",
             ),
         ],
     ),
     (
         "Lookup",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "LookupType",
-                None,
-                None,
-                "Different enumerations for GSUB and GPOS",
+                description="Different enumerations for GSUB and GPOS",
             ),
-            ("LookupFlag", "LookupFlag", None, None, "Lookup qualifiers"),
-            (
+            FieldSpec("LookupFlag", "LookupFlag", description="Lookup qualifiers"),
+            FieldSpec(
                 "uint16",
                 "SubTableCount",
-                None,
-                None,
-                "Number of SubTables for this lookup",
+                description="Number of SubTables for this lookup",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "SubTable",
-                "SubTableCount",
-                0,
-                "Array of offsets to SubTables-from beginning of Lookup table",
+                repeat="SubTableCount",
+                aux=0,
+                description="Array of offsets to SubTables-from beginning of Lookup table",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "MarkFilteringSet",
-                None,
-                "LookupFlag & 0x0010",
-                "If set, indicates that the lookup table structure is followed by a MarkFilteringSet field. The layout engine skips over all mark glyphs not in the mark filtering set indicated.",
+                aux="LookupFlag & 0x0010",
+                description="If set, indicates that the lookup table structure is followed by a MarkFilteringSet field. The layout engine skips over all mark glyphs not in the mark filtering set indicated.",
             ),
         ],
     ),
     (
         "CoverageFormat1",
         [
-            ("uint16", "CoverageFormat", None, None, "Format identifier-format = 1"),
-            ("uint16", "GlyphCount", None, None, "Number of glyphs in the GlyphArray"),
-            (
+            FieldSpec(
+                "uint16", "CoverageFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
+                "uint16", "GlyphCount", description="Number of glyphs in the GlyphArray"
+            ),
+            FieldSpec(
                 "GlyphID",
                 "GlyphArray",
-                "GlyphCount",
-                0,
-                "Array of GlyphIDs-in numerical order",
+                repeat="GlyphCount",
+                aux=0,
+                description="Array of GlyphIDs-in numerical order",
             ),
         ],
     ),
     (
         "CoverageFormat2",
         [
-            ("uint16", "CoverageFormat", None, None, "Format identifier-format = 2"),
-            ("uint16", "RangeCount", None, None, "Number of RangeRecords"),
-            (
+            FieldSpec(
+                "uint16", "CoverageFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec("uint16", "RangeCount", description="Number of RangeRecords"),
+            FieldSpec(
                 "struct",
                 "RangeRecord",
-                "RangeCount",
-                0,
-                "Array of glyph ranges-ordered by Start GlyphID",
+                repeat="RangeCount",
+                aux=0,
+                description="Array of glyph ranges-ordered by Start GlyphID",
             ),
         ],
     ),
     (
         "RangeRecord",
         [
-            ("GlyphID", "Start", None, None, "First GlyphID in the range"),
-            ("GlyphID", "End", None, None, "Last GlyphID in the range"),
-            (
+            FieldSpec("GlyphID", "Start", description="First GlyphID in the range"),
+            FieldSpec("GlyphID", "End", description="Last GlyphID in the range"),
+            FieldSpec(
                 "uint16",
                 "StartCoverageIndex",
-                None,
-                None,
-                "Coverage Index of first GlyphID in range",
+                description="Coverage Index of first GlyphID in range",
             ),
         ],
     ),
     (
         "ClassDefFormat1",
         [
-            ("uint16", "ClassFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "ClassFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "GlyphID",
                 "StartGlyph",
-                None,
-                None,
-                "First GlyphID of the ClassValueArray",
+                description="First GlyphID of the ClassValueArray",
             ),
-            ("uint16", "GlyphCount", None, None, "Size of the ClassValueArray"),
-            (
+            FieldSpec(
+                "uint16", "GlyphCount", description="Size of the ClassValueArray"
+            ),
+            FieldSpec(
                 "uint16",
                 "ClassValueArray",
-                "GlyphCount",
-                0,
-                "Array of Class Values-one per GlyphID",
+                repeat="GlyphCount",
+                aux=0,
+                description="Array of Class Values-one per GlyphID",
             ),
         ],
     ),
     (
         "ClassDefFormat2",
         [
-            ("uint16", "ClassFormat", None, None, "Format identifier-format = 2"),
-            ("uint16", "ClassRangeCount", None, None, "Number of ClassRangeRecords"),
-            (
+            FieldSpec(
+                "uint16", "ClassFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
+                "uint16", "ClassRangeCount", description="Number of ClassRangeRecords"
+            ),
+            FieldSpec(
                 "struct",
                 "ClassRangeRecord",
-                "ClassRangeCount",
-                0,
-                "Array of ClassRangeRecords-ordered by Start GlyphID",
+                repeat="ClassRangeCount",
+                aux=0,
+                description="Array of ClassRangeRecords-ordered by Start GlyphID",
             ),
         ],
     ),
     (
         "ClassRangeRecord",
         [
-            ("GlyphID", "Start", None, None, "First GlyphID in the range"),
-            ("GlyphID", "End", None, None, "Last GlyphID in the range"),
-            ("uint16", "Class", None, None, "Applied to all glyphs in the range"),
+            FieldSpec("GlyphID", "Start", description="First GlyphID in the range"),
+            FieldSpec("GlyphID", "End", description="Last GlyphID in the range"),
+            FieldSpec(
+                "uint16", "Class", description="Applied to all glyphs in the range"
+            ),
         ],
     ),
     (
         "Device",
         [
-            ("uint16", "StartSize", None, None, "Smallest size to correct-in ppem"),
-            ("uint16", "EndSize", None, None, "Largest size to correct-in ppem"),
-            (
+            FieldSpec(
+                "uint16", "StartSize", description="Smallest size to correct-in ppem"
+            ),
+            FieldSpec(
+                "uint16", "EndSize", description="Largest size to correct-in ppem"
+            ),
+            FieldSpec(
                 "uint16",
                 "DeltaFormat",
-                None,
-                None,
-                "Format of DeltaValue array data: 1, 2, or 3",
+                description="Format of DeltaValue array data: 1, 2, or 3",
             ),
-            (
+            FieldSpec(
                 "DeltaValue",
                 "DeltaValue",
-                None,
-                "DeltaFormat in (1,2,3)",
-                "Array of compressed data",
+                aux="DeltaFormat in (1,2,3)",
+                description="Array of compressed data",
             ),
         ],
     ),
@@ -397,983 +385,894 @@ otData = [
     (
         "GPOS",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the GPOS table- 0x00010000 or 0x00010001",
+                description="Version of the GPOS table- 0x00010000 or 0x00010001",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ScriptList",
-                None,
-                None,
-                "Offset to ScriptList table-from beginning of GPOS table",
+                description="Offset to ScriptList table-from beginning of GPOS table",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "FeatureList",
-                None,
-                None,
-                "Offset to FeatureList table-from beginning of GPOS table",
+                description="Offset to FeatureList table-from beginning of GPOS table",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "LookupList",
-                None,
-                None,
-                "Offset to LookupList table-from beginning of GPOS table",
+                description="Offset to LookupList table-from beginning of GPOS table",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "FeatureVariations",
-                None,
-                "Version >= 0x00010001",
-                "Offset to FeatureVariations table-from beginning of GPOS table",
+                aux="Version >= 0x00010001",
+                description="Offset to FeatureVariations table-from beginning of GPOS table",
             ),
         ],
     ),
     (
         "SinglePosFormat1",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of SinglePos subtable",
+                description="Offset to Coverage table-from beginning of SinglePos subtable",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ValueFormat",
-                None,
-                None,
-                "Defines the types of data in the ValueRecord",
+                description="Defines the types of data in the ValueRecord",
             ),
-            (
+            FieldSpec(
                 "ValueRecord",
                 "Value",
-                None,
-                None,
-                "Defines positioning value(s)-applied to all glyphs in the Coverage table",
+                description="Defines positioning value(s)-applied to all glyphs in the Coverage table",
             ),
         ],
     ),
     (
         "SinglePosFormat2",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 2"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of SinglePos subtable",
+                description="Offset to Coverage table-from beginning of SinglePos subtable",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ValueFormat",
-                None,
-                None,
-                "Defines the types of data in the ValueRecord",
+                description="Defines the types of data in the ValueRecord",
             ),
-            ("uint16", "ValueCount", None, None, "Number of ValueRecords"),
-            (
+            FieldSpec("uint16", "ValueCount", description="Number of ValueRecords"),
+            FieldSpec(
                 "ValueRecord",
                 "Value",
-                "ValueCount",
-                0,
-                "Array of ValueRecords-positioning values applied to glyphs",
+                repeat="ValueCount",
+                aux=0,
+                description="Array of ValueRecords-positioning values applied to glyphs",
             ),
         ],
     ),
     (
         "PairPosFormat1",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of PairPos subtable-only the first glyph in each pair",
+                description="Offset to Coverage table-from beginning of PairPos subtable-only the first glyph in each pair",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ValueFormat1",
-                None,
-                None,
-                "Defines the types of data in ValueRecord1-for the first glyph in the pair -may be zero (0)",
+                description="Defines the types of data in ValueRecord1-for the first glyph in the pair -may be zero (0)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ValueFormat2",
-                None,
-                None,
-                "Defines the types of data in ValueRecord2-for the second glyph in the pair -may be zero (0)",
+                description="Defines the types of data in ValueRecord2-for the second glyph in the pair -may be zero (0)",
             ),
-            ("uint16", "PairSetCount", None, None, "Number of PairSet tables"),
-            (
+            FieldSpec(
+                "uint16", "PairSetCount", description="Number of PairSet tables"
+            ),
+            FieldSpec(
                 "Offset",
                 "PairSet",
-                "PairSetCount",
-                0,
-                "Array of offsets to PairSet tables-from beginning of PairPos subtable-ordered by Coverage Index",
+                repeat="PairSetCount",
+                aux=0,
+                description="Array of offsets to PairSet tables-from beginning of PairPos subtable-ordered by Coverage Index",
             ),
         ],
     ),
     (
         "PairSet",
         [
-            ("uint16", "PairValueCount", None, None, "Number of PairValueRecords"),
-            (
+            FieldSpec(
+                "uint16", "PairValueCount", description="Number of PairValueRecords"
+            ),
+            FieldSpec(
                 "struct",
                 "PairValueRecord",
-                "PairValueCount",
-                0,
-                "Array of PairValueRecords-ordered by GlyphID of the second glyph",
+                repeat="PairValueCount",
+                aux=0,
+                description="Array of PairValueRecords-ordered by GlyphID of the second glyph",
             ),
         ],
     ),
     (
         "PairValueRecord",
         [
-            (
+            FieldSpec(
                 "GlyphID",
                 "SecondGlyph",
-                None,
-                None,
-                "GlyphID of second glyph in the pair-first glyph is listed in the Coverage table",
+                description="GlyphID of second glyph in the pair-first glyph is listed in the Coverage table",
             ),
-            (
+            FieldSpec(
                 "ValueRecord",
                 "Value1",
-                None,
-                None,
-                "Positioning data for the first glyph in the pair",
+                description="Positioning data for the first glyph in the pair",
             ),
-            (
+            FieldSpec(
                 "ValueRecord",
                 "Value2",
-                None,
-                None,
-                "Positioning data for the second glyph in the pair",
+                description="Positioning data for the second glyph in the pair",
             ),
         ],
     ),
     (
         "PairPosFormat2",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 2"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of PairPos subtable-for the first glyph of the pair",
+                description="Offset to Coverage table-from beginning of PairPos subtable-for the first glyph of the pair",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ValueFormat1",
-                None,
-                None,
-                "ValueRecord definition-for the first glyph of the pair-may be zero (0)",
+                description="ValueRecord definition-for the first glyph of the pair-may be zero (0)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ValueFormat2",
-                None,
-                None,
-                "ValueRecord definition-for the second glyph of the pair-may be zero (0)",
+                description="ValueRecord definition-for the second glyph of the pair-may be zero (0)",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ClassDef1",
-                None,
-                None,
-                "Offset to ClassDef table-from beginning of PairPos subtable-for the first glyph of the pair",
+                description="Offset to ClassDef table-from beginning of PairPos subtable-for the first glyph of the pair",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ClassDef2",
-                None,
-                None,
-                "Offset to ClassDef table-from beginning of PairPos subtable-for the second glyph of the pair",
+                description="Offset to ClassDef table-from beginning of PairPos subtable-for the second glyph of the pair",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "Class1Count",
-                None,
-                None,
-                "Number of classes in ClassDef1 table-includes Class0",
+                description="Number of classes in ClassDef1 table-includes Class0",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "Class2Count",
-                None,
-                None,
-                "Number of classes in ClassDef2 table-includes Class0",
+                description="Number of classes in ClassDef2 table-includes Class0",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "Class1Record",
-                "Class1Count",
-                0,
-                "Array of Class1 records-ordered by Class1",
+                repeat="Class1Count",
+                aux=0,
+                description="Array of Class1 records-ordered by Class1",
             ),
         ],
     ),
     (
         "Class1Record",
         [
-            (
+            FieldSpec(
                 "struct",
                 "Class2Record",
-                "Class2Count",
-                0,
-                "Array of Class2 records-ordered by Class2",
+                repeat="Class2Count",
+                aux=0,
+                description="Array of Class2 records-ordered by Class2",
             ),
         ],
     ),
     (
         "Class2Record",
         [
-            (
+            FieldSpec(
                 "ValueRecord",
                 "Value1",
-                None,
-                None,
-                "Positioning for first glyph-empty if ValueFormat1 = 0",
+                description="Positioning for first glyph-empty if ValueFormat1 = 0",
             ),
-            (
+            FieldSpec(
                 "ValueRecord",
                 "Value2",
-                None,
-                None,
-                "Positioning for second glyph-empty if ValueFormat2 = 0",
+                description="Positioning for second glyph-empty if ValueFormat2 = 0",
             ),
         ],
     ),
     (
         "CursivePosFormat1",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of CursivePos subtable",
+                description="Offset to Coverage table-from beginning of CursivePos subtable",
             ),
-            ("uint16", "EntryExitCount", None, None, "Number of EntryExit records"),
-            (
+            FieldSpec(
+                "uint16", "EntryExitCount", description="Number of EntryExit records"
+            ),
+            FieldSpec(
                 "struct",
                 "EntryExitRecord",
-                "EntryExitCount",
-                0,
-                "Array of EntryExit records-in Coverage Index order",
+                repeat="EntryExitCount",
+                aux=0,
+                description="Array of EntryExit records-in Coverage Index order",
             ),
         ],
     ),
     (
         "EntryExitRecord",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "EntryAnchor",
-                None,
-                None,
-                "Offset to EntryAnchor table-from beginning of CursivePos subtable-may be NULL",
+                description="Offset to EntryAnchor table-from beginning of CursivePos subtable-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ExitAnchor",
-                None,
-                None,
-                "Offset to ExitAnchor table-from beginning of CursivePos subtable-may be NULL",
+                description="Offset to ExitAnchor table-from beginning of CursivePos subtable-may be NULL",
             ),
         ],
     ),
     (
         "MarkBasePosFormat1",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "MarkCoverage",
-                None,
-                None,
-                "Offset to MarkCoverage table-from beginning of MarkBasePos subtable",
+                description="Offset to MarkCoverage table-from beginning of MarkBasePos subtable",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "BaseCoverage",
-                None,
-                None,
-                "Offset to BaseCoverage table-from beginning of MarkBasePos subtable",
+                description="Offset to BaseCoverage table-from beginning of MarkBasePos subtable",
             ),
-            ("uint16", "ClassCount", None, None, "Number of classes defined for marks"),
-            (
+            FieldSpec(
+                "uint16",
+                "ClassCount",
+                description="Number of classes defined for marks",
+            ),
+            FieldSpec(
                 "Offset",
                 "MarkArray",
-                None,
-                None,
-                "Offset to MarkArray table-from beginning of MarkBasePos subtable",
+                description="Offset to MarkArray table-from beginning of MarkBasePos subtable",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "BaseArray",
-                None,
-                None,
-                "Offset to BaseArray table-from beginning of MarkBasePos subtable",
+                description="Offset to BaseArray table-from beginning of MarkBasePos subtable",
             ),
         ],
     ),
     (
         "BaseArray",
         [
-            ("uint16", "BaseCount", None, None, "Number of BaseRecords"),
-            (
+            FieldSpec("uint16", "BaseCount", description="Number of BaseRecords"),
+            FieldSpec(
                 "struct",
                 "BaseRecord",
-                "BaseCount",
-                0,
-                "Array of BaseRecords-in order of BaseCoverage Index",
+                repeat="BaseCount",
+                aux=0,
+                description="Array of BaseRecords-in order of BaseCoverage Index",
             ),
         ],
     ),
     (
         "BaseRecord",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "BaseAnchor",
-                "ClassCount",
-                0,
-                "Array of offsets (one per class) to Anchor tables-from beginning of BaseArray table-ordered by class-zero-based",
+                repeat="ClassCount",
+                aux=0,
+                description="Array of offsets (one per class) to Anchor tables-from beginning of BaseArray table-ordered by class-zero-based",
             ),
         ],
     ),
     (
         "MarkLigPosFormat1",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "MarkCoverage",
-                None,
-                None,
-                "Offset to Mark Coverage table-from beginning of MarkLigPos subtable",
+                description="Offset to Mark Coverage table-from beginning of MarkLigPos subtable",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "LigatureCoverage",
-                None,
-                None,
-                "Offset to Ligature Coverage table-from beginning of MarkLigPos subtable",
+                description="Offset to Ligature Coverage table-from beginning of MarkLigPos subtable",
             ),
-            ("uint16", "ClassCount", None, None, "Number of defined mark classes"),
-            (
+            FieldSpec(
+                "uint16", "ClassCount", description="Number of defined mark classes"
+            ),
+            FieldSpec(
                 "Offset",
                 "MarkArray",
-                None,
-                None,
-                "Offset to MarkArray table-from beginning of MarkLigPos subtable",
+                description="Offset to MarkArray table-from beginning of MarkLigPos subtable",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "LigatureArray",
-                None,
-                None,
-                "Offset to LigatureArray table-from beginning of MarkLigPos subtable",
+                description="Offset to LigatureArray table-from beginning of MarkLigPos subtable",
             ),
         ],
     ),
     (
         "LigatureArray",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "LigatureCount",
-                None,
-                None,
-                "Number of LigatureAttach table offsets",
+                description="Number of LigatureAttach table offsets",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "LigatureAttach",
-                "LigatureCount",
-                0,
-                "Array of offsets to LigatureAttach tables-from beginning of LigatureArray table-ordered by LigatureCoverage Index",
+                repeat="LigatureCount",
+                aux=0,
+                description="Array of offsets to LigatureAttach tables-from beginning of LigatureArray table-ordered by LigatureCoverage Index",
             ),
         ],
     ),
     (
         "LigatureAttach",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "ComponentCount",
-                None,
-                None,
-                "Number of ComponentRecords in this ligature",
+                description="Number of ComponentRecords in this ligature",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "ComponentRecord",
-                "ComponentCount",
-                0,
-                "Array of Component records-ordered in writing direction",
+                repeat="ComponentCount",
+                aux=0,
+                description="Array of Component records-ordered in writing direction",
             ),
         ],
     ),
     (
         "ComponentRecord",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "LigatureAnchor",
-                "ClassCount",
-                0,
-                "Array of offsets (one per class) to Anchor tables-from beginning of LigatureAttach table-ordered by class-NULL if a component does not have an attachment for a class-zero-based array",
+                repeat="ClassCount",
+                aux=0,
+                description="Array of offsets (one per class) to Anchor tables-from beginning of LigatureAttach table-ordered by class-NULL if a component does not have an attachment for a class-zero-based array",
             ),
         ],
     ),
     (
         "MarkMarkPosFormat1",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Mark1Coverage",
-                None,
-                None,
-                "Offset to Combining Mark Coverage table-from beginning of MarkMarkPos subtable",
+                description="Offset to Combining Mark Coverage table-from beginning of MarkMarkPos subtable",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "Mark2Coverage",
-                None,
-                None,
-                "Offset to Base Mark Coverage table-from beginning of MarkMarkPos subtable",
+                description="Offset to Base Mark Coverage table-from beginning of MarkMarkPos subtable",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ClassCount",
-                None,
-                None,
-                "Number of Combining Mark classes defined",
+                description="Number of Combining Mark classes defined",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "Mark1Array",
-                None,
-                None,
-                "Offset to MarkArray table for Mark1-from beginning of MarkMarkPos subtable",
+                description="Offset to MarkArray table for Mark1-from beginning of MarkMarkPos subtable",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "Mark2Array",
-                None,
-                None,
-                "Offset to Mark2Array table for Mark2-from beginning of MarkMarkPos subtable",
+                description="Offset to Mark2Array table for Mark2-from beginning of MarkMarkPos subtable",
             ),
         ],
     ),
     (
         "Mark2Array",
         [
-            ("uint16", "Mark2Count", None, None, "Number of Mark2 records"),
-            (
+            FieldSpec("uint16", "Mark2Count", description="Number of Mark2 records"),
+            FieldSpec(
                 "struct",
                 "Mark2Record",
-                "Mark2Count",
-                0,
-                "Array of Mark2 records-in Coverage order",
+                repeat="Mark2Count",
+                aux=0,
+                description="Array of Mark2 records-in Coverage order",
             ),
         ],
     ),
     (
         "Mark2Record",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "Mark2Anchor",
-                "ClassCount",
-                0,
-                "Array of offsets (one per class) to Anchor tables-from beginning of Mark2Array table-zero-based array",
+                repeat="ClassCount",
+                aux=0,
+                description="Array of offsets (one per class) to Anchor tables-from beginning of Mark2Array table-zero-based array",
             ),
         ],
     ),
     (
         "PosLookupRecord",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "SequenceIndex",
-                None,
-                None,
-                "Index to input glyph sequence-first glyph = 0",
+                description="Index to input glyph sequence-first glyph = 0",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookupListIndex",
-                None,
-                None,
-                "Lookup to apply to that position-zero-based",
+                description="Lookup to apply to that position-zero-based",
             ),
         ],
     ),
     (
         "ContextPosFormat1",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of ContextPos subtable",
+                description="Offset to Coverage table-from beginning of ContextPos subtable",
             ),
-            ("uint16", "PosRuleSetCount", None, None, "Number of PosRuleSet tables"),
-            (
+            FieldSpec(
+                "uint16", "PosRuleSetCount", description="Number of PosRuleSet tables"
+            ),
+            FieldSpec(
                 "Offset",
                 "PosRuleSet",
-                "PosRuleSetCount",
-                0,
-                "Array of offsets to PosRuleSet tables-from beginning of ContextPos subtable-ordered by Coverage Index",
+                repeat="PosRuleSetCount",
+                aux=0,
+                description="Array of offsets to PosRuleSet tables-from beginning of ContextPos subtable-ordered by Coverage Index",
             ),
         ],
     ),
     (
         "PosRuleSet",
         [
-            ("uint16", "PosRuleCount", None, None, "Number of PosRule tables"),
-            (
+            FieldSpec(
+                "uint16", "PosRuleCount", description="Number of PosRule tables"
+            ),
+            FieldSpec(
                 "Offset",
                 "PosRule",
-                "PosRuleCount",
-                0,
-                "Array of offsets to PosRule tables-from beginning of PosRuleSet-ordered by preference",
+                repeat="PosRuleCount",
+                aux=0,
+                description="Array of offsets to PosRule tables-from beginning of PosRuleSet-ordered by preference",
             ),
         ],
     ),
     (
         "PosRule",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "GlyphCount",
-                None,
-                None,
-                "Number of glyphs in the Input glyph sequence",
+                description="Number of glyphs in the Input glyph sequence",
             ),
-            ("uint16", "PosCount", None, None, "Number of PosLookupRecords"),
-            (
+            FieldSpec("uint16", "PosCount", description="Number of PosLookupRecords"),
+            FieldSpec(
                 "GlyphID",
                 "Input",
-                "GlyphCount",
-                -1,
-                "Array of input GlyphIDs-starting with the second glyph",
+                repeat="GlyphCount",
+                aux=-1,
+                description="Array of input GlyphIDs-starting with the second glyph",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "PosLookupRecord",
-                "PosCount",
-                0,
-                "Array of positioning lookups-in design order",
+                repeat="PosCount",
+                aux=0,
+                description="Array of positioning lookups-in design order",
             ),
         ],
     ),
     (
         "ContextPosFormat2",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 2"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of ContextPos subtable",
+                description="Offset to Coverage table-from beginning of ContextPos subtable",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ClassDef",
-                None,
-                None,
-                "Offset to ClassDef table-from beginning of ContextPos subtable",
+                description="Offset to ClassDef table-from beginning of ContextPos subtable",
             ),
-            ("uint16", "PosClassSetCount", None, None, "Number of PosClassSet tables"),
-            (
+            FieldSpec(
+                "uint16", "PosClassSetCount", description="Number of PosClassSet tables"
+            ),
+            FieldSpec(
                 "Offset",
                 "PosClassSet",
-                "PosClassSetCount",
-                0,
-                "Array of offsets to PosClassSet tables-from beginning of ContextPos subtable-ordered by class-may be NULL",
+                repeat="PosClassSetCount",
+                aux=0,
+                description="Array of offsets to PosClassSet tables-from beginning of ContextPos subtable-ordered by class-may be NULL",
             ),
         ],
     ),
     (
         "PosClassSet",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "PosClassRuleCount",
-                None,
-                None,
-                "Number of PosClassRule tables",
+                description="Number of PosClassRule tables",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "PosClassRule",
-                "PosClassRuleCount",
-                0,
-                "Array of offsets to PosClassRule tables-from beginning of PosClassSet-ordered by preference",
+                repeat="PosClassRuleCount",
+                aux=0,
+                description="Array of offsets to PosClassRule tables-from beginning of PosClassSet-ordered by preference",
             ),
         ],
     ),
     (
         "PosClassRule",
         [
-            ("uint16", "GlyphCount", None, None, "Number of glyphs to be matched"),
-            ("uint16", "PosCount", None, None, "Number of PosLookupRecords"),
-            (
+            FieldSpec(
+                "uint16", "GlyphCount", description="Number of glyphs to be matched"
+            ),
+            FieldSpec("uint16", "PosCount", description="Number of PosLookupRecords"),
+            FieldSpec(
                 "uint16",
                 "Class",
-                "GlyphCount",
-                -1,
-                "Array of classes-beginning with the second class-to be matched to the input glyph sequence",
+                repeat="GlyphCount",
+                aux=-1,
+                description="Array of classes-beginning with the second class-to be matched to the input glyph sequence",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "PosLookupRecord",
-                "PosCount",
-                0,
-                "Array of positioning lookups-in design order",
+                repeat="PosCount",
+                aux=0,
+                description="Array of positioning lookups-in design order",
             ),
         ],
     ),
     (
         "ContextPosFormat3",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 3"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 3"
+            ),
+            FieldSpec(
                 "uint16",
                 "GlyphCount",
-                None,
-                None,
-                "Number of glyphs in the input sequence",
+                description="Number of glyphs in the input sequence",
             ),
-            ("uint16", "PosCount", None, None, "Number of PosLookupRecords"),
-            (
+            FieldSpec("uint16", "PosCount", description="Number of PosLookupRecords"),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                "GlyphCount",
-                0,
-                "Array of offsets to Coverage tables-from beginning of ContextPos subtable",
+                repeat="GlyphCount",
+                aux=0,
+                description="Array of offsets to Coverage tables-from beginning of ContextPos subtable",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "PosLookupRecord",
-                "PosCount",
-                0,
-                "Array of positioning lookups-in design order",
+                repeat="PosCount",
+                aux=0,
+                description="Array of positioning lookups-in design order",
             ),
         ],
     ),
     (
         "ChainContextPosFormat1",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of ContextPos subtable",
+                description="Offset to Coverage table-from beginning of ContextPos subtable",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ChainPosRuleSetCount",
-                None,
-                None,
-                "Number of ChainPosRuleSet tables",
+                description="Number of ChainPosRuleSet tables",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ChainPosRuleSet",
-                "ChainPosRuleSetCount",
-                0,
-                "Array of offsets to ChainPosRuleSet tables-from beginning of ContextPos subtable-ordered by Coverage Index",
+                repeat="ChainPosRuleSetCount",
+                aux=0,
+                description="Array of offsets to ChainPosRuleSet tables-from beginning of ContextPos subtable-ordered by Coverage Index",
             ),
         ],
     ),
     (
         "ChainPosRuleSet",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "ChainPosRuleCount",
-                None,
-                None,
-                "Number of ChainPosRule tables",
+                description="Number of ChainPosRule tables",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ChainPosRule",
-                "ChainPosRuleCount",
-                0,
-                "Array of offsets to ChainPosRule tables-from beginning of ChainPosRuleSet-ordered by preference",
+                repeat="ChainPosRuleCount",
+                aux=0,
+                description="Array of offsets to ChainPosRule tables-from beginning of ChainPosRuleSet-ordered by preference",
             ),
         ],
     ),
     (
         "ChainPosRule",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "BacktrackGlyphCount",
-                None,
-                None,
-                "Total number of glyphs in the backtrack sequence (number of glyphs to be matched before the first glyph)",
+                description="Total number of glyphs in the backtrack sequence (number of glyphs to be matched before the first glyph)",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "Backtrack",
-                "BacktrackGlyphCount",
-                0,
-                "Array of backtracking GlyphID's (to be matched before the input sequence)",
+                repeat="BacktrackGlyphCount",
+                aux=0,
+                description="Array of backtracking GlyphID's (to be matched before the input sequence)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "InputGlyphCount",
-                None,
-                None,
-                "Total number of glyphs in the input sequence (includes the first glyph)",
+                description="Total number of glyphs in the input sequence (includes the first glyph)",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "Input",
-                "InputGlyphCount",
-                -1,
-                "Array of input GlyphIDs (start with second glyph)",
+                repeat="InputGlyphCount",
+                aux=-1,
+                description="Array of input GlyphIDs (start with second glyph)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookAheadGlyphCount",
-                None,
-                None,
-                "Total number of glyphs in the look ahead sequence (number of glyphs to be matched after the input sequence)",
+                description="Total number of glyphs in the look ahead sequence (number of glyphs to be matched after the input sequence)",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "LookAhead",
-                "LookAheadGlyphCount",
-                0,
-                "Array of lookahead GlyphID's (to be matched after the input sequence)",
+                repeat="LookAheadGlyphCount",
+                aux=0,
+                description="Array of lookahead GlyphID's (to be matched after the input sequence)",
             ),
-            ("uint16", "PosCount", None, None, "Number of PosLookupRecords"),
-            (
+            FieldSpec("uint16", "PosCount", description="Number of PosLookupRecords"),
+            FieldSpec(
                 "struct",
                 "PosLookupRecord",
-                "PosCount",
-                0,
-                "Array of PosLookupRecords (in design order)",
+                repeat="PosCount",
+                aux=0,
+                description="Array of PosLookupRecords (in design order)",
             ),
         ],
     ),
     (
         "ChainContextPosFormat2",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 2"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of ChainContextPos subtable",
+                description="Offset to Coverage table-from beginning of ChainContextPos subtable",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "BacktrackClassDef",
-                None,
-                None,
-                "Offset to ClassDef table containing backtrack sequence context-from beginning of ChainContextPos subtable",
+                description="Offset to ClassDef table containing backtrack sequence context-from beginning of ChainContextPos subtable",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "InputClassDef",
-                None,
-                None,
-                "Offset to ClassDef table containing input sequence context-from beginning of ChainContextPos subtable",
+                description="Offset to ClassDef table containing input sequence context-from beginning of ChainContextPos subtable",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "LookAheadClassDef",
-                None,
-                None,
-                "Offset to ClassDef table containing lookahead sequence context-from beginning of ChainContextPos subtable",
+                description="Offset to ClassDef table containing lookahead sequence context-from beginning of ChainContextPos subtable",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ChainPosClassSetCount",
-                None,
-                None,
-                "Number of ChainPosClassSet tables",
+                description="Number of ChainPosClassSet tables",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ChainPosClassSet",
-                "ChainPosClassSetCount",
-                0,
-                "Array of offsets to ChainPosClassSet tables-from beginning of ChainContextPos subtable-ordered by input class-may be NULL",
+                repeat="ChainPosClassSetCount",
+                aux=0,
+                description="Array of offsets to ChainPosClassSet tables-from beginning of ChainContextPos subtable-ordered by input class-may be NULL",
             ),
         ],
     ),
     (
         "ChainPosClassSet",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "ChainPosClassRuleCount",
-                None,
-                None,
-                "Number of ChainPosClassRule tables",
+                description="Number of ChainPosClassRule tables",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ChainPosClassRule",
-                "ChainPosClassRuleCount",
-                0,
-                "Array of offsets to ChainPosClassRule tables-from beginning of ChainPosClassSet-ordered by preference",
+                repeat="ChainPosClassRuleCount",
+                aux=0,
+                description="Array of offsets to ChainPosClassRule tables-from beginning of ChainPosClassSet-ordered by preference",
             ),
         ],
     ),
     (
         "ChainPosClassRule",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "BacktrackGlyphCount",
-                None,
-                None,
-                "Total number of glyphs in the backtrack sequence (number of glyphs to be matched before the first glyph)",
+                description="Total number of glyphs in the backtrack sequence (number of glyphs to be matched before the first glyph)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "Backtrack",
-                "BacktrackGlyphCount",
-                0,
-                "Array of backtracking classes(to be matched before the input sequence)",
+                repeat="BacktrackGlyphCount",
+                aux=0,
+                description="Array of backtracking classes(to be matched before the input sequence)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "InputGlyphCount",
-                None,
-                None,
-                "Total number of classes in the input sequence (includes the first class)",
+                description="Total number of classes in the input sequence (includes the first class)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "Input",
-                "InputGlyphCount",
-                -1,
-                "Array of input classes(start with second class; to be matched with the input glyph sequence)",
+                repeat="InputGlyphCount",
+                aux=-1,
+                description="Array of input classes(start with second class; to be matched with the input glyph sequence)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookAheadGlyphCount",
-                None,
-                None,
-                "Total number of classes in the look ahead sequence (number of classes to be matched after the input sequence)",
+                description="Total number of classes in the look ahead sequence (number of classes to be matched after the input sequence)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookAhead",
-                "LookAheadGlyphCount",
-                0,
-                "Array of lookahead classes(to be matched after the input sequence)",
+                repeat="LookAheadGlyphCount",
+                aux=0,
+                description="Array of lookahead classes(to be matched after the input sequence)",
             ),
-            ("uint16", "PosCount", None, None, "Number of PosLookupRecords"),
-            (
+            FieldSpec("uint16", "PosCount", description="Number of PosLookupRecords"),
+            FieldSpec(
                 "struct",
                 "PosLookupRecord",
-                "PosCount",
-                0,
-                "Array of PosLookupRecords (in design order)",
+                repeat="PosCount",
+                aux=0,
+                description="Array of PosLookupRecords (in design order)",
             ),
         ],
     ),
     (
         "ChainContextPosFormat3",
         [
-            ("uint16", "PosFormat", None, None, "Format identifier-format = 3"),
-            (
+            FieldSpec(
+                "uint16", "PosFormat", description="Format identifier-format = 3"
+            ),
+            FieldSpec(
                 "uint16",
                 "BacktrackGlyphCount",
-                None,
-                None,
-                "Number of glyphs in the backtracking sequence",
+                description="Number of glyphs in the backtracking sequence",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "BacktrackCoverage",
-                "BacktrackGlyphCount",
-                0,
-                "Array of offsets to coverage tables in backtracking sequence, in glyph sequence order",
+                repeat="BacktrackGlyphCount",
+                aux=0,
+                description="Array of offsets to coverage tables in backtracking sequence, in glyph sequence order",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "InputGlyphCount",
-                None,
-                None,
-                "Number of glyphs in input sequence",
+                description="Number of glyphs in input sequence",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "InputCoverage",
-                "InputGlyphCount",
-                0,
-                "Array of offsets to coverage tables in input sequence, in glyph sequence order",
+                repeat="InputGlyphCount",
+                aux=0,
+                description="Array of offsets to coverage tables in input sequence, in glyph sequence order",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookAheadGlyphCount",
-                None,
-                None,
-                "Number of glyphs in lookahead sequence",
+                description="Number of glyphs in lookahead sequence",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "LookAheadCoverage",
-                "LookAheadGlyphCount",
-                0,
-                "Array of offsets to coverage tables in lookahead sequence, in glyph sequence order",
+                repeat="LookAheadGlyphCount",
+                aux=0,
+                description="Array of offsets to coverage tables in lookahead sequence, in glyph sequence order",
             ),
-            ("uint16", "PosCount", None, None, "Number of PosLookupRecords"),
-            (
+            FieldSpec("uint16", "PosCount", description="Number of PosLookupRecords"),
+            FieldSpec(
                 "struct",
                 "PosLookupRecord",
-                "PosCount",
-                0,
-                "Array of PosLookupRecords,in design order",
+                repeat="PosCount",
+                aux=0,
+                description="Array of PosLookupRecords,in design order",
             ),
         ],
     ),
     (
         "ExtensionPosFormat1",
         [
-            ("uint16", "ExtFormat", None, None, "Format identifier. Set to 1."),
-            (
+            FieldSpec(
+                "uint16", "ExtFormat", description="Format identifier. Set to 1."
+            ),
+            FieldSpec(
                 "uint16",
                 "ExtensionLookupType",
-                None,
-                None,
-                "Lookup type of subtable referenced by ExtensionOffset (i.e. the extension subtable).",
+                description="Lookup type of subtable referenced by ExtensionOffset (i.e. the extension subtable).",
             ),
-            ("LOffset", "ExtSubTable", None, None, "Offset to SubTable"),
+            FieldSpec("LOffset", "ExtSubTable", description="Offset to SubTable"),
         ],
     ),
     # 	('ValueRecord', [
@@ -1389,65 +1288,79 @@ otData = [
     (
         "AnchorFormat1",
         [
-            ("uint16", "AnchorFormat", None, None, "Format identifier-format = 1"),
-            ("int16", "XCoordinate", None, None, "Horizontal value-in design units"),
-            ("int16", "YCoordinate", None, None, "Vertical value-in design units"),
+            FieldSpec(
+                "uint16", "AnchorFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
+                "int16", "XCoordinate", description="Horizontal value-in design units"
+            ),
+            FieldSpec(
+                "int16", "YCoordinate", description="Vertical value-in design units"
+            ),
         ],
     ),
     (
         "AnchorFormat2",
         [
-            ("uint16", "AnchorFormat", None, None, "Format identifier-format = 2"),
-            ("int16", "XCoordinate", None, None, "Horizontal value-in design units"),
-            ("int16", "YCoordinate", None, None, "Vertical value-in design units"),
-            ("uint16", "AnchorPoint", None, None, "Index to glyph contour point"),
+            FieldSpec(
+                "uint16", "AnchorFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
+                "int16", "XCoordinate", description="Horizontal value-in design units"
+            ),
+            FieldSpec(
+                "int16", "YCoordinate", description="Vertical value-in design units"
+            ),
+            FieldSpec(
+                "uint16", "AnchorPoint", description="Index to glyph contour point"
+            ),
         ],
     ),
     (
         "AnchorFormat3",
         [
-            ("uint16", "AnchorFormat", None, None, "Format identifier-format = 3"),
-            ("int16", "XCoordinate", None, None, "Horizontal value-in design units"),
-            ("int16", "YCoordinate", None, None, "Vertical value-in design units"),
-            (
+            FieldSpec(
+                "uint16", "AnchorFormat", description="Format identifier-format = 3"
+            ),
+            FieldSpec(
+                "int16", "XCoordinate", description="Horizontal value-in design units"
+            ),
+            FieldSpec(
+                "int16", "YCoordinate", description="Vertical value-in design units"
+            ),
+            FieldSpec(
                 "Offset",
                 "XDeviceTable",
-                None,
-                None,
-                "Offset to Device table for X coordinate- from beginning of Anchor table (may be NULL)",
+                description="Offset to Device table for X coordinate- from beginning of Anchor table (may be NULL)",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "YDeviceTable",
-                None,
-                None,
-                "Offset to Device table for Y coordinate- from beginning of Anchor table (may be NULL)",
+                description="Offset to Device table for Y coordinate- from beginning of Anchor table (may be NULL)",
             ),
         ],
     ),
     (
         "MarkArray",
         [
-            ("uint16", "MarkCount", None, None, "Number of MarkRecords"),
-            (
+            FieldSpec("uint16", "MarkCount", description="Number of MarkRecords"),
+            FieldSpec(
                 "struct",
                 "MarkRecord",
-                "MarkCount",
-                0,
-                "Array of MarkRecords-in Coverage order",
+                repeat="MarkCount",
+                aux=0,
+                description="Array of MarkRecords-in Coverage order",
             ),
         ],
     ),
     (
         "MarkRecord",
         [
-            ("uint16", "Class", None, None, "Class defined for this mark"),
-            (
+            FieldSpec("uint16", "Class", description="Class defined for this mark"),
+            FieldSpec(
                 "Offset",
                 "MarkAnchor",
-                None,
-                None,
-                "Offset to Anchor table-from beginning of MarkArray table",
+                description="Offset to Anchor table-from beginning of MarkArray table",
             ),
         ],
     ),
@@ -1457,769 +1370,723 @@ otData = [
     (
         "GSUB",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the GSUB table- 0x00010000 or 0x00010001",
+                description="Version of the GSUB table- 0x00010000 or 0x00010001",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ScriptList",
-                None,
-                None,
-                "Offset to ScriptList table-from beginning of GSUB table",
+                description="Offset to ScriptList table-from beginning of GSUB table",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "FeatureList",
-                None,
-                None,
-                "Offset to FeatureList table-from beginning of GSUB table",
+                description="Offset to FeatureList table-from beginning of GSUB table",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "LookupList",
-                None,
-                None,
-                "Offset to LookupList table-from beginning of GSUB table",
+                description="Offset to LookupList table-from beginning of GSUB table",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "FeatureVariations",
-                None,
-                "Version >= 0x00010001",
-                "Offset to FeatureVariations table-from beginning of GSUB table",
+                aux="Version >= 0x00010001",
+                description="Offset to FeatureVariations table-from beginning of GSUB table",
             ),
         ],
     ),
     (
         "SingleSubstFormat1",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of Substitution table",
+                description="Offset to Coverage table-from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "DeltaGlyphID",
-                None,
-                None,
-                "Add to original GlyphID modulo 65536 to get substitute GlyphID",
+                description="Add to original GlyphID modulo 65536 to get substitute GlyphID",
             ),
         ],
     ),
     (
         "SingleSubstFormat2",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 2"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of Substitution table",
+                description="Offset to Coverage table-from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "GlyphCount",
-                None,
-                None,
-                "Number of GlyphIDs in the Substitute array",
+                description="Number of GlyphIDs in the Substitute array",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "Substitute",
-                "GlyphCount",
-                0,
-                "Array of substitute GlyphIDs-ordered by Coverage Index",
+                repeat="GlyphCount",
+                aux=0,
+                description="Array of substitute GlyphIDs-ordered by Coverage Index",
             ),
         ],
     ),
     (
         "MultipleSubstFormat1",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of Substitution table",
+                description="Offset to Coverage table-from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "SequenceCount",
-                None,
-                None,
-                "Number of Sequence table offsets in the Sequence array",
+                description="Number of Sequence table offsets in the Sequence array",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "Sequence",
-                "SequenceCount",
-                0,
-                "Array of offsets to Sequence tables-from beginning of Substitution table-ordered by Coverage Index",
+                repeat="SequenceCount",
+                aux=0,
+                description="Array of offsets to Sequence tables-from beginning of Substitution table-ordered by Coverage Index",
             ),
         ],
     ),
     (
         "Sequence",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "GlyphCount",
-                None,
-                None,
-                "Number of GlyphIDs in the Substitute array. This should always be greater than 0.",
+                description="Number of GlyphIDs in the Substitute array. This should always be greater than 0.",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "Substitute",
-                "GlyphCount",
-                0,
-                "String of GlyphIDs to substitute",
+                repeat="GlyphCount",
+                aux=0,
+                description="String of GlyphIDs to substitute",
             ),
         ],
     ),
     (
         "AlternateSubstFormat1",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of Substitution table",
+                description="Offset to Coverage table-from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "AlternateSetCount",
-                None,
-                None,
-                "Number of AlternateSet tables",
+                description="Number of AlternateSet tables",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "AlternateSet",
-                "AlternateSetCount",
-                0,
-                "Array of offsets to AlternateSet tables-from beginning of Substitution table-ordered by Coverage Index",
+                repeat="AlternateSetCount",
+                aux=0,
+                description="Array of offsets to AlternateSet tables-from beginning of Substitution table-ordered by Coverage Index",
             ),
         ],
     ),
     (
         "AlternateSet",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "GlyphCount",
-                None,
-                None,
-                "Number of GlyphIDs in the Alternate array",
+                description="Number of GlyphIDs in the Alternate array",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "Alternate",
-                "GlyphCount",
-                0,
-                "Array of alternate GlyphIDs-in arbitrary order",
+                repeat="GlyphCount",
+                aux=0,
+                description="Array of alternate GlyphIDs-in arbitrary order",
             ),
         ],
     ),
     (
         "LigatureSubstFormat1",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of Substitution table",
+                description="Offset to Coverage table-from beginning of Substitution table",
             ),
-            ("uint16", "LigSetCount", None, None, "Number of LigatureSet tables"),
-            (
+            FieldSpec(
+                "uint16", "LigSetCount", description="Number of LigatureSet tables"
+            ),
+            FieldSpec(
                 "Offset",
                 "LigatureSet",
-                "LigSetCount",
-                0,
-                "Array of offsets to LigatureSet tables-from beginning of Substitution table-ordered by Coverage Index",
+                repeat="LigSetCount",
+                aux=0,
+                description="Array of offsets to LigatureSet tables-from beginning of Substitution table-ordered by Coverage Index",
             ),
         ],
     ),
     (
         "LigatureSet",
         [
-            ("uint16", "LigatureCount", None, None, "Number of Ligature tables"),
-            (
+            FieldSpec(
+                "uint16", "LigatureCount", description="Number of Ligature tables"
+            ),
+            FieldSpec(
                 "Offset",
                 "Ligature",
-                "LigatureCount",
-                0,
-                "Array of offsets to Ligature tables-from beginning of LigatureSet table-ordered by preference",
+                repeat="LigatureCount",
+                aux=0,
+                description="Array of offsets to Ligature tables-from beginning of LigatureSet table-ordered by preference",
             ),
         ],
     ),
     (
         "Ligature",
         [
-            ("GlyphID", "LigGlyph", None, None, "GlyphID of ligature to substitute"),
-            ("uint16", "CompCount", None, None, "Number of components in the ligature"),
-            (
+            FieldSpec(
+                "GlyphID", "LigGlyph", description="GlyphID of ligature to substitute"
+            ),
+            FieldSpec(
+                "uint16",
+                "CompCount",
+                description="Number of components in the ligature",
+            ),
+            FieldSpec(
                 "GlyphID",
                 "Component",
-                "CompCount",
-                -1,
-                "Array of component GlyphIDs-start with the second component-ordered in writing direction",
+                repeat="CompCount",
+                aux=-1,
+                description="Array of component GlyphIDs-start with the second component-ordered in writing direction",
             ),
         ],
     ),
     (
         "SubstLookupRecord",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "SequenceIndex",
-                None,
-                None,
-                "Index into current glyph sequence-first glyph = 0",
+                description="Index into current glyph sequence-first glyph = 0",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookupListIndex",
-                None,
-                None,
-                "Lookup to apply to that position-zero-based",
+                description="Lookup to apply to that position-zero-based",
             ),
         ],
     ),
     (
         "ContextSubstFormat1",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of Substitution table",
+                description="Offset to Coverage table-from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "SubRuleSetCount",
-                None,
-                None,
-                "Number of SubRuleSet tables-must equal GlyphCount in Coverage table",
+                description="Number of SubRuleSet tables-must equal GlyphCount in Coverage table",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "SubRuleSet",
-                "SubRuleSetCount",
-                0,
-                "Array of offsets to SubRuleSet tables-from beginning of Substitution table-ordered by Coverage Index",
+                repeat="SubRuleSetCount",
+                aux=0,
+                description="Array of offsets to SubRuleSet tables-from beginning of Substitution table-ordered by Coverage Index",
             ),
         ],
     ),
     (
         "SubRuleSet",
         [
-            ("uint16", "SubRuleCount", None, None, "Number of SubRule tables"),
-            (
+            FieldSpec(
+                "uint16", "SubRuleCount", description="Number of SubRule tables"
+            ),
+            FieldSpec(
                 "Offset",
                 "SubRule",
-                "SubRuleCount",
-                0,
-                "Array of offsets to SubRule tables-from beginning of SubRuleSet table-ordered by preference",
+                repeat="SubRuleCount",
+                aux=0,
+                description="Array of offsets to SubRule tables-from beginning of SubRuleSet table-ordered by preference",
             ),
         ],
     ),
     (
         "SubRule",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "GlyphCount",
-                None,
-                None,
-                "Total number of glyphs in input glyph sequence-includes the first glyph",
+                description="Total number of glyphs in input glyph sequence-includes the first glyph",
             ),
-            ("uint16", "SubstCount", None, None, "Number of SubstLookupRecords"),
-            (
+            FieldSpec(
+                "uint16", "SubstCount", description="Number of SubstLookupRecords"
+            ),
+            FieldSpec(
                 "GlyphID",
                 "Input",
-                "GlyphCount",
-                -1,
-                "Array of input GlyphIDs-start with second glyph",
+                repeat="GlyphCount",
+                aux=-1,
+                description="Array of input GlyphIDs-start with second glyph",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "SubstLookupRecord",
-                "SubstCount",
-                0,
-                "Array of SubstLookupRecords-in design order",
+                repeat="SubstCount",
+                aux=0,
+                description="Array of SubstLookupRecords-in design order",
             ),
         ],
     ),
     (
         "ContextSubstFormat2",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 2"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of Substitution table",
+                description="Offset to Coverage table-from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ClassDef",
-                None,
-                None,
-                "Offset to glyph ClassDef table-from beginning of Substitution table",
+                description="Offset to glyph ClassDef table-from beginning of Substitution table",
             ),
-            ("uint16", "SubClassSetCount", None, None, "Number of SubClassSet tables"),
-            (
+            FieldSpec(
+                "uint16", "SubClassSetCount", description="Number of SubClassSet tables"
+            ),
+            FieldSpec(
                 "Offset",
                 "SubClassSet",
-                "SubClassSetCount",
-                0,
-                "Array of offsets to SubClassSet tables-from beginning of Substitution table-ordered by class-may be NULL",
+                repeat="SubClassSetCount",
+                aux=0,
+                description="Array of offsets to SubClassSet tables-from beginning of Substitution table-ordered by class-may be NULL",
             ),
         ],
     ),
     (
         "SubClassSet",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "SubClassRuleCount",
-                None,
-                None,
-                "Number of SubClassRule tables",
+                description="Number of SubClassRule tables",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "SubClassRule",
-                "SubClassRuleCount",
-                0,
-                "Array of offsets to SubClassRule tables-from beginning of SubClassSet-ordered by preference",
+                repeat="SubClassRuleCount",
+                aux=0,
+                description="Array of offsets to SubClassRule tables-from beginning of SubClassSet-ordered by preference",
             ),
         ],
     ),
     (
         "SubClassRule",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "GlyphCount",
-                None,
-                None,
-                "Total number of classes specified for the context in the rule-includes the first class",
+                description="Total number of classes specified for the context in the rule-includes the first class",
             ),
-            ("uint16", "SubstCount", None, None, "Number of SubstLookupRecords"),
-            (
+            FieldSpec(
+                "uint16", "SubstCount", description="Number of SubstLookupRecords"
+            ),
+            FieldSpec(
                 "uint16",
                 "Class",
-                "GlyphCount",
-                -1,
-                "Array of classes-beginning with the second class-to be matched to the input glyph class sequence",
+                repeat="GlyphCount",
+                aux=-1,
+                description="Array of classes-beginning with the second class-to be matched to the input glyph class sequence",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "SubstLookupRecord",
-                "SubstCount",
-                0,
-                "Array of Substitution lookups-in design order",
+                repeat="SubstCount",
+                aux=0,
+                description="Array of Substitution lookups-in design order",
             ),
         ],
     ),
     (
         "ContextSubstFormat3",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 3"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 3"
+            ),
+            FieldSpec(
                 "uint16",
                 "GlyphCount",
-                None,
-                None,
-                "Number of glyphs in the input glyph sequence",
+                description="Number of glyphs in the input glyph sequence",
             ),
-            ("uint16", "SubstCount", None, None, "Number of SubstLookupRecords"),
-            (
+            FieldSpec(
+                "uint16", "SubstCount", description="Number of SubstLookupRecords"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                "GlyphCount",
-                0,
-                "Array of offsets to Coverage table-from beginning of Substitution table-in glyph sequence order",
+                repeat="GlyphCount",
+                aux=0,
+                description="Array of offsets to Coverage table-from beginning of Substitution table-in glyph sequence order",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "SubstLookupRecord",
-                "SubstCount",
-                0,
-                "Array of SubstLookupRecords-in design order",
+                repeat="SubstCount",
+                aux=0,
+                description="Array of SubstLookupRecords-in design order",
             ),
         ],
     ),
     (
         "ChainContextSubstFormat1",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of Substitution table",
+                description="Offset to Coverage table-from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ChainSubRuleSetCount",
-                None,
-                None,
-                "Number of ChainSubRuleSet tables-must equal GlyphCount in Coverage table",
+                description="Number of ChainSubRuleSet tables-must equal GlyphCount in Coverage table",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ChainSubRuleSet",
-                "ChainSubRuleSetCount",
-                0,
-                "Array of offsets to ChainSubRuleSet tables-from beginning of Substitution table-ordered by Coverage Index",
+                repeat="ChainSubRuleSetCount",
+                aux=0,
+                description="Array of offsets to ChainSubRuleSet tables-from beginning of Substitution table-ordered by Coverage Index",
             ),
         ],
     ),
     (
         "ChainSubRuleSet",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "ChainSubRuleCount",
-                None,
-                None,
-                "Number of ChainSubRule tables",
+                description="Number of ChainSubRule tables",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ChainSubRule",
-                "ChainSubRuleCount",
-                0,
-                "Array of offsets to ChainSubRule tables-from beginning of ChainSubRuleSet table-ordered by preference",
+                repeat="ChainSubRuleCount",
+                aux=0,
+                description="Array of offsets to ChainSubRule tables-from beginning of ChainSubRuleSet table-ordered by preference",
             ),
         ],
     ),
     (
         "ChainSubRule",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "BacktrackGlyphCount",
-                None,
-                None,
-                "Total number of glyphs in the backtrack sequence (number of glyphs to be matched before the first glyph)",
+                description="Total number of glyphs in the backtrack sequence (number of glyphs to be matched before the first glyph)",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "Backtrack",
-                "BacktrackGlyphCount",
-                0,
-                "Array of backtracking GlyphID's (to be matched before the input sequence)",
+                repeat="BacktrackGlyphCount",
+                aux=0,
+                description="Array of backtracking GlyphID's (to be matched before the input sequence)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "InputGlyphCount",
-                None,
-                None,
-                "Total number of glyphs in the input sequence (includes the first glyph)",
+                description="Total number of glyphs in the input sequence (includes the first glyph)",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "Input",
-                "InputGlyphCount",
-                -1,
-                "Array of input GlyphIDs (start with second glyph)",
+                repeat="InputGlyphCount",
+                aux=-1,
+                description="Array of input GlyphIDs (start with second glyph)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookAheadGlyphCount",
-                None,
-                None,
-                "Total number of glyphs in the look ahead sequence (number of glyphs to be matched after the input sequence)",
+                description="Total number of glyphs in the look ahead sequence (number of glyphs to be matched after the input sequence)",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "LookAhead",
-                "LookAheadGlyphCount",
-                0,
-                "Array of lookahead GlyphID's (to be matched after the input sequence)",
+                repeat="LookAheadGlyphCount",
+                aux=0,
+                description="Array of lookahead GlyphID's (to be matched after the input sequence)",
             ),
-            ("uint16", "SubstCount", None, None, "Number of SubstLookupRecords"),
-            (
+            FieldSpec(
+                "uint16", "SubstCount", description="Number of SubstLookupRecords"
+            ),
+            FieldSpec(
                 "struct",
                 "SubstLookupRecord",
-                "SubstCount",
-                0,
-                "Array of SubstLookupRecords (in design order)",
+                repeat="SubstCount",
+                aux=0,
+                description="Array of SubstLookupRecords (in design order)",
             ),
         ],
     ),
     (
         "ChainContextSubstFormat2",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 2"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table-from beginning of Substitution table",
+                description="Offset to Coverage table-from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "BacktrackClassDef",
-                None,
-                None,
-                "Offset to glyph ClassDef table containing backtrack sequence data-from beginning of Substitution table",
+                description="Offset to glyph ClassDef table containing backtrack sequence data-from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "InputClassDef",
-                None,
-                None,
-                "Offset to glyph ClassDef table containing input sequence data-from beginning of Substitution table",
+                description="Offset to glyph ClassDef table containing input sequence data-from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "LookAheadClassDef",
-                None,
-                None,
-                "Offset to glyph ClassDef table containing lookahead sequence data-from beginning of Substitution table",
+                description="Offset to glyph ClassDef table containing lookahead sequence data-from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ChainSubClassSetCount",
-                None,
-                None,
-                "Number of ChainSubClassSet tables",
+                description="Number of ChainSubClassSet tables",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ChainSubClassSet",
-                "ChainSubClassSetCount",
-                0,
-                "Array of offsets to ChainSubClassSet tables-from beginning of Substitution table-ordered by input class-may be NULL",
+                repeat="ChainSubClassSetCount",
+                aux=0,
+                description="Array of offsets to ChainSubClassSet tables-from beginning of Substitution table-ordered by input class-may be NULL",
             ),
         ],
     ),
     (
         "ChainSubClassSet",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "ChainSubClassRuleCount",
-                None,
-                None,
-                "Number of ChainSubClassRule tables",
+                description="Number of ChainSubClassRule tables",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ChainSubClassRule",
-                "ChainSubClassRuleCount",
-                0,
-                "Array of offsets to ChainSubClassRule tables-from beginning of ChainSubClassSet-ordered by preference",
+                repeat="ChainSubClassRuleCount",
+                aux=0,
+                description="Array of offsets to ChainSubClassRule tables-from beginning of ChainSubClassSet-ordered by preference",
             ),
         ],
     ),
     (
         "ChainSubClassRule",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "BacktrackGlyphCount",
-                None,
-                None,
-                "Total number of glyphs in the backtrack sequence (number of glyphs to be matched before the first glyph)",
+                description="Total number of glyphs in the backtrack sequence (number of glyphs to be matched before the first glyph)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "Backtrack",
-                "BacktrackGlyphCount",
-                0,
-                "Array of backtracking classes(to be matched before the input sequence)",
+                repeat="BacktrackGlyphCount",
+                aux=0,
+                description="Array of backtracking classes(to be matched before the input sequence)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "InputGlyphCount",
-                None,
-                None,
-                "Total number of classes in the input sequence (includes the first class)",
+                description="Total number of classes in the input sequence (includes the first class)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "Input",
-                "InputGlyphCount",
-                -1,
-                "Array of input classes(start with second class; to be matched with the input glyph sequence)",
+                repeat="InputGlyphCount",
+                aux=-1,
+                description="Array of input classes(start with second class; to be matched with the input glyph sequence)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookAheadGlyphCount",
-                None,
-                None,
-                "Total number of classes in the look ahead sequence (number of classes to be matched after the input sequence)",
+                description="Total number of classes in the look ahead sequence (number of classes to be matched after the input sequence)",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookAhead",
-                "LookAheadGlyphCount",
-                0,
-                "Array of lookahead classes(to be matched after the input sequence)",
+                repeat="LookAheadGlyphCount",
+                aux=0,
+                description="Array of lookahead classes(to be matched after the input sequence)",
             ),
-            ("uint16", "SubstCount", None, None, "Number of SubstLookupRecords"),
-            (
+            FieldSpec(
+                "uint16", "SubstCount", description="Number of SubstLookupRecords"
+            ),
+            FieldSpec(
                 "struct",
                 "SubstLookupRecord",
-                "SubstCount",
-                0,
-                "Array of SubstLookupRecords (in design order)",
+                repeat="SubstCount",
+                aux=0,
+                description="Array of SubstLookupRecords (in design order)",
             ),
         ],
     ),
     (
         "ChainContextSubstFormat3",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 3"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 3"
+            ),
+            FieldSpec(
                 "uint16",
                 "BacktrackGlyphCount",
-                None,
-                None,
-                "Number of glyphs in the backtracking sequence",
+                description="Number of glyphs in the backtracking sequence",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "BacktrackCoverage",
-                "BacktrackGlyphCount",
-                0,
-                "Array of offsets to coverage tables in backtracking sequence, in glyph sequence order",
+                repeat="BacktrackGlyphCount",
+                aux=0,
+                description="Array of offsets to coverage tables in backtracking sequence, in glyph sequence order",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "InputGlyphCount",
-                None,
-                None,
-                "Number of glyphs in input sequence",
+                description="Number of glyphs in input sequence",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "InputCoverage",
-                "InputGlyphCount",
-                0,
-                "Array of offsets to coverage tables in input sequence, in glyph sequence order",
+                repeat="InputGlyphCount",
+                aux=0,
+                description="Array of offsets to coverage tables in input sequence, in glyph sequence order",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookAheadGlyphCount",
-                None,
-                None,
-                "Number of glyphs in lookahead sequence",
+                description="Number of glyphs in lookahead sequence",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "LookAheadCoverage",
-                "LookAheadGlyphCount",
-                0,
-                "Array of offsets to coverage tables in lookahead sequence, in glyph sequence order",
+                repeat="LookAheadGlyphCount",
+                aux=0,
+                description="Array of offsets to coverage tables in lookahead sequence, in glyph sequence order",
             ),
-            ("uint16", "SubstCount", None, None, "Number of SubstLookupRecords"),
-            (
+            FieldSpec(
+                "uint16", "SubstCount", description="Number of SubstLookupRecords"
+            ),
+            FieldSpec(
                 "struct",
                 "SubstLookupRecord",
-                "SubstCount",
-                0,
-                "Array of SubstLookupRecords, in design order",
+                repeat="SubstCount",
+                aux=0,
+                description="Array of SubstLookupRecords, in design order",
             ),
         ],
     ),
     (
         "ExtensionSubstFormat1",
         [
-            ("uint16", "ExtFormat", None, None, "Format identifier. Set to 1."),
-            (
+            FieldSpec(
+                "uint16", "ExtFormat", description="Format identifier. Set to 1."
+            ),
+            FieldSpec(
                 "uint16",
                 "ExtensionLookupType",
-                None,
-                None,
-                "Lookup type of subtable referenced by ExtensionOffset (i.e. the extension subtable).",
+                description="Lookup type of subtable referenced by ExtensionOffset (i.e. the extension subtable).",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "ExtSubTable",
-                None,
-                None,
-                "Array of offsets to Lookup tables-from beginning of LookupList -zero based (first lookup is Lookup index = 0)",
+                description="Array of offsets to Lookup tables-from beginning of LookupList -zero based (first lookup is Lookup index = 0)",
             ),
         ],
     ),
     (
         "ReverseChainSingleSubstFormat1",
         [
-            ("uint16", "SubstFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint16", "SubstFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                0,
-                "Offset to Coverage table - from beginning of Substitution table",
+                aux=0,
+                description="Offset to Coverage table - from beginning of Substitution table",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "BacktrackGlyphCount",
-                None,
-                None,
-                "Number of glyphs in the backtracking sequence",
+                description="Number of glyphs in the backtracking sequence",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "BacktrackCoverage",
-                "BacktrackGlyphCount",
-                0,
-                "Array of offsets to coverage tables in backtracking sequence, in glyph sequence order",
+                repeat="BacktrackGlyphCount",
+                aux=0,
+                description="Array of offsets to coverage tables in backtracking sequence, in glyph sequence order",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "LookAheadGlyphCount",
-                None,
-                None,
-                "Number of glyphs in lookahead sequence",
+                description="Number of glyphs in lookahead sequence",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "LookAheadCoverage",
-                "LookAheadGlyphCount",
-                0,
-                "Array of offsets to coverage tables in lookahead sequence, in glyph sequence order",
+                repeat="LookAheadGlyphCount",
+                aux=0,
+                description="Array of offsets to coverage tables in lookahead sequence, in glyph sequence order",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "GlyphCount",
-                None,
-                None,
-                "Number of GlyphIDs in the Substitute array",
+                description="Number of GlyphIDs in the Substitute array",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "Substitute",
-                "GlyphCount",
-                0,
-                "Array of substitute GlyphIDs-ordered by Coverage index",
+                repeat="GlyphCount",
+                aux=0,
+                description="Array of substitute GlyphIDs-ordered by Coverage index",
             ),
         ],
     ),
@@ -2229,180 +2096,174 @@ otData = [
     (
         "GDEF",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the GDEF table- 0x00010000, 0x00010002, or 0x00010003",
+                description="Version of the GDEF table- 0x00010000, 0x00010002, or 0x00010003",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "GlyphClassDef",
-                None,
-                None,
-                "Offset to class definition table for glyph type-from beginning of GDEF header (may be NULL)",
+                description="Offset to class definition table for glyph type-from beginning of GDEF header (may be NULL)",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "AttachList",
-                None,
-                None,
-                "Offset to list of glyphs with attachment points-from beginning of GDEF header (may be NULL)",
+                description="Offset to list of glyphs with attachment points-from beginning of GDEF header (may be NULL)",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "LigCaretList",
-                None,
-                None,
-                "Offset to list of positioning points for ligature carets-from beginning of GDEF header (may be NULL)",
+                description="Offset to list of positioning points for ligature carets-from beginning of GDEF header (may be NULL)",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "MarkAttachClassDef",
-                None,
-                None,
-                "Offset to class definition table for mark attachment type-from beginning of GDEF header (may be NULL)",
+                description="Offset to class definition table for mark attachment type-from beginning of GDEF header (may be NULL)",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "MarkGlyphSetsDef",
-                None,
-                "Version >= 0x00010002",
-                "Offset to the table of mark set definitions-from beginning of GDEF header (may be NULL)",
+                aux="Version >= 0x00010002",
+                description="Offset to the table of mark set definitions-from beginning of GDEF header (may be NULL)",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "VarStore",
-                None,
-                "Version >= 0x00010003",
-                "Offset to variation store (may be NULL)",
+                aux="Version >= 0x00010003",
+                description="Offset to variation store (may be NULL)",
             ),
         ],
     ),
     (
         "AttachList",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table - from beginning of AttachList table",
+                description="Offset to Coverage table - from beginning of AttachList table",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "GlyphCount",
-                None,
-                None,
-                "Number of glyphs with attachment points",
+                description="Number of glyphs with attachment points",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "AttachPoint",
-                "GlyphCount",
-                0,
-                "Array of offsets to AttachPoint tables-from beginning of AttachList table-in Coverage Index order",
+                repeat="GlyphCount",
+                aux=0,
+                description="Array of offsets to AttachPoint tables-from beginning of AttachList table-in Coverage Index order",
             ),
         ],
     ),
     (
         "AttachPoint",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "PointCount",
-                None,
-                None,
-                "Number of attachment points on this glyph",
+                description="Number of attachment points on this glyph",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "PointIndex",
-                "PointCount",
-                0,
-                "Array of contour point indices -in increasing numerical order",
+                repeat="PointCount",
+                aux=0,
+                description="Array of contour point indices -in increasing numerical order",
             ),
         ],
     ),
     (
         "LigCaretList",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table - from beginning of LigCaretList table",
+                description="Offset to Coverage table - from beginning of LigCaretList table",
             ),
-            ("uint16", "LigGlyphCount", None, None, "Number of ligature glyphs"),
-            (
+            FieldSpec(
+                "uint16", "LigGlyphCount", description="Number of ligature glyphs"
+            ),
+            FieldSpec(
                 "Offset",
                 "LigGlyph",
-                "LigGlyphCount",
-                0,
-                "Array of offsets to LigGlyph tables-from beginning of LigCaretList table-in Coverage Index order",
+                repeat="LigGlyphCount",
+                aux=0,
+                description="Array of offsets to LigGlyph tables-from beginning of LigCaretList table-in Coverage Index order",
             ),
         ],
     ),
     (
         "LigGlyph",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "CaretCount",
-                None,
-                None,
-                "Number of CaretValues for this ligature (components - 1)",
+                description="Number of CaretValues for this ligature (components - 1)",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "CaretValue",
-                "CaretCount",
-                0,
-                "Array of offsets to CaretValue tables-from beginning of LigGlyph table-in increasing coordinate order",
+                repeat="CaretCount",
+                aux=0,
+                description="Array of offsets to CaretValue tables-from beginning of LigGlyph table-in increasing coordinate order",
             ),
         ],
     ),
     (
         "CaretValueFormat1",
         [
-            ("uint16", "CaretValueFormat", None, None, "Format identifier-format = 1"),
-            ("int16", "Coordinate", None, None, "X or Y value, in design units"),
+            FieldSpec(
+                "uint16", "CaretValueFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
+                "int16", "Coordinate", description="X or Y value, in design units"
+            ),
         ],
     ),
     (
         "CaretValueFormat2",
         [
-            ("uint16", "CaretValueFormat", None, None, "Format identifier-format = 2"),
-            ("uint16", "CaretValuePoint", None, None, "Contour point index on glyph"),
+            FieldSpec(
+                "uint16", "CaretValueFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
+                "uint16", "CaretValuePoint", description="Contour point index on glyph"
+            ),
         ],
     ),
     (
         "CaretValueFormat3",
         [
-            ("uint16", "CaretValueFormat", None, None, "Format identifier-format = 3"),
-            ("int16", "Coordinate", None, None, "X or Y value, in design units"),
-            (
+            FieldSpec(
+                "uint16", "CaretValueFormat", description="Format identifier-format = 3"
+            ),
+            FieldSpec(
+                "int16", "Coordinate", description="X or Y value, in design units"
+            ),
+            FieldSpec(
                 "Offset",
                 "DeviceTable",
-                None,
-                None,
-                "Offset to Device table for X or Y value-from beginning of CaretValue table",
+                description="Offset to Device table for X or Y value-from beginning of CaretValue table",
             ),
         ],
     ),
     (
         "MarkGlyphSetsDef",
         [
-            ("uint16", "MarkSetTableFormat", None, None, "Format identifier == 1"),
-            ("uint16", "MarkSetCount", None, None, "Number of mark sets defined"),
-            (
+            FieldSpec(
+                "uint16", "MarkSetTableFormat", description="Format identifier == 1"
+            ),
+            FieldSpec(
+                "uint16", "MarkSetCount", description="Number of mark sets defined"
+            ),
+            FieldSpec(
                 "LOffset",
                 "Coverage",
-                "MarkSetCount",
-                0,
-                "Array of offsets to mark set coverage tables.",
+                repeat="MarkSetCount",
+                aux=0,
+                description="Array of offsets to mark set coverage tables.",
             ),
         ],
     ),
@@ -2412,276 +2273,245 @@ otData = [
     (
         "BASE",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the BASE table-initially 0x00010000",
+                description="Version of the BASE table-initially 0x00010000",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "HorizAxis",
-                None,
-                None,
-                "Offset to horizontal Axis table-from beginning of BASE table-may be NULL",
+                description="Offset to horizontal Axis table-from beginning of BASE table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "VertAxis",
-                None,
-                None,
-                "Offset to vertical Axis table-from beginning of BASE table-may be NULL",
+                description="Offset to vertical Axis table-from beginning of BASE table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "VarStore",
-                None,
-                "Version >= 0x00010001",
-                "Offset to variation store (may be NULL)",
+                aux="Version >= 0x00010001",
+                description="Offset to variation store (may be NULL)",
             ),
         ],
     ),
     (
         "Axis",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "BaseTagList",
-                None,
-                None,
-                "Offset to BaseTagList table-from beginning of Axis table-may be NULL",
+                description="Offset to BaseTagList table-from beginning of Axis table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "BaseScriptList",
-                None,
-                None,
-                "Offset to BaseScriptList table-from beginning of Axis table",
+                description="Offset to BaseScriptList table-from beginning of Axis table",
             ),
         ],
     ),
     (
         "BaseTagList",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "BaseTagCount",
-                None,
-                None,
-                "Number of baseline identification tags in this text direction-may be zero (0)",
+                description="Number of baseline identification tags in this text direction-may be zero (0)",
             ),
-            (
+            FieldSpec(
                 "Tag",
                 "BaselineTag",
-                "BaseTagCount",
-                0,
-                "Array of 4-byte baseline identification tags-must be in alphabetical order",
+                repeat="BaseTagCount",
+                aux=0,
+                description="Array of 4-byte baseline identification tags-must be in alphabetical order",
             ),
         ],
     ),
     (
         "BaseScriptList",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "BaseScriptCount",
-                None,
-                None,
-                "Number of BaseScriptRecords defined",
+                description="Number of BaseScriptRecords defined",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "BaseScriptRecord",
-                "BaseScriptCount",
-                0,
-                "Array of BaseScriptRecords-in alphabetical order by BaseScriptTag",
+                repeat="BaseScriptCount",
+                aux=0,
+                description="Array of BaseScriptRecords-in alphabetical order by BaseScriptTag",
             ),
         ],
     ),
     (
         "BaseScriptRecord",
         [
-            ("Tag", "BaseScriptTag", None, None, "4-byte script identification tag"),
-            (
+            FieldSpec(
+                "Tag", "BaseScriptTag", description="4-byte script identification tag"
+            ),
+            FieldSpec(
                 "Offset",
                 "BaseScript",
-                None,
-                None,
-                "Offset to BaseScript table-from beginning of BaseScriptList",
+                description="Offset to BaseScript table-from beginning of BaseScriptList",
             ),
         ],
     ),
     (
         "BaseScript",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "BaseValues",
-                None,
-                None,
-                "Offset to BaseValues table-from beginning of BaseScript table-may be NULL",
+                description="Offset to BaseValues table-from beginning of BaseScript table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "DefaultMinMax",
-                None,
-                None,
-                "Offset to MinMax table- from beginning of BaseScript table-may be NULL",
+                description="Offset to MinMax table- from beginning of BaseScript table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "BaseLangSysCount",
-                None,
-                None,
-                "Number of BaseLangSysRecords defined-may be zero (0)",
+                description="Number of BaseLangSysRecords defined-may be zero (0)",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "BaseLangSysRecord",
-                "BaseLangSysCount",
-                0,
-                "Array of BaseLangSysRecords-in alphabetical order by BaseLangSysTag",
+                repeat="BaseLangSysCount",
+                aux=0,
+                description="Array of BaseLangSysRecords-in alphabetical order by BaseLangSysTag",
             ),
         ],
     ),
     (
         "BaseLangSysRecord",
         [
-            (
+            FieldSpec(
                 "Tag",
                 "BaseLangSysTag",
-                None,
-                None,
-                "4-byte language system identification tag",
+                description="4-byte language system identification tag",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "MinMax",
-                None,
-                None,
-                "Offset to MinMax table-from beginning of BaseScript table",
+                description="Offset to MinMax table-from beginning of BaseScript table",
             ),
         ],
     ),
     (
         "BaseValues",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "DefaultIndex",
-                None,
-                None,
-                "Index number of default baseline for this script-equals index position of baseline tag in BaselineArray of the BaseTagList",
+                description="Index number of default baseline for this script-equals index position of baseline tag in BaselineArray of the BaseTagList",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "BaseCoordCount",
-                None,
-                None,
-                "Number of BaseCoord tables defined-should equal BaseTagCount in the BaseTagList",
+                description="Number of BaseCoord tables defined-should equal BaseTagCount in the BaseTagList",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "BaseCoord",
-                "BaseCoordCount",
-                0,
-                "Array of offsets to BaseCoord-from beginning of BaseValues table-order matches BaselineTag array in the BaseTagList",
+                repeat="BaseCoordCount",
+                aux=0,
+                description="Array of offsets to BaseCoord-from beginning of BaseValues table-order matches BaselineTag array in the BaseTagList",
             ),
         ],
     ),
     (
         "MinMax",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "MinCoord",
-                None,
-                None,
-                "Offset to BaseCoord table-defines minimum extent value-from the beginning of MinMax table-may be NULL",
+                description="Offset to BaseCoord table-defines minimum extent value-from the beginning of MinMax table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "MaxCoord",
-                None,
-                None,
-                "Offset to BaseCoord table-defines maximum extent value-from the beginning of MinMax table-may be NULL",
+                description="Offset to BaseCoord table-defines maximum extent value-from the beginning of MinMax table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "FeatMinMaxCount",
-                None,
-                None,
-                "Number of FeatMinMaxRecords-may be zero (0)",
+                description="Number of FeatMinMaxRecords-may be zero (0)",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "FeatMinMaxRecord",
-                "FeatMinMaxCount",
-                0,
-                "Array of FeatMinMaxRecords-in alphabetical order, by FeatureTableTag",
+                repeat="FeatMinMaxCount",
+                aux=0,
+                description="Array of FeatMinMaxRecords-in alphabetical order, by FeatureTableTag",
             ),
         ],
     ),
     (
         "FeatMinMaxRecord",
         [
-            (
+            FieldSpec(
                 "Tag",
                 "FeatureTableTag",
-                None,
-                None,
-                "4-byte feature identification tag-must match FeatureTag in FeatureList",
+                description="4-byte feature identification tag-must match FeatureTag in FeatureList",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "MinCoord",
-                None,
-                None,
-                "Offset to BaseCoord table-defines minimum extent value-from beginning of MinMax table-may be NULL",
+                description="Offset to BaseCoord table-defines minimum extent value-from beginning of MinMax table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "MaxCoord",
-                None,
-                None,
-                "Offset to BaseCoord table-defines maximum extent value-from beginning of MinMax table-may be NULL",
+                description="Offset to BaseCoord table-defines maximum extent value-from beginning of MinMax table-may be NULL",
             ),
         ],
     ),
     (
         "BaseCoordFormat1",
         [
-            ("uint16", "BaseCoordFormat", None, None, "Format identifier-format = 1"),
-            ("int16", "Coordinate", None, None, "X or Y value, in design units"),
+            FieldSpec(
+                "uint16", "BaseCoordFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
+                "int16", "Coordinate", description="X or Y value, in design units"
+            ),
         ],
     ),
     (
         "BaseCoordFormat2",
         [
-            ("uint16", "BaseCoordFormat", None, None, "Format identifier-format = 2"),
-            ("int16", "Coordinate", None, None, "X or Y value, in design units"),
-            ("GlyphID", "ReferenceGlyph", None, None, "GlyphID of control glyph"),
-            (
+            FieldSpec(
+                "uint16", "BaseCoordFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
+                "int16", "Coordinate", description="X or Y value, in design units"
+            ),
+            FieldSpec(
+                "GlyphID", "ReferenceGlyph", description="GlyphID of control glyph"
+            ),
+            FieldSpec(
                 "uint16",
                 "BaseCoordPoint",
-                None,
-                None,
-                "Index of contour point on the ReferenceGlyph",
+                description="Index of contour point on the ReferenceGlyph",
             ),
         ],
     ),
     (
         "BaseCoordFormat3",
         [
-            ("uint16", "BaseCoordFormat", None, None, "Format identifier-format = 3"),
-            ("int16", "Coordinate", None, None, "X or Y value, in design units"),
-            (
+            FieldSpec(
+                "uint16", "BaseCoordFormat", description="Format identifier-format = 3"
+            ),
+            FieldSpec(
+                "int16", "Coordinate", description="X or Y value, in design units"
+            ),
+            FieldSpec(
                 "Offset",
                 "DeviceTable",
-                None,
-                None,
-                "Offset to Device table for X or Y value",
+                description="Offset to Device table for X or Y value",
             ),
         ],
     ),
@@ -2691,255 +2521,215 @@ otData = [
     (
         "JSTF",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the JSTF table-initially set to 0x00010000",
+                description="Version of the JSTF table-initially set to 0x00010000",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "JstfScriptCount",
-                None,
-                None,
-                "Number of JstfScriptRecords in this table",
+                description="Number of JstfScriptRecords in this table",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "JstfScriptRecord",
-                "JstfScriptCount",
-                0,
-                "Array of JstfScriptRecords-in alphabetical order, by JstfScriptTag",
+                repeat="JstfScriptCount",
+                aux=0,
+                description="Array of JstfScriptRecords-in alphabetical order, by JstfScriptTag",
             ),
         ],
     ),
     (
         "JstfScriptRecord",
         [
-            ("Tag", "JstfScriptTag", None, None, "4-byte JstfScript identification"),
-            (
+            FieldSpec(
+                "Tag", "JstfScriptTag", description="4-byte JstfScript identification"
+            ),
+            FieldSpec(
                 "Offset",
                 "JstfScript",
-                None,
-                None,
-                "Offset to JstfScript table-from beginning of JSTF Header",
+                description="Offset to JstfScript table-from beginning of JSTF Header",
             ),
         ],
     ),
     (
         "JstfScript",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "ExtenderGlyph",
-                None,
-                None,
-                "Offset to ExtenderGlyph table-from beginning of JstfScript table-may be NULL",
+                description="Offset to ExtenderGlyph table-from beginning of JstfScript table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "DefJstfLangSys",
-                None,
-                None,
-                "Offset to Default JstfLangSys table-from beginning of JstfScript table-may be NULL",
+                description="Offset to Default JstfLangSys table-from beginning of JstfScript table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "JstfLangSysCount",
-                None,
-                None,
-                "Number of JstfLangSysRecords in this table- may be zero (0)",
+                description="Number of JstfLangSysRecords in this table- may be zero (0)",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "JstfLangSysRecord",
-                "JstfLangSysCount",
-                0,
-                "Array of JstfLangSysRecords-in alphabetical order, by JstfLangSysTag",
+                repeat="JstfLangSysCount",
+                aux=0,
+                description="Array of JstfLangSysRecords-in alphabetical order, by JstfLangSysTag",
             ),
         ],
     ),
     (
         "JstfLangSysRecord",
         [
-            ("Tag", "JstfLangSysTag", None, None, "4-byte JstfLangSys identifier"),
-            (
+            FieldSpec(
+                "Tag", "JstfLangSysTag", description="4-byte JstfLangSys identifier"
+            ),
+            FieldSpec(
                 "Offset",
                 "JstfLangSys",
-                None,
-                None,
-                "Offset to JstfLangSys table-from beginning of JstfScript table",
+                description="Offset to JstfLangSys table-from beginning of JstfScript table",
             ),
         ],
     ),
     (
         "ExtenderGlyph",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "GlyphCount",
-                None,
-                None,
-                "Number of Extender Glyphs in this script",
+                description="Number of Extender Glyphs in this script",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "ExtenderGlyph",
-                "GlyphCount",
-                0,
-                "GlyphIDs-in increasing numerical order",
+                repeat="GlyphCount",
+                aux=0,
+                description="GlyphIDs-in increasing numerical order",
             ),
         ],
     ),
     (
         "JstfLangSys",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "JstfPriorityCount",
-                None,
-                None,
-                "Number of JstfPriority tables",
+                description="Number of JstfPriority tables",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "JstfPriority",
-                "JstfPriorityCount",
-                0,
-                "Array of offsets to JstfPriority tables-from beginning of JstfLangSys table-in priority order",
+                repeat="JstfPriorityCount",
+                aux=0,
+                description="Array of offsets to JstfPriority tables-from beginning of JstfLangSys table-in priority order",
             ),
         ],
     ),
     (
         "JstfPriority",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "ShrinkageEnableGSUB",
-                None,
-                None,
-                "Offset to Shrinkage Enable JstfGSUBModList table-from beginning of JstfPriority table-may be NULL",
+                description="Offset to Shrinkage Enable JstfGSUBModList table-from beginning of JstfPriority table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ShrinkageDisableGSUB",
-                None,
-                None,
-                "Offset to Shrinkage Disable JstfGSUBModList table-from beginning of JstfPriority table-may be NULL",
+                description="Offset to Shrinkage Disable JstfGSUBModList table-from beginning of JstfPriority table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ShrinkageEnableGPOS",
-                None,
-                None,
-                "Offset to Shrinkage Enable JstfGPOSModList table-from beginning of JstfPriority table-may be NULL",
+                description="Offset to Shrinkage Enable JstfGPOSModList table-from beginning of JstfPriority table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ShrinkageDisableGPOS",
-                None,
-                None,
-                "Offset to Shrinkage Disable JstfGPOSModList table-from beginning of JstfPriority table-may be NULL",
+                description="Offset to Shrinkage Disable JstfGPOSModList table-from beginning of JstfPriority table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ShrinkageJstfMax",
-                None,
-                None,
-                "Offset to Shrinkage JstfMax table-from beginning of JstfPriority table -may be NULL",
+                description="Offset to Shrinkage JstfMax table-from beginning of JstfPriority table -may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ExtensionEnableGSUB",
-                None,
-                None,
-                "Offset to Extension Enable JstfGSUBModList table-may be NULL",
+                description="Offset to Extension Enable JstfGSUBModList table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ExtensionDisableGSUB",
-                None,
-                None,
-                "Offset to Extension Disable JstfGSUBModList table-from beginning of JstfPriority table-may be NULL",
+                description="Offset to Extension Disable JstfGSUBModList table-from beginning of JstfPriority table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ExtensionEnableGPOS",
-                None,
-                None,
-                "Offset to Extension Enable JstfGSUBModList table-may be NULL",
+                description="Offset to Extension Enable JstfGSUBModList table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ExtensionDisableGPOS",
-                None,
-                None,
-                "Offset to Extension Disable JstfGSUBModList table-from beginning of JstfPriority table-may be NULL",
+                description="Offset to Extension Disable JstfGSUBModList table-from beginning of JstfPriority table-may be NULL",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ExtensionJstfMax",
-                None,
-                None,
-                "Offset to Extension JstfMax table-from beginning of JstfPriority table -may be NULL",
+                description="Offset to Extension JstfMax table-from beginning of JstfPriority table -may be NULL",
             ),
         ],
     ),
     (
         "JstfGSUBModList",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "LookupCount",
-                None,
-                None,
-                "Number of lookups for this modification",
+                description="Number of lookups for this modification",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "GSUBLookupIndex",
-                "LookupCount",
-                0,
-                "Array of LookupIndex identifiers in GSUB-in increasing numerical order",
+                repeat="LookupCount",
+                aux=0,
+                description="Array of LookupIndex identifiers in GSUB-in increasing numerical order",
             ),
         ],
     ),
     (
         "JstfGPOSModList",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "LookupCount",
-                None,
-                None,
-                "Number of lookups for this modification",
+                description="Number of lookups for this modification",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "GPOSLookupIndex",
-                "LookupCount",
-                0,
-                "Array of LookupIndex identifiers in GPOS-in increasing numerical order",
+                repeat="LookupCount",
+                aux=0,
+                description="Array of LookupIndex identifiers in GPOS-in increasing numerical order",
             ),
         ],
     ),
     (
         "JstfMax",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "LookupCount",
-                None,
-                None,
-                "Number of lookup Indices for this modification",
+                description="Number of lookup Indices for this modification",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "Lookup",
-                "LookupCount",
-                0,
-                "Array of offsets to GPOS-type lookup tables-from beginning of JstfMax table-in design order",
+                repeat="LookupCount",
+                aux=0,
+                description="Array of offsets to GPOS-type lookup tables-from beginning of JstfMax table-in design order",
             ),
         ],
     ),
@@ -2949,174 +2739,169 @@ otData = [
     (
         "STAT",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the table-initially set to 0x00010000, currently 0x00010002.",
+                description="Version of the table-initially set to 0x00010000, currently 0x00010002.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "DesignAxisRecordSize",
-                None,
-                None,
-                "Size in bytes of each design axis record",
+                description="Size in bytes of each design axis record",
             ),
-            ("uint16", "DesignAxisCount", None, None, "Number of design axis records"),
-            (
+            FieldSpec(
+                "uint16", "DesignAxisCount", description="Number of design axis records"
+            ),
+            FieldSpec(
                 "LOffsetTo(AxisRecordArray)",
                 "DesignAxisRecord",
-                None,
-                None,
-                "Offset in bytes from the beginning of the STAT table to the start of the design axes array",
+                description="Offset in bytes from the beginning of the STAT table to the start of the design axes array",
             ),
-            ("uint16", "AxisValueCount", None, None, "Number of axis value tables"),
-            (
+            FieldSpec(
+                "uint16", "AxisValueCount", description="Number of axis value tables"
+            ),
+            FieldSpec(
                 "LOffsetTo(AxisValueArray)",
                 "AxisValueArray",
-                None,
-                None,
-                "Offset in bytes from the beginning of the STAT table to the start of the axes value offset array",
+                description="Offset in bytes from the beginning of the STAT table to the start of the axes value offset array",
             ),
-            (
+            FieldSpec(
                 "NameID",
                 "ElidedFallbackNameID",
-                None,
-                "Version >= 0x00010001",
-                "NameID to use when all style attributes are elided.",
+                aux="Version >= 0x00010001",
+                description="NameID to use when all style attributes are elided.",
             ),
         ],
     ),
     (
         "AxisRecordArray",
         [
-            ("AxisRecord", "Axis", "DesignAxisCount", 0, "Axis records"),
+            FieldSpec(
+                "AxisRecord",
+                "Axis",
+                repeat="DesignAxisCount",
+                aux=0,
+                description="Axis records",
+            ),
         ],
     ),
     (
         "AxisRecord",
         [
-            (
+            FieldSpec(
                 "Tag",
                 "AxisTag",
-                None,
-                None,
-                "A tag identifying the axis of design variation",
+                description="A tag identifying the axis of design variation",
             ),
-            (
+            FieldSpec(
                 "NameID",
                 "AxisNameID",
-                None,
-                None,
-                'The name ID for entries in the "name" table that provide a display string for this axis',
+                description='The name ID for entries in the "name" table that provide a display string for this axis',
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "AxisOrdering",
-                None,
-                None,
-                "A value that applications can use to determine primary sorting of face names, or for ordering of descriptors when composing family or face names",
+                description="A value that applications can use to determine primary sorting of face names, or for ordering of descriptors when composing family or face names",
             ),
-            (
+            FieldSpec(
                 "uint8",
                 "MoreBytes",
-                "DesignAxisRecordSize",
-                -8,
-                "Extra bytes.  Set to empty array.",
+                repeat="DesignAxisRecordSize",
+                aux=-8,
+                description="Extra bytes.  Set to empty array.",
             ),
         ],
     ),
     (
         "AxisValueArray",
         [
-            ("Offset", "AxisValue", "AxisValueCount", 0, "Axis values"),
+            FieldSpec(
+                "Offset",
+                "AxisValue",
+                repeat="AxisValueCount",
+                aux=0,
+                description="Axis values",
+            ),
         ],
     ),
     (
         "AxisValueFormat1",
         [
-            ("uint16", "Format", None, None, "Format, = 1"),
-            (
+            FieldSpec("uint16", "Format", description="Format, = 1"),
+            FieldSpec(
                 "uint16",
                 "AxisIndex",
-                None,
-                None,
-                "Index into the axis record array identifying the axis of design variation to which the axis value record applies.",
+                description="Index into the axis record array identifying the axis of design variation to which the axis value record applies.",
             ),
-            ("STATFlags", "Flags", None, None, "Flags."),
-            ("NameID", "ValueNameID", None, None, ""),
-            ("Fixed", "Value", None, None, ""),
+            FieldSpec("STATFlags", "Flags", description="Flags."),
+            FieldSpec("NameID", "ValueNameID"),
+            FieldSpec("Fixed", "Value"),
         ],
     ),
     (
         "AxisValueFormat2",
         [
-            ("uint16", "Format", None, None, "Format, = 2"),
-            (
+            FieldSpec("uint16", "Format", description="Format, = 2"),
+            FieldSpec(
                 "uint16",
                 "AxisIndex",
-                None,
-                None,
-                "Index into the axis record array identifying the axis of design variation to which the axis value record applies.",
+                description="Index into the axis record array identifying the axis of design variation to which the axis value record applies.",
             ),
-            ("STATFlags", "Flags", None, None, "Flags."),
-            ("NameID", "ValueNameID", None, None, ""),
-            ("Fixed", "NominalValue", None, None, ""),
-            ("Fixed", "RangeMinValue", None, None, ""),
-            ("Fixed", "RangeMaxValue", None, None, ""),
+            FieldSpec("STATFlags", "Flags", description="Flags."),
+            FieldSpec("NameID", "ValueNameID"),
+            FieldSpec("Fixed", "NominalValue"),
+            FieldSpec("Fixed", "RangeMinValue"),
+            FieldSpec("Fixed", "RangeMaxValue"),
         ],
     ),
     (
         "AxisValueFormat3",
         [
-            ("uint16", "Format", None, None, "Format, = 3"),
-            (
+            FieldSpec("uint16", "Format", description="Format, = 3"),
+            FieldSpec(
                 "uint16",
                 "AxisIndex",
-                None,
-                None,
-                "Index into the axis record array identifying the axis of design variation to which the axis value record applies.",
+                description="Index into the axis record array identifying the axis of design variation to which the axis value record applies.",
             ),
-            ("STATFlags", "Flags", None, None, "Flags."),
-            ("NameID", "ValueNameID", None, None, ""),
-            ("Fixed", "Value", None, None, ""),
-            ("Fixed", "LinkedValue", None, None, ""),
+            FieldSpec("STATFlags", "Flags", description="Flags."),
+            FieldSpec("NameID", "ValueNameID"),
+            FieldSpec("Fixed", "Value"),
+            FieldSpec("Fixed", "LinkedValue"),
         ],
     ),
     (
         "AxisValueFormat4",
         [
-            ("uint16", "Format", None, None, "Format, = 4"),
-            (
+            FieldSpec("uint16", "Format", description="Format, = 4"),
+            FieldSpec(
                 "uint16",
                 "AxisCount",
-                None,
-                None,
-                "The total number of axes contributing to this axis-values combination.",
+                description="The total number of axes contributing to this axis-values combination.",
             ),
-            ("STATFlags", "Flags", None, None, "Flags."),
-            ("NameID", "ValueNameID", None, None, ""),
-            (
+            FieldSpec("STATFlags", "Flags", description="Flags."),
+            FieldSpec("NameID", "ValueNameID"),
+            FieldSpec(
                 "struct",
                 "AxisValueRecord",
-                "AxisCount",
-                0,
-                "Array of AxisValue records that provide the combination of axis values, one for each contributing axis. ",
+                repeat="AxisCount",
+                aux=0,
+                description="Array of AxisValue records that provide the combination of axis values, one for each contributing axis. ",
             ),
         ],
     ),
     (
         "AxisValueRecord",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "AxisIndex",
-                None,
-                None,
-                "Index into the axis record array identifying the axis of design variation to which the axis value record applies.",
+                description="Index into the axis record array identifying the axis of design variation to which the axis value record applies.",
             ),
-            ("Fixed", "Value", None, None, "A numeric value for this attribute value."),
+            FieldSpec(
+                "Fixed",
+                "Value",
+                description="A numeric value for this attribute value.",
+            ),
         ],
     ),
     #
@@ -3126,222 +2911,188 @@ otData = [
     (
         "FeatureVariations",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the table-initially set to 0x00010000",
+                description="Version of the table-initially set to 0x00010000",
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "FeatureVariationCount",
-                None,
-                None,
-                "Number of records in the FeatureVariationRecord array",
+                description="Number of records in the FeatureVariationRecord array",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "FeatureVariationRecord",
-                "FeatureVariationCount",
-                0,
-                "Array of FeatureVariationRecord",
+                repeat="FeatureVariationCount",
+                aux=0,
+                description="Array of FeatureVariationRecord",
             ),
         ],
     ),
     (
         "FeatureVariationRecord",
         [
-            (
+            FieldSpec(
                 "LOffset",
                 "ConditionSet",
-                None,
-                None,
-                "Offset to a ConditionSet table, from beginning of the FeatureVariations table.",
+                description="Offset to a ConditionSet table, from beginning of the FeatureVariations table.",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "FeatureTableSubstitution",
-                None,
-                None,
-                "Offset to a FeatureTableSubstitution table, from beginning of the FeatureVariations table",
+                description="Offset to a FeatureTableSubstitution table, from beginning of the FeatureVariations table",
             ),
         ],
     ),
     (
         "ConditionList",
         [
-            (
+            FieldSpec(
                 "uint32",
                 "ConditionCount",
-                None,
-                None,
-                "Number of condition tables in the ConditionTable array",
+                description="Number of condition tables in the ConditionTable array",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "ConditionTable",
-                "ConditionCount",
-                0,
-                "Array of offset to condition tables, from the beginning of the ConditionList table.",
+                repeat="ConditionCount",
+                aux=0,
+                description="Array of offset to condition tables, from the beginning of the ConditionList table.",
             ),
         ],
     ),
     (
         "ConditionSet",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "ConditionCount",
-                None,
-                None,
-                "Number of condition tables in the ConditionTable array",
+                description="Number of condition tables in the ConditionTable array",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "ConditionTable",
-                "ConditionCount",
-                0,
-                "Array of offset to condition tables, from the beginning of the ConditionSet table.",
+                repeat="ConditionCount",
+                aux=0,
+                description="Array of offset to condition tables, from the beginning of the ConditionSet table.",
             ),
         ],
     ),
     (
         "ConditionTableFormat1",
         [
-            ("uint16", "Format", None, None, "Format, = 1"),
-            (
+            FieldSpec("uint16", "Format", description="Format, = 1"),
+            FieldSpec(
                 "uint16",
                 "AxisIndex",
-                None,
-                None,
-                "Index for the variation axis within the fvar table, base 0.",
+                description="Index for the variation axis within the fvar table, base 0.",
             ),
-            (
+            FieldSpec(
                 "F2Dot14",
                 "FilterRangeMinValue",
-                None,
-                None,
-                "Minimum normalized axis value of the font variation instances that satisfy this condition.",
+                description="Minimum normalized axis value of the font variation instances that satisfy this condition.",
             ),
-            (
+            FieldSpec(
                 "F2Dot14",
                 "FilterRangeMaxValue",
-                None,
-                None,
-                "Maximum value that satisfies this condition.",
+                description="Maximum value that satisfies this condition.",
             ),
         ],
     ),
     (
         "ConditionTableFormat2",
         [
-            ("uint16", "Format", None, None, "Format, = 2"),
-            (
-                "int16",
-                "DefaultValue",
-                None,
-                None,
-                "Value at default instance.",
+            FieldSpec("uint16", "Format", description="Format, = 2"),
+            FieldSpec(
+                "int16", "DefaultValue", description="Value at default instance."
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "VarIdx",
-                None,
-                None,
-                "Variation index to vary the value based on current designspace location.",
+                description="Variation index to vary the value based on current designspace location.",
             ),
         ],
     ),
     (
         "ConditionTableFormat3",
         [
-            ("uint16", "Format", None, None, "Format, = 3"),
-            (
+            FieldSpec("uint16", "Format", description="Format, = 3"),
+            FieldSpec(
                 "uint8",
                 "ConditionCount",
-                None,
-                None,
-                "Index for the variation axis within the fvar table, base 0.",
+                description="Index for the variation axis within the fvar table, base 0.",
             ),
-            (
+            FieldSpec(
                 "Offset24",
                 "ConditionTable",
-                "ConditionCount",
-                0,
-                "Array of condition tables for this conjunction (AND) expression.",
+                repeat="ConditionCount",
+                aux=0,
+                description="Array of condition tables for this conjunction (AND) expression.",
             ),
         ],
     ),
     (
         "ConditionTableFormat4",
         [
-            ("uint16", "Format", None, None, "Format, = 4"),
-            (
+            FieldSpec("uint16", "Format", description="Format, = 4"),
+            FieldSpec(
                 "uint8",
                 "ConditionCount",
-                None,
-                None,
-                "Index for the variation axis within the fvar table, base 0.",
+                description="Index for the variation axis within the fvar table, base 0.",
             ),
-            (
+            FieldSpec(
                 "Offset24",
                 "ConditionTable",
-                "ConditionCount",
-                0,
-                "Array of condition tables for this disjunction (OR) expression.",
+                repeat="ConditionCount",
+                aux=0,
+                description="Array of condition tables for this disjunction (OR) expression.",
             ),
         ],
     ),
     (
         "ConditionTableFormat5",
         [
-            ("uint16", "Format", None, None, "Format, = 5"),
-            (
-                "Offset24",
-                "ConditionTable",
-                None,
-                None,
-                "Condition to negate.",
+            FieldSpec("uint16", "Format", description="Format, = 5"),
+            FieldSpec(
+                "Offset24", "ConditionTable", description="Condition to negate."
             ),
         ],
     ),
     (
         "FeatureTableSubstitution",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the table-initially set to 0x00010000",
+                description="Version of the table-initially set to 0x00010000",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "SubstitutionCount",
-                None,
-                None,
-                "Number of records in the FeatureVariationRecords array",
+                description="Number of records in the FeatureVariationRecords array",
             ),
-            (
+            FieldSpec(
                 "FeatureTableSubstitutionRecord",
                 "SubstitutionRecord",
-                "SubstitutionCount",
-                0,
-                "Array of FeatureTableSubstitutionRecord",
+                repeat="SubstitutionCount",
+                aux=0,
+                description="Array of FeatureTableSubstitutionRecord",
             ),
         ],
     ),
     (
         "FeatureTableSubstitutionRecord",
         [
-            ("uint16", "FeatureIndex", None, None, "The feature table index to match."),
-            (
+            FieldSpec(
+                "uint16",
+                "FeatureIndex",
+                description="The feature table index to match.",
+            ),
+            FieldSpec(
                 "LOffset",
                 "Feature",
-                None,
-                None,
-                "Offset to an alternate feature table, from start of the FeatureTableSubstitution table.",
+                description="Offset to an alternate feature table, from start of the FeatureTableSubstitution table.",
             ),
         ],
     ),
@@ -3349,207 +3100,232 @@ otData = [
     (
         "VarRegionAxis",
         [
-            ("F2Dot14", "StartCoord", None, None, ""),
-            ("F2Dot14", "PeakCoord", None, None, ""),
-            ("F2Dot14", "EndCoord", None, None, ""),
+            FieldSpec("F2Dot14", "StartCoord"),
+            FieldSpec("F2Dot14", "PeakCoord"),
+            FieldSpec("F2Dot14", "EndCoord"),
         ],
     ),
     (
         "VarRegion",
         [
-            ("struct", "VarRegionAxis", "RegionAxisCount", 0, ""),
+            FieldSpec("struct", "VarRegionAxis", repeat="RegionAxisCount", aux=0),
         ],
     ),
     (
         "VarRegionList",
         [
-            ("uint16", "RegionAxisCount", None, None, ""),
-            ("uint16", "RegionCount", None, None, ""),
-            ("VarRegion", "Region", "RegionCount", 0, ""),
+            FieldSpec("uint16", "RegionAxisCount"),
+            FieldSpec("uint16", "RegionCount"),
+            FieldSpec("VarRegion", "Region", repeat="RegionCount", aux=0),
         ],
     ),
     (
         "VarData",
         [
-            ("uint16", "ItemCount", None, None, ""),
-            ("uint16", "NumShorts", None, None, ""),
-            ("uint16", "VarRegionCount", None, None, ""),
-            ("uint16", "VarRegionIndex", "VarRegionCount", 0, ""),
-            ("VarDataValue", "Item", "ItemCount", 0, ""),
+            FieldSpec("uint16", "ItemCount"),
+            FieldSpec("uint16", "NumShorts"),
+            FieldSpec("uint16", "VarRegionCount"),
+            FieldSpec("uint16", "VarRegionIndex", repeat="VarRegionCount", aux=0),
+            FieldSpec("VarDataValue", "Item", repeat="ItemCount", aux=0),
         ],
     ),
     (
         "VarStore",
         [
-            ("uint16", "Format", None, None, "Set to 1."),
-            ("LOffset", "VarRegionList", None, None, ""),
-            ("uint16", "VarDataCount", None, None, ""),
-            ("LOffset", "VarData", "VarDataCount", 0, ""),
+            FieldSpec("uint16", "Format", description="Set to 1."),
+            FieldSpec("LOffset", "VarRegionList"),
+            FieldSpec("uint16", "VarDataCount"),
+            FieldSpec("LOffset", "VarData", repeat="VarDataCount", aux=0),
         ],
     ),
     # Variation helpers
     (
         "VarIdxMap",
         [
-            ("uint16", "EntryFormat", None, None, ""),  # Automatically computed
-            ("uint16", "MappingCount", None, None, ""),  # Automatically computed
-            ("VarIdxMapValue", "mapping", "", 0, "Array of compressed data"),
+            FieldSpec("uint16", "EntryFormat"),  # Automatically computed
+            FieldSpec("uint16", "MappingCount"),  # Automatically computed
+            FieldSpec(
+                "VarIdxMapValue",
+                "mapping",
+                aux=0,
+                description="Array of compressed data",
+            ),
         ],
     ),
     (
         "DeltaSetIndexMapFormat0",
         [
-            ("uint8", "Format", None, None, "Format of the DeltaSetIndexMap = 0"),
-            ("uint8", "EntryFormat", None, None, ""),  # Automatically computed
-            ("uint16", "MappingCount", None, None, ""),  # Automatically computed
-            ("VarIdxMapValue", "mapping", "", 0, "Array of compressed data"),
+            FieldSpec(
+                "uint8", "Format", description="Format of the DeltaSetIndexMap = 0"
+            ),
+            FieldSpec("uint8", "EntryFormat"),  # Automatically computed
+            FieldSpec("uint16", "MappingCount"),  # Automatically computed
+            FieldSpec(
+                "VarIdxMapValue",
+                "mapping",
+                aux=0,
+                description="Array of compressed data",
+            ),
         ],
     ),
     (
         "DeltaSetIndexMapFormat1",
         [
-            ("uint8", "Format", None, None, "Format of the DeltaSetIndexMap = 1"),
-            ("uint8", "EntryFormat", None, None, ""),  # Automatically computed
-            ("uint32", "MappingCount", None, None, ""),  # Automatically computed
-            ("VarIdxMapValue", "mapping", "", 0, "Array of compressed data"),
+            FieldSpec(
+                "uint8", "Format", description="Format of the DeltaSetIndexMap = 1"
+            ),
+            FieldSpec("uint8", "EntryFormat"),  # Automatically computed
+            FieldSpec("uint32", "MappingCount"),  # Automatically computed
+            FieldSpec(
+                "VarIdxMapValue",
+                "mapping",
+                aux=0,
+                description="Array of compressed data",
+            ),
         ],
     ),
     # MultiVariationStore
     (
         "SparseVarRegionAxis",
         [
-            ("uint16", "AxisIndex", None, None, ""),
-            ("F2Dot14", "StartCoord", None, None, ""),
-            ("F2Dot14", "PeakCoord", None, None, ""),
-            ("F2Dot14", "EndCoord", None, None, ""),
+            FieldSpec("uint16", "AxisIndex"),
+            FieldSpec("F2Dot14", "StartCoord"),
+            FieldSpec("F2Dot14", "PeakCoord"),
+            FieldSpec("F2Dot14", "EndCoord"),
         ],
     ),
     (
         "SparseVarRegion",
         [
-            ("uint16", "SparseRegionCount", None, None, ""),
-            ("struct", "SparseVarRegionAxis", "SparseRegionCount", 0, ""),
+            FieldSpec("uint16", "SparseRegionCount"),
+            FieldSpec(
+                "struct", "SparseVarRegionAxis", repeat="SparseRegionCount", aux=0
+            ),
         ],
     ),
     (
         "SparseVarRegionList",
         [
-            ("uint16", "RegionCount", None, None, ""),
-            ("LOffsetTo(SparseVarRegion)", "Region", "RegionCount", 0, ""),
+            FieldSpec("uint16", "RegionCount"),
+            FieldSpec(
+                "LOffsetTo(SparseVarRegion)", "Region", repeat="RegionCount", aux=0
+            ),
         ],
     ),
     (
         "MultiVarData",
         [
-            ("uint8", "Format", None, None, "Set to 1."),
-            ("uint16", "VarRegionCount", None, None, ""),
-            ("uint16", "VarRegionIndex", "VarRegionCount", 0, ""),
-            ("TupleList", "Item", "", 0, ""),
+            FieldSpec("uint8", "Format", description="Set to 1."),
+            FieldSpec("uint16", "VarRegionCount"),
+            FieldSpec("uint16", "VarRegionIndex", repeat="VarRegionCount", aux=0),
+            FieldSpec("TupleList", "Item", aux=0),
         ],
     ),
     (
         "MultiVarStore",
         [
-            ("uint16", "Format", None, None, "Set to 1."),
-            ("LOffset", "SparseVarRegionList", None, None, ""),
-            ("uint16", "MultiVarDataCount", None, None, ""),
-            ("LOffset", "MultiVarData", "MultiVarDataCount", 0, ""),
+            FieldSpec("uint16", "Format", description="Set to 1."),
+            FieldSpec("LOffset", "SparseVarRegionList"),
+            FieldSpec("uint16", "MultiVarDataCount"),
+            FieldSpec("LOffset", "MultiVarData", repeat="MultiVarDataCount", aux=0),
         ],
     ),
     # VariableComposites
     (
         "VARC",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the HVAR table-initially = 0x00010000",
+                description="Version of the HVAR table-initially = 0x00010000",
             ),
-            ("LOffset", "Coverage", None, None, ""),
-            ("LOffset", "MultiVarStore", None, None, "(may be NULL)"),
-            ("LOffset", "ConditionList", None, None, "(may be NULL)"),
-            ("LOffset", "AxisIndicesList", None, None, "(may be NULL)"),
-            ("LOffset", "VarCompositeGlyphs", None, None, ""),
+            FieldSpec("LOffset", "Coverage"),
+            FieldSpec("LOffset", "MultiVarStore", description="(may be NULL)"),
+            FieldSpec("LOffset", "ConditionList", description="(may be NULL)"),
+            FieldSpec("LOffset", "AxisIndicesList", description="(may be NULL)"),
+            FieldSpec("LOffset", "VarCompositeGlyphs"),
         ],
     ),
     (
         "AxisIndicesList",
         [
-            ("TupleList", "Item", "", 0, ""),
+            FieldSpec("TupleList", "Item", aux=0),
         ],
     ),
     (
         "VarCompositeGlyphs",
         [
-            ("VarCompositeGlyphList", "VarCompositeGlyph", "", None, ""),
+            FieldSpec("VarCompositeGlyphList", "VarCompositeGlyph"),
         ],
     ),
     # Glyph advance variations
     (
         "HVAR",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the HVAR table-initially = 0x00010000",
+                description="Version of the HVAR table-initially = 0x00010000",
             ),
-            ("LOffset", "VarStore", None, None, ""),
-            ("LOffsetTo(VarIdxMap)", "AdvWidthMap", None, None, ""),
-            ("LOffsetTo(VarIdxMap)", "LsbMap", None, None, ""),
-            ("LOffsetTo(VarIdxMap)", "RsbMap", None, None, ""),
+            FieldSpec("LOffset", "VarStore"),
+            FieldSpec("LOffsetTo(VarIdxMap)", "AdvWidthMap"),
+            FieldSpec("LOffsetTo(VarIdxMap)", "LsbMap"),
+            FieldSpec("LOffsetTo(VarIdxMap)", "RsbMap"),
         ],
     ),
     (
         "VVAR",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the VVAR table-initially = 0x00010000",
+                description="Version of the VVAR table-initially = 0x00010000",
             ),
-            ("LOffset", "VarStore", None, None, ""),
-            ("LOffsetTo(VarIdxMap)", "AdvHeightMap", None, None, ""),
-            ("LOffsetTo(VarIdxMap)", "TsbMap", None, None, ""),
-            ("LOffsetTo(VarIdxMap)", "BsbMap", None, None, ""),
-            ("LOffsetTo(VarIdxMap)", "VOrgMap", None, None, "Vertical origin mapping."),
+            FieldSpec("LOffset", "VarStore"),
+            FieldSpec("LOffsetTo(VarIdxMap)", "AdvHeightMap"),
+            FieldSpec("LOffsetTo(VarIdxMap)", "TsbMap"),
+            FieldSpec("LOffsetTo(VarIdxMap)", "BsbMap"),
+            FieldSpec(
+                "LOffsetTo(VarIdxMap)",
+                "VOrgMap",
+                description="Vertical origin mapping.",
+            ),
         ],
     ),
     # Font-wide metrics variations
     (
         "MetricsValueRecord",
         [
-            ("Tag", "ValueTag", None, None, "4-byte font-wide measure identifier"),
-            ("uint32", "VarIdx", None, None, "Combined outer-inner variation index"),
-            (
+            FieldSpec(
+                "Tag", "ValueTag", description="4-byte font-wide measure identifier"
+            ),
+            FieldSpec(
+                "uint32", "VarIdx", description="Combined outer-inner variation index"
+            ),
+            FieldSpec(
                 "uint8",
                 "MoreBytes",
-                "ValueRecordSize",
-                -8,
-                "Extra bytes.  Set to empty array.",
+                repeat="ValueRecordSize",
+                aux=-8,
+                description="Extra bytes.  Set to empty array.",
             ),
         ],
     ),
     (
         "MVAR",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the MVAR table-initially = 0x00010000",
+                description="Version of the MVAR table-initially = 0x00010000",
             ),
-            ("uint16", "Reserved", None, None, "Set to 0"),
-            ("uint16", "ValueRecordSize", None, None, ""),
-            ("uint16", "ValueRecordCount", None, None, ""),
-            ("Offset", "VarStore", None, None, ""),
-            ("MetricsValueRecord", "ValueRecord", "ValueRecordCount", 0, ""),
+            FieldSpec("uint16", "Reserved", description="Set to 0"),
+            FieldSpec("uint16", "ValueRecordSize"),
+            FieldSpec("uint16", "ValueRecordCount"),
+            FieldSpec("Offset", "VarStore"),
+            FieldSpec(
+                "MetricsValueRecord", "ValueRecord", repeat="ValueRecordCount", aux=0
+            ),
         ],
     ),
     #
@@ -3558,748 +3334,584 @@ otData = [
     (
         "MATH",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the MATH table-initially set to 0x00010000.",
+                description="Version of the MATH table-initially set to 0x00010000.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "MathConstants",
-                None,
-                None,
-                "Offset to MathConstants table - from the beginning of MATH table.",
+                description="Offset to MathConstants table - from the beginning of MATH table.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "MathGlyphInfo",
-                None,
-                None,
-                "Offset to MathGlyphInfo table - from the beginning of MATH table.",
+                description="Offset to MathGlyphInfo table - from the beginning of MATH table.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "MathVariants",
-                None,
-                None,
-                "Offset to MathVariants table - from the beginning of MATH table.",
+                description="Offset to MathVariants table - from the beginning of MATH table.",
             ),
         ],
     ),
     (
         "MathValueRecord",
         [
-            ("int16", "Value", None, None, "The X or Y value in design units."),
-            (
+            FieldSpec(
+                "int16", "Value", description="The X or Y value in design units."
+            ),
+            FieldSpec(
                 "Offset",
                 "DeviceTable",
-                None,
-                None,
-                "Offset to the device table - from the beginning of parent table. May be NULL. Suggested format for device table is 1.",
+                description="Offset to the device table - from the beginning of parent table. May be NULL. Suggested format for device table is 1.",
             ),
         ],
     ),
     (
         "MathConstants",
         [
-            (
+            FieldSpec(
                 "int16",
                 "ScriptPercentScaleDown",
-                None,
-                None,
-                "Percentage of scaling down for script level 1. Suggested value: 80%.",
+                description="Percentage of scaling down for script level 1. Suggested value: 80%.",
             ),
-            (
+            FieldSpec(
                 "int16",
                 "ScriptScriptPercentScaleDown",
-                None,
-                None,
-                "Percentage of scaling down for script level 2 (ScriptScript). Suggested value: 60%.",
+                description="Percentage of scaling down for script level 2 (ScriptScript). Suggested value: 60%.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "DelimitedSubFormulaMinHeight",
-                None,
-                None,
-                "Minimum height required for a delimited expression to be treated as a subformula. Suggested value: normal line height x1.5.",
+                description="Minimum height required for a delimited expression to be treated as a subformula. Suggested value: normal line height x1.5.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "DisplayOperatorMinHeight",
-                None,
-                None,
-                "Minimum height of n-ary operators (such as integral and summation) for formulas in display mode.",
+                description="Minimum height of n-ary operators (such as integral and summation) for formulas in display mode.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "MathLeading",
-                None,
-                None,
-                "White space to be left between math formulas to ensure proper line spacing. For example, for applications that treat line gap as a part of line ascender, formulas with ink  going above (os2.sTypoAscender + os2.sTypoLineGap - MathLeading) or with ink going below os2.sTypoDescender will result in increasing line height.",
+                description="White space to be left between math formulas to ensure proper line spacing. For example, for applications that treat line gap as a part of line ascender, formulas with ink  going above (os2.sTypoAscender + os2.sTypoLineGap - MathLeading) or with ink going below os2.sTypoDescender will result in increasing line height.",
             ),
-            ("MathValueRecord", "AxisHeight", None, None, "Axis height of the font."),
-            (
+            FieldSpec(
+                "MathValueRecord", "AxisHeight", description="Axis height of the font."
+            ),
+            FieldSpec(
                 "MathValueRecord",
                 "AccentBaseHeight",
-                None,
-                None,
-                "Maximum (ink) height of accent base that does not require raising the accents. Suggested: x-height of the font (os2.sxHeight) plus any possible overshots.",
+                description="Maximum (ink) height of accent base that does not require raising the accents. Suggested: x-height of the font (os2.sxHeight) plus any possible overshots.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "FlattenedAccentBaseHeight",
-                None,
-                None,
-                "Maximum (ink) height of accent base that does not require flattening the accents. Suggested: cap height of the font (os2.sCapHeight).",
+                description="Maximum (ink) height of accent base that does not require flattening the accents. Suggested: cap height of the font (os2.sCapHeight).",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SubscriptShiftDown",
-                None,
-                None,
-                "The standard shift down applied to subscript elements. Positive for moving in the downward direction. Suggested: os2.ySubscriptYOffset.",
+                description="The standard shift down applied to subscript elements. Positive for moving in the downward direction. Suggested: os2.ySubscriptYOffset.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SubscriptTopMax",
-                None,
-                None,
-                "Maximum allowed height of the (ink) top of subscripts that does not require moving subscripts further down. Suggested: 4/5 x-height.",
+                description="Maximum allowed height of the (ink) top of subscripts that does not require moving subscripts further down. Suggested: 4/5 x-height.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SubscriptBaselineDropMin",
-                None,
-                None,
-                "Minimum allowed drop of the baseline of subscripts relative to the (ink) bottom of the base. Checked for bases that are treated as a box or extended shape. Positive for subscript baseline dropped below the base bottom.",
+                description="Minimum allowed drop of the baseline of subscripts relative to the (ink) bottom of the base. Checked for bases that are treated as a box or extended shape. Positive for subscript baseline dropped below the base bottom.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SuperscriptShiftUp",
-                None,
-                None,
-                "Standard shift up applied to superscript elements. Suggested: os2.ySuperscriptYOffset.",
+                description="Standard shift up applied to superscript elements. Suggested: os2.ySuperscriptYOffset.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SuperscriptShiftUpCramped",
-                None,
-                None,
-                "Standard shift of superscripts relative to the base, in cramped style.",
+                description="Standard shift of superscripts relative to the base, in cramped style.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SuperscriptBottomMin",
-                None,
-                None,
-                "Minimum allowed height of the (ink) bottom of superscripts that does not require moving subscripts further up. Suggested: 1/4 x-height.",
+                description="Minimum allowed height of the (ink) bottom of superscripts that does not require moving subscripts further up. Suggested: 1/4 x-height.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SuperscriptBaselineDropMax",
-                None,
-                None,
-                "Maximum allowed drop of the baseline of superscripts relative to the (ink) top of the base. Checked for bases that are treated as a box or extended shape. Positive for superscript baseline below the base top.",
+                description="Maximum allowed drop of the baseline of superscripts relative to the (ink) top of the base. Checked for bases that are treated as a box or extended shape. Positive for superscript baseline below the base top.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SubSuperscriptGapMin",
-                None,
-                None,
-                "Minimum gap between the superscript and subscript ink. Suggested: 4x default rule thickness.",
+                description="Minimum gap between the superscript and subscript ink. Suggested: 4x default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SuperscriptBottomMaxWithSubscript",
-                None,
-                None,
-                "The maximum level to which the (ink) bottom of superscript can be pushed to increase the gap between superscript and subscript, before subscript starts being moved down. Suggested: 4/5 x-height.",
+                description="The maximum level to which the (ink) bottom of superscript can be pushed to increase the gap between superscript and subscript, before subscript starts being moved down. Suggested: 4/5 x-height.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SpaceAfterScript",
-                None,
-                None,
-                "Extra white space to be added after each subscript and superscript. Suggested: 0.5pt for a 12 pt font.",
+                description="Extra white space to be added after each subscript and superscript. Suggested: 0.5pt for a 12 pt font.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "UpperLimitGapMin",
-                None,
-                None,
-                "Minimum gap between the (ink) bottom of the upper limit, and the (ink) top of the base operator.",
+                description="Minimum gap between the (ink) bottom of the upper limit, and the (ink) top of the base operator.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "UpperLimitBaselineRiseMin",
-                None,
-                None,
-                "Minimum distance between baseline of upper limit and (ink) top of the base operator.",
+                description="Minimum distance between baseline of upper limit and (ink) top of the base operator.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "LowerLimitGapMin",
-                None,
-                None,
-                "Minimum gap between (ink) top of the lower limit, and (ink) bottom of the base operator.",
+                description="Minimum gap between (ink) top of the lower limit, and (ink) bottom of the base operator.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "LowerLimitBaselineDropMin",
-                None,
-                None,
-                "Minimum distance between baseline of the lower limit and (ink) bottom of the base operator.",
+                description="Minimum distance between baseline of the lower limit and (ink) bottom of the base operator.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "StackTopShiftUp",
-                None,
-                None,
-                "Standard shift up applied to the top element of a stack.",
+                description="Standard shift up applied to the top element of a stack.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "StackTopDisplayStyleShiftUp",
-                None,
-                None,
-                "Standard shift up applied to the top element of a stack in display style.",
+                description="Standard shift up applied to the top element of a stack in display style.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "StackBottomShiftDown",
-                None,
-                None,
-                "Standard shift down applied to the bottom element of a stack. Positive for moving in the downward direction.",
+                description="Standard shift down applied to the bottom element of a stack. Positive for moving in the downward direction.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "StackBottomDisplayStyleShiftDown",
-                None,
-                None,
-                "Standard shift down applied to the bottom element of a stack in display style. Positive for moving in the downward direction.",
+                description="Standard shift down applied to the bottom element of a stack in display style. Positive for moving in the downward direction.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "StackGapMin",
-                None,
-                None,
-                "Minimum gap between (ink) bottom of the top element of a stack, and the (ink) top of the bottom element. Suggested: 3x default rule thickness.",
+                description="Minimum gap between (ink) bottom of the top element of a stack, and the (ink) top of the bottom element. Suggested: 3x default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "StackDisplayStyleGapMin",
-                None,
-                None,
-                "Minimum gap between (ink) bottom of the top element of a stack, and the (ink) top of the bottom element in display style. Suggested: 7x default rule thickness.",
+                description="Minimum gap between (ink) bottom of the top element of a stack, and the (ink) top of the bottom element in display style. Suggested: 7x default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "StretchStackTopShiftUp",
-                None,
-                None,
-                "Standard shift up applied to the top element of the stretch stack.",
+                description="Standard shift up applied to the top element of the stretch stack.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "StretchStackBottomShiftDown",
-                None,
-                None,
-                "Standard shift down applied to the bottom element of the stretch stack. Positive for moving in the downward direction.",
+                description="Standard shift down applied to the bottom element of the stretch stack. Positive for moving in the downward direction.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "StretchStackGapAboveMin",
-                None,
-                None,
-                "Minimum gap between the ink of the stretched element, and the (ink) bottom of the element above. Suggested: UpperLimitGapMin",
+                description="Minimum gap between the ink of the stretched element, and the (ink) bottom of the element above. Suggested: UpperLimitGapMin",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "StretchStackGapBelowMin",
-                None,
-                None,
-                "Minimum gap between the ink of the stretched element, and the (ink) top of the element below. Suggested: LowerLimitGapMin.",
+                description="Minimum gap between the ink of the stretched element, and the (ink) top of the element below. Suggested: LowerLimitGapMin.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "FractionNumeratorShiftUp",
-                None,
-                None,
-                "Standard shift up applied to the numerator.",
+                description="Standard shift up applied to the numerator.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "FractionNumeratorDisplayStyleShiftUp",
-                None,
-                None,
-                "Standard shift up applied to the numerator in display style. Suggested: StackTopDisplayStyleShiftUp.",
+                description="Standard shift up applied to the numerator in display style. Suggested: StackTopDisplayStyleShiftUp.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "FractionDenominatorShiftDown",
-                None,
-                None,
-                "Standard shift down applied to the denominator. Positive for moving in the downward direction.",
+                description="Standard shift down applied to the denominator. Positive for moving in the downward direction.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "FractionDenominatorDisplayStyleShiftDown",
-                None,
-                None,
-                "Standard shift down applied to the denominator in display style. Positive for moving in the downward direction. Suggested: StackBottomDisplayStyleShiftDown.",
+                description="Standard shift down applied to the denominator in display style. Positive for moving in the downward direction. Suggested: StackBottomDisplayStyleShiftDown.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "FractionNumeratorGapMin",
-                None,
-                None,
-                "Minimum tolerated gap between the (ink) bottom of the numerator and the ink of the fraction bar. Suggested: default rule thickness",
+                description="Minimum tolerated gap between the (ink) bottom of the numerator and the ink of the fraction bar. Suggested: default rule thickness",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "FractionNumDisplayStyleGapMin",
-                None,
-                None,
-                "Minimum tolerated gap between the (ink) bottom of the numerator and the ink of the fraction bar in display style. Suggested: 3x default rule thickness.",
+                description="Minimum tolerated gap between the (ink) bottom of the numerator and the ink of the fraction bar in display style. Suggested: 3x default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "FractionRuleThickness",
-                None,
-                None,
-                "Thickness of the fraction bar. Suggested: default rule thickness.",
+                description="Thickness of the fraction bar. Suggested: default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "FractionDenominatorGapMin",
-                None,
-                None,
-                "Minimum tolerated gap between the (ink) top of the denominator and the ink of the fraction bar. Suggested: default rule thickness",
+                description="Minimum tolerated gap between the (ink) top of the denominator and the ink of the fraction bar. Suggested: default rule thickness",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "FractionDenomDisplayStyleGapMin",
-                None,
-                None,
-                "Minimum tolerated gap between the (ink) top of the denominator and the ink of the fraction bar in display style. Suggested: 3x default rule thickness.",
+                description="Minimum tolerated gap between the (ink) top of the denominator and the ink of the fraction bar in display style. Suggested: 3x default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SkewedFractionHorizontalGap",
-                None,
-                None,
-                "Horizontal distance between the top and bottom elements of a skewed fraction.",
+                description="Horizontal distance between the top and bottom elements of a skewed fraction.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "SkewedFractionVerticalGap",
-                None,
-                None,
-                "Vertical distance between the ink of the top and bottom elements of a skewed fraction.",
+                description="Vertical distance between the ink of the top and bottom elements of a skewed fraction.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "OverbarVerticalGap",
-                None,
-                None,
-                "Distance between the overbar and the (ink) top of he base. Suggested: 3x default rule thickness.",
+                description="Distance between the overbar and the (ink) top of he base. Suggested: 3x default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "OverbarRuleThickness",
-                None,
-                None,
-                "Thickness of overbar. Suggested: default rule thickness.",
+                description="Thickness of overbar. Suggested: default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "OverbarExtraAscender",
-                None,
-                None,
-                "Extra white space reserved above the overbar. Suggested: default rule thickness.",
+                description="Extra white space reserved above the overbar. Suggested: default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "UnderbarVerticalGap",
-                None,
-                None,
-                "Distance between underbar and (ink) bottom of the base. Suggested: 3x default rule thickness.",
+                description="Distance between underbar and (ink) bottom of the base. Suggested: 3x default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "UnderbarRuleThickness",
-                None,
-                None,
-                "Thickness of underbar. Suggested: default rule thickness.",
+                description="Thickness of underbar. Suggested: default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "UnderbarExtraDescender",
-                None,
-                None,
-                "Extra white space reserved below the underbar. Always positive. Suggested: default rule thickness.",
+                description="Extra white space reserved below the underbar. Always positive. Suggested: default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "RadicalVerticalGap",
-                None,
-                None,
-                "Space between the (ink) top of the expression and the bar over it. Suggested: 1 1/4 default rule thickness.",
+                description="Space between the (ink) top of the expression and the bar over it. Suggested: 1 1/4 default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "RadicalDisplayStyleVerticalGap",
-                None,
-                None,
-                "Space between the (ink) top of the expression and the bar over it. Suggested: default rule thickness + 1/4 x-height.",
+                description="Space between the (ink) top of the expression and the bar over it. Suggested: default rule thickness + 1/4 x-height.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "RadicalRuleThickness",
-                None,
-                None,
-                "Thickness of the radical rule. This is the thickness of the rule in designed or constructed radical signs. Suggested: default rule thickness.",
+                description="Thickness of the radical rule. This is the thickness of the rule in designed or constructed radical signs. Suggested: default rule thickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "RadicalExtraAscender",
-                None,
-                None,
-                "Extra white space reserved above the radical. Suggested: RadicalRuleThickness.",
+                description="Extra white space reserved above the radical. Suggested: RadicalRuleThickness.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "RadicalKernBeforeDegree",
-                None,
-                None,
-                "Extra horizontal kern before the degree of a radical, if such is present. Suggested: 5/18 of em.",
+                description="Extra horizontal kern before the degree of a radical, if such is present. Suggested: 5/18 of em.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "RadicalKernAfterDegree",
-                None,
-                None,
-                "Negative kern after the degree of a radical, if such is present. Suggested: 10/18 of em.",
+                description="Negative kern after the degree of a radical, if such is present. Suggested: 10/18 of em.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "RadicalDegreeBottomRaisePercent",
-                None,
-                None,
-                "Height of the bottom of the radical degree, if such is present, in proportion to the ascender of the radical sign. Suggested: 60%.",
+                description="Height of the bottom of the radical degree, if such is present, in proportion to the ascender of the radical sign. Suggested: 60%.",
             ),
         ],
     ),
     (
         "MathGlyphInfo",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "MathItalicsCorrectionInfo",
-                None,
-                None,
-                "Offset to MathItalicsCorrectionInfo table - from the beginning of MathGlyphInfo table.",
+                description="Offset to MathItalicsCorrectionInfo table - from the beginning of MathGlyphInfo table.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "MathTopAccentAttachment",
-                None,
-                None,
-                "Offset to MathTopAccentAttachment table - from the beginning of MathGlyphInfo table.",
+                description="Offset to MathTopAccentAttachment table - from the beginning of MathGlyphInfo table.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "ExtendedShapeCoverage",
-                None,
-                None,
-                "Offset to coverage table for Extended Shape glyphs - from the  beginning of MathGlyphInfo table. When the left or right glyph of a box is an extended shape variant, the (ink) box (and not the default position defined by values in MathConstants table) should be used for vertical positioning purposes. May be NULL.",
+                description="Offset to coverage table for Extended Shape glyphs - from the  beginning of MathGlyphInfo table. When the left or right glyph of a box is an extended shape variant, the (ink) box (and not the default position defined by values in MathConstants table) should be used for vertical positioning purposes. May be NULL.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "MathKernInfo",
-                None,
-                None,
-                "Offset to MathKernInfo table - from the beginning of MathGlyphInfo table.",
+                description="Offset to MathKernInfo table - from the beginning of MathGlyphInfo table.",
             ),
         ],
     ),
     (
         "MathItalicsCorrectionInfo",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "Coverage",
-                None,
-                None,
-                "Offset to Coverage table - from the beginning of MathItalicsCorrectionInfo table.",
+                description="Offset to Coverage table - from the beginning of MathItalicsCorrectionInfo table.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ItalicsCorrectionCount",
-                None,
-                None,
-                "Number of italics correction values. Should coincide with the number of covered glyphs.",
+                description="Number of italics correction values. Should coincide with the number of covered glyphs.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "ItalicsCorrection",
-                "ItalicsCorrectionCount",
-                0,
-                "Array of MathValueRecords defining italics correction values for each covered glyph.",
+                repeat="ItalicsCorrectionCount",
+                aux=0,
+                description="Array of MathValueRecords defining italics correction values for each covered glyph.",
             ),
         ],
     ),
     (
         "MathTopAccentAttachment",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "TopAccentCoverage",
-                None,
-                None,
-                "Offset to Coverage table - from the beginning of  MathTopAccentAttachment table.",
+                description="Offset to Coverage table - from the beginning of  MathTopAccentAttachment table.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "TopAccentAttachmentCount",
-                None,
-                None,
-                "Number of top accent attachment point values. Should coincide with the number of covered glyphs",
+                description="Number of top accent attachment point values. Should coincide with the number of covered glyphs",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "TopAccentAttachment",
-                "TopAccentAttachmentCount",
-                0,
-                "Array of MathValueRecords defining top accent attachment points for each covered glyph",
+                repeat="TopAccentAttachmentCount",
+                aux=0,
+                description="Array of MathValueRecords defining top accent attachment points for each covered glyph",
             ),
         ],
     ),
     (
         "MathKernInfo",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "MathKernCoverage",
-                None,
-                None,
-                "Offset to Coverage table - from the beginning of the MathKernInfo table.",
+                description="Offset to Coverage table - from the beginning of the MathKernInfo table.",
             ),
-            ("uint16", "MathKernCount", None, None, "Number of MathKernInfoRecords."),
-            (
+            FieldSpec(
+                "uint16", "MathKernCount", description="Number of MathKernInfoRecords."
+            ),
+            FieldSpec(
                 "MathKernInfoRecord",
                 "MathKernInfoRecords",
-                "MathKernCount",
-                0,
-                "Array of MathKernInfoRecords, per-glyph information for mathematical positioning of subscripts and superscripts.",
+                repeat="MathKernCount",
+                aux=0,
+                description="Array of MathKernInfoRecords, per-glyph information for mathematical positioning of subscripts and superscripts.",
             ),
         ],
     ),
     (
         "MathKernInfoRecord",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "TopRightMathKern",
-                None,
-                None,
-                "Offset to MathKern table for top right corner - from the beginning of MathKernInfo table. May be NULL.",
+                description="Offset to MathKern table for top right corner - from the beginning of MathKernInfo table. May be NULL.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "TopLeftMathKern",
-                None,
-                None,
-                "Offset to MathKern table for the top left corner - from the beginning of MathKernInfo table. May be NULL.",
+                description="Offset to MathKern table for the top left corner - from the beginning of MathKernInfo table. May be NULL.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "BottomRightMathKern",
-                None,
-                None,
-                "Offset to MathKern table for bottom right corner - from the beginning of MathKernInfo table. May be NULL.",
+                description="Offset to MathKern table for bottom right corner - from the beginning of MathKernInfo table. May be NULL.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "BottomLeftMathKern",
-                None,
-                None,
-                "Offset to MathKern table for bottom left corner - from the beginning of MathKernInfo table. May be NULL.",
+                description="Offset to MathKern table for bottom left corner - from the beginning of MathKernInfo table. May be NULL.",
             ),
         ],
     ),
     (
         "MathKern",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "HeightCount",
-                None,
-                None,
-                "Number of heights on which the kern value changes.",
+                description="Number of heights on which the kern value changes.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "CorrectionHeight",
-                "HeightCount",
-                0,
-                "Array of correction heights at which the kern value changes. Sorted by the height value in design units.",
+                repeat="HeightCount",
+                aux=0,
+                description="Array of correction heights at which the kern value changes. Sorted by the height value in design units.",
             ),
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "KernValue",
-                "HeightCount",
-                1,
-                "Array of kern values corresponding to heights. First value is the kern value for all heights less or equal than the first height in this table.Last value is the value to be applied for all heights greater than the last height in this table. Negative values are interpreted as move glyphs closer to each other.",
+                repeat="HeightCount",
+                aux=1,
+                description="Array of kern values corresponding to heights. First value is the kern value for all heights less or equal than the first height in this table.Last value is the value to be applied for all heights greater than the last height in this table. Negative values are interpreted as move glyphs closer to each other.",
             ),
         ],
     ),
     (
         "MathVariants",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "MinConnectorOverlap",
-                None,
-                None,
-                "Minimum overlap of connecting glyphs during glyph construction,  in design units.",
+                description="Minimum overlap of connecting glyphs during glyph construction,  in design units.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "VertGlyphCoverage",
-                None,
-                None,
-                "Offset to Coverage table - from the beginning of MathVariants table.",
+                description="Offset to Coverage table - from the beginning of MathVariants table.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "HorizGlyphCoverage",
-                None,
-                None,
-                "Offset to Coverage table - from the beginning of MathVariants table.",
+                description="Offset to Coverage table - from the beginning of MathVariants table.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "VertGlyphCount",
-                None,
-                None,
-                "Number of glyphs for which information is provided for vertically growing variants.",
+                description="Number of glyphs for which information is provided for vertically growing variants.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "HorizGlyphCount",
-                None,
-                None,
-                "Number of glyphs for which information is provided for horizontally growing variants.",
+                description="Number of glyphs for which information is provided for horizontally growing variants.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "VertGlyphConstruction",
-                "VertGlyphCount",
-                0,
-                "Array of offsets to MathGlyphConstruction tables - from the beginning of the MathVariants table, for shapes growing in vertical direction.",
+                repeat="VertGlyphCount",
+                aux=0,
+                description="Array of offsets to MathGlyphConstruction tables - from the beginning of the MathVariants table, for shapes growing in vertical direction.",
             ),
-            (
+            FieldSpec(
                 "Offset",
                 "HorizGlyphConstruction",
-                "HorizGlyphCount",
-                0,
-                "Array of offsets to MathGlyphConstruction tables - from the beginning of the MathVariants table, for shapes growing in horizontal direction.",
+                repeat="HorizGlyphCount",
+                aux=0,
+                description="Array of offsets to MathGlyphConstruction tables - from the beginning of the MathVariants table, for shapes growing in horizontal direction.",
             ),
         ],
     ),
     (
         "MathGlyphConstruction",
         [
-            (
+            FieldSpec(
                 "Offset",
                 "GlyphAssembly",
-                None,
-                None,
-                "Offset to GlyphAssembly table for this shape - from the beginning of MathGlyphConstruction table. May be NULL",
+                description="Offset to GlyphAssembly table for this shape - from the beginning of MathGlyphConstruction table. May be NULL",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "VariantCount",
-                None,
-                None,
-                "Count of glyph growing variants for this glyph.",
+                description="Count of glyph growing variants for this glyph.",
             ),
-            (
+            FieldSpec(
                 "MathGlyphVariantRecord",
                 "MathGlyphVariantRecord",
-                "VariantCount",
-                0,
-                "MathGlyphVariantRecords for alternative variants of the glyphs.",
+                repeat="VariantCount",
+                aux=0,
+                description="MathGlyphVariantRecords for alternative variants of the glyphs.",
             ),
         ],
     ),
     (
         "MathGlyphVariantRecord",
         [
-            ("GlyphID", "VariantGlyph", None, None, "Glyph ID for the variant."),
-            (
+            FieldSpec(
+                "GlyphID", "VariantGlyph", description="Glyph ID for the variant."
+            ),
+            FieldSpec(
                 "uint16",
                 "AdvanceMeasurement",
-                None,
-                None,
-                "Advance width/height, in design units, of the variant, in the direction of requested glyph extension.",
+                description="Advance width/height, in design units, of the variant, in the direction of requested glyph extension.",
             ),
         ],
     ),
     (
         "GlyphAssembly",
         [
-            (
+            FieldSpec(
                 "MathValueRecord",
                 "ItalicsCorrection",
-                None,
-                None,
-                "Italics correction of this GlyphAssembly. Should not depend on the assembly size.",
+                description="Italics correction of this GlyphAssembly. Should not depend on the assembly size.",
             ),
-            ("uint16", "PartCount", None, None, "Number of parts in this assembly."),
-            (
+            FieldSpec(
+                "uint16", "PartCount", description="Number of parts in this assembly."
+            ),
+            FieldSpec(
                 "GlyphPartRecord",
                 "PartRecords",
-                "PartCount",
-                0,
-                "Array of part records, from left to right and bottom to top.",
+                repeat="PartCount",
+                aux=0,
+                description="Array of part records, from left to right and bottom to top.",
             ),
         ],
     ),
     (
         "GlyphPartRecord",
         [
-            ("GlyphID", "glyph", None, None, "Glyph ID for the part."),
-            (
+            FieldSpec("GlyphID", "glyph", description="Glyph ID for the part."),
+            FieldSpec(
                 "uint16",
                 "StartConnectorLength",
-                None,
-                None,
-                "Advance width/ height of the straight bar connector material, in design units, is at the beginning of the glyph, in the direction of the extension.",
+                description="Advance width/ height of the straight bar connector material, in design units, is at the beginning of the glyph, in the direction of the extension.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "EndConnectorLength",
-                None,
-                None,
-                "Advance width/ height of the straight bar connector material, in design units, is at the end of the glyph, in the direction of the extension.",
+                description="Advance width/ height of the straight bar connector material, in design units, is at the end of the glyph, in the direction of the extension.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "FullAdvance",
-                None,
-                None,
-                "Full advance width/height for this part, in the direction of the extension. In design units.",
+                description="Full advance width/height for this part, in the direction of the extension. In design units.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "PartFlags",
-                None,
-                None,
-                "Part qualifiers. PartFlags enumeration currently uses only one bit: 0x0001 fExtender: If set, the part can be skipped or repeated. 0xFFFE Reserved",
+                description="Part qualifiers. PartFlags enumeration currently uses only one bit: 0x0001 fExtender: If set, the part can be skipped or repeated. 0xFFFE Reserved",
             ),
         ],
     ),
@@ -4309,14 +3921,16 @@ otData = [
     (
         "AATLookupSegment",
         [
-            ("uint16", "lastGlyph", None, None, "Last glyph index in this segment."),
-            ("uint16", "firstGlyph", None, None, "First glyph index in this segment."),
-            (
+            FieldSpec(
+                "uint16", "lastGlyph", description="Last glyph index in this segment."
+            ),
+            FieldSpec(
+                "uint16", "firstGlyph", description="First glyph index in this segment."
+            ),
+            FieldSpec(
                 "uint16",
                 "value",
-                None,
-                None,
-                "A 16-bit offset from the start of the table to the data.",
+                description="A 16-bit offset from the start of the table to the data.",
             ),
         ],
     ),
@@ -4326,47 +3940,53 @@ otData = [
     (
         "ankr",
         [
-            ("struct", "AnchorPoints", None, None, "Anchor points table."),
+            FieldSpec("struct", "AnchorPoints", description="Anchor points table."),
         ],
     ),
     (
         "AnchorPointsFormat0",
         [
-            ("uint16", "Format", None, None, "Format of the anchor points table, = 0."),
-            ("uint16", "Flags", None, None, "Flags. Currenty unused, set to zero."),
-            (
+            FieldSpec(
+                "uint16",
+                "Format",
+                description="Format of the anchor points table, = 0.",
+            ),
+            FieldSpec(
+                "uint16", "Flags", description="Flags. Currenty unused, set to zero."
+            ),
+            FieldSpec(
                 "AATLookupWithDataOffset(AnchorGlyphData)",
                 "Anchors",
-                None,
-                None,
-                "Table of with anchor overrides for each glyph.",
+                description="Table of with anchor overrides for each glyph.",
             ),
         ],
     ),
     (
         "AnchorGlyphData",
         [
-            (
+            FieldSpec(
                 "uint32",
                 "AnchorPointCount",
-                None,
-                None,
-                "Number of anchor points for this glyph.",
+                description="Number of anchor points for this glyph.",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "AnchorPoint",
-                "AnchorPointCount",
-                0,
-                "Individual anchor points.",
+                repeat="AnchorPointCount",
+                aux=0,
+                description="Individual anchor points.",
             ),
         ],
     ),
     (
         "AnchorPoint",
         [
-            ("int16", "XCoordinate", None, None, "X coordinate of this anchor point."),
-            ("int16", "YCoordinate", None, None, "Y coordinate of this anchor point."),
+            FieldSpec(
+                "int16", "XCoordinate", description="X coordinate of this anchor point."
+            ),
+            FieldSpec(
+                "int16", "YCoordinate", description="Y coordinate of this anchor point."
+            ),
         ],
     ),
     #
@@ -4375,121 +3995,111 @@ otData = [
     (
         "bsln",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version number of the AAT baseline table (0x00010000 for the initial version).",
+                description="Version number of the AAT baseline table (0x00010000 for the initial version).",
             ),
-            ("struct", "Baseline", None, None, "Baseline table."),
+            FieldSpec("struct", "Baseline", description="Baseline table."),
         ],
     ),
     (
         "BaselineFormat0",
         [
-            ("uint16", "Format", None, None, "Format of the baseline table, = 0."),
-            (
+            FieldSpec(
+                "uint16", "Format", description="Format of the baseline table, = 0."
+            ),
+            FieldSpec(
                 "uint16",
                 "DefaultBaseline",
-                None,
-                None,
-                "Default baseline value for all glyphs. This value can be from 0 through 31.",
+                description="Default baseline value for all glyphs. This value can be from 0 through 31.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "Delta",
-                32,
-                0,
-                "These are the FUnit distance deltas from the font’s natural baseline to the other baselines used in the font. A total of 32 deltas must be assigned.",
+                repeat=32,
+                aux=0,
+                description="These are the FUnit distance deltas from the font’s natural baseline to the other baselines used in the font. A total of 32 deltas must be assigned.",
             ),
         ],
     ),
     (
         "BaselineFormat1",
         [
-            ("uint16", "Format", None, None, "Format of the baseline table, = 1."),
-            (
+            FieldSpec(
+                "uint16", "Format", description="Format of the baseline table, = 1."
+            ),
+            FieldSpec(
                 "uint16",
                 "DefaultBaseline",
-                None,
-                None,
-                "Default baseline value for all glyphs. This value can be from 0 through 31.",
+                description="Default baseline value for all glyphs. This value can be from 0 through 31.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "Delta",
-                32,
-                0,
-                "These are the FUnit distance deltas from the font’s natural baseline to the other baselines used in the font. A total of 32 deltas must be assigned.",
+                repeat=32,
+                aux=0,
+                description="These are the FUnit distance deltas from the font’s natural baseline to the other baselines used in the font. A total of 32 deltas must be assigned.",
             ),
-            (
+            FieldSpec(
                 "AATLookup(uint16)",
                 "BaselineValues",
-                None,
-                None,
-                "Lookup table that maps glyphs to their baseline values.",
+                description="Lookup table that maps glyphs to their baseline values.",
             ),
         ],
     ),
     (
         "BaselineFormat2",
         [
-            ("uint16", "Format", None, None, "Format of the baseline table, = 1."),
-            (
+            FieldSpec(
+                "uint16", "Format", description="Format of the baseline table, = 1."
+            ),
+            FieldSpec(
                 "uint16",
                 "DefaultBaseline",
-                None,
-                None,
-                "Default baseline value for all glyphs. This value can be from 0 through 31.",
+                description="Default baseline value for all glyphs. This value can be from 0 through 31.",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "StandardGlyph",
-                None,
-                None,
-                "Glyph index of the glyph in this font to be used to set the baseline values. This glyph must contain a set of control points (whose numbers are contained in the following field) that determines baseline distances.",
+                description="Glyph index of the glyph in this font to be used to set the baseline values. This glyph must contain a set of control points (whose numbers are contained in the following field) that determines baseline distances.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ControlPoint",
-                32,
-                0,
-                "Array of 32 control point numbers, associated with the standard glyph. A value of 0xFFFF means there is no corresponding control point in the standard glyph.",
+                repeat=32,
+                aux=0,
+                description="Array of 32 control point numbers, associated with the standard glyph. A value of 0xFFFF means there is no corresponding control point in the standard glyph.",
             ),
         ],
     ),
     (
         "BaselineFormat3",
         [
-            ("uint16", "Format", None, None, "Format of the baseline table, = 1."),
-            (
+            FieldSpec(
+                "uint16", "Format", description="Format of the baseline table, = 1."
+            ),
+            FieldSpec(
                 "uint16",
                 "DefaultBaseline",
-                None,
-                None,
-                "Default baseline value for all glyphs. This value can be from 0 through 31.",
+                description="Default baseline value for all glyphs. This value can be from 0 through 31.",
             ),
-            (
+            FieldSpec(
                 "GlyphID",
                 "StandardGlyph",
-                None,
-                None,
-                "Glyph index of the glyph in this font to be used to set the baseline values. This glyph must contain a set of control points (whose numbers are contained in the following field) that determines baseline distances.",
+                description="Glyph index of the glyph in this font to be used to set the baseline values. This glyph must contain a set of control points (whose numbers are contained in the following field) that determines baseline distances.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "ControlPoint",
-                32,
-                0,
-                "Array of 32 control point numbers, associated with the standard glyph. A value of 0xFFFF means there is no corresponding control point in the standard glyph.",
+                repeat=32,
+                aux=0,
+                description="Array of 32 control point numbers, associated with the standard glyph. A value of 0xFFFF means there is no corresponding control point in the standard glyph.",
             ),
-            (
+            FieldSpec(
                 "AATLookup(uint16)",
                 "BaselineValues",
-                None,
-                None,
-                "Lookup table that maps glyphs to their baseline values.",
+                description="Lookup table that maps glyphs to their baseline values.",
             ),
         ],
     ),
@@ -4499,44 +4109,44 @@ otData = [
     (
         "cidg",
         [
-            ("struct", "CIDGlyphMapping", None, None, "CID-to-glyph mapping table."),
+            FieldSpec(
+                "struct", "CIDGlyphMapping", description="CID-to-glyph mapping table."
+            ),
         ],
     ),
     (
         "CIDGlyphMappingFormat0",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "Format",
-                None,
-                None,
-                "Format of the CID-to-glyph mapping table, = 0.",
+                description="Format of the CID-to-glyph mapping table, = 0.",
             ),
-            ("uint16", "DataFormat", None, None, "Currenty unused, set to zero."),
-            ("uint32", "StructLength", None, None, "Size of the table in bytes."),
-            ("uint16", "Registry", None, None, "The registry ID."),
-            (
+            FieldSpec(
+                "uint16", "DataFormat", description="Currenty unused, set to zero."
+            ),
+            FieldSpec(
+                "uint32", "StructLength", description="Size of the table in bytes."
+            ),
+            FieldSpec("uint16", "Registry", description="The registry ID."),
+            FieldSpec(
                 "char64",
                 "RegistryName",
-                None,
-                None,
-                "The registry name in ASCII; unused bytes should be set to 0.",
+                description="The registry name in ASCII; unused bytes should be set to 0.",
             ),
-            ("uint16", "Order", None, None, "The order ID."),
-            (
+            FieldSpec("uint16", "Order", description="The order ID."),
+            FieldSpec(
                 "char64",
                 "OrderName",
-                None,
-                None,
-                "The order name in ASCII; unused bytes should be set to 0.",
+                description="The order name in ASCII; unused bytes should be set to 0.",
             ),
-            ("uint16", "SupplementVersion", None, None, "The supplement version."),
-            (
+            FieldSpec(
+                "uint16", "SupplementVersion", description="The supplement version."
+            ),
+            FieldSpec(
                 "CIDGlyphMap",
                 "Mapping",
-                None,
-                None,
-                "A mapping from CIDs to the glyphs in the font, starting with CID 0. If a CID from the identified collection has no glyph in the font, 0xFFFF is used",
+                description="A mapping from CIDs to the glyphs in the font, starting with CID 0. If a CID from the identified collection has no glyph in the font, 0xFFFF is used",
             ),
         ],
     ),
@@ -4546,87 +4156,81 @@ otData = [
     (
         "feat",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the feat table-initially set to 0x00010000.",
+                description="Version of the feat table-initially set to 0x00010000.",
             ),
-            ("FeatureNames", "FeatureNames", None, None, "The feature names."),
+            FieldSpec(
+                "FeatureNames", "FeatureNames", description="The feature names."
+            ),
         ],
     ),
     (
         "FeatureNames",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "FeatureNameCount",
-                None,
-                None,
-                "Number of entries in the feature name array.",
+                description="Number of entries in the feature name array.",
             ),
-            ("uint16", "Reserved1", None, None, "Reserved (set to zero)."),
-            ("uint32", "Reserved2", None, None, "Reserved (set to zero)."),
-            (
+            FieldSpec("uint16", "Reserved1", description="Reserved (set to zero)."),
+            FieldSpec("uint32", "Reserved2", description="Reserved (set to zero)."),
+            FieldSpec(
                 "FeatureName",
                 "FeatureName",
-                "FeatureNameCount",
-                0,
-                "The feature name array.",
+                repeat="FeatureNameCount",
+                aux=0,
+                description="The feature name array.",
             ),
         ],
     ),
     (
         "FeatureName",
         [
-            ("uint16", "FeatureType", None, None, "Feature type."),
-            (
+            FieldSpec("uint16", "FeatureType", description="Feature type."),
+            FieldSpec(
                 "uint16",
                 "SettingsCount",
-                None,
-                None,
-                "The number of records in the setting name array.",
+                description="The number of records in the setting name array.",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "Settings",
-                None,
-                None,
-                "Offset to setting table for this feature.",
+                description="Offset to setting table for this feature.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "FeatureFlags",
-                None,
-                None,
-                "Single-bit flags associated with the feature type.",
+                description="Single-bit flags associated with the feature type.",
             ),
-            (
+            FieldSpec(
                 "NameID",
                 "FeatureNameID",
-                None,
-                None,
-                "The name table index for the feature name.",
+                description="The name table index for the feature name.",
             ),
         ],
     ),
     (
         "Settings",
         [
-            ("Setting", "Setting", "SettingsCount", 0, "The setting array."),
+            FieldSpec(
+                "Setting",
+                "Setting",
+                repeat="SettingsCount",
+                aux=0,
+                description="The setting array.",
+            ),
         ],
     ),
     (
         "Setting",
         [
-            ("uint16", "SettingValue", None, None, "The setting."),
-            (
+            FieldSpec("uint16", "SettingValue", description="The setting."),
+            FieldSpec(
                 "NameID",
                 "SettingNameID",
-                None,
-                None,
-                "The name table index for the setting name.",
+                description="The name table index for the setting name.",
             ),
         ],
     ),
@@ -4636,44 +4240,44 @@ otData = [
     (
         "gcid",
         [
-            ("struct", "GlyphCIDMapping", None, None, "Glyph to CID mapping table."),
+            FieldSpec(
+                "struct", "GlyphCIDMapping", description="Glyph to CID mapping table."
+            ),
         ],
     ),
     (
         "GlyphCIDMappingFormat0",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "Format",
-                None,
-                None,
-                "Format of the glyph-to-CID mapping table, = 0.",
+                description="Format of the glyph-to-CID mapping table, = 0.",
             ),
-            ("uint16", "DataFormat", None, None, "Currenty unused, set to zero."),
-            ("uint32", "StructLength", None, None, "Size of the table in bytes."),
-            ("uint16", "Registry", None, None, "The registry ID."),
-            (
+            FieldSpec(
+                "uint16", "DataFormat", description="Currenty unused, set to zero."
+            ),
+            FieldSpec(
+                "uint32", "StructLength", description="Size of the table in bytes."
+            ),
+            FieldSpec("uint16", "Registry", description="The registry ID."),
+            FieldSpec(
                 "char64",
                 "RegistryName",
-                None,
-                None,
-                "The registry name in ASCII; unused bytes should be set to 0.",
+                description="The registry name in ASCII; unused bytes should be set to 0.",
             ),
-            ("uint16", "Order", None, None, "The order ID."),
-            (
+            FieldSpec("uint16", "Order", description="The order ID."),
+            FieldSpec(
                 "char64",
                 "OrderName",
-                None,
-                None,
-                "The order name in ASCII; unused bytes should be set to 0.",
+                description="The order name in ASCII; unused bytes should be set to 0.",
             ),
-            ("uint16", "SupplementVersion", None, None, "The supplement version."),
-            (
+            FieldSpec(
+                "uint16", "SupplementVersion", description="The supplement version."
+            ),
+            FieldSpec(
                 "GlyphCIDMap",
                 "Mapping",
-                None,
-                None,
-                "The CIDs for the glyphs in the font, starting with glyph 0. If a glyph does not correspond to a CID in the identified collection, 0xFFFF is used",
+                description="The CIDs for the glyphs in the font, starting with glyph 0. If a glyph does not correspond to a CID in the identified collection, 0xFFFF is used",
             ),
         ],
     ),
@@ -4683,77 +4287,73 @@ otData = [
     (
         "lcar",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version number of the ligature caret table (0x00010000 for the initial version).",
+                description="Version number of the ligature caret table (0x00010000 for the initial version).",
             ),
-            ("struct", "LigatureCarets", None, None, "Ligature carets table."),
+            FieldSpec(
+                "struct", "LigatureCarets", description="Ligature carets table."
+            ),
         ],
     ),
     (
         "LigatureCaretsFormat0",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "Format",
-                None,
-                None,
-                "Format of the ligature caret table. Format 0 indicates division points are distances in font units, Format 1 indicates division points are indexes of control points.",
+                description="Format of the ligature caret table. Format 0 indicates division points are distances in font units, Format 1 indicates division points are indexes of control points.",
             ),
-            (
+            FieldSpec(
                 "AATLookup(LigCaretDistances)",
                 "Carets",
-                None,
-                None,
-                "Lookup table associating ligature glyphs with their caret positions, in font unit distances.",
+                description="Lookup table associating ligature glyphs with their caret positions, in font unit distances.",
             ),
         ],
     ),
     (
         "LigatureCaretsFormat1",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "Format",
-                None,
-                None,
-                "Format of the ligature caret table. Format 0 indicates division points are distances in font units, Format 1 indicates division points are indexes of control points.",
+                description="Format of the ligature caret table. Format 0 indicates division points are distances in font units, Format 1 indicates division points are indexes of control points.",
             ),
-            (
+            FieldSpec(
                 "AATLookup(LigCaretPoints)",
                 "Carets",
-                None,
-                None,
-                "Lookup table associating ligature glyphs with their caret positions, as control points.",
+                description="Lookup table associating ligature glyphs with their caret positions, as control points.",
             ),
         ],
     ),
     (
         "LigCaretDistances",
         [
-            ("uint16", "DivsionPointCount", None, None, "Number of division points."),
-            (
+            FieldSpec(
+                "uint16", "DivsionPointCount", description="Number of division points."
+            ),
+            FieldSpec(
                 "int16",
                 "DivisionPoint",
-                "DivsionPointCount",
-                0,
-                "Distance in font units through which a subdivision is made orthogonally to the baseline.",
+                repeat="DivsionPointCount",
+                aux=0,
+                description="Distance in font units through which a subdivision is made orthogonally to the baseline.",
             ),
         ],
     ),
     (
         "LigCaretPoints",
         [
-            ("uint16", "DivsionPointCount", None, None, "Number of division points."),
-            (
+            FieldSpec(
+                "uint16", "DivsionPointCount", description="Number of division points."
+            ),
+            FieldSpec(
                 "int16",
                 "DivisionPoint",
-                "DivsionPointCount",
-                0,
-                "The number of the control point through which a subdivision is made orthogonally to the baseline.",
+                repeat="DivsionPointCount",
+                aux=0,
+                description="The number of the control point through which a subdivision is made orthogonally to the baseline.",
             ),
         ],
     ),
@@ -4763,96 +4363,80 @@ otData = [
     (
         "mort",
         [
-            ("Version", "Version", None, None, "Version of the mort table."),
-            (
+            FieldSpec("Version", "Version", description="Version of the mort table."),
+            FieldSpec(
                 "uint32",
                 "MorphChainCount",
-                None,
-                None,
-                "Number of metamorphosis chains.",
+                description="Number of metamorphosis chains.",
             ),
-            (
+            FieldSpec(
                 "MortChain",
                 "MorphChain",
-                "MorphChainCount",
-                0,
-                "Array of metamorphosis chains.",
+                repeat="MorphChainCount",
+                aux=0,
+                description="Array of metamorphosis chains.",
             ),
         ],
     ),
     (
         "MortChain",
         [
-            (
+            FieldSpec(
                 "Flags32",
                 "DefaultFlags",
-                None,
-                None,
-                "The default specification for subtables.",
+                description="The default specification for subtables.",
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "StructLength",
-                None,
-                None,
-                "Total byte count, including this header; must be a multiple of 4.",
+                description="Total byte count, including this header; must be a multiple of 4.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "MorphFeatureCount",
-                None,
-                None,
-                "Number of metamorphosis feature entries.",
+                description="Number of metamorphosis feature entries.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "MorphSubtableCount",
-                None,
-                None,
-                "The number of subtables in the chain.",
+                description="The number of subtables in the chain.",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "MorphFeature",
-                "MorphFeatureCount",
-                0,
-                "Array of metamorphosis features.",
+                repeat="MorphFeatureCount",
+                aux=0,
+                description="Array of metamorphosis features.",
             ),
-            (
+            FieldSpec(
                 "MortSubtable",
                 "MorphSubtable",
-                "MorphSubtableCount",
-                0,
-                "Array of metamorphosis subtables.",
+                repeat="MorphSubtableCount",
+                aux=0,
+                description="Array of metamorphosis subtables.",
             ),
         ],
     ),
     (
         "MortSubtable",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "StructLength",
-                None,
-                None,
-                "Total subtable length, including this header.",
+                description="Total subtable length, including this header.",
             ),
-            (
+            FieldSpec(
                 "uint8",
                 "CoverageFlags",
-                None,
-                None,
-                "Most significant byte of coverage flags.",
+                description="Most significant byte of coverage flags.",
             ),
-            ("uint8", "MorphType", None, None, "Subtable type."),
-            (
+            FieldSpec("uint8", "MorphType", description="Subtable type."),
+            FieldSpec(
                 "Flags32",
                 "SubFeatureFlags",
-                None,
-                None,
-                "The 32-bit mask identifying which subtable this is (the subtable being executed if the AND of this value and the processed defaultFlags is nonzero).",
+                description="The 32-bit mask identifying which subtable this is (the subtable being executed if the AND of this value and the processed defaultFlags is nonzero).",
             ),
-            ("SubStruct", "SubStruct", None, None, "SubTable."),
+            FieldSpec("SubStruct", "SubStruct", description="SubTable."),
         ],
     ),
     #
@@ -4861,95 +4445,79 @@ otData = [
     (
         "morx",
         [
-            ("uint16", "Version", None, None, "Version of the morx table."),
-            ("uint16", "Reserved", None, None, "Reserved (set to zero)."),
-            (
+            FieldSpec("uint16", "Version", description="Version of the morx table."),
+            FieldSpec("uint16", "Reserved", description="Reserved (set to zero)."),
+            FieldSpec(
                 "uint32",
                 "MorphChainCount",
-                None,
-                None,
-                "Number of extended metamorphosis chains.",
+                description="Number of extended metamorphosis chains.",
             ),
-            (
+            FieldSpec(
                 "MorxChain",
                 "MorphChain",
-                "MorphChainCount",
-                0,
-                "Array of extended metamorphosis chains.",
+                repeat="MorphChainCount",
+                aux=0,
+                description="Array of extended metamorphosis chains.",
             ),
         ],
     ),
     (
         "MorxChain",
         [
-            (
+            FieldSpec(
                 "Flags32",
                 "DefaultFlags",
-                None,
-                None,
-                "The default specification for subtables.",
+                description="The default specification for subtables.",
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "StructLength",
-                None,
-                None,
-                "Total byte count, including this header; must be a multiple of 4.",
+                description="Total byte count, including this header; must be a multiple of 4.",
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "MorphFeatureCount",
-                None,
-                None,
-                "Number of feature subtable entries.",
+                description="Number of feature subtable entries.",
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "MorphSubtableCount",
-                None,
-                None,
-                "The number of subtables in the chain.",
+                description="The number of subtables in the chain.",
             ),
-            (
+            FieldSpec(
                 "MorphFeature",
                 "MorphFeature",
-                "MorphFeatureCount",
-                0,
-                "Array of metamorphosis features.",
+                repeat="MorphFeatureCount",
+                aux=0,
+                description="Array of metamorphosis features.",
             ),
-            (
+            FieldSpec(
                 "MorxSubtable",
                 "MorphSubtable",
-                "MorphSubtableCount",
-                0,
-                "Array of extended metamorphosis subtables.",
+                repeat="MorphSubtableCount",
+                aux=0,
+                description="Array of extended metamorphosis subtables.",
             ),
         ],
     ),
     (
         "MorphFeature",
         [
-            ("uint16", "FeatureType", None, None, "The type of feature."),
-            (
+            FieldSpec("uint16", "FeatureType", description="The type of feature."),
+            FieldSpec(
                 "uint16",
                 "FeatureSetting",
-                None,
-                None,
-                "The feature's setting (aka selector).",
+                description="The feature's setting (aka selector).",
             ),
-            (
+            FieldSpec(
                 "Flags32",
                 "EnableFlags",
-                None,
-                None,
-                "Flags for the settings that this feature and setting enables.",
+                description="Flags for the settings that this feature and setting enables.",
             ),
-            (
+            FieldSpec(
                 "Flags32",
                 "DisableFlags",
-                None,
-                None,
-                "Complement of flags for the settings that this feature and setting disable.",
+                description="Complement of flags for the settings that this feature and setting disable.",
             ),
         ],
     ),
@@ -4959,134 +4527,108 @@ otData = [
     (
         "MorxSubtable",
         [
-            (
+            FieldSpec(
                 "uint32",
                 "StructLength",
-                None,
-                None,
-                "Total subtable length, including this header.",
+                description="Total subtable length, including this header.",
             ),
-            (
+            FieldSpec(
                 "uint8",
                 "CoverageFlags",
-                None,
-                None,
-                "Most significant byte of coverage flags.",
+                description="Most significant byte of coverage flags.",
             ),
-            ("uint16", "Reserved", None, None, "Unused."),
-            ("uint8", "MorphType", None, None, "Subtable type."),
-            (
+            FieldSpec("uint16", "Reserved", description="Unused."),
+            FieldSpec("uint8", "MorphType", description="Subtable type."),
+            FieldSpec(
                 "Flags32",
                 "SubFeatureFlags",
-                None,
-                None,
-                "The 32-bit mask identifying which subtable this is (the subtable being executed if the AND of this value and the processed defaultFlags is nonzero).",
+                description="The 32-bit mask identifying which subtable this is (the subtable being executed if the AND of this value and the processed defaultFlags is nonzero).",
             ),
-            ("SubStruct", "SubStruct", None, None, "SubTable."),
+            FieldSpec("SubStruct", "SubStruct", description="SubTable."),
         ],
     ),
     (
         "StateHeader",
         [
-            (
+            FieldSpec(
                 "uint32",
                 "ClassCount",
-                None,
-                None,
-                "Number of classes, which is the number of 16-bit entry indices in a single line in the state array.",
+                description="Number of classes, which is the number of 16-bit entry indices in a single line in the state array.",
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "MorphClass",
-                None,
-                None,
-                "Offset from the start of this state table header to the start of the class table.",
+                description="Offset from the start of this state table header to the start of the class table.",
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "StateArrayOffset",
-                None,
-                None,
-                "Offset from the start of this state table header to the start of the state array.",
+                description="Offset from the start of this state table header to the start of the state array.",
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "EntryTableOffset",
-                None,
-                None,
-                "Offset from the start of this state table header to the start of the entry table.",
+                description="Offset from the start of this state table header to the start of the entry table.",
             ),
         ],
     ),
     (
         "RearrangementMorph",
         [
-            (
+            FieldSpec(
                 "STXHeader(RearrangementMorphAction)",
                 "StateTable",
-                None,
-                None,
-                "Finite-state transducer table for indic rearrangement.",
+                description="Finite-state transducer table for indic rearrangement.",
             ),
         ],
     ),
     (
         "ContextualMorph",
         [
-            (
+            FieldSpec(
                 "STXHeader(ContextualMorphAction)",
                 "StateTable",
-                None,
-                None,
-                "Finite-state transducer for contextual glyph substitution.",
+                description="Finite-state transducer for contextual glyph substitution.",
             ),
         ],
     ),
     (
         "LigatureMorph",
         [
-            (
+            FieldSpec(
                 "STXHeader(LigatureMorphAction)",
                 "StateTable",
-                None,
-                None,
-                "Finite-state transducer for ligature substitution.",
+                description="Finite-state transducer for ligature substitution.",
             ),
         ],
     ),
     (
         "NoncontextualMorph",
         [
-            (
+            FieldSpec(
                 "AATLookup(GlyphID)",
                 "Substitution",
-                None,
-                None,
-                "The noncontextual glyph substitution table.",
+                description="The noncontextual glyph substitution table.",
             ),
         ],
     ),
     (
         "InsertionMorph",
         [
-            (
+            FieldSpec(
                 "STXHeader(InsertionMorphAction)",
                 "StateTable",
-                None,
-                None,
-                "Finite-state transducer for glyph insertion.",
+                description="Finite-state transducer for glyph insertion.",
             ),
         ],
     ),
     (
         "MorphClass",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "FirstGlyph",
-                None,
-                None,
-                "Glyph index of the first glyph in the class table.",
+                description="Glyph index of the first glyph in the class table.",
             ),
             # ('uint16', 'GlyphCount', None, None, 'Number of glyphs in class table.'),
             # ('uint8', 'GlyphClass', 'GlyphCount', 0, 'The class codes (indexed by glyph index minus firstGlyph). Class codes range from 0 to the value of stateSize minus 1.'),
@@ -5100,46 +4642,38 @@ otData = [
     (
         "prop",
         [
-            (
+            FieldSpec(
                 "Fixed",
                 "Version",
-                None,
-                None,
-                "Version number of the AAT glyphs property table. Version 1.0 is the initial table version. Version 2.0, which is recognized by macOS 8.5 and later, adds support for the “attaches on right” bit. Version 3.0, which gets recognized by macOS X and iOS, adds support for the additional directional properties defined in Unicode 3.0.",
+                description="Version number of the AAT glyphs property table. Version 1.0 is the initial table version. Version 2.0, which is recognized by macOS 8.5 and later, adds support for the “attaches on right” bit. Version 3.0, which gets recognized by macOS X and iOS, adds support for the additional directional properties defined in Unicode 3.0.",
             ),
-            ("struct", "GlyphProperties", None, None, "Glyph properties."),
+            FieldSpec("struct", "GlyphProperties", description="Glyph properties."),
         ],
     ),
     (
         "GlyphPropertiesFormat0",
         [
-            ("uint16", "Format", None, None, "Format, = 0."),
-            (
+            FieldSpec("uint16", "Format", description="Format, = 0."),
+            FieldSpec(
                 "uint16",
                 "DefaultProperties",
-                None,
-                None,
-                "Default properties applied to a glyph. Since there is no lookup table in prop format 0, the default properties get applied to every glyph in the font.",
+                description="Default properties applied to a glyph. Since there is no lookup table in prop format 0, the default properties get applied to every glyph in the font.",
             ),
         ],
     ),
     (
         "GlyphPropertiesFormat1",
         [
-            ("uint16", "Format", None, None, "Format, = 1."),
-            (
+            FieldSpec("uint16", "Format", description="Format, = 1."),
+            FieldSpec(
                 "uint16",
                 "DefaultProperties",
-                None,
-                None,
-                "Default properties applied to a glyph if that glyph is not present in the Properties lookup table.",
+                description="Default properties applied to a glyph if that glyph is not present in the Properties lookup table.",
             ),
-            (
+            FieldSpec(
                 "AATLookup(uint16)",
                 "Properties",
-                None,
-                None,
-                "Lookup data associating glyphs with their properties.",
+                description="Lookup data associating glyphs with their properties.",
             ),
         ],
     ),
@@ -5149,111 +4683,89 @@ otData = [
     (
         "opbd",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version number of the optical bounds table (0x00010000 for the initial version).",
+                description="Version number of the optical bounds table (0x00010000 for the initial version).",
             ),
-            ("struct", "OpticalBounds", None, None, "Optical bounds table."),
+            FieldSpec("struct", "OpticalBounds", description="Optical bounds table."),
         ],
     ),
     (
         "OpticalBoundsFormat0",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "Format",
-                None,
-                None,
-                "Format of the optical bounds table, = 0.",
+                description="Format of the optical bounds table, = 0.",
             ),
-            (
+            FieldSpec(
                 "AATLookup(OpticalBoundsDeltas)",
                 "OpticalBoundsDeltas",
-                None,
-                None,
-                "Lookup table associating glyphs with their optical bounds, given as deltas in font units.",
+                description="Lookup table associating glyphs with their optical bounds, given as deltas in font units.",
             ),
         ],
     ),
     (
         "OpticalBoundsFormat1",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "Format",
-                None,
-                None,
-                "Format of the optical bounds table, = 1.",
+                description="Format of the optical bounds table, = 1.",
             ),
-            (
+            FieldSpec(
                 "AATLookup(OpticalBoundsPoints)",
                 "OpticalBoundsPoints",
-                None,
-                None,
-                "Lookup table associating glyphs with their optical bounds, given as references to control points.",
+                description="Lookup table associating glyphs with their optical bounds, given as references to control points.",
             ),
         ],
     ),
     (
         "OpticalBoundsDeltas",
         [
-            (
+            FieldSpec(
                 "int16",
                 "Left",
-                None,
-                None,
-                "Delta value for the left-side optical edge.",
+                description="Delta value for the left-side optical edge.",
             ),
-            ("int16", "Top", None, None, "Delta value for the top-side optical edge."),
-            (
+            FieldSpec(
+                "int16", "Top", description="Delta value for the top-side optical edge."
+            ),
+            FieldSpec(
                 "int16",
                 "Right",
-                None,
-                None,
-                "Delta value for the right-side optical edge.",
+                description="Delta value for the right-side optical edge.",
             ),
-            (
+            FieldSpec(
                 "int16",
                 "Bottom",
-                None,
-                None,
-                "Delta value for the bottom-side optical edge.",
+                description="Delta value for the bottom-side optical edge.",
             ),
         ],
     ),
     (
         "OpticalBoundsPoints",
         [
-            (
+            FieldSpec(
                 "int16",
                 "Left",
-                None,
-                None,
-                "Control point index for the left-side optical edge, or -1 if this glyph has none.",
+                description="Control point index for the left-side optical edge, or -1 if this glyph has none.",
             ),
-            (
+            FieldSpec(
                 "int16",
                 "Top",
-                None,
-                None,
-                "Control point index for the top-side optical edge, or -1 if this glyph has none.",
+                description="Control point index for the top-side optical edge, or -1 if this glyph has none.",
             ),
-            (
+            FieldSpec(
                 "int16",
                 "Right",
-                None,
-                None,
-                "Control point index for the right-side optical edge, or -1 if this glyph has none.",
+                description="Control point index for the right-side optical edge, or -1 if this glyph has none.",
             ),
-            (
+            FieldSpec(
                 "int16",
                 "Bottom",
-                None,
-                None,
-                "Control point index for the bottom-side optical edge, or -1 if this glyph has none.",
+                description="Control point index for the bottom-side optical edge, or -1 if this glyph has none.",
             ),
         ],
     ),
@@ -5263,43 +4775,81 @@ otData = [
     (
         "TSIC",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of table initially set to 0x00010000.",
+                description="Version of table initially set to 0x00010000.",
             ),
-            ("uint16", "Flags", None, None, "TSIC flags - set to 0"),
-            ("uint16", "AxisCount", None, None, "Axis count from fvar"),
-            ("uint16", "RecordCount", None, None, "TSIC record count"),
-            ("uint16", "Reserved", None, None, "Set to 0"),
-            ("Tag", "AxisArray", "AxisCount", 0, "Array of axis tags in fvar order"),
-            (
+            FieldSpec("uint16", "Flags", description="TSIC flags - set to 0"),
+            FieldSpec("uint16", "AxisCount", description="Axis count from fvar"),
+            FieldSpec("uint16", "RecordCount", description="TSIC record count"),
+            FieldSpec("uint16", "Reserved", description="Set to 0"),
+            FieldSpec(
+                "Tag",
+                "AxisArray",
+                repeat="AxisCount",
+                aux=0,
+                description="Array of axis tags in fvar order",
+            ),
+            FieldSpec(
                 "LocationRecord",
                 "RecordLocations",
-                "RecordCount",
-                0,
-                "Location in variation space of TSIC record",
+                repeat="RecordCount",
+                aux=0,
+                description="Location in variation space of TSIC record",
             ),
-            ("TSICRecord", "Record", "RecordCount", 0, "Array of TSIC records"),
+            FieldSpec(
+                "TSICRecord",
+                "Record",
+                repeat="RecordCount",
+                aux=0,
+                description="Array of TSIC records",
+            ),
         ],
     ),
     (
         "LocationRecord",
         [
-            ("F2Dot14", "Axis", "AxisCount", 0, "Axis record"),
+            FieldSpec(
+                "F2Dot14", "Axis", repeat="AxisCount", aux=0, description="Axis record"
+            ),
         ],
     ),
     (
         "TSICRecord",
         [
-            ("uint16", "Flags", None, None, "Record flags - set to 0"),
-            ("uint16", "NumCVTEntries", None, None, "Number of CVT number value pairs"),
-            ("uint16", "NameLength", None, None, "Length of optional user record name"),
-            ("uint16", "NameArray", "NameLength", 0, "Unicode 16 name"),
-            ("uint16", "CVTArray", "NumCVTEntries", 0, "CVT number array"),
-            ("int16", "CVTValueArray", "NumCVTEntries", 0, "CVT value"),
+            FieldSpec("uint16", "Flags", description="Record flags - set to 0"),
+            FieldSpec(
+                "uint16",
+                "NumCVTEntries",
+                description="Number of CVT number value pairs",
+            ),
+            FieldSpec(
+                "uint16",
+                "NameLength",
+                description="Length of optional user record name",
+            ),
+            FieldSpec(
+                "uint16",
+                "NameArray",
+                repeat="NameLength",
+                aux=0,
+                description="Unicode 16 name",
+            ),
+            FieldSpec(
+                "uint16",
+                "CVTArray",
+                repeat="NumCVTEntries",
+                aux=0,
+                description="CVT number array",
+            ),
+            FieldSpec(
+                "int16",
+                "CVTValueArray",
+                repeat="NumCVTEntries",
+                aux=0,
+                description="CVT value",
+            ),
         ],
     ),
     #
@@ -5308,232 +4858,231 @@ otData = [
     (
         "COLR",
         [
-            ("uint16", "Version", None, None, "Table version number (starts at 0)."),
-            (
+            FieldSpec(
+                "uint16", "Version", description="Table version number (starts at 0)."
+            ),
+            FieldSpec(
                 "uint16",
                 "BaseGlyphRecordCount",
-                None,
-                None,
-                "Number of Base Glyph Records.",
+                description="Number of Base Glyph Records.",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "BaseGlyphRecordArray",
-                None,
-                None,
-                "Offset (from beginning of COLR table) to Base Glyph records.",
+                description="Offset (from beginning of COLR table) to Base Glyph records.",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "LayerRecordArray",
-                None,
-                None,
-                "Offset (from beginning of COLR table) to Layer Records.",
+                description="Offset (from beginning of COLR table) to Layer Records.",
             ),
-            ("uint16", "LayerRecordCount", None, None, "Number of Layer Records."),
-            (
+            FieldSpec(
+                "uint16", "LayerRecordCount", description="Number of Layer Records."
+            ),
+            FieldSpec(
                 "LOffset",
                 "BaseGlyphList",
-                None,
-                "Version >= 1",
-                "Offset (from beginning of COLR table) to array of Version-1 Base Glyph records.",
+                aux="Version >= 1",
+                description="Offset (from beginning of COLR table) to array of Version-1 Base Glyph records.",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "LayerList",
-                None,
-                "Version >= 1",
-                "Offset (from beginning of COLR table) to LayerList.",
+                aux="Version >= 1",
+                description="Offset (from beginning of COLR table) to LayerList.",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "ClipList",
-                None,
-                "Version >= 1",
-                "Offset to ClipList table (may be NULL)",
+                aux="Version >= 1",
+                description="Offset to ClipList table (may be NULL)",
             ),
-            (
+            FieldSpec(
                 "LOffsetTo(DeltaSetIndexMap)",
                 "VarIndexMap",
-                None,
-                "Version >= 1",
-                "Offset to DeltaSetIndexMap table (may be NULL)",
+                aux="Version >= 1",
+                description="Offset to DeltaSetIndexMap table (may be NULL)",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "VarStore",
-                None,
-                "Version >= 1",
-                "Offset to variation store (may be NULL)",
+                aux="Version >= 1",
+                description="Offset to variation store (may be NULL)",
             ),
         ],
     ),
     (
         "BaseGlyphRecordArray",
         [
-            (
+            FieldSpec(
                 "BaseGlyphRecord",
                 "BaseGlyphRecord",
-                "BaseGlyphRecordCount",
-                0,
-                "Base Glyph records.",
+                repeat="BaseGlyphRecordCount",
+                aux=0,
+                description="Base Glyph records.",
             ),
         ],
     ),
     (
         "BaseGlyphRecord",
         [
-            (
+            FieldSpec(
                 "GlyphID",
                 "BaseGlyph",
-                None,
-                None,
-                "Glyph ID of reference glyph. This glyph is for reference only and is not rendered for color.",
+                description="Glyph ID of reference glyph. This glyph is for reference only and is not rendered for color.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "FirstLayerIndex",
-                None,
-                None,
-                "Index (from beginning of the Layer Records) to the layer record. There will be numLayers consecutive entries for this base glyph.",
+                description="Index (from beginning of the Layer Records) to the layer record. There will be numLayers consecutive entries for this base glyph.",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "NumLayers",
-                None,
-                None,
-                "Number of color layers associated with this glyph.",
+                description="Number of color layers associated with this glyph.",
             ),
         ],
     ),
     (
         "LayerRecordArray",
         [
-            ("LayerRecord", "LayerRecord", "LayerRecordCount", 0, "Layer records."),
+            FieldSpec(
+                "LayerRecord",
+                "LayerRecord",
+                repeat="LayerRecordCount",
+                aux=0,
+                description="Layer records.",
+            ),
         ],
     ),
     (
         "LayerRecord",
         [
-            (
+            FieldSpec(
                 "GlyphID",
                 "LayerGlyph",
-                None,
-                None,
-                "Glyph ID of layer glyph (must be in z-order from bottom to top).",
+                description="Glyph ID of layer glyph (must be in z-order from bottom to top).",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "PaletteIndex",
-                None,
-                None,
-                "Index value to use with a selected color palette.",
+                description="Index value to use with a selected color palette.",
             ),
         ],
     ),
     (
         "BaseGlyphList",
         [
-            (
+            FieldSpec(
                 "uint32",
                 "BaseGlyphCount",
-                None,
-                None,
-                "Number of Version-1 Base Glyph records",
+                description="Number of Version-1 Base Glyph records",
             ),
-            (
+            FieldSpec(
                 "struct",
                 "BaseGlyphPaintRecord",
-                "BaseGlyphCount",
-                0,
-                "Array of Version-1 Base Glyph records",
+                repeat="BaseGlyphCount",
+                aux=0,
+                description="Array of Version-1 Base Glyph records",
             ),
         ],
     ),
     (
         "BaseGlyphPaintRecord",
         [
-            ("GlyphID", "BaseGlyph", None, None, "Glyph ID of reference glyph."),
-            (
+            FieldSpec(
+                "GlyphID", "BaseGlyph", description="Glyph ID of reference glyph."
+            ),
+            FieldSpec(
                 "LOffset",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of BaseGlyphPaintRecord) to Paint, typically a PaintColrLayers.",
+                description="Offset (from beginning of BaseGlyphPaintRecord) to Paint, typically a PaintColrLayers.",
             ),
         ],
     ),
     (
         "LayerList",
         [
-            ("uint32", "LayerCount", None, None, "Number of Version-1 Layers"),
-            (
+            FieldSpec(
+                "uint32", "LayerCount", description="Number of Version-1 Layers"
+            ),
+            FieldSpec(
                 "LOffset",
                 "Paint",
-                "LayerCount",
-                0,
-                "Array of offsets to Paint tables, from the start of the LayerList table.",
+                repeat="LayerCount",
+                aux=0,
+                description="Array of offsets to Paint tables, from the start of the LayerList table.",
             ),
         ],
     ),
     (
         "ClipListFormat1",
         [
-            (
+            FieldSpec(
                 "uint8",
                 "Format",
-                None,
-                None,
-                "Format for ClipList with 16bit glyph IDs: 1",
+                description="Format for ClipList with 16bit glyph IDs: 1",
             ),
-            ("uint32", "ClipCount", None, None, "Number of Clip records."),
-            (
+            FieldSpec("uint32", "ClipCount", description="Number of Clip records."),
+            FieldSpec(
                 "struct",
                 "ClipRecord",
-                "ClipCount",
-                0,
-                "Array of Clip records sorted by glyph ID.",
+                repeat="ClipCount",
+                aux=0,
+                description="Array of Clip records sorted by glyph ID.",
             ),
         ],
     ),
     (
         "ClipRecord",
         [
-            ("uint16", "StartGlyphID", None, None, "First glyph ID in the range."),
-            ("uint16", "EndGlyphID", None, None, "Last glyph ID in the range."),
-            ("Offset24", "ClipBox", None, None, "Offset to a ClipBox table."),
+            FieldSpec(
+                "uint16", "StartGlyphID", description="First glyph ID in the range."
+            ),
+            FieldSpec(
+                "uint16", "EndGlyphID", description="Last glyph ID in the range."
+            ),
+            FieldSpec(
+                "Offset24", "ClipBox", description="Offset to a ClipBox table."
+            ),
         ],
     ),
     (
         "ClipBoxFormat1",
         [
-            (
+            FieldSpec(
                 "uint8",
                 "Format",
-                None,
-                None,
-                "Format for ClipBox without variation: set to 1.",
+                description="Format for ClipBox without variation: set to 1.",
             ),
-            ("int16", "xMin", None, None, "Minimum x of clip box."),
-            ("int16", "yMin", None, None, "Minimum y of clip box."),
-            ("int16", "xMax", None, None, "Maximum x of clip box."),
-            ("int16", "yMax", None, None, "Maximum y of clip box."),
+            FieldSpec("int16", "xMin", description="Minimum x of clip box."),
+            FieldSpec("int16", "yMin", description="Minimum y of clip box."),
+            FieldSpec("int16", "xMax", description="Maximum x of clip box."),
+            FieldSpec("int16", "yMax", description="Maximum y of clip box."),
         ],
     ),
     (
         "ClipBoxFormat2",
         [
-            ("uint8", "Format", None, None, "Format for variable ClipBox: set to 2."),
-            ("int16", "xMin", None, None, "Minimum x of clip box. VarIndexBase + 0."),
-            ("int16", "yMin", None, None, "Minimum y of clip box. VarIndexBase + 1."),
-            ("int16", "xMax", None, None, "Maximum x of clip box. VarIndexBase + 2."),
-            ("int16", "yMax", None, None, "Maximum y of clip box. VarIndexBase + 3."),
-            (
+            FieldSpec(
+                "uint8", "Format", description="Format for variable ClipBox: set to 2."
+            ),
+            FieldSpec(
+                "int16", "xMin", description="Minimum x of clip box. VarIndexBase + 0."
+            ),
+            FieldSpec(
+                "int16", "yMin", description="Minimum y of clip box. VarIndexBase + 1."
+            ),
+            FieldSpec(
+                "int16", "xMax", description="Maximum x of clip box. VarIndexBase + 2."
+            ),
+            FieldSpec(
+                "int16", "yMax", description="Maximum y of clip box. VarIndexBase + 3."
+            ),
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -5549,144 +5098,164 @@ otData = [
     (
         "Affine2x3",
         [
-            ("Fixed", "xx", None, None, "x-part of x basis vector"),
-            ("Fixed", "yx", None, None, "y-part of x basis vector"),
-            ("Fixed", "xy", None, None, "x-part of y basis vector"),
-            ("Fixed", "yy", None, None, "y-part of y basis vector"),
-            ("Fixed", "dx", None, None, "Translation in x direction"),
-            ("Fixed", "dy", None, None, "Translation in y direction"),
+            FieldSpec("Fixed", "xx", description="x-part of x basis vector"),
+            FieldSpec("Fixed", "yx", description="y-part of x basis vector"),
+            FieldSpec("Fixed", "xy", description="x-part of y basis vector"),
+            FieldSpec("Fixed", "yy", description="y-part of y basis vector"),
+            FieldSpec("Fixed", "dx", description="Translation in x direction"),
+            FieldSpec("Fixed", "dy", description="Translation in y direction"),
         ],
     ),
     (
         "VarAffine2x3",
         [
-            ("Fixed", "xx", None, None, "x-part of x basis vector. VarIndexBase + 0."),
-            ("Fixed", "yx", None, None, "y-part of x basis vector. VarIndexBase + 1."),
-            ("Fixed", "xy", None, None, "x-part of y basis vector. VarIndexBase + 2."),
-            ("Fixed", "yy", None, None, "y-part of y basis vector. VarIndexBase + 3."),
-            (
+            FieldSpec(
+                "Fixed", "xx", description="x-part of x basis vector. VarIndexBase + 0."
+            ),
+            FieldSpec(
+                "Fixed", "yx", description="y-part of x basis vector. VarIndexBase + 1."
+            ),
+            FieldSpec(
+                "Fixed", "xy", description="x-part of y basis vector. VarIndexBase + 2."
+            ),
+            FieldSpec(
+                "Fixed", "yy", description="y-part of y basis vector. VarIndexBase + 3."
+            ),
+            FieldSpec(
                 "Fixed",
                 "dx",
-                None,
-                None,
-                "Translation in x direction. VarIndexBase + 4.",
+                description="Translation in x direction. VarIndexBase + 4.",
             ),
-            (
+            FieldSpec(
                 "Fixed",
                 "dy",
-                None,
-                None,
-                "Translation in y direction. VarIndexBase + 5.",
+                description="Translation in y direction. VarIndexBase + 5.",
             ),
-            (
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
     (
         "ColorStop",
         [
-            ("F2Dot14", "StopOffset", None, None, ""),
-            ("uint16", "PaletteIndex", None, None, "Index for a CPAL palette entry."),
-            ("F2Dot14", "Alpha", None, None, "Values outsided [0.,1.] reserved"),
+            FieldSpec("F2Dot14", "StopOffset"),
+            FieldSpec(
+                "uint16", "PaletteIndex", description="Index for a CPAL palette entry."
+            ),
+            FieldSpec(
+                "F2Dot14", "Alpha", description="Values outsided [0.,1.] reserved"
+            ),
         ],
     ),
     (
         "VarColorStop",
         [
-            ("F2Dot14", "StopOffset", None, None, "VarIndexBase + 0."),
-            ("uint16", "PaletteIndex", None, None, "Index for a CPAL palette entry."),
-            (
+            FieldSpec("F2Dot14", "StopOffset", description="VarIndexBase + 0."),
+            FieldSpec(
+                "uint16", "PaletteIndex", description="Index for a CPAL palette entry."
+            ),
+            FieldSpec(
                 "F2Dot14",
                 "Alpha",
-                None,
-                None,
-                "Values outsided [0.,1.] reserved. VarIndexBase + 1.",
+                description="Values outsided [0.,1.] reserved. VarIndexBase + 1.",
             ),
-            (
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
     (
         "ColorLine",
         [
-            (
+            FieldSpec(
                 "ExtendMode",
                 "Extend",
-                None,
-                None,
-                "Enum {PAD = 0, REPEAT = 1, REFLECT = 2}",
+                description="Enum {PAD = 0, REPEAT = 1, REFLECT = 2}",
             ),
-            ("uint16", "StopCount", None, None, "Number of Color stops."),
-            ("ColorStop", "ColorStop", "StopCount", 0, "Array of Color stops."),
+            FieldSpec("uint16", "StopCount", description="Number of Color stops."),
+            FieldSpec(
+                "ColorStop",
+                "ColorStop",
+                repeat="StopCount",
+                aux=0,
+                description="Array of Color stops.",
+            ),
         ],
     ),
     (
         "VarColorLine",
         [
-            (
+            FieldSpec(
                 "ExtendMode",
                 "Extend",
-                None,
-                None,
-                "Enum {PAD = 0, REPEAT = 1, REFLECT = 2}",
+                description="Enum {PAD = 0, REPEAT = 1, REFLECT = 2}",
             ),
-            ("uint16", "StopCount", None, None, "Number of Color stops."),
-            ("VarColorStop", "ColorStop", "StopCount", 0, "Array of Color stops."),
+            FieldSpec("uint16", "StopCount", description="Number of Color stops."),
+            FieldSpec(
+                "VarColorStop",
+                "ColorStop",
+                repeat="StopCount",
+                aux=0,
+                description="Array of Color stops.",
+            ),
         ],
     ),
     # PaintColrLayers
     (
         "PaintFormat1",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 1"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 1"
+            ),
+            FieldSpec(
                 "uint8",
                 "NumLayers",
-                None,
-                None,
-                "Number of offsets to Paint to read from LayerList.",
+                description="Number of offsets to Paint to read from LayerList.",
             ),
-            ("uint32", "FirstLayerIndex", None, None, "Index into LayerList."),
+            FieldSpec(
+                "uint32", "FirstLayerIndex", description="Index into LayerList."
+            ),
         ],
     ),
     # PaintSolid
     (
         "PaintFormat2",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 2"),
-            ("uint16", "PaletteIndex", None, None, "Index for a CPAL palette entry."),
-            ("F2Dot14", "Alpha", None, None, "Values outsided [0.,1.] reserved"),
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 2"
+            ),
+            FieldSpec(
+                "uint16", "PaletteIndex", description="Index for a CPAL palette entry."
+            ),
+            FieldSpec(
+                "F2Dot14", "Alpha", description="Values outsided [0.,1.] reserved"
+            ),
         ],
     ),
     # PaintVarSolid
     (
         "PaintFormat3",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 3"),
-            ("uint16", "PaletteIndex", None, None, "Index for a CPAL palette entry."),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 3"
+            ),
+            FieldSpec(
+                "uint16", "PaletteIndex", description="Index for a CPAL palette entry."
+            ),
+            FieldSpec(
                 "F2Dot14",
                 "Alpha",
-                None,
-                None,
-                "Values outsided [0.,1.] reserved. VarIndexBase + 0.",
+                description="Values outsided [0.,1.] reserved. VarIndexBase + 0.",
             ),
-            (
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -5694,46 +5263,44 @@ otData = [
     (
         "PaintFormat4",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 4"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 4"
+            ),
+            FieldSpec(
                 "Offset24",
                 "ColorLine",
-                None,
-                None,
-                "Offset (from beginning of PaintLinearGradient table) to ColorLine subtable.",
+                description="Offset (from beginning of PaintLinearGradient table) to ColorLine subtable.",
             ),
-            ("int16", "x0", None, None, ""),
-            ("int16", "y0", None, None, ""),
-            ("int16", "x1", None, None, ""),
-            ("int16", "y1", None, None, ""),
-            ("int16", "x2", None, None, ""),
-            ("int16", "y2", None, None, ""),
+            FieldSpec("int16", "x0"),
+            FieldSpec("int16", "y0"),
+            FieldSpec("int16", "x1"),
+            FieldSpec("int16", "y1"),
+            FieldSpec("int16", "x2"),
+            FieldSpec("int16", "y2"),
         ],
     ),
     # PaintVarLinearGradient
     (
         "PaintFormat5",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 5"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 5"
+            ),
+            FieldSpec(
                 "LOffset24To(VarColorLine)",
                 "ColorLine",
-                None,
-                None,
-                "Offset (from beginning of PaintVarLinearGradient table) to VarColorLine subtable.",
+                description="Offset (from beginning of PaintVarLinearGradient table) to VarColorLine subtable.",
             ),
-            ("int16", "x0", None, None, "VarIndexBase + 0."),
-            ("int16", "y0", None, None, "VarIndexBase + 1."),
-            ("int16", "x1", None, None, "VarIndexBase + 2."),
-            ("int16", "y1", None, None, "VarIndexBase + 3."),
-            ("int16", "x2", None, None, "VarIndexBase + 4."),
-            ("int16", "y2", None, None, "VarIndexBase + 5."),
-            (
+            FieldSpec("int16", "x0", description="VarIndexBase + 0."),
+            FieldSpec("int16", "y0", description="VarIndexBase + 1."),
+            FieldSpec("int16", "x1", description="VarIndexBase + 2."),
+            FieldSpec("int16", "y1", description="VarIndexBase + 3."),
+            FieldSpec("int16", "x2", description="VarIndexBase + 4."),
+            FieldSpec("int16", "y2", description="VarIndexBase + 5."),
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -5741,46 +5308,44 @@ otData = [
     (
         "PaintFormat6",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 6"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 6"
+            ),
+            FieldSpec(
                 "Offset24",
                 "ColorLine",
-                None,
-                None,
-                "Offset (from beginning of PaintRadialGradient table) to ColorLine subtable.",
+                description="Offset (from beginning of PaintRadialGradient table) to ColorLine subtable.",
             ),
-            ("int16", "x0", None, None, ""),
-            ("int16", "y0", None, None, ""),
-            ("uint16", "r0", None, None, ""),
-            ("int16", "x1", None, None, ""),
-            ("int16", "y1", None, None, ""),
-            ("uint16", "r1", None, None, ""),
+            FieldSpec("int16", "x0"),
+            FieldSpec("int16", "y0"),
+            FieldSpec("uint16", "r0"),
+            FieldSpec("int16", "x1"),
+            FieldSpec("int16", "y1"),
+            FieldSpec("uint16", "r1"),
         ],
     ),
     # PaintVarRadialGradient
     (
         "PaintFormat7",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 7"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 7"
+            ),
+            FieldSpec(
                 "LOffset24To(VarColorLine)",
                 "ColorLine",
-                None,
-                None,
-                "Offset (from beginning of PaintVarRadialGradient table) to VarColorLine subtable.",
+                description="Offset (from beginning of PaintVarRadialGradient table) to VarColorLine subtable.",
             ),
-            ("int16", "x0", None, None, "VarIndexBase + 0."),
-            ("int16", "y0", None, None, "VarIndexBase + 1."),
-            ("uint16", "r0", None, None, "VarIndexBase + 2."),
-            ("int16", "x1", None, None, "VarIndexBase + 3."),
-            ("int16", "y1", None, None, "VarIndexBase + 4."),
-            ("uint16", "r1", None, None, "VarIndexBase + 5."),
-            (
+            FieldSpec("int16", "x0", description="VarIndexBase + 0."),
+            FieldSpec("int16", "y0", description="VarIndexBase + 1."),
+            FieldSpec("uint16", "r0", description="VarIndexBase + 2."),
+            FieldSpec("int16", "x1", description="VarIndexBase + 3."),
+            FieldSpec("int16", "y1", description="VarIndexBase + 4."),
+            FieldSpec("uint16", "r1", description="VarIndexBase + 5."),
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -5788,29 +5353,25 @@ otData = [
     (
         "PaintFormat8",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 8"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 8"
+            ),
+            FieldSpec(
                 "Offset24",
                 "ColorLine",
-                None,
-                None,
-                "Offset (from beginning of PaintSweepGradient table) to ColorLine subtable.",
+                description="Offset (from beginning of PaintSweepGradient table) to ColorLine subtable.",
             ),
-            ("int16", "centerX", None, None, "Center x coordinate."),
-            ("int16", "centerY", None, None, "Center y coordinate."),
-            (
+            FieldSpec("int16", "centerX", description="Center x coordinate."),
+            FieldSpec("int16", "centerY", description="Center y coordinate."),
+            FieldSpec(
                 "BiasedAngle",
                 "startAngle",
-                None,
-                None,
-                "Start of the angular range of the gradient.",
+                description="Start of the angular range of the gradient.",
             ),
-            (
+            FieldSpec(
                 "BiasedAngle",
                 "endAngle",
-                None,
-                None,
-                "End of the angular range of the gradient.",
+                description="End of the angular range of the gradient.",
             ),
         ],
     ),
@@ -5818,36 +5379,34 @@ otData = [
     (
         "PaintFormat9",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 9"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 9"
+            ),
+            FieldSpec(
                 "LOffset24To(VarColorLine)",
                 "ColorLine",
-                None,
-                None,
-                "Offset (from beginning of PaintVarSweepGradient table) to VarColorLine subtable.",
+                description="Offset (from beginning of PaintVarSweepGradient table) to VarColorLine subtable.",
             ),
-            ("int16", "centerX", None, None, "Center x coordinate. VarIndexBase + 0."),
-            ("int16", "centerY", None, None, "Center y coordinate. VarIndexBase + 1."),
-            (
+            FieldSpec(
+                "int16", "centerX", description="Center x coordinate. VarIndexBase + 0."
+            ),
+            FieldSpec(
+                "int16", "centerY", description="Center y coordinate. VarIndexBase + 1."
+            ),
+            FieldSpec(
                 "BiasedAngle",
                 "startAngle",
-                None,
-                None,
-                "Start of the angular range of the gradient. VarIndexBase + 2.",
+                description="Start of the angular range of the gradient. VarIndexBase + 2.",
             ),
-            (
+            FieldSpec(
                 "BiasedAngle",
                 "endAngle",
-                None,
-                None,
-                "End of the angular range of the gradient. VarIndexBase + 3.",
+                description="End of the angular range of the gradient. VarIndexBase + 3.",
             ),
-            (
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -5855,28 +5414,30 @@ otData = [
     (
         "PaintFormat10",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 10"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 10"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintGlyph table) to Paint subtable.",
+                description="Offset (from beginning of PaintGlyph table) to Paint subtable.",
             ),
-            ("GlyphID", "Glyph", None, None, "Glyph ID for the source outline."),
+            FieldSpec(
+                "GlyphID", "Glyph", description="Glyph ID for the source outline."
+            ),
         ],
     ),
     # PaintColrGlyph
     (
         "PaintFormat11",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 11"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 11"
+            ),
+            FieldSpec(
                 "GlyphID",
                 "Glyph",
-                None,
-                None,
-                "Virtual glyph ID for a BaseGlyphList base glyph.",
+                description="Virtual glyph ID for a BaseGlyphList base glyph.",
             ),
         ],
     ),
@@ -5884,20 +5445,18 @@ otData = [
     (
         "PaintFormat12",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 12"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 12"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintTransform table) to Paint subtable.",
+                description="Offset (from beginning of PaintTransform table) to Paint subtable.",
             ),
-            (
+            FieldSpec(
                 "LOffset24To(Affine2x3)",
                 "Transform",
-                None,
-                None,
-                "2x3 matrix for 2D affine transformations.",
+                description="2x3 matrix for 2D affine transformations.",
             ),
         ],
     ),
@@ -5905,20 +5464,18 @@ otData = [
     (
         "PaintFormat13",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 13"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 13"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintVarTransform table) to Paint subtable.",
+                description="Offset (from beginning of PaintVarTransform table) to Paint subtable.",
             ),
-            (
+            FieldSpec(
                 "LOffset24To(VarAffine2x3)",
                 "Transform",
-                None,
-                None,
-                "2x3 matrix for 2D affine transformations.",
+                description="2x3 matrix for 2D affine transformations.",
             ),
         ],
     ),
@@ -5926,50 +5483,44 @@ otData = [
     (
         "PaintFormat14",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 14"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 14"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintTranslate table) to Paint subtable.",
+                description="Offset (from beginning of PaintTranslate table) to Paint subtable.",
             ),
-            ("int16", "dx", None, None, "Translation in x direction."),
-            ("int16", "dy", None, None, "Translation in y direction."),
+            FieldSpec("int16", "dx", description="Translation in x direction."),
+            FieldSpec("int16", "dy", description="Translation in y direction."),
         ],
     ),
     # PaintVarTranslate
     (
         "PaintFormat15",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 15"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 15"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintVarTranslate table) to Paint subtable.",
+                description="Offset (from beginning of PaintVarTranslate table) to Paint subtable.",
             ),
-            (
+            FieldSpec(
                 "int16",
                 "dx",
-                None,
-                None,
-                "Translation in x direction. VarIndexBase + 0.",
+                description="Translation in x direction. VarIndexBase + 0.",
             ),
-            (
+            FieldSpec(
                 "int16",
                 "dy",
-                None,
-                None,
-                "Translation in y direction. VarIndexBase + 1.",
+                description="Translation in y direction. VarIndexBase + 1.",
             ),
-            (
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -5977,38 +5528,36 @@ otData = [
     (
         "PaintFormat16",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 16"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 16"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintScale table) to Paint subtable.",
+                description="Offset (from beginning of PaintScale table) to Paint subtable.",
             ),
-            ("F2Dot14", "scaleX", None, None, ""),
-            ("F2Dot14", "scaleY", None, None, ""),
+            FieldSpec("F2Dot14", "scaleX"),
+            FieldSpec("F2Dot14", "scaleY"),
         ],
     ),
     # PaintVarScale
     (
         "PaintFormat17",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 17"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 17"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintVarScale table) to Paint subtable.",
+                description="Offset (from beginning of PaintVarScale table) to Paint subtable.",
             ),
-            ("F2Dot14", "scaleX", None, None, "VarIndexBase + 0."),
-            ("F2Dot14", "scaleY", None, None, "VarIndexBase + 1."),
-            (
+            FieldSpec("F2Dot14", "scaleX", description="VarIndexBase + 0."),
+            FieldSpec("F2Dot14", "scaleY", description="VarIndexBase + 1."),
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -6016,42 +5565,40 @@ otData = [
     (
         "PaintFormat18",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 18"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 18"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintScaleAroundCenter table) to Paint subtable.",
+                description="Offset (from beginning of PaintScaleAroundCenter table) to Paint subtable.",
             ),
-            ("F2Dot14", "scaleX", None, None, ""),
-            ("F2Dot14", "scaleY", None, None, ""),
-            ("int16", "centerX", None, None, ""),
-            ("int16", "centerY", None, None, ""),
+            FieldSpec("F2Dot14", "scaleX"),
+            FieldSpec("F2Dot14", "scaleY"),
+            FieldSpec("int16", "centerX"),
+            FieldSpec("int16", "centerY"),
         ],
     ),
     # PaintVarScaleAroundCenter
     (
         "PaintFormat19",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 19"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 19"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintVarScaleAroundCenter table) to Paint subtable.",
+                description="Offset (from beginning of PaintVarScaleAroundCenter table) to Paint subtable.",
             ),
-            ("F2Dot14", "scaleX", None, None, "VarIndexBase + 0."),
-            ("F2Dot14", "scaleY", None, None, "VarIndexBase + 1."),
-            ("int16", "centerX", None, None, "VarIndexBase + 2."),
-            ("int16", "centerY", None, None, "VarIndexBase + 3."),
-            (
+            FieldSpec("F2Dot14", "scaleX", description="VarIndexBase + 0."),
+            FieldSpec("F2Dot14", "scaleY", description="VarIndexBase + 1."),
+            FieldSpec("int16", "centerX", description="VarIndexBase + 2."),
+            FieldSpec("int16", "centerY", description="VarIndexBase + 3."),
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -6059,36 +5606,34 @@ otData = [
     (
         "PaintFormat20",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 20"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 20"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintScaleUniform table) to Paint subtable.",
+                description="Offset (from beginning of PaintScaleUniform table) to Paint subtable.",
             ),
-            ("F2Dot14", "scale", None, None, ""),
+            FieldSpec("F2Dot14", "scale"),
         ],
     ),
     # PaintVarScaleUniform
     (
         "PaintFormat21",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 21"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 21"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintVarScaleUniform table) to Paint subtable.",
+                description="Offset (from beginning of PaintVarScaleUniform table) to Paint subtable.",
             ),
-            ("F2Dot14", "scale", None, None, "VarIndexBase + 0."),
-            (
+            FieldSpec("F2Dot14", "scale", description="VarIndexBase + 0."),
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -6096,40 +5641,38 @@ otData = [
     (
         "PaintFormat22",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 22"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 22"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintScaleUniformAroundCenter table) to Paint subtable.",
+                description="Offset (from beginning of PaintScaleUniformAroundCenter table) to Paint subtable.",
             ),
-            ("F2Dot14", "scale", None, None, ""),
-            ("int16", "centerX", None, None, ""),
-            ("int16", "centerY", None, None, ""),
+            FieldSpec("F2Dot14", "scale"),
+            FieldSpec("int16", "centerX"),
+            FieldSpec("int16", "centerY"),
         ],
     ),
     # PaintVarScaleUniformAroundCenter
     (
         "PaintFormat23",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 23"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 23"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintVarScaleUniformAroundCenter table) to Paint subtable.",
+                description="Offset (from beginning of PaintVarScaleUniformAroundCenter table) to Paint subtable.",
             ),
-            ("F2Dot14", "scale", None, None, "VarIndexBase + 0"),
-            ("int16", "centerX", None, None, "VarIndexBase + 1"),
-            ("int16", "centerY", None, None, "VarIndexBase + 2"),
-            (
+            FieldSpec("F2Dot14", "scale", description="VarIndexBase + 0"),
+            FieldSpec("int16", "centerX", description="VarIndexBase + 1"),
+            FieldSpec("int16", "centerY", description="VarIndexBase + 2"),
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -6137,36 +5680,34 @@ otData = [
     (
         "PaintFormat24",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 24"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 24"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintRotate table) to Paint subtable.",
+                description="Offset (from beginning of PaintRotate table) to Paint subtable.",
             ),
-            ("Angle", "angle", None, None, ""),
+            FieldSpec("Angle", "angle"),
         ],
     ),
     # PaintVarRotate
     (
         "PaintFormat25",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 25"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 25"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintVarRotate table) to Paint subtable.",
+                description="Offset (from beginning of PaintVarRotate table) to Paint subtable.",
             ),
-            ("Angle", "angle", None, None, "VarIndexBase + 0."),
-            (
+            FieldSpec("Angle", "angle", description="VarIndexBase + 0."),
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -6174,40 +5715,38 @@ otData = [
     (
         "PaintFormat26",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 26"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 26"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintRotateAroundCenter table) to Paint subtable.",
+                description="Offset (from beginning of PaintRotateAroundCenter table) to Paint subtable.",
             ),
-            ("Angle", "angle", None, None, ""),
-            ("int16", "centerX", None, None, ""),
-            ("int16", "centerY", None, None, ""),
+            FieldSpec("Angle", "angle"),
+            FieldSpec("int16", "centerX"),
+            FieldSpec("int16", "centerY"),
         ],
     ),
     # PaintVarRotateAroundCenter
     (
         "PaintFormat27",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 27"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 27"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintVarRotateAroundCenter table) to Paint subtable.",
+                description="Offset (from beginning of PaintVarRotateAroundCenter table) to Paint subtable.",
             ),
-            ("Angle", "angle", None, None, "VarIndexBase + 0."),
-            ("int16", "centerX", None, None, "VarIndexBase + 1."),
-            ("int16", "centerY", None, None, "VarIndexBase + 2."),
-            (
+            FieldSpec("Angle", "angle", description="VarIndexBase + 0."),
+            FieldSpec("int16", "centerX", description="VarIndexBase + 1."),
+            FieldSpec("int16", "centerY", description="VarIndexBase + 2."),
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -6215,38 +5754,36 @@ otData = [
     (
         "PaintFormat28",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 28"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 28"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintSkew table) to Paint subtable.",
+                description="Offset (from beginning of PaintSkew table) to Paint subtable.",
             ),
-            ("Angle", "xSkewAngle", None, None, ""),
-            ("Angle", "ySkewAngle", None, None, ""),
+            FieldSpec("Angle", "xSkewAngle"),
+            FieldSpec("Angle", "ySkewAngle"),
         ],
     ),
     # PaintVarSkew
     (
         "PaintFormat29",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 29"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 29"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintVarSkew table) to Paint subtable.",
+                description="Offset (from beginning of PaintVarSkew table) to Paint subtable.",
             ),
-            ("Angle", "xSkewAngle", None, None, "VarIndexBase + 0."),
-            ("Angle", "ySkewAngle", None, None, "VarIndexBase + 1."),
-            (
+            FieldSpec("Angle", "xSkewAngle", description="VarIndexBase + 0."),
+            FieldSpec("Angle", "ySkewAngle", description="VarIndexBase + 1."),
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -6254,42 +5791,40 @@ otData = [
     (
         "PaintFormat30",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 30"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 30"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintSkewAroundCenter table) to Paint subtable.",
+                description="Offset (from beginning of PaintSkewAroundCenter table) to Paint subtable.",
             ),
-            ("Angle", "xSkewAngle", None, None, ""),
-            ("Angle", "ySkewAngle", None, None, ""),
-            ("int16", "centerX", None, None, ""),
-            ("int16", "centerY", None, None, ""),
+            FieldSpec("Angle", "xSkewAngle"),
+            FieldSpec("Angle", "ySkewAngle"),
+            FieldSpec("int16", "centerX"),
+            FieldSpec("int16", "centerY"),
         ],
     ),
     # PaintVarSkewAroundCenter
     (
         "PaintFormat31",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 31"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 31"
+            ),
+            FieldSpec(
                 "Offset24",
                 "Paint",
-                None,
-                None,
-                "Offset (from beginning of PaintVarSkewAroundCenter table) to Paint subtable.",
+                description="Offset (from beginning of PaintVarSkewAroundCenter table) to Paint subtable.",
             ),
-            ("Angle", "xSkewAngle", None, None, "VarIndexBase + 0."),
-            ("Angle", "ySkewAngle", None, None, "VarIndexBase + 1."),
-            ("int16", "centerX", None, None, "VarIndexBase + 2."),
-            ("int16", "centerY", None, None, "VarIndexBase + 3."),
-            (
+            FieldSpec("Angle", "xSkewAngle", description="VarIndexBase + 0."),
+            FieldSpec("Angle", "ySkewAngle", description="VarIndexBase + 1."),
+            FieldSpec("int16", "centerX", description="VarIndexBase + 2."),
+            FieldSpec("int16", "centerY", description="VarIndexBase + 3."),
+            FieldSpec(
                 "VarIndex",
                 "VarIndexBase",
-                None,
-                None,
-                "Base index into DeltaSetIndexMap.",
+                description="Base index into DeltaSetIndexMap.",
             ),
         ],
     ),
@@ -6297,27 +5832,23 @@ otData = [
     (
         "PaintFormat32",
         [
-            ("uint8", "PaintFormat", None, None, "Format identifier-format = 32"),
-            (
+            FieldSpec(
+                "uint8", "PaintFormat", description="Format identifier-format = 32"
+            ),
+            FieldSpec(
                 "LOffset24To(Paint)",
                 "SourcePaint",
-                None,
-                None,
-                "Offset (from beginning of PaintComposite table) to source Paint subtable.",
+                description="Offset (from beginning of PaintComposite table) to source Paint subtable.",
             ),
-            (
+            FieldSpec(
                 "CompositeMode",
                 "CompositeMode",
-                None,
-                None,
-                "A CompositeMode enumeration value.",
+                description="A CompositeMode enumeration value.",
             ),
-            (
+            FieldSpec(
                 "LOffset24To(Paint)",
                 "BackdropPaint",
-                None,
-                None,
-                "Offset (from beginning of PaintComposite table) to backdrop Paint subtable.",
+                description="Offset (from beginning of PaintComposite table) to backdrop Paint subtable.",
             ),
         ],
     ),
@@ -6327,74 +5858,62 @@ otData = [
     (
         "AxisValueMap",
         [
-            (
+            FieldSpec(
                 "F2Dot14",
                 "FromCoordinate",
-                None,
-                None,
-                "A normalized coordinate value obtained using default normalization",
+                description="A normalized coordinate value obtained using default normalization",
             ),
-            (
+            FieldSpec(
                 "F2Dot14",
                 "ToCoordinate",
-                None,
-                None,
-                "The modified, normalized coordinate value",
+                description="The modified, normalized coordinate value",
             ),
         ],
     ),
     (
         "AxisSegmentMap",
         [
-            (
+            FieldSpec(
                 "uint16",
                 "PositionMapCount",
-                None,
-                None,
-                "The number of correspondence pairs for this axis",
+                description="The number of correspondence pairs for this axis",
             ),
-            (
+            FieldSpec(
                 "AxisValueMap",
                 "AxisValueMap",
-                "PositionMapCount",
-                0,
-                "The array of axis value map records for this axis",
+                repeat="PositionMapCount",
+                aux=0,
+                description="The array of axis value map records for this axis",
             ),
         ],
     ),
     (
         "avar",
         [
-            (
+            FieldSpec(
                 "Version",
                 "Version",
-                None,
-                None,
-                "Version of the avar table- 0x00010000 or 0x00020000",
+                description="Version of the avar table- 0x00010000 or 0x00020000",
             ),
-            ("uint16", "Reserved", None, None, "Permanently reserved; set to zero"),
-            (
+            FieldSpec(
+                "uint16", "Reserved", description="Permanently reserved; set to zero"
+            ),
+            FieldSpec(
                 "uint16",
                 "AxisCount",
-                None,
-                None,
-                'The number of variation axes for this font. This must be the same number as axisCount in the "fvar" table',
+                description='The number of variation axes for this font. This must be the same number as axisCount in the "fvar" table',
             ),
-            (
+            FieldSpec(
                 "AxisSegmentMap",
                 "AxisSegmentMap",
-                "AxisCount",
-                0,
-                'The segment maps array — one segment map for each axis, in the order of axes specified in the "fvar" table',
+                repeat="AxisCount",
+                aux=0,
+                description='The segment maps array — one segment map for each axis, in the order of axes specified in the "fvar" table',
             ),
-            (
-                "LOffsetTo(DeltaSetIndexMap)",
-                "VarIdxMap",
-                None,
-                "Version >= 0x00020000",
-                "",
+            FieldSpec(
+                "LOffsetTo(DeltaSetIndexMap)", "VarIdxMap", aux="Version >= 0x00020000"
             ),
-            ("LOffset", "VarStore", None, "Version >= 0x00020000", ""),
+            FieldSpec("LOffset", "VarStore", aux="Version >= 0x00020000"),
         ],
     ),
     #
@@ -6405,83 +5924,65 @@ otData = [
     (
         "PatchMapFormat2",
         [
-            (
-                "uint8",
-                "Format",
-                None,
-                None,
-                "Set to 2, identifies this as format 2.",
+            FieldSpec(
+                "uint8", "Format", description="Set to 2, identifies this as format 2."
             ),
-            ("uint24", "Reserved", None, None, "Not used, set to 0."),
-            (
+            FieldSpec("uint24", "Reserved", description="Not used, set to 0."),
+            FieldSpec(
                 "uint8",
                 "Flags",
-                None,
-                None,
-                "Bit 0: CffCharStringsOffset present. Bit 1: Cff2CharStringsOffset present.",
+                description="Bit 0: CffCharStringsOffset present. Bit 1: Cff2CharStringsOffset present.",
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "CompatibilityId",
-                4,
-                0,
-                "Unique ID to identify compatible patches (16 bytes).",
+                repeat=4,
+                aux=0,
+                description="Unique ID to identify compatible patches (16 bytes).",
             ),
-            (
+            FieldSpec(
                 "uint8",
                 "DefaultPatchFormat",
-                None,
-                None,
-                "Default format of patches linked to by urlTemplate.",
+                description="Default format of patches linked to by urlTemplate.",
             ),
-            (
+            FieldSpec(
                 "uint24",
                 "NumEntries",
-                None,
-                None,
-                "Number of entries encoded in this table.",
+                description="Number of entries encoded in this table.",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "MappingEntries",
-                None,
-                None,
-                "Offset to a MappingEntries sub-table.",
+                description="Offset to a MappingEntries sub-table.",
             ),
-            (
+            FieldSpec(
                 "LOffset",
                 "EntryIdStringData",
-                None,
-                None,
-                "Offset to entry ID string data block. May be null (0).",
+                description="Offset to entry ID string data block. May be null (0).",
             ),
-            (
+            FieldSpec(
                 "uint16",
                 "UrlTemplateLength",
-                None,
-                None,
-                "Length of the urlTemplate byte array.",
+                description="Length of the urlTemplate byte array.",
             ),
-            (
+            FieldSpec(
                 "uint8",
                 "UrlTemplate",
-                "UrlTemplateLength",
-                0,
-                "URL Template bytes used to produce URL strings for each entry.",
+                repeat="UrlTemplateLength",
+                aux=0,
+                description="URL Template bytes used to produce URL strings for each entry.",
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "CffCharStringsOffset",
-                None,
-                "Flags & 0x01",
-                "Offset from start of CFF table to CharStrings INDEX.",
+                aux="Flags & 0x01",
+                description="Offset from start of CFF table to CharStrings INDEX.",
             ),
-            (
+            FieldSpec(
                 "uint32",
                 "Cff2CharStringsOffset",
-                None,
-                "Flags & 0x02",
-                "Offset from start of CFF2 table to CharStrings INDEX.",
+                aux="Flags & 0x02",
+                description="Offset from start of CFF2 table to CharStrings INDEX.",
             ),
         ],
     ),
@@ -6489,7 +5990,13 @@ otData = [
     # 'MappingEntriesConverter' is used to do a stateful parsing of all records.
     (
         "MappingEntries",
-        [("MappingEntries", "entries", None, None, "Array of MappingEntry records.")],
+        [
+            FieldSpec(
+                "MappingEntries",
+                "entries",
+                description="Array of MappingEntry records.",
+            )
+        ],
     ),
     ("EntryIdStringData", []),
 ]

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -54,9 +54,7 @@ otData = [
     (
         "LangSysRecord",
         [
-            FieldSpec(
-                "Tag", "LangSysTag", description="4-byte LangSysTag identifier"
-            ),
+            FieldSpec("Tag", "LangSysTag", description="4-byte LangSysTag identifier"),
             FieldSpec(
                 "Offset",
                 "LangSys",
@@ -189,9 +187,7 @@ otData = [
                 "FeatUITooltipTextNameID",
                 description="Feature UI tooltip text NameID.",
             ),
-            FieldSpec(
-                "NameID", "SampleTextNameID", description="Sample text NameID."
-            ),
+            FieldSpec("NameID", "SampleTextNameID", description="Sample text NameID."),
             FieldSpec(
                 "uint16",
                 "NumNamedParameters",
@@ -483,9 +479,7 @@ otData = [
                 "ValueFormat2",
                 description="Defines the types of data in ValueRecord2-for the second glyph in the pair -may be zero (0)",
             ),
-            FieldSpec(
-                "uint16", "PairSetCount", description="Number of PairSet tables"
-            ),
+            FieldSpec("uint16", "PairSetCount", description="Number of PairSet tables"),
             FieldSpec(
                 "Offset",
                 "PairSet",
@@ -879,9 +873,7 @@ otData = [
     (
         "PosRuleSet",
         [
-            FieldSpec(
-                "uint16", "PosRuleCount", description="Number of PosRule tables"
-            ),
+            FieldSpec("uint16", "PosRuleCount", description="Number of PosRule tables"),
             FieldSpec(
                 "Offset",
                 "PosRule",
@@ -1626,9 +1618,7 @@ otData = [
     (
         "SubRuleSet",
         [
-            FieldSpec(
-                "uint16", "SubRuleCount", description="Number of SubRule tables"
-            ),
+            FieldSpec("uint16", "SubRuleCount", description="Number of SubRule tables"),
             FieldSpec(
                 "Offset",
                 "SubRule",
@@ -3054,9 +3044,7 @@ otData = [
         "ConditionTableFormat5",
         [
             FieldSpec("uint16", "Format", description="Format, = 5"),
-            FieldSpec(
-                "Offset24", "ConditionTable", description="Condition to negate."
-            ),
+            FieldSpec("Offset24", "ConditionTable", description="Condition to negate."),
         ],
     ),
     (
@@ -4164,9 +4152,7 @@ otData = [
                 "Version",
                 description="Version of the feat table-initially set to 0x00010000.",
             ),
-            FieldSpec(
-                "FeatureNames", "FeatureNames", description="The feature names."
-            ),
+            FieldSpec("FeatureNames", "FeatureNames", description="The feature names."),
         ],
     ),
     (
@@ -4295,9 +4281,7 @@ otData = [
                 "Version",
                 description="Version number of the ligature caret table (0x00010000 for the initial version).",
             ),
-            FieldSpec(
-                "struct", "LigatureCarets", description="Ligature carets table."
-            ),
+            FieldSpec("struct", "LigatureCarets", description="Ligature carets table."),
         ],
     ),
     (
@@ -5006,9 +4990,7 @@ otData = [
     (
         "LayerList",
         [
-            FieldSpec(
-                "uint32", "LayerCount", description="Number of Version-1 Layers"
-            ),
+            FieldSpec("uint32", "LayerCount", description="Number of Version-1 Layers"),
             FieldSpec(
                 "LOffset",
                 "Paint",
@@ -5045,9 +5027,7 @@ otData = [
             FieldSpec(
                 "uint16", "EndGlyphID", description="Last glyph ID in the range."
             ),
-            FieldSpec(
-                "Offset24", "ClipBox", description="Offset to a ClipBox table."
-            ),
+            FieldSpec("Offset24", "ClipBox", description="Offset to a ClipBox table."),
         ],
     ),
     (
@@ -5220,9 +5200,7 @@ otData = [
                 "NumLayers",
                 description="Number of offsets to Paint to read from LayerList.",
             ),
-            FieldSpec(
-                "uint32", "FirstLayerIndex", description="Index into LayerList."
-            ),
+            FieldSpec("uint32", "FirstLayerIndex", description="Index into LayerList."),
         ],
     ),
     # PaintSolid

--- a/Lib/fontTools/ttLib/tables/otDataSchema.py
+++ b/Lib/fontTools/ttLib/tables/otDataSchema.py
@@ -1,0 +1,39 @@
+"""fontTools.ttLib.tables.otDataSchema -- contains the FieldSpec dataclass, which is
+used to define the schema of OpenType tables in otData.py.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class FieldSpec:
+    """Represents a single field in an OpenType table schema.
+
+    These are defined in `otData.py` and used to construct converters in
+    `otConverters.py`.
+
+    Attributes:
+        type: The type of the field. This string is used by `otConverters.py` to
+            select or construct the appropriate converter. It can be a simple
+            type name (e.g. 'uint16', 'Tag', 'Offset'), a specialized type (e.g.
+            'ValueRecord', 'DeltaValue'), or a more complex expression (e.g.
+            'OffsetTo(AatStateTable)', 'AATLookup(UShort)') which is evaluated
+            to create a converter factory.
+        name: The name of the field as defined in the OpenType specification.
+        repeat: If the field is an array, this defines how many times it
+            repeats. It can be an integer, or the name of another field (usually
+            a 'Count' field) that contains the number of repetitions. If it is a
+            string, it is used to lookup the count value from the table.
+        aux: Auxiliary data used by some converters. When `repeat` is not set
+            and `aux` is a string, it is often compiled into a Python
+            expression for evaluation. For repeating structs, it is often used
+            as a constant or an expression.
+        description: A human-readable description of the field's purpose.
+    """
+
+    type: str
+    name: str
+    repeat: Any = None
+    aux: Any = None
+    description: str = ""

--- a/Lib/fontTools/ttLib/tables/otDataSchema.py
+++ b/Lib/fontTools/ttLib/tables/otDataSchema.py
@@ -2,12 +2,10 @@
 used to define the schema of OpenType tables in otData.py.
 """
 
-from dataclasses import dataclass
-from typing import Any
+from typing import Any, NamedTuple
 
 
-@dataclass
-class FieldSpec:
+class FieldSpec(NamedTuple):
     """Represents a single field in an OpenType table schema.
 
     These are defined in `otData.py` and used to construct converters in

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -2619,7 +2619,7 @@ def _buildClasses():
     namespace = globals()
 
     # populate module with classes
-    for name, table in otData:
+    for name, fields in otData:
         baseClass = BaseTable
         m = formatPat.match(name)
         if m:
@@ -2628,7 +2628,7 @@ def _buildClasses():
             # the first row of a format-switching otData table describes the Format;
             # the first column defines the type of the Format field.
             # Currently this can be either 'uint16' or 'uint8'.
-            formatType = table[0][0]
+            formatType = fields[0].type
             baseClass = getFormatSwitchingBaseTableClass(formatType)
         if name not in namespace:
             # the class doesn't exist yet, so the base implementation is used.
@@ -2702,7 +2702,7 @@ def _buildClasses():
     # add converters to classes
     from .otConverters import buildConverters
 
-    for name, table in otData:
+    for name, fields in otData:
         m = formatPat.match(name)
         if m:
             # XxxFormatN subtable, add converter to "base" table
@@ -2712,13 +2712,13 @@ def _buildClasses():
             if not hasattr(cls, "converters"):
                 cls.converters = {}
                 cls.convertersByName = {}
-            converters, convertersByName = buildConverters(table[1:], namespace)
+            converters, convertersByName = buildConverters(fields[1:], namespace)
             cls.converters[format] = converters
             cls.convertersByName[format] = convertersByName
             # XXX Add staticSize?
         else:
             cls = namespace[name]
-            cls.converters, cls.convertersByName = buildConverters(table, namespace)
+            cls.converters, cls.convertersByName = buildConverters(fields, namespace)
             # XXX Add staticSize?
 
 


### PR DESCRIPTION
Moves OpenType table definitions from raw tuples to a structured dataclass. 

* Introduces `FieldSpec(type, name, repeat, aux, description)`.
* Updates `otData.py` to use the new dataclass for all schema definitions.
* Adjusts `otConverters.py` and `otTables.py` to consume the dataclass objects.
* Makes it easier to track and extend usage