### PR TITLE
[beyond64k] Drop post 2.0 names at 65536 glyphs, not 65537

### DIFF
--- a/Lib/fontTools/merge/__init__.py
+++ b/Lib/fontTools/merge/__init__.py
@@ -97,7 +97,8 @@ class Merger(object):
         fonts = self._openFonts(fontfiles)
         glyphOrders = [list(font.getGlyphOrder()) for font in fonts]
         computeMegaGlyphOrder(self, glyphOrders)
-        self.beyond64k = len(self.glyphOrder) > 0x10000 or any(
+        # maxp.numGlyphs is uint16: needs upper tables above 0xFFFF, not 0x10000.
+        self.beyond64k = len(self.glyphOrder) > 0xFFFF or any(
             _fontHasUpperTables(font) for font in fonts
         )
 

--- a/Lib/fontTools/ttLib/beyond64k.py
+++ b/Lib/fontTools/ttLib/beyond64k.py
@@ -643,7 +643,8 @@ def _drop_beyond64k_cmap_format4(font: TTFont) -> None:
 
 
 def _drop_beyond64k_post_glyph_names(font: TTFont) -> None:
-    if "post" not in font or len(font.getGlyphOrder()) <= 0x10000:
+    # post 2.0 numberOfGlyphs is uint16: drop above 0xFFFF, not 0x10000.
+    if "post" not in font or len(font.getGlyphOrder()) <= 0xFFFF:
         return
 
     post = font["post"]

--- a/Tests/ttLib/beyond64k_test.py
+++ b/Tests/ttLib/beyond64k_test.py
@@ -760,6 +760,37 @@ def test_upper_tables_drops_beyond64k_post_glyph_names():
     post.compile(font)
 
 
+@pytest.mark.parametrize(
+    "num_glyphs, dropped",
+    [(0xFFFF, False), (0x10000, True), (0x10001, True)],
+)
+def test_upper_tables_drops_post_glyph_names_at_glyph_count_boundary(
+    num_glyphs, dropped
+):
+    # post 2.0 numberOfGlyphs is uint16, so a font with 0x10000 (65536) glyphs
+    # cannot keep version 2.0 even though every glyph id (0..0xFFFF) still fits:
+    # the count overflows. The drop must trigger at > 0xFFFF, not > 0x10000.
+    font = TTFont()
+    font.setGlyphOrder([".notdef"] + [f"glyph{i}" for i in range(1, num_glyphs)])
+    assert len(font.getGlyphOrder()) == num_glyphs
+    post = font["post"] = newTable("post")
+    post.formatType = 2.0
+    post.italicAngle = 0
+    post.underlinePosition = 0
+    post.underlineThickness = 0
+    post.isFixedPitch = 0
+    post.minMemType42 = 0
+    post.maxMemType42 = 0
+    post.minMemType1 = 0
+    post.maxMemType1 = 0
+    post.extraNames = []
+    post.mapping = {}
+
+    upper_tables(font)
+
+    assert post.formatType == (3.0 if dropped else 2.0)
+
+
 @pytest.mark.parametrize("tag", ["glyf", "GLYF"])
 def test_accepts_either_table_spelling(tag):
     font = TTFont()


### PR DESCRIPTION
post 2.0 numberOfGlyphs is uint16, so a glyph count of exactly 65536 already overflows it even though every glyph id still fits. _drop_beyond64k_post_glyph_names gated on > 0x10000 (i.e. >= 65537) instead of > 0xFFFF (>= 65536), leaving such a font with an unencodable post 2.0 table.