### PR TITLE
[misc.xmlWriter] escape the CDATA terminator in writecdata

### DIFF
--- a/Lib/fontTools/misc/xmlWriter.py
+++ b/Lib/fontTools/misc/xmlWriter.py
@@ -93,6 +93,9 @@ class XMLWriter(object):
 
     def writecdata(self, string):
         """Writes text in a CDATA section."""
+        # a CDATA section can't hold "]]>", so close it and open a new one around
+        # the ">"; the two sections read back as the original text
+        string = string.replace("]]>", "]]]]><![CDATA[>")
         self._writeraw("<![CDATA[" + string + "]]>")
 
     def write8bit(self, data, strip=False):

--- a/Tests/misc/xmlWriter_test.py
+++ b/Tests/misc/xmlWriter_test.py
@@ -76,6 +76,14 @@ class TestXMLWriter(unittest.TestCase):
         writer.writecdata("foo&bar")
         self.assertEqual(HEADER + b"<![CDATA[foo&bar]]>", writer.file.getvalue())
 
+    def test_writecdata_split_terminator(self):
+        writer = XMLWriter(BytesIO())
+        writer.writecdata("foo]]><tag/>bar")
+        self.assertEqual(
+            HEADER + b"<![CDATA[foo]]]]><![CDATA[><tag/>bar]]>",
+            writer.file.getvalue(),
+        )
+
     def test_simpletag(self):
         writer = XMLWriter(BytesIO())
         writer.simpletag("tag", a="1", b="2")

--- a/Tests/ttLib/tables/S_V_G__test.py
+++ b/Tests/ttLib/tables/S_V_G__test.py
@@ -142,6 +142,26 @@ def test_round_trip_ttx(font):
     assert getXML(table.toXML, font) == OTSVG_TTX
 
 
+def test_round_trip_ttx_doc_containing_cdata_end(font):
+    # a document containing "]]>" must not escape the CDATA section it is
+    # written into, or the dump reads back as different tables
+    doc = (
+        ']]></svgDoc></SVG><name><namerecord nameID="6" platformID="3" '
+        'platEncID="1" langID="0x409">x</namerecord></name>'
+        '<SVG><svgDoc startGlyphID="1" endGlyphID="1"><![CDATA[y'
+    )
+    table = table_S_V_G_()
+    table.docList = [(doc, 1, 1)]
+    xml = getXML(table.toXML, font)
+
+    table = table_S_V_G_()
+    for name, attrs, content in parseXML(xml):
+        table.fromXML(name, attrs, content, font)
+
+    assert len(table.docList) == 1
+    assert table.docList[0].data == doc
+
+
 def test_unpack_svg_doc_as_3_tuple():
     # test that the legacy docList as list of 3-tuples interface still works
     # even after the new SVGDocument class with extra `compressed` attribute


### PR DESCRIPTION
Dumping a font whose `SVG ` document contains `]]>`, then reading the dump back:

    tables present: ['GlyphOrder', 'SVG ', 'name']
    smuggled name records: [(6, 'INJECTED-PSNAME')]

The input font has no `name` table. `writecdata` pastes the string straight
between `<![CDATA[` and `]]>`, so a document carrying its own terminator closes
the section early and everything after it is read as markup. All three callers
(`SVG `, `bgcl`, `Debg`) hand it data taken verbatim from the font, and
`json.dumps` in the latter two escapes quotes and backslashes but not `]]>`, so
a crafted font decides what its own TTX says and a dump/inspect/recompile pass
rebuilds a font holding tables that were never visible in the dump.

Splitting the section around the terminator leaves the text identical on
re-read, so existing dumps only gain the split.
