### PR TITLE
Raise TTLibError (not RecursionError) on recursive components in recalcBounds (#3899)

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1222,7 +1222,13 @@ class Glyph(object):
             g = glyfTable[glyphName]
 
             if boundsDone is None or glyphName not in boundsDone:
-                g.recalcBounds(glyfTable, boundsDone=boundsDone)
+                try:
+                    g.recalcBounds(glyfTable, boundsDone=boundsDone)
+                except RecursionError:
+                    raise ttLib.TTLibError(
+                        "glyph '%s' contains a recursive component reference"
+                        % glyphName
+                    )
                 if boundsDone is not None:
                     boundsDone.add(glyphName)
             # empty components shouldn't update the bounds of the parent glyph

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -270,6 +270,66 @@ class GlyfTableTest(unittest.TestCase):
         ):
             glyph_A.getCoordinates(glyphSet)
 
+    def test_recalcBounds_recursiveComponent(self):
+        # Integer-translate-only components take the fast path
+        # (tryRecalcBoundsComposite); a recursive reference there must raise
+        # TTLibError just like the getCoordinates slow path, rather than let a
+        # raw RecursionError escape.
+        # https://github.com/fonttools/fonttools/issues/3899
+        def make(glyphSet, name, ref, dx, dy):
+            pen = TTGlyphPen(glyphSet)
+            pen.addComponent(ref, (1, 0, 0, 1, dx, dy))
+            glyphSet[name] = pen.glyph()
+
+        # A -> B -> A cycle, all plain integer translates.
+        glyphSet = {}
+        glyphSet["A"] = glyphSet["B"] = TTGlyphPen(glyphSet).glyph()
+        make(glyphSet, "A", "B", 10, 0)
+        make(glyphSet, "B", "A", 0, 10)
+        # sanity check that this exercises the integer-translate fast path
+        self.assertTrue(glyphSet["A"].components[0]._hasOnlyIntegerTranslate())
+        with self.assertRaisesRegex(
+            TTLibError, "glyph '.' contains a recursive component reference"
+        ):
+            glyphSet["A"].recalcBounds(glyphSet)
+        # and via the boundsDone set that table__g_l_y_f.compile() passes
+        with self.assertRaisesRegex(
+            TTLibError, "glyph '.' contains a recursive component reference"
+        ):
+            glyphSet["A"].recalcBounds(glyphSet, boundsDone=set())
+
+        # A glyph that references itself.
+        glyphSet = {}
+        glyphSet["A"] = TTGlyphPen(glyphSet).glyph()
+        make(glyphSet, "A", "A", 5, 5)
+        with self.assertRaisesRegex(
+            TTLibError, "glyph 'A' contains a recursive component reference"
+        ):
+            glyphSet["A"].recalcBounds(glyphSet)
+
+        # A valid acyclic integer-translate composite must still compute the
+        # correct bounds (the recursion guard must not affect normal glyphs).
+        glyphSet = {}
+        pen = TTGlyphPen(glyphSet)
+        pen.moveTo((5, 5))
+        pen.lineTo((10, 10))
+        pen.lineTo((10, 5))
+        pen.lineTo((5, 5))
+        pen.closePath()
+        glyphSet["base"] = pen.glyph()
+        make(glyphSet, "A", "base", 100, 200)
+        glyphSet["base"].recalcBounds(glyphSet)
+        glyphSet["A"].recalcBounds(glyphSet, boundsDone=set())
+        self.assertEqual(
+            (
+                glyphSet["A"].xMin,
+                glyphSet["A"].yMin,
+                glyphSet["A"].xMax,
+                glyphSet["A"].yMax,
+            ),
+            (105, 205, 110, 210),
+        )
+
     def test_trim_remove_hinting_composite_glyph(self):
         glyphSet = {"dummy": TTGlyphPen(None).glyph()}
 

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -270,22 +270,22 @@ class GlyfTableTest(unittest.TestCase):
         ):
             glyph_A.getCoordinates(glyphSet)
 
+    def _makeComponentGlyph(self, glyphSet, name, ref, dx, dy):
+        pen = TTGlyphPen(glyphSet)
+        pen.addComponent(ref, (1, 0, 0, 1, dx, dy))
+        glyphSet[name] = pen.glyph()
+
     def test_recalcBounds_recursiveComponent(self):
         # Integer-translate-only components take the fast path
         # (tryRecalcBoundsComposite); a recursive reference there must raise
         # TTLibError just like the getCoordinates slow path, rather than let a
         # raw RecursionError escape.
         # https://github.com/fonttools/fonttools/issues/3899
-        def make(glyphSet, name, ref, dx, dy):
-            pen = TTGlyphPen(glyphSet)
-            pen.addComponent(ref, (1, 0, 0, 1, dx, dy))
-            glyphSet[name] = pen.glyph()
-
         # A -> B -> A cycle, all plain integer translates.
         glyphSet = {}
         glyphSet["A"] = glyphSet["B"] = TTGlyphPen(glyphSet).glyph()
