### PR TITLE
[beyond-64k] Support uppercase tables and keep GDEF 1.4 in varLib.instancer

### DIFF
--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -961,10 +961,14 @@ def _instantiateGvarGlyph(
 def instantiateGvarGlyph(varfont, glyphname, axisLimits, optimize=True):
     """Remove?
     https://github.com/fonttools/fonttools/pull/2266"""
-    gvar = varfont["gvar"]
-    glyf = varfont["glyf"]
-    hMetrics = varfont["hmtx"].metrics
-    vMetrics = getattr(varfont.get("vmtx"), "metrics", None)
+    gvarTag = "GVAR" if "GVAR" in varfont else "gvar"
+    glyfTag = "GLYF" if gvarTag == "GVAR" else "glyf"
+    hmtxTag = "HMTX" if gvarTag == "GVAR" else "hmtx"
+    vmtxTag = "VMTX" if gvarTag == "GVAR" else "vmtx"
+    gvar = varfont[gvarTag]
+    glyf = varfont[glyfTag]
+    hMetrics = varfont[hmtxTag].metrics
+    vMetrics = getattr(varfont.get(vmtxTag), "metrics", None)
     _instantiateGvarGlyph(
         glyphname, glyf, gvar, hMetrics, vMetrics, axisLimits, optimize=optimize
     )
@@ -973,10 +977,14 @@ def instantiateGvarGlyph(varfont, glyphname, axisLimits, optimize=True):
 def instantiateGvar(varfont, axisLimits, optimize=True):
     log.info("Instantiating glyf/gvar tables")
 
-    gvar = varfont["gvar"]
-    glyf = varfont["glyf"]
-    hMetrics = varfont["hmtx"].metrics
-    vMetrics = getattr(varfont.get("vmtx"), "metrics", None)
+    gvarTag = "GVAR" if "GVAR" in varfont else "gvar"
+    glyfTag = "GLYF" if gvarTag == "GVAR" else "glyf"
+    hmtxTag = "HMTX" if gvarTag == "GVAR" else "hmtx"
+    vmtxTag = "VMTX" if gvarTag == "GVAR" else "vmtx"
+    gvar = varfont[gvarTag]
+    glyf = varfont[glyfTag]
+    hMetrics = varfont[hmtxTag].metrics
+    vMetrics = getattr(varfont.get(vmtxTag), "metrics", None)
     # Get list of glyph names sorted by component depth.
     # If a composite glyph is processed before its base glyph, the bounds may
     # be calculated incorrectly because deltas haven't been applied to the
@@ -998,7 +1006,7 @@ def instantiateGvar(varfont, axisLimits, optimize=True):
         )
 
     if not gvar.variations:
-        del varfont["gvar"]
+        del varfont[gvarTag]
 
 
 def setCvarDeltas(cvt, deltas):
