### PR TITLE
[glyf] Use reverse glyph map for O(1) __setitem__ membership

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -338,12 +338,23 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
 
     def __setitem__(self, glyphName, glyph):
         self.glyphs[glyphName] = glyph
-        if glyphName not in self.glyphOrder:
+        # Use the reverse glyph map for O(1) membership so that building a font by
+        # repeatedly assigning glyphs stays linear instead of quadratic. Rebuild
+        # the map if it is missing or no longer matches the length of glyphOrder;
+        # reordering goes through setGlyphOrder, which clears it.
+        rev = getattr(self, "_reverseGlyphOrder", None)
+        if rev is None or len(rev) != len(self.glyphOrder):
+            self._buildReverseGlyphOrderDict()
+            rev = self._reverseGlyphOrder
+        if glyphName not in rev:
+            rev[glyphName] = len(self.glyphOrder)
             self.glyphOrder.append(glyphName)
 
     def __delitem__(self, glyphName):
         del self.glyphs[glyphName]
         self.glyphOrder.remove(glyphName)
+        # glyph ids after the removed one shift down; rebuild lazily on next use.
+        self._reverseGlyphOrder = {}
 
     def __len__(self):
         assert len(self.glyphOrder) == len(self.glyphs)

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -419,6 +419,59 @@ class GlyfTableTest(unittest.TestCase):
         del glyf["b"]
         assert glyf.getGlyphID("c") == 2
 
+    # __setitem__ uses the reverse glyph map for O(1) membership; the tests below
+    # check it keeps glyphOrder and the reverse map consistent across the
+    # supported paths.
+
+    def test_setitem_prepopulated_glyphOrder_no_duplicate(self):
+        # with glyphOrder already populated, assigning a glyph by an
+        # already-listed name must not re-append it to glyphOrder.
+        glyf = newTable("glyf")
+        glyf.glyphs = {}
+        glyf.glyphOrder = [".notdef", "a", "b"]
+        for name in list(glyf.glyphOrder):
+            glyf[name] = Glyph()
+        assert glyf.glyphOrder == [".notdef", "a", "b"]
+        assert glyf.getGlyphID("b") == 2
+
+    def test_setitem_appends_new_glyph(self):
+        # assigning a name that isn't in glyphOrder appends it and resolves
+        glyf = newTable("glyf")
+        glyf.glyphs = {}
+        glyf.glyphOrder = [".notdef", "a"]
+        for name in list(glyf.glyphOrder):
+            glyf[name] = Glyph()
+        glyf["b"] = Glyph()
+        assert glyf.glyphOrder == [".notdef", "a", "b"]
+        assert glyf.getGlyphID("b") == 2
+
+    def test_setitem_after_setGlyphOrder_reorder(self):
+        # reordering through the public setGlyphOrder clears the reverse map, so
+        # re-assigning an already-listed glyph afterwards must not duplicate it
+        glyf = newTable("glyf")
+        glyf.glyphs = {}
+        glyf.glyphOrder = [".notdef", "a", "b"]
+        for name in list(glyf.glyphOrder):
+            glyf[name] = Glyph()
+        glyf.setGlyphOrder(["b", "a", ".notdef"])
+        glyf["a"] = Glyph()
+        assert glyf.glyphOrder == ["b", "a", ".notdef"]
+        assert glyf.getGlyphID("a") == 1
+
+    def test_setitem_after_delitem(self):
+        # deletion invalidates the reverse map and shifts later ids; a following
+        # assignment must still keep glyphOrder and the map consistent
+        glyf = newTable("glyf")
+        glyf.glyphs = {}
+        glyf.glyphOrder = [".notdef", "a", "b"]
+        for name in list(glyf.glyphOrder):
+            glyf[name] = Glyph()
+        del glyf["a"]
+        assert glyf.glyphOrder == [".notdef", "b"]
+        glyf["c"] = Glyph()
+        assert glyf.glyphOrder == [".notdef", "b", "c"]
+        assert glyf.getGlyphID("c") == 2
+
 
 class GlyphTest:
     def test_getCoordinates(self):


### PR DESCRIPTION
`table__g_l_y_f.__setitem__` tested `glyphName not in self.glyphOrder`, a linear scan of the glyphOrder list on every assignment. So repeatedly assigning glyphs over a pre-populated glyphOrder (like ufo2ft outlineCompiler currently does) was O(n^2) in the glyph count, which means several seconds of pure scanning for a 60k-glyph font.

We can instead use the existing reverse glyph map (`self._reverseGlyphOrder`, the same we added to speed up `getGlyphID`) for O(1) membership, rebuilding it when it is missing or its length no longer matches `self.glyphOrder`, and invalidating it on `__delitem__`.

Reordering goes through `setGlyphOrder` as usual, which already clears the map. And editing glyphOrder directly in-place behind the table's back was never supported.

This is somewhat related to #2605, a separate correctness issue about the TTFont-level `_reverseGlyphOrderDict` going stale (see #3582), I have not changed it here.

It's also relevant for #4097 because that's exactly how I stumbled into this perf issue: by writing unit tests for ufo2ft's beyond-64k PR (https://github.com/googlefonts/ufo2ft/pull/987).

In ufo2ft I ended up circumventing the `glyf.__setitem__` altogether and directly assigning the inner `glyf.glyphs` dictionary (like our own fontBuilder does): https://github.com/googlefonts/ufo2ft/pull/991

But It'd still be good to have this optimization in case someone else may benefit.