### PR TITLE
[varLib.instancer] Instance the BASE table

### DIFF
--- a/Lib/fontTools/varLib/instancer/__init__.py
+++ b/Lib/fontTools/varLib/instancer/__init__.py
@@ -1318,8 +1318,36 @@ def instantiateItemVariationStore(
     return defaultDeltas
 
 
+def _instantiateBASE(varfont, axisLimits):
+    if "BASE" not in varfont:
+        return
+
+    base = varfont["BASE"].table
+    varStore = getattr(base, "VarStore", None)
+    if varStore is None:
+        return
+
+    log.info("Instantiating BASE table")
+
+    fvarAxes = varfont["fvar"].axes
+    defaultDeltas = instantiateItemVariationStore(varStore, fvarAxes, axisLimits)
+
+    merger = MutatorMerger(
+        varfont, defaultDeltas, deleteVariations=(not varStore.VarRegionList.Region)
+    )
+    merger.mergeTables(varfont, [varfont], ["BASE"])
+
+    if varStore.VarRegionList.Region:
+        base.remap_device_varidxes(varStore.optimize())
+    else:
+        # Downgrade BASE, it no longer references an ItemVariationStore.
+        del base.VarStore
+        base.Version = 0x00010000
+
+
 def instantiateOTL(varfont, axisLimits):
-    # TODO(anthrotype) Support partial instancing of JSTF and BASE tables
+    # TODO(anthrotype) Support partial instancing of JSTF table
+    _instantiateBASE(varfont, axisLimits)
 
     if (
         "GDEF" not in varfont

--- a/Lib/fontTools/varLib/merger.py
+++ b/Lib/fontTools/varLib/merger.py
@@ -1127,7 +1127,7 @@ class MutatorMerger(AligningMerger):
         self.deleteVariations = deleteVariations
 
 
-@MutatorMerger.merger(ot.CaretValue)
+@MutatorMerger.merger((ot.CaretValue, ot.BaseCoord))
 def merge(merger, self, lst):
     # Hack till we become selfless.
     self.__dict__ = lst[0].__dict__.copy()

--- a/Lib/fontTools/varLib/varStore.py
+++ b/Lib/fontTools/varLib/varStore.py
@@ -396,6 +396,7 @@ def Object_remap_device_varidxes(self, varidxes_map):
 
 ot.GDEF.remap_device_varidxes = Object_remap_device_varidxes
 ot.GPOS.remap_device_varidxes = Object_remap_device_varidxes
+ot.BASE.remap_device_varidxes = Object_remap_device_varidxes
 
 
 class _Encoding(object):

--- a/Tests/varLib/instancer/instancer_test.py
+++ b/Tests/varLib/instancer/instancer_test.py
@@ -14,6 +14,7 @@ from fontTools.varLib.mvar import MVAR_ENTRIES
 from fontTools.varLib import builder
 from fontTools.varLib import featureVars
 from fontTools.varLib import models
+from fontTools.varLib import varStore
 import collections
 from copy import deepcopy
 from io import BytesIO, StringIO
@@ -869,6 +870,65 @@ def varfontGPOS2():
     return makeParametrizedVF(glyphOrder, features, values, increments)
 
 
+@pytest.fixture
+def varfontBASE():
+    # The feature file syntax has no way to express variable baseline
+    # coordinates, so the BASE table is built here: a single 'romn' baseline
+    # for 'latn' at -120 by default, -100 at wght=1.0 and -110 at wdth=1.0.
+    vf = makeParametrizedVF(
+        [".notdef", "A"], "feature kern { pos A A %d; } kern;", [-80], [(-10, -5)]
+    )
+    axisTags = [axis.axisTag for axis in vf["fvar"].axes]
+    storeBuilder = varStore.OnlineVarStoreBuilder(axisTags)
+    storeBuilder.setModel(
+        models.VariationModel([{}, {"wght": 1.0}, {"wdth": 1.0}], axisOrder=axisTags)
+    )
+    default, varIdx = storeBuilder.storeMasters([-120, -100, -110])
+
+    coord = otTables.BaseCoord()
+    coord.Format = 3
+    coord.Coordinate = default
+    coord.DeviceTable = builder.buildVarDevTable(varIdx)
+
+    baseValues = otTables.BaseValues()
+    baseValues.DefaultIndex = 0
+    baseValues.BaseCoord = [coord]
+    baseValues.BaseCoordCount = 1
+
+    baseScript = otTables.BaseScript()
+    baseScript.BaseValues = baseValues
+    baseScript.DefaultMinMax = None
+    baseScript.BaseLangSysRecord = []
+    baseScript.BaseLangSysCount = 0
+
+    scriptRecord = otTables.BaseScriptRecord()
+    scriptRecord.BaseScriptTag = "latn"
+    scriptRecord.BaseScript = baseScript
+
+    axis = otTables.Axis()
+    axis.BaseTagList = otTables.BaseTagList()
+    axis.BaseTagList.BaselineTag = ["romn"]
+    axis.BaseTagList.BaseTagCount = 1
+    axis.BaseScriptList = otTables.BaseScriptList()
+    axis.BaseScriptList.BaseScriptRecord = [scriptRecord]
+    axis.BaseScriptList.BaseScriptCount = 1
+
+    base = otTables.BASE()
+    base.Version = 0x00010001
+    base.HorizAxis = axis
+    base.VertAxis = None
+    base.VarStore = storeBuilder.finish()
+
+    vf["BASE"] = ttLib.newTable("BASE")
+    vf["BASE"].table = base
+    return vf
+
+
+def getBaseCoord(varfont):
+    axis = varfont["BASE"].table.HorizAxis
+    return axis.BaseScriptList.BaseScriptRecord[0].BaseScript.BaseValues.BaseCoord[0]
+
+
 class InstantiateOTLTest(object):
     @pytest.mark.parametrize(
         "location, expected",
@@ -1114,6 +1174,51 @@ class InstantiateOTLTest(object):
         valueRec1 = pairPos.PairSet[0].PairValueRecord[0].Value1
         assert not hasattr(valueRec1, "XAdvDevice")
         assert valueRec1.XAdvance == -25
+
+    @pytest.mark.parametrize(
+        "location, expected",
+        [
+            ({"wght": 0.0}, -120),
+            ({"wght": 0.5}, -110),
+            ({"wght": 1.0}, -100),
+            ({"wdth": 1.0}, -110),
+            ({"wdth": 0.5}, -115),
+        ],
+    )
+    def test_pin_and_drop_axis_BASE(self, varfontBASE, location, expected):
+        vf = varfontBASE
+
+        instancer.instantiateOTL(vf, instancer.NormalizedAxisLimits(location))
+
+        base = vf["BASE"].table
+        assert base.Version == 0x00010001
+        assert base.VarStore
+        coord = getBaseCoord(vf)
+        assert coord.Format == 3
+        assert coord.DeviceTable.DeltaFormat == 0x8000
+        assert coord.Coordinate == expected
+
+    @pytest.mark.parametrize(
+        "location, expected",
+        [
+            ({"wght": 0.0, "wdth": 0.0}, -120),
+            ({"wght": 1.0, "wdth": 0.0}, -100),
+            ({"wght": 0.0, "wdth": 1.0}, -110),
+            ({"wght": 1.0, "wdth": 1.0}, -90),
+        ],
+    )
+    def test_full_instance_BASE(self, varfontBASE, location, expected):
+        vf = varfontBASE
+
+        instancer.instantiateOTL(vf, instancer.NormalizedAxisLimits(location))
+
+        base = vf["BASE"].table
+        assert base.Version == 0x00010000
+        assert not hasattr(base, "VarStore")
+        coord = getBaseCoord(vf)
+        assert coord.Format == 1
+        assert not hasattr(coord, "DeviceTable")
+        assert coord.Coordinate == expected
 
 
 class InstantiateAvarTest(object):


### PR DESCRIPTION
`varLib.instancer` leaves the BASE table untouched. A font whose BASE carries variations keeps its Format 3 baseline coordinates, their VariationIndex device tables and the whole ItemVariationStore after instancing, so the instance still uses the default master's baselines, and after a full pin it also ends up carrying variation data with no `fvar` behind it.

Minimal reproduction: take a variable font whose `latn`/`romn` baseline is -120 at the default and -100 at `wght=1.0`, then pin `wght=700`. Before this change the BaseCoord is still `Format 3, Coordinate -120` with its device table and VarStore in place; after it, it is `Format 1, Coordinate -100` and the table has been downgraded to version 1.0.

BASE is now instanced next to GDEF and GPOS. Each BaseCoord goes through `MutatorMerger`, which BaseCoord can share with CaretValue because both have the same Format 3 shape, and then the device varidxes are remapped onto the optimised store, or the store is dropped and the table downgraded when no regions are left.

The `TODO(anthrotype)` in `instantiateOTL` mentioned JSTF and BASE; I left it in place for JSTF, which this does not touch.

One note on the tests: neither feaLib nor varLib can produce a variable BASE table today, so the fixture builds one directly with `OnlineVarStoreBuilder`. The cases cover partial instancing along each axis and full pins at the four corners. Eight of the nine fail before the change. The full test suite passes, and `black` and `mypy` are clean.