### PR TITLE
sanitise glyph name in EBDT/CBDT extfile export

### DIFF
--- a/Lib/fontTools/ttLib/tables/E_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_D_T_.py
@@ -18,6 +18,13 @@ from .BitmapGlyphMetrics import (
 from . import DefaultTable
 import itertools
 import os
+import re
+from urllib.parse import quote
+
+# a glyph name is usable as a filename as-is unless it contains a path
+# separator (on any platform, not just this one) or the '%' that marks an
+# encoded name
+_UNSAFE_IN_FILENAME = re.compile(r"[%/\\]")
 import struct
 import logging
 
@@ -398,6 +405,21 @@ def _readBitwiseImageData(bitmapObject, name, attrs, content, ttFont):
     )
 
 
+def _extFileName(glyphName):
+    # Glyph names come straight from the font and may contain path separators
+    # (e.g. a crafted 'post' table), which would let the exported bitmap escape
+    # the output folder. Names that are usable as a filename verbatim -- i.e.
+    # every real glyph name -- are returned unchanged, so existing exports keep
+    # their filenames; the rest are percent-encoded and marked with a leading
+    # '%'. The mapping has to be injective, or two glyphs quietly share one
+    # file and the second overwrites the first: a plain name is never encoded
+    # and never contains '%', an encoded one always starts with '%', and
+    # percent-encoding is itself reversible, so no two names can meet.
+    if glyphName not in ("", ".", "..") and not _UNSAFE_IN_FILENAME.search(glyphName):
+        return glyphName
+    return "%" + quote(glyphName, safe="", encoding="utf-8", errors="surrogatepass")
+
+
 def _writeExtFileImageData(strikeIndex, glyphName, bitmapObject, writer, ttFont):
     try:
         folder = os.path.dirname(writer.file.name)
@@ -405,10 +427,7 @@ def _writeExtFileImageData(strikeIndex, glyphName, bitmapObject, writer, ttFont)
         # fall back to current directory if output file's directory isn't found
         folder = "."
     folder = os.path.join(folder, "bitmaps")
-    # glyph names come straight from the font and may contain path separators
-    # (e.g. a crafted 'post' table); keep only the final component so a name
-    # like "../../evil" can't write the bitmap outside the export folder.
-    filename = os.path.basename(glyphName) + bitmapObject.fileExtension
+    filename = _extFileName(glyphName) + bitmapObject.fileExtension
     if not os.path.isdir(folder):
         os.makedirs(folder)
     folder = os.path.join(folder, "strike%d" % strikeIndex)

--- a/Lib/fontTools/ttLib/tables/E_B_D_T_.py
+++ b/Lib/fontTools/ttLib/tables/E_B_D_T_.py
@@ -405,7 +405,10 @@ def _writeExtFileImageData(strikeIndex, glyphName, bitmapObject, writer, ttFont)
         # fall back to current directory if output file's directory isn't found
         folder = "."
     folder = os.path.join(folder, "bitmaps")
-    filename = glyphName + bitmapObject.fileExtension
+    # glyph names come straight from the font and may contain path separators
+    # (e.g. a crafted 'post' table); keep only the final component so a name
+    # like "../../evil" can't write the bitmap outside the export folder.
+    filename = os.path.basename(glyphName) + bitmapObject.fileExtension
     if not os.path.isdir(folder):
         os.makedirs(folder)
     folder = os.path.join(folder, "strike%d" % strikeIndex)

--- a/Tests/ttLib/tables/E_B_D_T_test.py
+++ b/Tests/ttLib/tables/E_B_D_T_test.py
@@ -1,4 +1,6 @@
-from fontTools.ttLib.tables.E_B_D_T_ import _writeExtFileImageData
+import pytest
+
+from fontTools.ttLib.tables.E_B_D_T_ import _extFileName, _writeExtFileImageData
 
 
 class _Writer:
@@ -17,16 +19,84 @@ class _Bitmap:
     imageData = b"\xde\xad\xbe\xef"
 
 
+def _export(tmp_path, glyphName, data=b"\xde\xad\xbe\xef"):
+    out = tmp_path / "out"
+    out.mkdir(exist_ok=True)
+    writer = _Writer(str(out / "font.ttx"))
+    bitmap = _Bitmap()
+    bitmap.imageData = data
+    _writeExtFileImageData(0, glyphName, bitmap, writer, None)
+    return out / "bitmaps" / "strike0"
+
+
 def test_extfile_export_contains_crafted_glyph_name(tmp_path):
     # A font can name a glyph with path separators (e.g. via a crafted 'post'
     # table); the "extfile" bitmap export must keep the file inside the folder.
