### PR TITLE
Avoid the undocumented `glob.glob1` API, removed in Python 3.15

### DIFF
--- a/MetaTools/buildTableList.py
+++ b/MetaTools/buildTableList.py
@@ -12,7 +12,7 @@ fontToolsDir = os.path.normpath(fontToolsDir)
 tablesDir = os.path.join(fontToolsDir, "Lib", "fontTools", "ttLib", "tables")
 docFile = os.path.join(fontToolsDir, "Doc/source/ttx.rst")
 
-names = glob.glob1(tablesDir, "*.py")
+names = glob.glob("*.py", root_dir=tablesDir)
 
 modules = []
 tables = []

--- a/MetaTools/check_table_coverage.py
+++ b/MetaTools/check_table_coverage.py
@@ -141,7 +141,7 @@ KNOWN_GAPS: dict[str, set[str]] = {
 def get_table_modules() -> list[tuple[str, str]]:
     """Return sorted list of (module_name, tag_raw) for all table .py files."""
     modules = []
-    for filename in glob.glob1(TABLES_DIR, "*.py"):
+    for filename in glob.glob("*.py", root_dir=TABLES_DIR):
         name = filename[:-3]
         try:
             tag = identifierToTag(name)  # may contain trailing spaces, e.g. "cvt "


### PR DESCRIPTION
See https://docs.python.org/3.15/whatsnew/3.15.html#glob.

See also https://docs.python.org/3.15/library/glob.html#glob.glob, which notes that the `root_dir` keyword was added in Python 3.10. Since that’s the minimum version supported by `fonttools`, we can rely on it being available.