### PR TITLE
[ttLib] Fix DefaultTable typing

### DIFF
--- a/Lib/fontTools/ttLib/tables/DefaultTable.py
+++ b/Lib/fontTools/ttLib/tables/DefaultTable.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from fontTools.misc.xmlWriter import XMLWriter
     from fontTools.ttLib import TTFont
 
+XMLAttrs = dict[str, str]
+XMLContent = list[str | tuple[str, XMLAttrs, "XMLContent"]]
+
 
 class DefaultTable:
     dependencies: list[str] = []
@@ -26,9 +29,7 @@ class DefaultTable:
     def compile(self, ttFont: TTFont) -> bytes:
         return self.data
 
-    def toXML(
-        self, writer: XMLWriter, ttFont: TTFont, **kwargs: dict[str, Any]
-    ) -> None:
+    def toXML(self, writer: XMLWriter, ttFont: TTFont, **kwargs: Any) -> None:
         if hasattr(self, "ERROR"):
             writer.comment("An error occurred during the decompilation of this table")
             writer.newline()
@@ -41,7 +42,7 @@ class DefaultTable:
         writer.newline()
 
     def fromXML(
-        self, name: str, attrs: dict[str, str], content: str, ttFont: TTFont
+        self, name: str, attrs: XMLAttrs, content: XMLContent, ttFont: TTFont
     ) -> None:
         from fontTools import ttLib
         from fontTools.misc.textTools import readHex
@@ -53,11 +54,11 @@ class DefaultTable:
     def __repr__(self) -> str:
         return "<'%s' table at %x>" % (self.tableTag, id(self))
 
-    def __eq__(self, other: Any) -> bool:
-        if type(self) != type(other):
+    def __eq__(self, other: object) -> bool:
+        if type(self) is not type(other):
             return NotImplemented
         return self.__dict__ == other.__dict__
 
-    def __ne__(self, other: Any) -> bool:
+    def __ne__(self, other: object) -> bool:
         result = self.__eq__(other)
         return result if result is NotImplemented else not result


### PR DESCRIPTION
### 1. Why `**kwargs: Any`

In Python typing, `**kwargs: T` annotates the type of each keyword argument value, not the type of the `kwargs` dictionary itself.

https://peps.python.org/pep-0484/#arbitrary-argument-lists-and-default-argument-values

Therefore:

```python
def toXML(..., **kwargs: Any) -> None:
```

means that inside the function, `kwargs` has the type:

```python
dict[str, Any]
```

If written as:

```python
def toXML(..., **kwargs: dict[str, Any]) -> None:
```

it would mean that every extra keyword argument value must be a `dict[str, Any]`, which does not match the actual call sites.

For example, `TTFont._tableToXML` may pass `splitGlyphs` to the `glyf` table:

```python
table.toXML(writer, self, splitGlyphs=splitGlyphs)
```

Here `splitGlyphs` is a `bool`, not a dictionary.

### 2. Why `other: object`

Comparison methods can be called with any object, so `other` should be typed as `object` instead of `Any`.

This also matches the standard library stub signature for `object.__eq__` / `object.__ne__` in typeshed:

https://github.com/python/typeshed/blob/main/stdlib/builtins.pyi

```python
class object:
    def __eq__(self, value: object, /) -> bool: ...
    def __ne__(self, value: object, /) -> bool: ...
```

Using `object` expresses that equality comparison accepts any object while still preserving type checking. `Any` would unnecessarily opt out of type checking for the parameter.

### 3. Source of `XMLContent` and subclass examples

`XMLReader` builds `content` as a recursive XML content structure:

- text nodes are `str`
- child elements are tuples: `(name, attrs, content)`

Therefore, the type is defined as:

```python
XMLAttrs = dict[str, str]
XMLContent = list[str | tuple[str, XMLAttrs, "XMLContent"]]
```

This structure matches how `DefaultTable` and its subclasses actually consume `content`.

For example, `DefaultTable.fromXML` passes `content` to `readHex`:

```python
self.decompile(readHex(content), ttFont)
```

`readHex` iterates over `content` and only consumes string chunks.

`table__g_l_y_f.fromXML` iterates over `content`, skips non-tuple text nodes, unpacks child elements, and passes nested content to `glyph.fromXML`:

```python
for element in content:
    if not isinstance(element, tuple):
        continue
    name, attrs, content = element
    glyph.fromXML(name, attrs, content, ttFont)
```

`table_C_P_A_L_.fromXML` iterates over `content`, skips `str` text nodes, and reads attributes from child element tuples:

```python
for element in content:
    if isinstance(element, str):
        continue
    attrs = element[1]
    color = Color.fromHex(attrs["value"])
```

`table__m_e_t_a.fromXML` passes `content` to `readHex(content)` or `strjoin(content)`, both of which consume string chunks from the content list:

```python
self.data[attrs["tag"]] = readHex(content)
self.data[attrs["tag"]] = strjoin(content).strip()
```

`table_S_V_G_.fromXML` also reads text content through `strjoin(content)`:

```python
doc = strjoin(content)
doc = doc.strip()
```

These examples show that `content` should not be typed as a single `str` or as `list[str]`; it needs to represent both text nodes and recursive child elements, so `XMLContent` is more accurate.

When a `DefaultTable` subclass adds type annotations to its own `fromXML` implementation, it should reuse these aliases instead of redefining the XML content shape locally:

```python
from fontTools.ttLib.tables.DefaultTable import XMLAttrs, XMLContent

def fromXML(
    self,
    name: str,
    attrs: XMLAttrs,
    content: XMLContent,
    ttFont: TTFont,
) -> None:
    ...
```

This keeps subclass annotations consistent with the base `DefaultTable.fromXML` signature and avoids duplicating the recursive `XMLContent` definition:

```python
XMLAttrs = dict[str, str]
XMLContent = list[str | tuple[str, XMLAttrs, "XMLContent"]]
```