-    out = tmp_path / "out"
-    out.mkdir()
-    writer = _Writer(str(out / "font.ttx"))
-
-    _writeExtFileImageData(0, "../../../pwned", _Bitmap(), writer, None)
+    strike = _export(tmp_path, "../../../pwned")
 
     assert not (tmp_path / "pwned.bin").exists()
-    written = out / "bitmaps" / "strike0" / "pwned.bin"
-    assert written.exists()
+    (written,) = list(strike.iterdir())
     assert written.read_bytes() == b"\xde\xad\xbe\xef"
+
+
+def test_extfile_export_plain_names_are_unchanged(tmp_path):
+    # ordinary glyph names must keep their filename, or existing exports change
+    strike = _export(tmp_path, "uni0041")
+
+    assert (strike / "uni0041.bin").exists()
+
+
+@pytest.mark.parametrize(
+    "first, second",
+    [
+        ("a/b", "b"),  # a name that collides once its directory part is dropped
+        ("../b", "b"),
+        ("x/", "y/"),  # names whose final component is empty
+        (".", ".."),
+        # a plain name spelled like the escaped form of another name: the
+        # escaping has to be injective, not merely separator-free
+        ("a/b", _extFileName("a/b")),
+        ("%2Fb", "/b"),
+        ("%", ""),
+    ],
+)
+def test_extfile_export_distinct_names_dont_collide(tmp_path, first, second):
+    # dropping the directory part alone would map both onto the same file, so
+    # the second export would silently overwrite the first
+    _export(tmp_path, first, b"FIRST")
+    strike = _export(tmp_path, second, b"SECOND")
+
+    written = sorted(p.read_bytes() for p in strike.iterdir())
+    assert written == [b"FIRST", b"SECOND"]
+
+
+def test_extfile_name_mapping_is_injective():
+    # every distinct glyph name must get a distinct filename, or one export
+    # silently overwrites another
+    names = [
+        "a",
+        "b",
+        "uni0041",
+        "a.alt",
+        "%",
+        "%25",
+        "%2Fb",
+        "/b",
+        "a/b",
+        "../b",
+        "..",
+        ".",
+        "",
+        "x/",
+        "y/",
+        "a\\b",
+        "\u00e9",
+        _extFileName("a/b"),
+        _extFileName(""),
+        _extFileName(".."),
+    ]
+    mapped = [_extFileName(n) for n in names]
+
+    assert len(set(mapped)) == len(set(names))
+    assert all("/" not in m and "\\" not in m for m in mapped)
+    assert all(m not in ("", ".", "..") for m in mapped)

--- a/Tests/ttLib/tables/E_B_D_T_test.py
+++ b/Tests/ttLib/tables/E_B_D_T_test.py
@@ -1,0 +1,32 @@
+from fontTools.ttLib.tables.E_B_D_T_ import _writeExtFileImageData
+
+
+class _Writer:
+    def __init__(self, name):
+        self.file = type("_File", (), {"name": name})()
+
+    def simpletag(self, tag, **kwargs):
+        pass
+
+    def newline(self):
+        pass
+
+
+class _Bitmap:
+    fileExtension = ".bin"
+    imageData = b"\xde\xad\xbe\xef"
+
+
+def test_extfile_export_contains_crafted_glyph_name(tmp_path):
+    # A font can name a glyph with path separators (e.g. via a crafted 'post'
+    # table); the "extfile" bitmap export must keep the file inside the folder.
+    out = tmp_path / "out"
+    out.mkdir()
+    writer = _Writer(str(out / "font.ttx"))
+
+    _writeExtFileImageData(0, "../../../pwned", _Bitmap(), writer, None)
+
+    assert not (tmp_path / "pwned.bin").exists()
+    written = out / "bitmaps" / "strike0" / "pwned.bin"
+    assert written.exists()
+    assert written.read_bytes() == b"\xde\xad\xbe\xef"


### PR DESCRIPTION
`ttx -z extfile` on a font whose 'post' table names a glyph `../../../x`:

    open(".../out/bitmaps/strike0/../../../x.png", "wb")

_writeExtFileImageData (shared by EBDT and CBDT) builds the export filename by
concatenating the glyph name onto the strike folder, so a crafted name walks out
of the bitmaps directory and the image bytes get written wherever the path
resolves. Glyph names are arbitrary Pascal strings read from the font, so
dumping an untrusted bitmap font with this option is an arbitrary file write.

The fix keeps only the final path component of the name before joining. Real
glyph names carry no separators, so their output is unchanged.