### PR TITLE
Declare Cython extensions as free-threading compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -476,16 +476,20 @@ class cython_build_ext(_build_ext):
         # optionally enable line tracing for test coverage support
         linetrace = os.environ.get("CYTHON_TRACE") == "1"
 
+        directives = {
+            "linetrace": linetrace,
+            "language_level": 3,
+            "embedsignature": True,
+        }
+        if sys.version_info >= (3, 13):
+            directives["freethreading_compatible"] = True
+
         self.distribution.ext_modules[:] = cythonize(
             self.distribution.ext_modules,
             force=linetrace or self.force,
             annotate=os.environ.get("CYTHON_ANNOTATE") == "1",
             quiet=not self.verbose,
-            compiler_directives={
-                "linetrace": linetrace,
-                "language_level": 3,
-                "embedsignature": True,
-            },
+            compiler_directives=directives,
         )
 
         _build_ext.finalize_options(self)


### PR DESCRIPTION
On free-threaded Python (3.13t, 3.14t), importing a C extension that hasn't declared itself compatible causes the interpreter to re-enable the GIL, defeating the purpose of the free-threaded build.

All six Cython extensions in fonttools are safe for concurrent use without the GIL:

- `cu2qu`, `qu2cu`, `bezierTools`, `iup`: pure functions with no module-level mutable state
- `momentsPen`, `lexer`: per-instance state only, no shared mutation

This adds the `freethreading_compatible` Cython compiler directive when building on Python 3.13+, following the same approach as [SQLAlchemy](https://github.com/sqlalchemy/sqlalchemy/blob/8849e2b775c186da6f037d5403df777ad667c852/setup.py#L59-L61).

cibuildwheel already builds free-threaded 3.14t wheels by default, so no CI changes are needed.

Fixes #4073

