### PR TITLE
[misc.filesystem] contain OSFS paths within the filesystem root

### DIFF
--- a/Lib/fontTools/misc/filesystem/_errors.py
+++ b/Lib/fontTools/misc/filesystem/_errors.py
@@ -55,7 +55,7 @@ class ResourceReadOnly(ResourceError):
 
 
 class IllegalBackReference(ValueError):
+    # Named after fs.errors.IllegalBackReference (which is also a ValueError and
+    # not an FSError) so that code catching the upstream error keeps working.
     def __init__(self, path):
-        super().__init__(
-            f"path {path!r} contains back-references outside of filesystem"
-        )
+        super().__init__(f"path {path!r} resolves outside of the filesystem root")

--- a/Lib/fontTools/misc/filesystem/_errors.py
+++ b/Lib/fontTools/misc/filesystem/_errors.py
@@ -52,3 +52,10 @@ class DestinationExists(ResourceError):
 
 class ResourceReadOnly(ResourceError):
     pass
+
+
+class IllegalBackReference(ValueError):
+    def __init__(self, path):
+        super().__init__(
+            f"path {path!r} contains back-references outside of filesystem"
+        )

--- a/Lib/fontTools/misc/filesystem/_osfs.py
+++ b/Lib/fontTools/misc/filesystem/_osfs.py
@@ -52,7 +52,13 @@ class OSFS(FS):
     def _abs(self, rel_path: str) -> Path:
         self.check()
         abs_path = (self._root / rel_path.strip("/")).resolve()
-        if abs_path != self._root and self._root not in abs_path.parents:
+        # resolve() expands symlinks as well as back-references, so a symlink
+        # inside the root that points outside it is rejected too. That is
+        # stricter than pyfilesystem2, whose OSFS normalizes textually and
+        # follows symlinks out of the root, and deliberately so: paths reaching
+        # here can come from untrusted data, e.g. a glyph file name read from a
+        # third-party UFO's contents.plist.
+        if not abs_path.is_relative_to(self._root):
             raise IllegalBackReference(rel_path)
         return abs_path
 

