### PR TITLE
[OS/2] fix setUnicodeRanges round-trip for reserved bits 123-127

### DIFF
--- a/Lib/fontTools/ttLib/tables/O_S_2f_2.py
+++ b/Lib/fontTools/ttLib/tables/O_S_2f_2.py
@@ -320,10 +320,10 @@ class table_O_S_2f_2(DefaultTable.DefaultTable):
                 ul2 |= 1 << (bit - 32)
             elif 64 <= bit < 96:
                 ul3 |= 1 << (bit - 64)
-            elif 96 <= bit < 123:
+            elif 96 <= bit < 128:
                 ul4 |= 1 << (bit - 96)
             else:
-                raise ValueError("expected 0 <= int <= 122, found: %r" % bit)
+                raise ValueError("expected 0 <= int <= 127, found: %r" % bit)
         self.ulUnicodeRange1, self.ulUnicodeRange2 = ul1, ul2
         self.ulUnicodeRange3, self.ulUnicodeRange4 = ul3, ul4
 

--- a/Tests/ttLib/tables/O_S_2f_2_test.py
+++ b/Tests/ttLib/tables/O_S_2f_2_test.py
@@ -33,11 +33,11 @@ class OS2TableTest(unittest.TestCase):
         table.ulUnicodeRange2 = 0
         table.ulUnicodeRange3 = 0
         table.ulUnicodeRange4 = 0
-        bits = set(range(123))
+        bits = set(range(128))
         table.setUnicodeRanges(bits)
         self.assertEqual(table.getUnicodeRanges(), bits)
         with self.assertRaises(ValueError):
-            table.setUnicodeRanges([-1, 127, 255])
+            table.setUnicodeRanges([-1, 128, 255])
 
     def test_recalcUnicodeRanges(self):
         font, os2, cmap = self.makeOS2_cmap(


### PR DESCRIPTION
Bits 123-127 are reserved in the OpenType spec and not assigned to any Unicode block, so the cap at 123 in `setUnicodeRanges` was intentional. However, `getUnicodeRanges` reads all 128 raw bits, so a font with those reserved bits already set (by another tool) will have them returned by `getUnicodeRanges` but later rejected by `setUnicodeRanges` -- causing a crash in `recalcUnicodeRanges(pruneOnly=True)` (used by the subsetter), which is meant to be conservative (only clear bits with no intersection, leave everything else alone).

We should just accept bits 0-127 to allow the round-trip, without assigning any meaning to the reserved range.

Fixes #4087