### PR TITLE
[svgLib.path] Don't crash on a redundant closepath (Z Z)

### DIFF
--- a/Lib/fontTools/svgLib/path/parser.py
+++ b/Lib/fontTools/svgLib/path/parser.py
@@ -171,11 +171,15 @@ def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):
 
         elif command == "Z":
             # Close path
-            if current_pos != start_pos:
-                pen.lineTo((start_pos.real, start_pos.imag))
-            pen.closePath()
-            current_pos = start_pos
-            start_pos = None
+            # A redundant Z with no open subpath (e.g. "M0,0 Z Z") is valid
+            # per the SVG path grammar and has no effect; ignore it instead of
+            # crashing on start_pos being None.
+            if start_pos is not None:
+                if current_pos != start_pos:
+                    pen.lineTo((start_pos.real, start_pos.imag))
+                pen.closePath()
+                current_pos = start_pos
+                start_pos = None
             command = None  # You can't have implicit commands after closing.
 
         elif command == "L":

--- a/Tests/svgLib/path/parser_test.py
+++ b/Tests/svgLib/path/parser_test.py
@@ -32,6 +32,27 @@ import pytest
                 ("closePath", ()),
             ],
         ),
+        # a redundant Z after a subpath is already closed is a no-op
+        # (valid per the SVG path grammar); it must not crash nor emit
+        # a second closePath.
+        (
+            "M 100 100 L 300 100 L 200 300 z z",
+            [
+                ("moveTo", ((100.0, 100.0),)),
+                ("lineTo", ((300.0, 100.0),)),
+                ("lineTo", ((200.0, 300.0),)),
+                ("lineTo", ((100.0, 100.0),)),
+                ("closePath", ()),
+            ],
+        ),
+        # a redundant Z following an empty (moveto-only) closed subpath
+        (
+            "M 100 100 Z Z",
+            [
+                ("moveTo", ((100.0, 100.0),)),
+                ("closePath", ()),
+            ],
+        ),
         (
             "M100,200 C100,100 250,100 250,200 S400,300 400,200",
             [


### PR DESCRIPTION
## Summary

`svgLib.path.parse_path()` crashes with a cryptic `AttributeError` on any SVG path that contains **two consecutive closepath (`Z`) commands**, e.g. `"M0,0 L1,1 Z Z"` or `"M0,0 Z Z"`.

```pycon
>>> from fontTools.svgLib.path import parse_path
>>> from fontTools.pens.recordingPen import RecordingPen
>>> parse_path("M0,0 L1,1 Z Z", RecordingPen())
Traceback (most recent call last):
  ...
  File ".../fontTools/svgLib/path/parser.py", line 175, in parse_path
    pen.lineTo((start_pos.real, start_pos.imag))
                ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'real'
```

A redundant closepath is **valid** per the [SVG path grammar](https://www.w3.org/TR/SVG/paths.html#PathDataBNF) (`drawto-commands` permits a repeated `closepath`), and browsers render `M0,0 L1,1 Z Z` identically to a single `Z`. fontTools should not crash on it.

## Root cause

Closing a subpath (`Z`) sets `start_pos = None` to mark that there is no longer an open subpath:

```python
elif command == "Z":
    # Close path
    if current_pos != start_pos:
        pen.lineTo((start_pos.real, start_pos.imag))
    pen.closePath()
    current_pos = start_pos
    start_pos = None
    command = None
```

A **following** `Z` re-enters the same branch. The guard `current_pos != start_pos` now compares a `complex` against `None` (always `True`), so it calls `pen.lineTo((start_pos.real, start_pos.imag))` with `start_pos is None` → `AttributeError`.

## Fix

Guard the close-path body on `start_pos is not None`, so a redundant `Z` with no open subpath is a no-op (matching the spec / browser behaviour) instead of a crash. `command` is still reset to `None` in both cases. Non-redundant `Z` behaviour is completely unchanged.

```python
elif command == "Z":
    # Close path
    # A redundant Z with no open subpath (e.g. "M0,0 Z Z") is valid
    # per the SVG path grammar and has no effect; ignore it instead of
    # crashing on start_pos being None.
    if start_pos is not None:
        if current_pos != start_pos:
            pen.lineTo((start_pos.real, start_pos.imag))
        pen.closePath()
        current_pos = start_pos
        start_pos = None
    command = None  # You can't have implicit commands after closing.
```

### Before / after

| input | before | after |
|---|---|---|
| `M0,0 L1,1 Z Z` | `AttributeError` | same output as a single `Z` (one `closePath`, no extra ops) |
| `M0,0 Z Z` | `AttributeError` | `moveTo`, `closePath` |
| `M0,0 L1,1 Z` | `moveTo, lineTo, lineTo, closePath` | unchanged |

## Tests

Added two parametrized regression cases to `Tests/svgLib/path/parser_test.py` (`"... z z"` after a real subpath, and `"M 100 100 Z Z"` after an empty moveto-only subpath).

Proven to guard the bug — stashing **only** the source fix and running the suite:

```
FAILED Tests/svgLib/path/parser_test.py::test_parse_path[M 100 100 L 300 100 L 200 300 z z-expected2]
FAILED Tests/svgLib/path/parser_test.py::test_parse_path[M 100 100 Z Z-expected3]
2 failed, 36 passed
```

With the fix restored: `38 passed`. Broader sweep (`Tests/svgLib Tests/pens Tests/misc Tests/ufoLib Tests/feaLib Tests/cu2qu`) `1566 passed, 24 skipped, 2 xfailed` — no regressions.

`black --check` is clean on the added lines (the tool flags a pre-existing blank-line nit near the imports at the top of `parser.py`, unrelated to this change and left untouched).

Diff: +30 / −5 across the parser and its tests.