--- a/Lib/fontTools/misc/filesystem/_osfs.py
+++ b/Lib/fontTools/misc/filesystem/_osfs.py
@@ -14,6 +14,7 @@ from ._errors import (
     DirectoryExpected,
     DirectoryNotEmpty,
     FileExpected,
+    IllegalBackReference,
     IllegalDestination,
     ResourceError,
     ResourceNotFound,
@@ -50,7 +51,10 @@ class OSFS(FS):
 
     def _abs(self, rel_path: str) -> Path:
         self.check()
-        return (self._root / rel_path.strip("/")).resolve()
+        abs_path = (self._root / rel_path.strip("/")).resolve()
+        if abs_path != self._root and self._root not in abs_path.parents:
+            raise IllegalBackReference(rel_path)
+        return abs_path
 
     def open(self, path: str, mode: str = "rb", **kwargs) -> IO[Any]:
         try:

--- a/Lib/fontTools/misc/filesystem/_path.py
+++ b/Lib/fontTools/misc/filesystem/_path.py
@@ -65,3 +65,11 @@ def normpath(path: str) -> str:
         # but we want forward slashes, so we convert them back
         normalized = normalized.replace("\\", "/")
     return normalized
+
+
+def escapes_root(path: str) -> bool:
+    # Check whether `path` normalizes to a location outside the filesystem root.
+    # This is a purely textual test, for use where a path can be rejected before
+    # anything touches the disk; OSFS._abs does the authoritative check.
+    normalized = normpath(relpath(path))
+    return normalized == ".." or normalized.startswith("../")

--- a/Lib/fontTools/misc/filesystem/_zipfs.py
+++ b/Lib/fontTools/misc/filesystem/_zipfs.py
@@ -9,9 +9,14 @@ import zipfile
 from datetime import datetime
 
 from ._base import FS
-from ._errors import FileExpected, ResourceNotFound, ResourceReadOnly
+from ._errors import (
+    FileExpected,
+    IllegalBackReference,
+    ResourceNotFound,
+    ResourceReadOnly,
+)
 from ._info import Info
-from ._path import dirname, forcedir, normpath, relpath
+from ._path import dirname, escapes_root, forcedir, normpath, relpath
 from ._tempfs import TempFS
 
 if typing.TYPE_CHECKING:
@@ -66,14 +71,30 @@ class ReadZipFS(FS):
     @property
     def _directory(self) -> TempFS:
         if self._directory_fs is None:
-            self._directory_fs = _fs = TempFS()
+            # Reject escaping member names up front, so the error names the zip
+            # entry rather than a path the caller never passed.
             for zip_name in self._zip.namelist():
-                resource_name = zip_name
-                if resource_name.endswith("/"):
-                    _fs.makedirs(resource_name, recreate=True)
-                else:
-                    _fs.makedirs(dirname(resource_name), recreate=True)
-                    _fs.create(resource_name)
+                if escapes_root(zip_name):
+                    raise IllegalBackReference(zip_name)
+            # Populate a local mirror and only publish it once it is complete:
+            # an archive can fail partway through for reasons the pre-scan can't
+            # see (a member named both as a file and as a directory, an escaping
+            # name that only pathlib recognises on this platform), and a cached
+            # half-built mirror would answer later calls from a silently
+            # truncated view of the zip instead of failing again.
+            _fs = TempFS()
+            try:
+                for zip_name in self._zip.namelist():
+                    resource_name = zip_name
+                    if resource_name.endswith("/"):
+                        _fs.makedirs(resource_name, recreate=True)
+                    else:
+                        _fs.makedirs(dirname(resource_name), recreate=True)
+                        _fs.create(resource_name)
+            except Exception:
+                _fs.close()
+                raise
+            self._directory_fs = _fs
         return self._directory_fs
 
     def close(self):

--- a/Tests/misc/filesystem_test.py
+++ b/Tests/misc/filesystem_test.py
@@ -43,6 +43,22 @@ def test_subfs_rejects_traversal_out_of_root(tmp_path):
         sub.readbytes("../../outside.txt")
 
 
+def test_osfs_rejects_symlink_out_of_root(tmp_path):
+    # resolve() expands symlinks, so a link inside the root that points outside
+    # it is rejected as well; this is stricter than pyfilesystem2 and intended.
+    (tmp_path / "outside").mkdir()
+    (tmp_path / "outside" / "secret.txt").write_bytes(b"secret")
+    root = tmp_path / "root"
+    root.mkdir()
+    try:
+        (root / "link").symlink_to(tmp_path / "outside", target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported")
+    ofs = OSFS(root)
+    with pytest.raises(IllegalBackReference):
+        ofs.readbytes("link/secret.txt")
+
+
 def _evil_zip(path):
     with zipfile.ZipFile(path, "w") as z:
         z.writestr("font.ufo/metainfo.plist", b"x")

--- a/Tests/misc/filesystem_test.py
+++ b/Tests/misc/filesystem_test.py
@@ -1,0 +1,54 @@
+import zipfile
+
+import pytest
+
+from fontTools.misc.filesystem._errors import IllegalBackReference
+from fontTools.misc.filesystem._osfs import OSFS
+from fontTools.misc.filesystem._zipfs import ReadZipFS
+
+
+def test_osfs_reads_within_root(tmp_path):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "a.txt").write_bytes(b"hello")
+    ofs = OSFS(tmp_path)
+    assert ofs.readbytes("sub/a.txt") == b"hello"
+    # a back-reference that stays within the root is still resolved
+    assert ofs.readbytes("sub/../sub/a.txt") == b"hello"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../outside.txt",
+        "../../etc/hosts",
+        "sub/../../outside.txt",
+        "nonexistent/../../outside.txt",
+    ],
+)
+def test_osfs_rejects_traversal(tmp_path, path):
+    (tmp_path.parent / "outside.txt").write_bytes(b"secret")
+    ofs = OSFS(tmp_path)
+    with pytest.raises(IllegalBackReference):
+        ofs.readbytes(path)
+
+
+def test_subfs_rejects_traversal_out_of_root(tmp_path):
+    # mirrors how ufoLib opens a glyph set: an OSFS rooted at the UFO, a SubFS
+    # into "glyphs", and a file name coming from the untrusted contents.plist
+    ufo = tmp_path / "font.ufo"
+    (ufo / "glyphs").mkdir(parents=True)
+    (tmp_path / "outside.txt").write_bytes(b"secret")
+    sub = OSFS(ufo).opendir("glyphs")
+    with pytest.raises(IllegalBackReference):
+        sub.readbytes("../../outside.txt")
+
+
+def test_readzipfs_member_cannot_escape_root(tmp_path):
+    zip_path = tmp_path / "evil.zip"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr("font.ufo/metainfo.plist", b"x")
+        z.writestr("../escaped.txt", b"pwned")
+    zfs = ReadZipFS(str(zip_path))
+    # building the directory mirror must not create files outside its root
+    with pytest.raises(IllegalBackReference):
+        zfs.exists("font.ufo/metainfo.plist")