@@ -1053,12 +1061,13 @@ def verticalMetricsKeptInSync(varfont):
     https://googlefonts.github.io/gf-guide/metrics.html#7-hhea-and-typo-metrics-should-be-equal
     https://github.com/fonttools/fonttools/issues/3297
     """
+    hheaTag = "HHEA" if "HHEA" in varfont else "hhea"
     current_os2_vmetrics = [
         getattr(varfont["OS/2"], attr)
         for attr in ("sTypoAscender", "sTypoDescender", "sTypoLineGap")
     ]
     metrics_are_synced = current_os2_vmetrics == [
-        getattr(varfont["hhea"], attr) for attr in ("ascender", "descender", "lineGap")
+        getattr(varfont[hheaTag], attr) for attr in ("ascender", "descender", "lineGap")
     ]
 
     yield metrics_are_synced
@@ -1072,7 +1081,7 @@ def verticalMetricsKeptInSync(varfont):
             for attr, value in zip(
                 ("ascender", "descender", "lineGap"), new_os2_vmetrics
             ):
-                setattr(varfont["hhea"], attr, value)
+                setattr(varfont[hheaTag], attr, value)
 
 
 def instantiateMVAR(varfont, axisLimits):
@@ -1110,7 +1119,9 @@ def _instantiateVHVAR(varfont, axisLimits, tableFields, *, round=round):
     vhvar = varfont[tableTag].table
     varStore = vhvar.VarStore
 
-    if "glyf" in varfont:
+    glyfTag = "GLYF" if "GLYF" in varfont else "glyf"
+
+    if glyfTag in varfont:
         # Deltas from gvar table have already been applied to the hmtx/vmtx. For full
         # instances (i.e. all axes pinned), we can simply drop HVAR/VVAR and return
         if set(location).issuperset(axis.axisTag for axis in fvarAxes):
@@ -1120,14 +1131,17 @@ def _instantiateVHVAR(varfont, axisLimits, tableFields, *, round=round):
 
     defaultDeltas = instantiateItemVariationStore(varStore, fvarAxes, axisLimits)
 
-    if "glyf" not in varfont:
+    if glyfTag not in varfont:
         # CFF2 fonts need hmtx/vmtx updated here. For glyf fonts, the instantiateGvar
         # function already updated the hmtx/vmtx from phantom points. Maybe remove
         # that and do it here for both CFF2 and glyf fonts?
         #
         # Specially, if a font has glyf but not gvar, the hmtx/vmtx will not have been
         # updated by instantiateGvar. Though one can call that a faulty font.
-        metricsTag = "vmtx" if tableTag == "VVAR" else "hmtx"
+        if tableTag == "VVAR":
+            metricsTag = "VMTX" if "VMTX" in varfont else "vmtx"
+        else:
+            metricsTag = "HMTX" if "HMTX" in varfont else "hmtx"
         if metricsTag in varfont:
             advMapping = getattr(vhvar, tableFields.advMapping)
             metricsTable = varfont[metricsTag]
@@ -1359,6 +1373,19 @@ def instantiateOTL(varfont, axisLimits):
         gdef.remap_device_varidxes(varIndexMapping)
         if "GPOS" in varfont:
             varfont["GPOS"].table.remap_device_varidxes(varIndexMapping)
+    elif any(
+        getattr(gdef, name, None) is not None
+        for name in (
+            "GlyphClassDef2",
+            "AttachList2",
+            "LigCaretList2",
+            "MarkAttachClassDef2",
+            "MarkGlyphSetsDef2",
+        )
+    ):
+        # beyond-64k GDEF: keep v1.4 and NULL the VarStore, don't drop the *2 fields
+        gdef.VarStore = None
+        gdef.Version = 0x00010004
     else:
         # Downgrade GDEF.
         del gdef.VarStore
@@ -1648,8 +1675,10 @@ def normalize(value, triple, avarMapping):
 def sanityCheckVariableTables(varfont):
     if "fvar" not in varfont:
         raise ValueError("Missing required table fvar")
-    if "gvar" in varfont:
-        if "glyf" not in varfont:
+    gvarTag = "GVAR" if "GVAR" in varfont else "gvar"
+    if gvarTag in varfont:
+        glyfTag = "GLYF" if gvarTag == "GVAR" else "glyf"
+        if glyfTag not in varfont:
             raise ValueError("Can't have gvar without glyf")
 
 
@@ -1749,7 +1778,7 @@ def instantiateVariableFont(
             varfont, normalizedLimits, downgrade=downgradeCFF2
         )
 
-    if "gvar" in varfont:
+    if "gvar" in varfont or "GVAR" in varfont:
         instantiateGvar(varfont, normalizedLimits, optimize=optimize)
 
     if "cvar" in varfont:
@@ -1797,8 +1826,9 @@ def instantiateVariableFont(
 
     if "fvar" not in varfont:
         if overlap == OverlapMode.KEEP_AND_SET_FLAGS:
-            if "glyf" in varfont:
-                setMacOverlapFlags(varfont["glyf"])
+            glyfTag = "GLYF" if "GLYF" in varfont else "glyf"
+            if glyfTag in varfont:
+                setMacOverlapFlags(varfont[glyfTag])
         elif overlap in (OverlapMode.REMOVE, OverlapMode.REMOVE_AND_IGNORE_ERRORS):
             from fontTools.ttLib.removeOverlaps import removeOverlaps
 

--- a/Tests/varLib/instancer/instancer_test.py
+++ b/Tests/varLib/instancer/instancer_test.py
@@ -1115,6 +1115,148 @@ class InstantiateOTLTest(object):
         assert not hasattr(valueRec1, "XAdvDevice")
         assert valueRec1.XAdvance == -25
 
+    def test_full_instance_save_beyond64k(self):
+        """A fully-instanced beyond-64k VF can be saved and reloaded.
+
+        The variation tables use the uppercase companion spelling (GVAR, GLYF,
+        HMTX, ...). Full instancing must instance and drop GVAR/HVAR -- which it
+        only does once it resolves their uppercase tags -- and keep the extended
+        GDEF at v1.4, NULLing its VarStore once the instance consumes it rather
+        than downgrading the table and dropping the extended *2 fields like
+        GlyphClassDef2.
+        """
+        from fontTools.fontBuilder import FontBuilder
+        from fontTools.pens.ttGlyphPen import TTGlyphPen
+        from fontTools.ttLib.beyond64k import upper_tables
+
+        order = [".notdef"] + ["g%05d" % i for i in range(1, 0x10001)]  # 65537
+        HI = "g65536"  # glyph id > 0xFFFF, the point of beyond-64k
+        ACUTE = "g65530"
+
+        def make_hi(scale):
+            # a triangle that scales with the master, so gvar carries a real
+            # delta for this beyond-64k glyph id
+            pen = TTGlyphPen(None)
+            pen.moveTo((100 * scale, 0))
+            pen.lineTo((100 * scale, 100 * scale))
+            pen.lineTo((0, 100 * scale))
+            pen.closePath()
+            return pen.glyph()
+
+        def make_master(scale):
+            fb = FontBuilder(unitsPerEm=1000)
+            fb.setupGlyphOrder(order)
+            glyphs = {g: _g_l_y_f.Glyph() for g in order}
+            glyphs[HI] = make_hi(scale)
+            fb.setupGlyf(glyphs)
+            fb.setupHorizontalMetrics({g: (500, 0) for g in order})
+            fb.setupHorizontalHeader(ascent=800, descent=-200)
+            fb.setupNameTable({"familyName": "TestBeyond64k", "styleName": "R"})
+            fb.setupPost(keepGlyphNames=False)
+            addOpenTypeFeaturesFromString(
+                fb.font,
+                "markClass %(ACUTE)s <anchor %(a)d %(a)d> @TOP;\n"
+                "feature mark { pos base %(HI)s <anchor %(a)d %(a)d> mark @TOP; } mark;\n"
+                "table GDEF { GlyphClassDef ,,[%(ACUTE)s],; } GDEF;\n"
+                % dict(ACUTE=ACUTE, HI=HI, a=10 * scale),
+            )
+            return fb.font
+
+        doc = designspaceLib.DesignSpaceDocument()
+        doc.addAxis(
+            designspaceLib.AxisDescriptor(
+                tag="wght", name="Weight", minimum=0, default=0, maximum=1000
+            )
+        )
+        for loc, scale in [(0, 1), (1000, 2)]:
+            doc.addSource(
+                designspaceLib.SourceDescriptor(
+                    font=make_master(scale), location={"Weight": loc}
+                )
+            )
+        vf, _, _ = varLib.build(doc)
+        assert vf.hasExtendedGlyphIDs()
+        # ufo2ft uppercases the companion tables on the final VF, not the masters
+        upper_tables(vf)
+        assert "GVAR" in vf and "gvar" not in vf
+        assert vf["GVAR"].variations[HI]  # the beyond-64k glyph carries a delta
+        assert vf["GDEF"].table.Version == 0x00010004
+        assert vf["GDEF"].table.VarStore is not None  # consumed by the full instance
+
+        # the single axis -> pinning it is a full instance
+        instancer.instantiateVariableFont(vf, {"wght": 500}, inplace=True)
+
+        # GVAR/HVAR instanced then dropped; GDEF stays extended (v1.4)
+        assert "GVAR" not in vf and "gvar" not in vf
+        assert "HVAR" not in vf
+        assert vf["GDEF"].table.Version == 0x00010004
+
+        # the step that used to crash: save the fully-instanced font
+        data = BytesIO()
+        vf.save(data)
+        data.seek(0)
+        reloaded = ttLib.TTFont(data)
+        reloaded.ensureDecompiled()
+
+        assert reloaded.getGlyphCount() == 65537
+        assert "GLYF" in reloaded and "LOCA" in reloaded
+        assert reloaded["GDEF"].table.Version == 0x00010004
+        assert reloaded["GDEF"].table.VarStore is None  # NULLed, not removed
+        assert reloaded["GDEF"].table.GlyphClassDef2 is not None  # extended field kept
+        # the beyond-64k mark-class value (3) survives at v1.4; resolve the acute
+        # glyph by id since keepGlyphNames=False drops the names on reload
+        acuteName = reloaded.getGlyphName(65530)
+        assert reloaded["GDEF"].table.GlyphClassDef2.classDefs[acuteName] == 3
+
+        # the gvar delta for the beyond-64k glyph was applied to its outline at
+        # the pinned location: each master triangle scales 1x <-> 2x, so 500
+        # (normalized 0.5) interpolates the coordinates halfway
+        glyf = reloaded["GLYF"]
+        hiGlyph = glyf[reloaded.getGlyphName(65536)]
+        assert [tuple(pt) for pt in hiGlyph.coordinates] == [
+            (150, 0),
+            (150, 150),
+            (0, 150),
+        ]
+
+        # the GPOS mark anchor interpolated at the pinned location: 10 <-> 20 -> 15
+        gpos = reloaded["GPOS"].table
+        markBasePos = gpos.LookupList2.Lookup[0].SubTable[0]
+        assert markBasePos.Format == 2  # extended MarkBasePos
+        anchor = markBasePos.BaseArray.BaseRecord[0].BaseAnchor[0]
+        assert (anchor.XCoordinate, anchor.YCoordinate) == (15, 15)
+
+    def test_partial_instance_save_beyond64k(self):
+        """Partially instancing a beyond-64k VF retains and rewrites GVAR.
+
+        Pinning one of two axes leaves residual variations, so the uppercase
+        GVAR (and the companion metric tables) must be instanced in place and
+        the font must still save and reload.
+        """
+        from fontTools.ttLib.beyond64k import upper_tables
+
+        vf = ttLib.TTFont()
+        vf.importXML(os.path.join(TESTDATA, "PartialInstancerTest-VF.ttx"))
+        upper_tables(vf)
+        assert "GVAR" in vf and "GLYF" in vf and "HMTX" in vf
+
+        axes = {a.axisTag: a for a in vf["fvar"].axes}
+        instancer.instantiateVariableFont(
+            vf, {"wght": axes["wght"].defaultValue}, inplace=True
+        )
+
+        # the wdth axis survives, so GVAR keeps residual variations
+        assert [a.axisTag for a in vf["fvar"].axes] == ["wdth"]
+        assert "GVAR" in vf
+
+        data = BytesIO()
+        vf.save(data)
+        data.seek(0)
+        reloaded = ttLib.TTFont(data)
+        reloaded.ensureDecompiled()
+        assert "GVAR" in reloaded and "GLYF" in reloaded
+        assert reloaded.getGlyphOrder() == vf.getGlyphOrder()
+
 
 class InstantiateAvarTest(object):
     @pytest.mark.parametrize("location", [{"wght": 0.0}, {"wdth": 0.0}])


### PR DESCRIPTION
The instancer addressed tables by their lowercase tags (gvar, glyf, hmtx, hhea), so on a beyond-64k font that uses the uppercase companion tables nothing matched: GVAR was never instanced or dropped, and saving a full instance then raised KeyError('fvar') from gvar's compile reaching the deleted fvar. Resolve each tag to whichever spelling is present.

Also don't downgrade the GDEF v1.4 when instancing fully consumes the VarStore, make the latter None instead.