### PR TITLE
[instancer] Fix Private-dict vsindex handling in instantiateCFF2

### DIFF
--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -776,21 +776,15 @@ def instantiateCFF2(
                 storeBlendsToVarStore(arg)
 
     # Add private blend lists to VarStore so we can instantiate values
-    for opcode, name, arg_type, default, converter in privateDictOperators2:
-        if arg_type not in ("number", "delta", "array"):
-            continue
-
-        vsindex = 0
-        for private in privateDicts:
+    for private in privateDicts:
+        vsindex = getattr(private, "vsindex", 0)
+        for opcode, name, arg_type, default, converter in privateDictOperators2:
+            if arg_type not in ("number", "delta", "array") or name == "vsindex":
+                continue
             if not hasattr(private, name):
                 continue
+
             values = getattr(private, name)
-
-            # This is safe here since "vsindex" is the first in the privateDictOperators2
-            if name == "vsindex":
-                vsindex = values[0]
-                continue
-
             if arg_type == "number":
                 values = [values]
 
@@ -821,18 +815,12 @@ def instantiateCFF2(
             command[1][:] = newArgs
 
     # Read back new private blends from the instantiated VarStore
-    for opcode, name, arg_type, default, converter in privateDictOperators2:
-        if arg_type not in ("number", "delta", "array"):
-            continue
-
-        vsindex = 0
-        for private in privateDicts:
-            if not hasattr(private, name):
+    for private in privateDicts:
+        vsindex = getattr(private, "vsindex", 0)
+        for opcode, name, arg_type, default, converter in privateDictOperators2:
+            if arg_type not in ("number", "delta", "array") or name == "vsindex":
                 continue
-
-            # This is safe here since "vsindex" is the first in the privateDictOperators2
-            if name == "vsindex":
-                vsindex = values[0]
+            if not hasattr(private, name):
                 continue
 
             values = getattr(private, name)
@@ -884,7 +872,12 @@ def instantiateCFF2(
                 command[1][0] = vsindexMapping[command[1][0]]
     for private in privateDicts:
         if hasattr(private, "vsindex"):
-            private.vsindex = vsindexMapping[private.vsindex]
+            if private.vsindex in vsindexMapping:
+                private.vsindex = vsindexMapping[private.vsindex]
+            else:
+                # The referenced VarData lost all its regions; the dict's
+                # blends have dissolved into plain values.
+                del private.vsindex
 
     # Remove initial vsindex commands that are implied
     for commands, private in zip(allCommands, allCommandPrivates):

--- a/Tests/varLib/instancer/instancer_test.py
+++ b/Tests/varLib/instancer/instancer_test.py
@@ -106,6 +106,41 @@ class InstantiateCFF2Test(object):
         program = varfont["CFF2"].cff.topDictIndex[0].CharStrings.values()[1].program
         assert program == expected
 
+    def test_private_dict_vsindex(self):
+        # https://github.com/fonttools/fonttools/issues/4129
+        from fontTools.cffLib import FontDict, PrivateDict
+        from fontTools.varLib.varStore import VarStoreInstancer
+
+        varfont = ttLib.TTFont()
+        varfont.importXML(os.path.join(TESTDATA, "CFF2Instancer-VF-2.ttx"))
+        topDict = varfont["CFF2"].cff.topDictIndex[0]
+
+        # Add a Private dict with a non-zero vsindex and blended values;
+        # its blends reference VarData 1, not VarData 0.
+        fontDict = FontDict()
+        fontDict.setCFF2(True)
+        private = PrivateDict()
+        private.vstore = topDict.VarStore
+        private.vsindex = 1
+        private.BlueValues = [[-12, 10, 20, 40], [0, 5, -5, 15]]
+        fontDict.Private = private
+        topDict.FDArray.append(fontDict)
+
+        pinned = {"wght": 1.0, "wdth": 1.0}
+        vsi = VarStoreInstancer(
+            topDict.VarStore.otVarStore, varfont["fvar"].axes, pinned
+        )
+        expected = [
+            v[0] + round(vsi.interpolateFromDeltas(1, v[1:]))
+            for v in private.BlueValues
+        ]
+
+        instancer.instantiateCFF2(varfont, instancer.NormalizedAxisLimits(pinned))
+
+        assert private.BlueValues == expected
+        # The store emptied; the dict's vsindex must be gone with it.
+        assert not hasattr(private, "vsindex")
+
     @pytest.mark.parametrize(
         "source_ttx, expected_ttx",
         [


### PR DESCRIPTION
The private-dict blend passes in `instantiateCFF2` mishandled `vsindex` three ways (#4129):

1. the read-back loop consulted a stale `values` binding from a previous iteration (the *"This is safe here"* comment doesn't hold for that loop's ordering);
2. `private.vsindex` is a scalar but was subscripted as `values[0]`, raising `TypeError` as soon as a Private dict actually carries one;
3. `vsindex` was tracked per operator name rather than per dict, applying the last dict's index to every dict's blends.

Fixed by iterating the dicts in the outer loop and resolving each dict's own `vsindex` up front — analogous to what aaa3e274 did for the charstring side. Also guards the post-instancing `vsindexMapping` lookup: a dict whose VarData lost all regions has no entry, and its blends have dissolved into plain values, so the `vsindex` is dropped instead of raising `KeyError`.

The new test adds a Private dict with `vsindex 1` and blended BlueValues to CFF2Instancer-VF-2 and checks the instanced values against `VarStoreInstancer` evaluated on VarData 1 (discriminating against the wrong-dict/wrong-index failure modes); it crashes with `TypeError` before the fix.

Fixes #4129

🤖 Generated with [Claude Code](https://claude.com/claude-code)