--- a/Tests/misc/filesystem_test.py
+++ b/Tests/misc/filesystem_test.py
@@ -43,12 +43,48 @@ def test_subfs_rejects_traversal_out_of_root(tmp_path):
         sub.readbytes("../../outside.txt")
 
 
-def test_readzipfs_member_cannot_escape_root(tmp_path):
-    zip_path = tmp_path / "evil.zip"
-    with zipfile.ZipFile(zip_path, "w") as z:
+def _evil_zip(path):
+    with zipfile.ZipFile(path, "w") as z:
         z.writestr("font.ufo/metainfo.plist", b"x")
         z.writestr("../escaped.txt", b"pwned")
-    zfs = ReadZipFS(str(zip_path))
+        z.writestr("font.ufo/lib.plist", b"y")
+    return ReadZipFS(str(path))
+
+
+def test_readzipfs_member_cannot_escape_root(tmp_path):
+    zfs = _evil_zip(tmp_path / "evil.zip")
     # building the directory mirror must not create files outside its root
-    with pytest.raises(IllegalBackReference):
+    with pytest.raises(IllegalBackReference) as excinfo:
         zfs.exists("font.ufo/metainfo.plist")
+    # the offending zip entry is named, not the path the caller asked for
+    assert "../escaped.txt" in str(excinfo.value)
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_readzipfs_failed_mirror_is_not_cached(tmp_path):
+    # the mirror can also fail to build for reasons the member-name pre-scan
+    # cannot see -- here a member named both as a file and as a directory, which
+    # makes makedirs raise -- and the half-built mirror must not be published
+    zip_path = tmp_path / "conflict.zip"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr("node", b"file")
+        z.writestr("node/child.txt", b"x")
+        z.writestr("after.txt", b"y")
+    zfs = ReadZipFS(str(zip_path))
+    for _ in range(2):
+        with pytest.raises(OSError):
+            zfs.exists("after.txt")
+    assert zfs._directory_fs is None
+
+
+def test_readzipfs_rejection_is_repeatable(tmp_path):
+    # the mirror is built lazily and cached; rejecting an archive must not leave
+    # a half-built one behind, or a second call would answer from a silently
+    # truncated view of the zip instead of failing again
+    zfs = _evil_zip(tmp_path / "evil.zip")
+    for _ in range(2):
+        with pytest.raises(IllegalBackReference):
+            zfs.exists("font.ufo/metainfo.plist")
+    # a member listed after the offending one must not read as missing
+    with pytest.raises(IllegalBackReference):
+        zfs.exists("font.ufo/lib.plist")


### PR DESCRIPTION
OSFS._abs resolved root/rel_path without verifying the result stayed inside root, so an untrusted UFO glyphs/contents.plist entry or .ufoz member of the form ../../x escaped the filesystem root (arbitrary read for a directory UFO, and file creation via the ZipFS temp mirror for a zip UFO); reject any path that resolves outside root, as pyfilesystem2's own OSFS does.
