### PR TITLE
[beyond64k] Support > 64k glyphs in HVAR/VVAR and fix head/LOCA save order

### DIFF
--- a/Lib/fontTools/ttLib/tables/_h_e_a_d.py
+++ b/Lib/fontTools/ttLib/tables/_h_e_a_d.py
@@ -44,7 +44,7 @@ class table__h_e_a_d(DefaultTable.DefaultTable):
     See also https://learn.microsoft.com/en-us/typography/opentype/spec/head
     """
 
-    dependencies = ["maxp", "loca", "CFF ", "CFF2"]
+    dependencies = ["maxp", "MAXP", "loca", "LOCA", "CFF ", "CFF2"]
 
     def decompile(self, data, ttFont):
         dummy, rest = sstruct.unpack2(headFormat, data, self)

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -4304,10 +4304,26 @@ otData = [
     ),
     # Variation helpers
     (
-        "VarIdxMap",
+        "VarIdxMapFormat0",
         [
-            FieldSpec("uint16", "EntryFormat"),  # Automatically computed
+            FieldSpec("uint8", "Format", description="Format of the VarIdxMap = 0"),
+            FieldSpec("uint8", "EntryFormat"),  # Automatically computed
             FieldSpec("uint16", "MappingCount"),  # Automatically computed
+            FieldSpec(
+                "VarIdxMapValue",
+                "mapping",
+                repeat="",
+                aux=0,
+                description="Array of compressed data",
+            ),
+        ],
+    ),
+    (
+        "VarIdxMapFormat1",
+        [
+            FieldSpec("uint8", "Format", description="Format of the VarIdxMap = 1"),
+            FieldSpec("uint8", "EntryFormat"),  # Automatically computed
+            FieldSpec("uint32", "MappingCount"),  # Automatically computed
             FieldSpec(
                 "VarIdxMapValue",
                 "mapping",

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -1108,7 +1108,14 @@ class DeltaSetIndexMap(getFormatSwitchingBaseTableClass("uint8")):
         return self.mapping[i] if i < len(self.mapping) else NO_VARIATION_INDEX
 
 
-class VarIdxMap(BaseTable):
+class VarIdxMap(DeltaSetIndexMap):
+    """Glyph-id-indexed delta-set index map (HVAR/VVAR).
+
+    Shares DeltaSetIndexMap's format-switching wire format (Format 0 / Format 1)
+    but exposes a name-keyed ``.mapping`` dict, since here the map index is the
+    glyph id.
+    """
+
     def populateDefaults(self, propagator=None):
         if not hasattr(self, "mapping"):
             self.mapping = {}
@@ -1119,6 +1126,10 @@ class VarIdxMap(BaseTable):
         mapList = rawTable["mapping"]
         mapList.extend([mapList[-1]] * (len(glyphOrder) - len(mapList)))
         self.mapping = dict(zip(glyphOrder, mapList))
+        # Format is derived from the mapping size in preWrite; don't keep it around
+        # so it isn't emitted to TTX (matching Coverage/ClassDef, and keeping the
+        # pre-format-switching VarIdxMap TTX output unchanged).
+        del self.Format
 
     def preWrite(self, font):
         mapping = getattr(self, "mapping", None)
@@ -1130,6 +1141,7 @@ class VarIdxMap(BaseTable):
         while len(mapping) > 1 and mapping[-2] == mapping[-1]:
             del mapping[-1]
 
+        self.Format = 1 if len(mapping) > 0xFFFF else 0
         rawTable = {"mapping": mapping}
         rawTable["MappingCount"] = len(mapping)
         rawTable["EntryFormat"] = DeltaSetIndexMap.getEntryFormat(mapping)

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -652,7 +652,10 @@ def _add_VHVAR(font, axisTags, tableFields, getAdvanceMetrics):
         )
 
     directStore = None
-    if singleModel:
+    # The direct (no-map) store indexes a single VarData by glyph id, but
+    # VarData.ItemCount is uint16, so it cannot represent > 0xFFFF glyphs. Skip it
+    # past the boundary and rely on the indirect (mapped) store.
+    if singleModel and len(glyphOrder) <= 0xFFFF:
         # Build direct mapping
         supports = next(iter(vhAdvanceDeltasAndSupports.values()))[1][1:]
         varTupleList = builder.buildVarRegionList(supports, axisTags)

--- a/Tests/ttLib/beyond64k_test.py
+++ b/Tests/ttLib/beyond64k_test.py
@@ -550,6 +550,62 @@ def test_round_trip_companion_tables():
     assert glyph_paths(font) == expected_paths
 
 
+def test_head_written_after_LOCA_with_long_loca():
+    # A beyond-64k font with long loca must write 'head' after the uppercase 'LOCA'
+    # companion (head.dependencies), otherwise head freezes a stale indexToLocFormat
+    # before LOCA is compiled and the saved font is corrupt. Build a font whose glyf
+    # exceeds the short-loca limit, uppercase it, and round-trip.
+    from fontTools.fontBuilder import FontBuilder
+    from fontTools.pens.ttGlyphPen import TTGlyphPen
+
+    def big_glyph():
+        # large coordinate deltas -> 2-byte coords, so a few glyphs exceed the
+        # short-loca limit (0x1FFFE) without a huge point count
+        pen = TTGlyphPen(None)
+        pen.moveTo((0, 0))
+        for i in range(1, 12000):  # < 65535 points/contour
+            # % 20000 wraps coords into a bounded box so the int16 glyph bbox
+            # (xMin/xMax/yMin/yMax) doesn't overflow
+            pen.lineTo(((i * 977) % 20000, (i * 1013) % 20000))
+        pen.closePath()
+        return pen.glyph()
+
+    order = [".notdef", "A", "B", "C", "D"]
+    glyphs = {g: Glyph() for g in order}
+    for g in ("A", "B", "C"):
+        glyphs[g] = big_glyph()
+
+    fb = FontBuilder(unitsPerEm=1000)
+    fb.setupGlyphOrder(order)
+    fb.setupCharacterMap({0x41: "A"})
+    fb.setupGlyf(glyphs)
+    fb.setupHorizontalMetrics({g: (500, 0) for g in order})
+    fb.setupHorizontalHeader(ascent=800, descent=-200)
+    fb.setupNameTable({"familyName": "Test", "styleName": "Regular"})
+    fb.setupOS2()
+    fb.setupPost()
+    fb.setupMaxp()
+    font = fb.font
+
+    assert len(font["glyf"].compile(font)) > 0x1FFFE, "test font must need long loca"
+    expected_coords = list(font["glyf"]["A"].coordinates)
+
+    upper_tables(font, validate=False)
+    assert "LOCA" in font
+
+    data = BytesIO()
+    font.save(data)
+    data.seek(0)
+    font = TTFont(data)
+
+    # Without the head.dependencies fix this is 0 (stale), making the reloaded loca
+    # offsets garbage.
+    assert font["head"].indexToLocFormat == 1
+    # 'A' is the second glyph; names are kept (< 64k glyphs). Its outline must
+    # survive the round-trip intact.
+    assert list(font["GLYF"]["A"].coordinates) == expected_coords
+
+
 def test_upper_tables_replaces_bmp_format4_cmap_with_format12():
     font = TTFont()
     font.setGlyphOrder(

--- a/Tests/ttLib/tables/otTables_test.py
+++ b/Tests/ttLib/tables/otTables_test.py
@@ -153,6 +153,38 @@ class ClassDefTest(unittest.TestCase):
         )
 
 
+def test_VarIdxMap_format0_roundtrip():
+    # VarIdxMap is the HVAR/VVAR glyph-indexed delta-set index map; it shares the
+    # format-switching DeltaSetIndexMap wire format (Format 0 here).
+    font = FakeFont([".notdef", "a", "b", "c"])
+    table = otTables.VarIdxMap()
+    table.mapping = {".notdef": 0, "a": 1, "b": 0, "c": 0}
+    data = compileTable(table, font)
+    assert data[:2] == "00"  # Format 0 (uint8)
+    table2 = decompileTable(otTables.VarIdxMap(), data, font)
+    assert table2.mapping == {".notdef": 0, "a": 1, "b": 0, "c": 0}
+    # Format is derived in preWrite; it is not retained after decompile, so it is
+    # not emitted to TTX (matching Coverage/ClassDef).
+    assert not hasattr(table2, "Format")
+
+
+def test_VarIdxMap_format1_beyond_64k():
+    # 65537 glyphs; only the highest (gid 0x10000 > 0xFFFF) varies, so the map
+    # cannot be trimmed below 65536 entries and must use Format 1.
+    glyphs = [".notdef"] + ["g%05d" % i for i in range(1, 0x10001)]
+    font = FakeFont(glyphs)
+    table = otTables.VarIdxMap()
+    table.mapping = {g: 0 for g in glyphs}
+    table.mapping[glyphs[-1]] = 1
+    data = compileTable(table, font)
+    assert data[:2] == "01"  # Format 1 (uint8)
+    assert data[4:12] == "00010001"  # uint32 MappingCount = 0x10001
+    table2 = decompileTable(otTables.VarIdxMap(), data, font)
+    assert table2.mapping[glyphs[-1]] == 1
+    assert table2.mapping[glyphs[0]] == 0
+    assert not hasattr(table2, "Format")
+
+
 class SingleSubstTest(unittest.TestCase):
     def setUp(self):
         self.glyphs = ".notdef A B C D E a b c d e".split()

--- a/Tests/varLib/builder_test.py
+++ b/Tests/varLib/builder_test.py
@@ -241,6 +241,56 @@ def test_empty_vhvar_size():
         assert len(vf[table].compile(vf)) <= optimal_size
 
 
+def test_vhvar_beyond_64k():
+    """varLib can build HVAR/VVAR for fonts with more than 0xFFFF glyphs.
+
+    The advance store uses the indirect mapping (the direct/no-map store can't
+    index more than 0xFFFF glyphs, since VarData.ItemCount is uint16), and the
+    advance index map escalates to DeltaSetIndexMap Format 1 (uint32 MappingCount)
+    when a glyph beyond gid 0xFFFF varies.
+    """
+    from fontTools.ttLib.tables._g_l_y_f import Glyph
+    from fontTools.ttLib.tables.otBase import OTTableWriter
+
+    n = 0x10001  # 65537 glyphs -> highest gid is 0x10000
+    glyph_order = [".notdef"] + ["g%05d" % i for i in range(1, n)]
+    high = glyph_order[-1]
+
+    doc = DesignSpaceDocument()
+    doc.addAxis(
+        AxisDescriptor(tag="wght", name="Weight", minimum=0, default=0, maximum=1000)
+    )
+    # the two advances just need to differ so the high glyph actually varies
+    for wght, adv in ((0, 480), (1000, 520)):
+        fb = FontBuilder(unitsPerEm=1000)
+        fb.setupGlyphOrder(glyph_order)
+        fb.setupGlyf({g: Glyph() for g in glyph_order})
+        # Only the highest glyph's advances vary, so the map cannot be trimmed
+        # below 65536 entries and must use Format 1.
+        hmetrics = {g: (500, 0) for g in glyph_order}
+        vmetrics = {g: (500, 0) for g in glyph_order}
+        hmetrics[high] = vmetrics[high] = (adv, 0)
+        fb.setupHorizontalMetrics(hmetrics)
+        fb.setupHorizontalHeader(ascent=1000, descent=0)
+        fb.setupVerticalMetrics(vmetrics)
+        fb.setupVerticalHeader(ascent=1000, descent=0)
+        fb.setupNameTable({"familyName": "TestBeyond64k", "styleName": "Regular"})
+        fb.setupPost(keepGlyphNames=False)
+        doc.addSource(SourceDescriptor(font=fb.font, location={"Weight": wght}))
+
+    vf, *_ = build(doc)
+
+    for tableTag, mapName in (("HVAR", "AdvWidthMap"), ("VVAR", "AdvHeightMap")):
+        assert tableTag in vf
+        advMap = getattr(vf[tableTag].table, mapName)
+        assert advMap is not None
+        writer = OTTableWriter()
+        advMap.compile(writer, vf)
+        assert (
+            writer.getAllData()[0] == 1
+        ), f"{tableTag}.{mapName} should use DeltaSetIndexMap Format 1"
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
Two fixes on top of @behdad's `beyond-64k` branch, found while reviewing and building variable fonts with more than 0xFFFF glyphs.

varLib couldn't build HVAR/VVAR past 64k glyphs because `_add_VHVAR` raised `struct.error` from two uint16 ceilings. 

The direct (no-map) advance store packs one VarData item per glyph, but VarData.ItemCount is uint16, so it can't index more than 0xFFFF glyphs; an indirect store is needed when > 64k.

And the HVVAR's `VarIdxMap` had a fixed uint16 MappingCount: we need to make VarIdxMap a subclass of the
format-switching `DeltaSetIndexMap` so it bumps to Format 1 (uint32 MappingCount) once the map exceeds 0xFFFF entries, while keeping its glyph-name-keyed mapping (the `DeltaSetIndexMap` class is also used by COLRv1 and avar2 and the mapping keys there are not glyph names, so we need a distinct class even though the serialized table is the same).
I don't see another way to avoid breaking existing users of either VarIdxMap or DeltaSetIndexMap.

Separately, head must depend on the uppercase MAXP/LOCA companions. The latter sort last in the save order, so a beyond-64k font with long loca wrote head before LOCA and froze a stale `indexToLocFormat`, corrupting the saved offsets. Listing the two uppercase tables as `head.dependencies` makes head write after them, matching post which already depends on both maxp and MAXP.