### PR TITLE
[feaLib] Fix name-table parsing for multibyte Mac encodings (#1196)

### DIFF
--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -2,7 +2,7 @@ from fontTools.feaLib.error import FeatureLibError
 from fontTools.feaLib.lexer import Lexer, IncludingLexer, NonIncludingLexer
 from fontTools.feaLib.variableScalar import VariableScalar
 from fontTools.misc.encodingTools import getEncoding
-from fontTools.misc.textTools import bytechr, tobytes, tostr
+from fontTools.misc.textTools import tobytes, tostr
 import fontTools.feaLib.ast as ast
 import logging
 import os
@@ -1273,8 +1273,18 @@ class Parser(object):
         if encoding == "utf_16_be":
             s = re.sub(r"\\[0-9a-fA-F]{4}", self.unescape_unichr_, string)
         else:
-            unescape = lambda m: self.unescape_byte_(m, encoding)
-            s = re.sub(r"\\[0-9a-fA-F]{2}", unescape, string)
+            # Build the full byte sequence from literal characters plus
+            # \XX escapes, then decode in one go. This is required for
+            # multibyte encodings (e.g. x_mac_japanese_ttx) where bytes
+            # belonging to a single character may straddle literal/escape
+            # boundaries — e.g. "\95F" is one Shift-JIS char (0x95 0x46).
+            out = bytearray()
+            for token in re.split(r"(\\[0-9a-fA-F]{2})", string):
+                if len(token) == 3 and token[0] == "\\":
+                    out.append(int(token[1:], 16))
+                elif token:
+                    out.extend(token.encode(encoding))
+            s = bytes(out).decode(encoding)
         # We now have a Unicode string, but it might contain surrogate pairs.
         # We convert surrogates to actual Unicode by round-tripping through
         # Python's UTF-16 codec in a special mode.
@@ -1285,11 +1295,6 @@ class Parser(object):
     def unescape_unichr_(match):
         n = match.group(0)[1:]
         return chr(int(n, 16))
-
-    @staticmethod
-    def unescape_byte_(match, encoding):
-        n = match.group(0)[1:]
-        return bytechr(int(n, 16)).decode(encoding)
 
     def find_previous(self, statements, class_):
         for previous in reversed(statements):

--- a/Lib/fontTools/feaLib/parser.py
+++ b/Lib/fontTools/feaLib/parser.py
@@ -1284,7 +1284,7 @@ class Parser(object):
                     out.append(int(token[1:], 16))
                 elif token:
                     out.extend(token.encode(encoding))
-            s = bytes(out).decode(encoding)
+            s = out.decode(encoding)
         # We now have a Unicode string, but it might contain surrogate pairs.
         # We convert surrogates to actual Unicode by round-tripping through
         # Python's UTF-16 codec in a special mode.

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -72,14 +72,14 @@ class BuilderTest(unittest.TestCase):
         spec9a spec9a2 spec9b spec9c1 spec9c2 spec9c3 spec9d spec9e spec9f
         spec9g spec10
         bug453 bug457 bug463 bug501 bug502 bug504 bug505 bug506 bug509
-        bug512 bug514 bug568 bug633 bug1307 bug1459 bug2276 variable_bug2772
+        bug512 bug514 bug568 bug633 bug1196 bug1307 bug1459 bug2276 variable_bug2772
         name size size2 multiple_feature_blocks omitted_GlyphClassDef
         ZeroValue_SinglePos_horizontal ZeroValue_SinglePos_vertical
         ZeroValue_PairPos_horizontal ZeroValue_PairPos_vertical
         ZeroValue_ChainSinglePos_horizontal ZeroValue_ChainSinglePos_vertical
-        PairPosSubtable ChainSubstSubtable SubstSubtable ChainPosSubtable 
-        LigatureSubtable AlternateSubtable MultipleSubstSubtable 
-        SingleSubstSubtable aalt_chain_contextual_subst AlternateChained 
+        PairPosSubtable ChainSubstSubtable SubstSubtable ChainPosSubtable
+        LigatureSubtable AlternateSubtable MultipleSubstSubtable
+        SingleSubstSubtable aalt_chain_contextual_subst AlternateChained
         MultipleLookupsPerGlyph MultipleLookupsPerGlyph2 GSUB_6_formats
         GSUB_5_formats delete_glyph STAT_test STAT_test_elidedFallbackNameID
         variable_scalar_valuerecord variable_scalar_anchor variable_conditionset

--- a/Tests/feaLib/data/bug1196.fea
+++ b/Tests/feaLib/data/bug1196.fea
@@ -1,0 +1,8 @@
+table name {
+	nameid 0 "Copyright \00a9 2001-2010 Adobe Systems Incorporated. All Rights Reserved.";
+	nameid 0 1 "Copyright \a9 2001-2010 Adobe Systems Incorporated. All Rights Reserved.";
+	nameid 0 1 1 11 "Copyright \fd 2001-2010 Adobe Systems Incorporated. All Rights Reserved.";
+	nameid 9 "Masahiko Kozuka \5c0f\585a\660c\5f66";          # Windows (Unicode)
+	nameid 9 1 "Masahiko Kozuka";                             # Macintosh (Mac Roman)
+	nameid 9 1 1 11 "Masahiko Kozuka \8f\ac\92\cb\8f\b9\95F"; # Macintosh (Japanese)
+} name;

--- a/Tests/feaLib/data/bug1196.ttx
+++ b/Tests/feaLib/data/bug1196.ttx
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <name>
+    <namerecord nameID="0" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Copyright © 2001-2010 Adobe Systems Incorporated. All Rights Reserved.
+    </namerecord>
+    <namerecord nameID="9" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Masahiko Kozuka
+    </namerecord>
+    <namerecord nameID="0" platformID="1" platEncID="1" langID="0xb" unicode="True">
+      Copyright © 2001-2010 Adobe Systems Incorporated. All Rights Reserved.
+    </namerecord>
+    <namerecord nameID="9" platformID="1" platEncID="1" langID="0xb" unicode="True">
+      Masahiko Kozuka 小塚昌彦
+    </namerecord>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright © 2001-2010 Adobe Systems Incorporated. All Rights Reserved.
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Masahiko Kozuka 小塚昌彦
+    </namerecord>
+  </name>
+
+</ttFont>

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -1336,6 +1336,25 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(name.string, "Jovica Veljović")
         self.assertEqual(name.asFea(), r'nameid 9 1 0 18 "Jovica Veljovi\e6";')
 
+    def test_nameid_mac_japanese(self):
+        # Literal text and \XX escapes are combined into a single byte
+        # sequence before decoding, so multibyte Shift-JIS chars work even
+        # when one of the constituent bytes is a printable ASCII char (#1196).
+        # Here \95F is the Shift-JIS byte pair 0x95 0x46 = 彦.
+        doc = self.parse(
+            r'table name { nameid 9 1 1 11 "Kozuka \8f\ac\92\cb\8f\b9\95F"; } name;'
+        )
+        name = doc.statements[0].statements[0]
+        self.assertEqual(name.nameID, 9)
+        self.assertEqual(name.platformID, 1)
+        self.assertEqual(name.platEncID, 1)
+        self.assertEqual(name.langID, 11)
+        self.assertEqual(name.string, "Kozuka 小塚昌彦")
+        self.assertEqual(
+            name.asFea(),
+            r'nameid 9 1 1 11 "Kozuka \8f\ac\92\cb\8f\b9\95F";',
+        )
+
     def test_nameid_unsupported_platform(self):
         self.assertRaisesRegex(
             FeatureLibError,


### PR DESCRIPTION
The `unescape_string_` helper used to decode each `\XX` escape as a single byte, which broke multibyte encodings (`x_mac_japanese_ttx` and friends) whenever one character's bytes were split across escapes or across an escape/literal-ASCII boundary (e.g. `\95F` = Shift-JIS `0x95` `0x46` = 彦).

Build the full byte sequence from literal chars + `\XX` escapes and decode it in one pass.

Fixes #1196