### PR TITLE
[designspaceLib] Fix map_backward for many-to-one axis maps

### DIFF
--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1041,13 +1041,25 @@ class AxisDescriptor(AbstractAxisDescriptor):
 
     def map_backward(self, v):
         """Maps value from axis mapping's output (design) to input (user)."""
-        from fontTools.varLib.models import piecewiseLinearMap
-
         if isinstance(v, tuple):
             v = v[0]
         if not self.map:
             return v
-        return piecewiseLinearMap(v, {v: k for k, v in self.map})
+        # Build (design, user) pairs sorted by design then user, keeping
+        # both endpoints of any many-to-one (flat) segments so we can
+        # invert them and interpolation is correct on both sides.
+        # https://github.com/googlefonts/ufo2ft/issues/978
+        backward = sorted((design, user) for user, design in self.map)
+        design0, user0 = backward[0]
+        if v <= design0:
+            return v + user0 - design0
+        for (design1, user1), (design2, user2) in zip(backward, backward[1:]):
+            if design1 <= v <= design2:
+                if design1 == design2:
+                    return user1
+                return user1 + (user2 - user1) * (v - design1) / (design2 - design1)
+        designN, userN = backward[-1]
+        return v + userN - designN
 
 
 class DiscreteAxisDescriptor(AbstractAxisDescriptor):

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -1206,3 +1206,29 @@ def test_preserveEmptyConditionSet():
     roundtripped_ds = DesignSpaceDocument.fromstring(ds_str)
     assert len(roundtripped_ds.rules) == 1
     assert len(roundtripped_ds.rules[0].conditionSets) == 1
+
+
+def test_map_backward_many_to_one():
+    """Test that map_backward handles many-to-one (flat segment) axis maps.
+
+    Regression test for https://github.com/googlefonts/ufo2ft/issues/978
+    """
+    ax = AxisDescriptor()
+    ax.name = "Weight"
+    ax.tag = "wght"
+    ax.minimum = 100
+    ax.default = 100
+    ax.maximum = 1000
+    # Many-to-one: both user=900 and user=1000 map to design=1000
+    ax.map = [
+        (100, 100),
+        (800, 780),
+        (900, 1000),
+        (1000, 1000),
+    ]
+
+    # map_backward(800) should interpolate between (780, 800) and (1000, 900),
+    # NOT between (780, 800) and (1000, 1000).
+    result = ax.map_backward(800)
+    expected = 800 + (800 - 780) / (1000 - 780) * (900 - 800)  # ~809.09
+    assert result == pytest.approx(expected)

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -1232,3 +1232,89 @@ def test_map_backward_many_to_one():
     result = ax.map_backward(800)
     expected = 800 + (800 - 780) / (1000 - 780) * (900 - 800)  # ~809.09
     assert result == pytest.approx(expected)
+
+
+def test_map_backward_many_to_one_mid_range():
+    """Test map_backward with a flat segment in the middle of the axis range."""
+    ax = AxisDescriptor()
+    ax.name = "Weight"
+    ax.tag = "wght"
+    ax.minimum = 100
+    ax.default = 100
+    ax.maximum = 1000
+    # Many-to-one in the middle: both user=400 and user=500 map to design=50
+    ax.map = [
+        (100, 10),
+        (400, 50),
+        (500, 50),
+        (700, 80),
+        (900, 100),
+    ]
+
+    # Before the flat segment: interpolate between (10, 100) and (50, 400)
+    result = ax.map_backward(45)
+    expected = 100 + (45 - 10) / (50 - 10) * (400 - 100)  # 362.5
+    assert result == pytest.approx(expected)
+
+    # After the flat segment: interpolate between (50, 500) and (80, 700)
+    result = ax.map_backward(65)
+    expected = 500 + (65 - 50) / (80 - 50) * (700 - 500)  # 600
+    assert result == pytest.approx(expected)
+
+
+def test_map_backward_many_to_one_at_flat_value():
+    """Test map_backward queried exactly at the flat design value."""
+    ax = AxisDescriptor()
+    ax.name = "Weight"
+    ax.tag = "wght"
+    ax.minimum = 100
+    ax.default = 100
+    ax.maximum = 1000
+    ax.map = [
+        (100, 100),
+        (800, 780),
+        (900, 1000),
+        (1000, 1000),
+    ]
+
+    # map_backward(1000) should return 900 (first user value reaching design=1000)
+    assert ax.map_backward(1000) == 900
+
+    # map_backward(780) should still return 800
+    assert ax.map_backward(780) == 800
+
+
+def test_map_backward_many_to_one_unsorted_input():
+    """Test map_backward with map entries not in user-value order."""
+    ax = AxisDescriptor()
+    ax.name = "Weight"
+    ax.tag = "wght"
+    ax.minimum = 100
+    ax.default = 100
+    ax.maximum = 1000
+    # Same map as the extreme case, but entries shuffled
+    ax.map = [
+        (1000, 1000),
+        (100, 100),
+        (900, 1000),
+        (800, 780),
+    ]
+
+    result = ax.map_backward(800)
+    expected = 800 + (800 - 780) / (1000 - 780) * (900 - 800)  # ~809.09
+    assert result == pytest.approx(expected)
+
+
+def test_map_backward_single_entry():
+    """Test map_backward with a single map entry."""
+    ax = AxisDescriptor()
+    ax.name = "Weight"
+    ax.tag = "wght"
+    ax.minimum = 100
+    ax.default = 100
+    ax.maximum = 1000
+    ax.map = [(100, 200)]
+
+    assert ax.map_backward(200) == 100
+    assert ax.map_backward(300) == 200
+    assert ax.map_backward(100) == 0


### PR DESCRIPTION
`AxisDescriptor.map_backward()` used a dict comprehension (`{d: u for u, d in map}`) to invert the axis map, which silently dropped entries when multiple user-space values mapped to the same design-space value (a "flat segment" is valid per the [avar spec](https://learn.microsoft.com/en-us/typography/opentype/spec/avar#table-formats), which allows `toCoordinate` to be "greater than or equal to" the preceding one).

This produced wrong interpolation for nearby design values, leading to incorrect normalized coordinates for any code relying on `map_backward` (e.g. ufo2ft feature writers when remapping design -> user coordinates for VariableScalars). 

Replace with a sorted list of `(design, user)` pairs that preserves both endpoints of flat segments, so the inverse interpolation is correct on both sides of the flat region.

Fixes https://github.com/googlefonts/ufo2ft/issues/978
