### PR TITLE
[cu2qu] Use _complex_div_by_real in split_cubic_into_three

### DIFF
--- a/Lib/fontTools/cu2qu/cu2qu.py
+++ b/Lib/fontTools/cu2qu/cu2qu.py
@@ -240,9 +240,9 @@ def split_cubic_into_three(p0, p1, p2, p3):
     mid2 = (p0 + 6 * p1 + 12 * p2 + 8 * p3) * (1 / 27)
     deriv2 = (4 * p3 - 3 * p1 - p0) * (1 / 27)
     return (
-        (p0, (2 * p0 + p1) / 3.0, mid1 - deriv1, mid1),
+        (p0, _complex_div_by_real(2 * p0 + p1, 3.0), mid1 - deriv1, mid1),
         (mid1, mid1 + deriv1, mid2 - deriv2, mid2),
-        (mid2, mid2 + deriv2, (p2 + 2 * p3) / 3.0, p3),
+        (mid2, mid2 + deriv2, _complex_div_by_real(p2 + 2 * p3, 3.0), p3),
     )
 
 

--- a/Tests/cu2qu/cu2qu_test.py
+++ b/Tests/cu2qu/cu2qu_test.py
@@ -254,6 +254,28 @@ def test_cu2qu_complex_division_floating_point_precision():
     assert result[1][5][1] == 326.49999999999994
 
 
+def test_cu2qu_split_cubic_into_three_complex_division():
+    # Same class of bug as test_cu2qu_complex_division_floating_point_precision above,
+    # but in split_cubic_into_three which has its own / 3.0 expressions not covered by
+    # the calc_cubic_points fix in PR #3930. These curves from JosefinSans-Italic
+    # (ordmasculine glyph, three masters) trigger n=3 splitting where the mathematical
+    # result is exactly 504.5. Cython's C complex division produces 504.49999999999994
+    # (just below .5, rounds down to 504) while pure Python gives 504.5000000000001
+    # (just above .5, rounds up to 505) — a ±1 coordinate difference in the final font.
+    # Pure Python already produces the correct result; this only fails under Cython.
+    # See: https://github.com/fonttools/fonttools/issues/3928
+
+    curves = [
+        [(217.833, 408.833), (299.667, 403.833), (372.333, 463.833), (382.5, 545.167)],
+        [(217, 413), (303, 408), (374, 468), (385, 551)],
+        [(213, 426), (313, 420), (381, 482), (392, 571)],
+    ]
+
+    result = curves_to_quadratic(curves, max_errors=[1.0] * len(curves))
+
+    assert result[0][3][1] == 504.5000000000001
+
+
 def test_curves_to_quadratic_rejects_mismatched_max_errors():
     curves = [[(0, 0), (0, 1), (2, 1), (2, 0)]]
     with pytest.raises(ValueError, match="max_errors must match"):


### PR DESCRIPTION
Apply the same fix from PR #3930 to the two remaining `/ 3.0` expressions in `split_cubic_into_three` which I missed in the original `calc_cubic_points` fix.

Cython's C complex division (`__divdc3`) uses multiply-by-reciprocal internally, producing a 1-ULP difference from Python's scalar division. This sometimes causes ±1 off-curve coordinate rounding e.g. on fonts with fractional default-master coordinates like JosefinSans-Italic.

By doing `_complex_div_by_real` we use the same division operator that pure-Python fontTools (and Rust fontc) use

Fixes https://github.com/fonttools/fonttools/issues/3928