### PR TITLE
[subset] keep East Asian spacing palt by default

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -3356,7 +3356,7 @@ class Options(object):
         "rand": ["rand"],
         "justify": ["jalt"],
         "private": ["Harf", "HARF", "Buzz", "BUZZ"],
-        "east_asian_spacing": ["chws", "vchw", "halt", "vhal"],
+        "east_asian_spacing": ["chws", "vchw", "halt", "vhal", "palt"],
         # Complex shapers
         "arabic": [
             "init",


### PR DESCRIPTION
Add `palt` (Proportional Alternate Widths) to the `east_asian_spacing` group of the default layout features.

This mirrors HarfBuzz, which recently added `palt` to its default subset layout features in harfbuzz/harfbuzz#6007. `palt` is one of the most commonly used optional features in Japanese typography, yet it was silently dropped during subsetting unless explicitly requested. Its vertical counterpart `vpal` is already retained by default (in the `vertical` group), so this also removes that asymmetry.

Follows the precedent of 5d6e1c750 ("keep East Asian spacing vhal, halt, chws, vchw by default", harfbuzz/harfbuzz#4451).