### PR TITLE
Implement splitSinglePos for overflow recovery (#4091)

### DIFF
--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -2368,6 +2368,33 @@ def splitLigatureSubst(oldSubTable, newSubTable, overflowRecord):
     return ok
 
 
+def splitSinglePos(oldSubTable, newSubTable, overflowRecord):
+    # Only Format 2 (one Value per covered glyph) is worth splitting; a Format 1
+    # subtable shares a single Value across its whole Coverage, so there is
+    # nothing worth splitting.
+    if oldSubTable.Format != 2 or len(oldSubTable.Coverage.glyphs) <= 1:
+        return False
+
+    newSubTable.Format = oldSubTable.Format
+    newSubTable.ValueFormat = oldSubTable.ValueFormat
+
+    coverage = oldSubTable.Coverage.glyphs
+    values = oldSubTable.Value
+    oldCount = len(coverage) // 2
+
+    newSubTable.Coverage = oldSubTable.Coverage.__class__()
+    newSubTable.Coverage.glyphs = coverage[oldCount:]
+    newSubTable.Value = values[oldCount:]
+
+    oldSubTable.Coverage.glyphs = coverage[:oldCount]
+    oldSubTable.Value = values[:oldCount]
+
+    oldSubTable.ValueCount = len(oldSubTable.Value)
+    newSubTable.ValueCount = len(newSubTable.Value)
+
+    return True
+
+
 def splitPairPos(oldSubTable, newSubTable, overflowRecord):
     st = oldSubTable
     ok = False
@@ -2511,7 +2538,7 @@ splitTable = {
         # 					8: splitReverseChainSingleSubst,
     },
     "GPOS": {
-        # 					1: splitSinglePos,
+        1: splitSinglePos,
         2: splitPairPos,
         # 					3: splitCursivePos,
         4: splitMarkBasePos,

--- a/Tests/ttLib/tables/otTables_test.py
+++ b/Tests/ttLib/tables/otTables_test.py
@@ -785,6 +785,78 @@ def test_splitSinglePos_format1():
     assert not otTables.splitSinglePos(subTable, otTables.SinglePos(), None)
 
 
+def test_splitSinglePos_overflow_end_to_end():
+    # A SinglePos Format 2 whose ValueArray pushes its own Coverage offset past
+    # uint16 must be split when packing. With ValueFormat=1 (2 bytes per Value)
+    # the Coverage offset is ~8 + 2*N bytes, so it overflows above ~32763 glyphs.
+    # https://github.com/fonttools/fonttools/issues/4091
+    from fontTools.ttLib import TTFont, getTableClass
+
+    N = 40000
+    glyphs = [f"g{i}" for i in range(N)]
+    font = TTFont()
+    font.setGlyphOrder([".notdef"] + glyphs)
+    # exercise the pure-fontTools overflow recovery, not the harfbuzz repacker
+    font.cfg["fontTools.ttLib.tables.otBase:USE_HARFBUZZ_REPACKER"] = False
+
+    subTable = otTables.SinglePos()
+    subTable.Format = 2
+    subTable.Coverage = otTables.Coverage()
+    subTable.Coverage.glyphs = list(glyphs)
+    subTable.ValueFormat = 0x0001  # XPlacement
+    subTable.Value = []
+    for i in range(N):
+        value = otTables.ValueRecord()
+        value.XPlacement = -(i % 100 + 1)
+        subTable.Value.append(value)
+
+    lookup = otTables.Lookup()
+    lookup.LookupType = 1
+    lookup.LookupFlag = 0
+    lookup.SubTable = [subTable]
+
+    feature = otTables.Feature()
+    feature.FeatureParams = None
+    feature.LookupListIndex = [0]
+    featureRecord = otTables.FeatureRecord()
+    featureRecord.FeatureTag = "kern"
+    featureRecord.Feature = feature
+    langSys = otTables.DefaultLangSys()
+    langSys.LookupOrder = None
+    langSys.ReqFeatureIndex = 0xFFFF
+    langSys.FeatureIndex = [0]
+    script = otTables.Script()
+    script.DefaultLangSys = langSys
+    script.LangSysRecord = []
+    scriptRecord = otTables.ScriptRecord()
+    scriptRecord.ScriptTag = "DFLT"
+    scriptRecord.Script = script
+
+    gpos = otTables.GPOS()
+    gpos.Version = 0x00010000
+    gpos.ScriptList = otTables.ScriptList()
+    gpos.ScriptList.ScriptRecord = [scriptRecord]
+    gpos.FeatureList = otTables.FeatureList()
+    gpos.FeatureList.FeatureRecord = [featureRecord]
+    gpos.LookupList = otTables.LookupList()
+    gpos.LookupList.Lookup = [lookup]
+
+    table = getTableClass("GPOS")()
+    table.table = gpos
+    font["GPOS"] = table
+
+    data = table.compile(font)
+
+    rebuilt = getTableClass("GPOS")()
+    rebuilt.decompile(data, font)
+    subTables = rebuilt.table.LookupList.Lookup[0].SubTable
+    assert len(subTables) > 1  # the oversized subtable was split
+    coverage = [g for st in subTables for g in st.Coverage.glyphs]
+    values = [v.XPlacement for st in subTables for v in st.Value]
+    assert coverage == glyphs
+    assert values == [-(i % 100 + 1) for i in range(N)]
+
+
 class ColrV1Test(unittest.TestCase):
     def setUp(self):
         self.font = FakeFont([".notdef", "meh"])

--- a/Tests/ttLib/tables/otTables_test.py
+++ b/Tests/ttLib/tables/otTables_test.py
@@ -749,6 +749,42 @@ def test_splitMarkBasePos():
     ]
 
 
+def test_splitSinglePos():
+    from fontTools.otlLib.builder import buildSinglePosSubtable, buildValue
+
+    mapping = {
+        "a": buildValue({"XPlacement": -10}),
+        "b": buildValue({"XPlacement": -20}),
+        "c": buildValue({"XPlacement": -30}),
+    }
+    glyphMap = {g: i for i, g in enumerate(["a", "b", "c"])}
+
+    oldSubTable = buildSinglePosSubtable(mapping, glyphMap)
+    assert oldSubTable.Format == 2
+    newSubTable = otTables.SinglePos()
+
+    ok = otTables.splitSinglePos(oldSubTable, newSubTable, overflowRecord=None)
+    assert ok
+
+    assert oldSubTable.Coverage.glyphs == ["a"]
+    assert [v.XPlacement for v in oldSubTable.Value] == [-10]
+    assert oldSubTable.ValueCount == 1
+
+    assert newSubTable.Format == 2
+    assert newSubTable.Coverage.glyphs == ["b", "c"]
+    assert [v.XPlacement for v in newSubTable.Value] == [-20, -30]
+    assert newSubTable.ValueCount == 2
+
+
+def test_splitSinglePos_format1():
+    # Format 1 has a single shared Value with nothing to split.
+    subTable = otTables.SinglePos()
+    subTable.Format = 1
+    subTable.Coverage = otTables.Coverage()
+    subTable.Coverage.glyphs = ["a", "b"]
+    assert not otTables.splitSinglePos(subTable, otTables.SinglePos(), None)
+
+
 class ColrV1Test(unittest.TestCase):
     def setUp(self):
         self.font = FakeFont([".notdef", "meh"])


### PR DESCRIPTION
## Summary

Implements `splitSinglePos`, the missing GPOS lookup-type-1 entry in the overflow-recovery `splitTable` dispatch (it was commented out at `otTables.py`). Until now, a `SinglePos Format 2` subtable whose internal `Coverage` offset overflowed uint16 could not be split, so `fixSubTableOverFlows` logged *"Don't know how to split GPOS lookup type 1"* and packing failed.

This is the type-1 sibling of the already-present `splitPairPos` / `splitMarkBasePos`, and the same class of gap as #1328 (type 6).

## Implementation

`SinglePos Format 2`'s `Value` array is 1:1 with its `Coverage`, so the subtable splits cleanly along the coverage — the same shape as `splitPairPos`. `Format 1` shares a single `Value` across the whole coverage and has nothing to split, so it returns `False`.

Verified end-to-end: a single `SinglePos Format 2` with 40 000 glyphs (whose `Coverage` offset overflows) now compiles, splitting into two subtables that round-trip back to all 40 000 glyphs.

## Note on the #4091 reproducer

The N=4000 reproducer in the issue actually hits a **different**, architectural limit: the `LookupList`'s `Offset16` cap. With ~4000 lookups, the offset to lookup ~3596 (≈ 8000-byte offset array + 3596×16 bytes per extension-wrapped lookup) exceeds 65535 even when every lookup is promoted to Extension — no subtable split can recover it (the fix there is fewer/merged lookups). `splitSinglePos` is still a genuine missing feature and resolves the *splittable* case this issue named as fix #1.

## Test

`test_splitSinglePos` (Format 2 splits along coverage) and `test_splitSinglePos_format1` (Format 1 is unsplittable) in `Tests/ttLib/tables/otTables_test.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)