-        make(glyphSet, "A", "B", 10, 0)
-        make(glyphSet, "B", "A", 0, 10)
+        self._makeComponentGlyph(glyphSet, "A", "B", 10, 0)
+        self._makeComponentGlyph(glyphSet, "B", "A", 0, 10)
         # sanity check that this exercises the integer-translate fast path
         self.assertTrue(glyphSet["A"].components[0]._hasOnlyIntegerTranslate())
         with self.assertRaisesRegex(
@@ -298,15 +298,16 @@ class GlyfTableTest(unittest.TestCase):
         ):
             glyphSet["A"].recalcBounds(glyphSet, boundsDone=set())
 
-        # A glyph that references itself.
+    def test_recalcBounds_selfReferencingComponent(self):
         glyphSet = {}
         glyphSet["A"] = TTGlyphPen(glyphSet).glyph()
-        make(glyphSet, "A", "A", 5, 5)
+        self._makeComponentGlyph(glyphSet, "A", "A", 5, 5)
         with self.assertRaisesRegex(
             TTLibError, "glyph 'A' contains a recursive component reference"
         ):
             glyphSet["A"].recalcBounds(glyphSet)
 
+    def test_recalcBounds_acyclicComposite(self):
         # A valid acyclic integer-translate composite must still compute the
         # correct bounds (the recursion guard must not affect normal glyphs).
         glyphSet = {}
@@ -317,7 +318,7 @@ class GlyfTableTest(unittest.TestCase):
         pen.lineTo((5, 5))
         pen.closePath()
         glyphSet["base"] = pen.glyph()
-        make(glyphSet, "A", "base", 100, 200)
+        self._makeComponentGlyph(glyphSet, "A", "base", 100, 200)
         glyphSet["base"].recalcBounds(glyphSet)
         glyphSet["A"].recalcBounds(glyphSet, boundsDone=set())
         self.assertEqual(


### PR DESCRIPTION
Fixes #3899.

### The bug

`Glyph.recalcBounds()` lets a raw `RecursionError` escape on a composite glyph whose components form a reference cycle, as long as the components are plain integer translates:

```python
import sys
from fontTools.ttLib import newTable
from fontTools.ttLib.tables._g_l_y_f import Glyph, GlyphComponent
sys.setrecursionlimit(300)

def comp(ref, x, y):
    g = Glyph(); g.numberOfContours = -1
    c = GlyphComponent(); c.glyphName = ref; c.x, c.y = x, y; c.flags = 0
    g.components = [c]; return g

glyf = newTable("glyf"); glyf.glyphs = {}; glyf.glyphOrder = ["A", "B"]
glyf.glyphs["A"] = comp("B", 10, 0)
glyf.glyphs["B"] = comp("A", 0, 10)
glyf.glyphs["A"].recalcBounds(glyf)      # RecursionError: maximum recursion depth exceeded
```

This shows up on real fonts (issue #3899 hit it on PDF-embedded TTFs) and propagates out of `compile()`, which calls `recalcBounds(boundsDone=set())`.

### Why `TTLibError` is the right result

The slow path for the same invalid input, `Glyph.getCoordinates()`, already handles this:

```python
try:
    coordinates, endPts, flags = g.getCoordinates(glyfTable, round=round)
except RecursionError:
    raise ttLib.TTLibError(
        "glyph '%s' contains a recursive component reference" % compo.glyphName
    )
```

So a cyclic composite *with a transform* (which takes the slow path) already raises a clean `TTLibError`, while a cyclic composite that is *integer-translate-only* (the fast path) crashes with a raw `RecursionError`. The two paths disagree on identical input; this aligns them.

### Root cause

`Glyph.tryRecalcBoundsComposite()` is the integer-translate fast path added for faster `glyf` compiles. Its `boundsDone` set is a dedup cache, not a cycle breaker — it is `None` on the public `recalcBounds()` entry, and even when a set is passed, `boundsDone.add(glyphName)` runs only *after* the recursive `recalcBounds` returns, so a cycle never gets recorded. Unlike `getCoordinates`, it had no `RecursionError` guard.

### The fix

Wrap the recursive call exactly as `getCoordinates` does, so both paths raise the same `TTLibError`:

```python
try:
    g.recalcBounds(glyfTable, boundsDone=boundsDone)
except RecursionError:
    raise ttLib.TTLibError(
        "glyph '%s' contains a recursive component reference" % glyphName
    )
```

### Tests

`test_recalcBounds_recursiveComponent` builds integer-translate composites (asserting the fast path is taken via `_hasOnlyIntegerTranslate()`) and checks that an `A↔B` cycle and a self-referencing glyph each raise `TTLibError` — both directly and via the `boundsDone=set()` path that `compile()` uses — while a valid acyclic composite still computes the correct translated bounds. The new test triggers `RecursionError` on `main` and passes with the fix; the existing `_g_l_y_f` suite (62 tests) stays green, black-clean.
