### PR TITLE
Round-trip empty Macintosh cmap format 2 subtables (#3663)

### DIFF
--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -450,6 +450,10 @@ class SubHeader(object):
 class cmap_format_2(CmapSubtable):
     def setIDDelta(self, subHeader):
         subHeader.idDelta = 0
+        # An empty subheader (an all-notdef two-byte range) has no glyphs to
+        # adjust, so leave idDelta at 0 and bail before indexing the array.
+        if not subHeader.glyphIndexArray:
+            return
         # find the minGI which is not zero.
         minGI = subHeader.glyphIndexArray[0]
         for gid in subHeader.glyphIndexArray:
@@ -645,8 +649,9 @@ class cmap_format_2(CmapSubtable):
         # We force this subheader entry 0 to exist in the subHeaderList in the case where some one comes up
         # with a cmap where all the one byte char codes map to notdef,
         # with the result that the subhead 0 would not get created just by processing the item list.
-        charCode = charCodes[0]
-        if charCode > 255:
+        # The same is true for an entirely empty (all-notdef) cmap, where there
+        # are no char codes to process at all.
+        if not charCodes or charCodes[0] > 255:
             subHeader = SubHeader()
             subHeader.firstCode = 0
             subHeader.entryCount = 0

--- a/Tests/ttLib/tables/_c_m_a_p_test.py
+++ b/Tests/ttLib/tables/_c_m_a_p_test.py
@@ -1,6 +1,7 @@
 import io
 import os
 import re
+import struct
 from fontTools import ttLib
 from fontTools.fontBuilder import FontBuilder
 import unittest
@@ -97,6 +98,42 @@ class CmapSubtableTest(unittest.TestCase):
         data = subtable.compile(font)
         subtable2 = CmapSubtable.newSubtable(4)
         subtable2.decompile(data, font)
+        self.assertEqual(subtable2.cmap, {})
+
+    def test_compile_decompile_2_empty(self):
+        # An all-.notdef (empty) Macintosh format 2 cmap must round-trip
+        # instead of crashing on compile, just like format 4 above.
+        # https://github.com/fonttools/fonttools/issues/3663
+        subtable = self.makeSubtable(2, 1, 3, 0)
+        subtable.cmap = {}
+        font = ttLib.TTFont()
+        font.setGlyphOrder([])
+        data = subtable.compile(font)
+        subtable2 = CmapSubtable.newSubtable(2)
+        subtable2.decompile(data, font)
+        self.assertEqual(subtable2.cmap, {})
+
+    def test_decompile_compile_2_all_notdef(self):
+        # A binary format 2 subtable whose only subheader maps its whole range
+        # to .notdef (entryCount 0, the spec's way of encoding a notdef range)
+        # decompiles to an empty cmap; recompiling it must not raise.
+        # https://github.com/fonttools/fonttools/issues/3663
+        font = ttLib.TTFont()
+        font.setGlyphOrder([".notdef", "A", "B"])
+        subHeaderKeys = b"\x00\x00" * 256  # every first byte -> subHeader 0
+        # subHeader 0: firstCode, entryCount, idDelta, idRangeOffset all zero
+        subHeader0 = struct.pack(">HHhH", 0, 0, 0, 0)
+        body = subHeaderKeys + subHeader0
+        data = struct.pack(">HHH", 2, 6 + len(body), 0) + body
+
+        subtable = CmapSubtable.newSubtable(2)
+        subtable.platformID, subtable.platEncID = 1, 3
+        subtable.decompile(data, font)
+        self.assertEqual(subtable.cmap, {})
+
+        # recompiling and decompiling again must still give the empty cmap
+        subtable2 = CmapSubtable.newSubtable(2)
+        subtable2.decompile(subtable.compile(font), font)
         self.assertEqual(subtable2.cmap, {})
 
     def test_decompile_4(self):


### PR DESCRIPTION
Fixes #3663.

### The bug

A Macintosh `cmap` format 2 (high-byte) subtable whose only subheader maps its whole range to `.notdef` — i.e. an empty cmap, which is a legal way to encode a notdef range — decompiles cleanly to `{}` but crashes when recompiled:

```python
subtable = CmapSubtable.newSubtable(2)
subtable.platformID, subtable.platEncID, subtable.language = 1, 3, 0
subtable.cmap = {}
font = TTFont(); font.setGlyphOrder([])
subtable.compile(font)        # IndexError: list index out of range
```

The analogous empty case for format 4 is already supported and tested (`test_compile_decompile_4_empty`), so the inconsistency is clear: an empty cmap must round-trip, not crash. Reported in #3663 on a real font with a Mac Korean format 2 subtable.

### Root cause

`cmap_format_2.compile` (`Lib/fontTools/ttLib/tables/_c_m_a_p.py`):

- It indexes `charCode = charCodes[0]` to decide whether to force-create subHeader 0 (the comment already anticipates "a cmap where all the one byte char codes map to notdef"), but `charCodes` is empty when the whole cmap is empty → `IndexError`.
- Once that is fixed, `setIDDelta` then does `minGI = subHeader.glyphIndexArray[0]` on the empty subHeader 0, which has an empty `glyphIndexArray` → a second `IndexError`.

### The fix

Two minimal guards that extend the existing notdef handling to the empty case:

- Force subHeader 0 when there are **no** char codes at all, not only when the first one is > 255: `if not charCodes or charCodes[0] > 255:`.
- In `setIDDelta`, return early (leaving `idDelta = 0`) when the subheader's `glyphIndexArray` is empty — an all-notdef range has no glyphs to adjust.

With these, an empty format 2 subtable compiles to a valid subtable and round-trips back to `{}`; a normal two-byte (real Mac high-byte) cmap is unaffected.

### Tests

`test_compile_decompile_2_empty` mirrors the existing format-4 empty test (compile an empty format-2 cmap and decompile back to `{}`). `test_decompile_compile_2_all_notdef` builds the actual binary all-notdef subtable from #3663, decompiles it to `{}`, then recompiles and decompiles again to confirm the round-trip. Both fail on `main` with the original `IndexError` and pass with the fix; the full `Tests/ttLib/tables/` + `Tests/ttx` suites stay green (1390 passed), black-clean.
