### PR TITLE
[instancer] Don't crash on CFF2 fonts without a VariationStore

### DIFF
--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -675,7 +675,9 @@ def instantiateCFF2(
 
     cff = varfont["CFF2"].cff
     topDict = cff.topDictIndex[0]
-    varStore = topDict.VarStore.otVarStore
+    varStore = getattr(topDict, "VarStore", None)
+    if varStore is not None:
+        varStore = varStore.otVarStore
     if not varStore:
         if downgrade:
             from fontTools.cffLib.CFF2ToCFF import convertCFF2ToCFF

--- a/Tests/varLib/instancer/instancer_test.py
+++ b/Tests/varLib/instancer/instancer_test.py
@@ -106,6 +106,18 @@ class InstantiateCFF2Test(object):
         program = varfont["CFF2"].cff.topDictIndex[0].CharStrings.values()[1].program
         assert program == expected
 
+    def test_no_varstore(self, varfont):
+        varfont = ttLib.TTFont()
+        varfont.importXML(os.path.join(TESTDATA, "CFF2Instancer-VF-1.ttx"))
+
+        # Fully instancing empties the VarStore and removes it from the table.
+        instancer.instantiateCFF2(varfont, instancer.NormalizedAxisLimits({"wght": 0}))
+        assert not hasattr(varfont["CFF2"].cff.topDictIndex[0], "VarStore")
+
+        # A CFF2 table without a VariationStore must survive instancing.
+        # https://github.com/fonttools/fonttools/issues/4130
+        instancer.instantiateCFF2(varfont, instancer.NormalizedAxisLimits({"wght": 0}))
+
     @pytest.mark.parametrize(
         "source_ttx, expected_ttx",
         [


### PR DESCRIPTION
`instantiateCFF2` accessed `topDict.VarStore` before its no-VarStore early-out could run, raising `AttributeError` for any font pairing a static CFF2 table with fvar (variations coming from HVAR etc.).

Test: fully instancing legitimately deletes the VarStore from the table; instancing that result again used to reproduce the crash.

Fixes #4130

🤖 Generated with [Claude Code](https://claude.com/claude-code)