### PR TITLE
[name] Keep trailing whitespace when reading a namerecord from XML

### DIFF
--- a/Lib/fontTools/ttLib/tables/_n_a_m_e.py
+++ b/Lib/fontTools/ttLib/tables/_n_a_m_e.py
@@ -18,6 +18,7 @@ from fontTools import ttLib
 import fontTools.ttLib.tables.otTables as otTables
 from fontTools.ttLib.tables import C_P_A_L_
 from . import DefaultTable
+import re
 import struct
 import logging
 
@@ -498,6 +499,18 @@ def _makeMacName(name, nameID, language, font=None):
         return None
 
 
+_xmlIndentation = re.compile(r"\A\n[ \t]*|\n[ \t]*\Z")
+
+
+def _stripXMLIndentation(s):
+    """Undo the newline and indentation that NameRecord.toXML puts around a value.
+
+    Only the layout the writer added is removed, so whitespace belonging to the
+    string itself survives the round-trip.
+    """
+    return _xmlIndentation.sub("", s)
+
+
 class NameRecord(object):
     def getEncoding(self, default="ascii"):
         """Returns the Python encoding name for this name entry based on its platformID,
@@ -627,7 +640,7 @@ class NameRecord(object):
         self.platformID = safeEval(attrs["platformID"])
         self.platEncID = safeEval(attrs["platEncID"])
         self.langID = safeEval(attrs["langID"])
-        s = strjoin(content).strip()
+        s = _stripXMLIndentation(strjoin(content))
         encoding = self.getEncoding()
         if self.encodingIsUnicodeCompatible() or safeEval(
             attrs.get("unicode", "False")

--- a/Tests/ttLib/tables/_n_a_m_e_test.py
+++ b/Tests/ttLib/tables/_n_a_m_e_test.py
@@ -3,7 +3,7 @@ from fontTools.misc.loggingTools import CapturingLogHandler
 from fontTools.misc.testTools import FakeFont
 from fontTools.misc.textTools import bytesjoin, tostr, Tag
 from fontTools.misc.xmlWriter import XMLWriter
-from io import BytesIO
+from io import BytesIO, StringIO
 import struct
 import unittest
 from fontTools.ttLib import TTFont, newTable
@@ -468,6 +468,25 @@ class NameRecordTest(unittest.TestCase):
                 "</namerecord>",
             ],
             self.toXML(name),
+        )
+
+    def test_XML_roundtrip_keeps_trailing_whitespace(self):
+        font = TTFont()
+        font["name"] = table = newTable("name")
+        table.names = [
+            makeName("Trailing CR\r", 111, 3, 1, 0x409),
+            makeName("Trailing CRLF\r\n", 112, 3, 1, 0x409),
+            makeName("Trailing spaces  ", 113, 3, 1, 0x409),
+            makeName("Multi\r\nline\r\n", 114, 3, 1, 0x409),
+            makeName("Plain", 115, 3, 1, 0x409),
+        ]
+        buf = StringIO()
+        font.saveXML(buf, tables=["name"])
+        font2 = TTFont()
+        font2.importXML(StringIO(buf.getvalue()))
+        self.assertEqual(
+            [n.toUnicode() for n in table.names],
+            [n.toUnicode() for n in font2["name"].names],
         )
 
     def test_toXML_macroman_actual_utf16be(self):


### PR DESCRIPTION
`ttx font.ttf` followed by `ttx font.ttx` silently drops trailing whitespace from `name` records. Calibri, shipped on every Windows install, loses the final CRLF of its licence text:

```
nameID 13, platform 3: '...OTHER DEALINGS IN THE SOFTWARE.\r\n'
                    -> '...OTHER DEALINGS IN THE SOFTWARE.'
```

`NameRecord.toXML` wraps the value in `writer.newline()` plus indentation, and `fromXML` undid that with `strjoin(content).strip()`. Since #3868 the writer escapes control characters, so a trailing `\r` reaches the parser intact as `&#13;` and is then thrown away by `.strip()`. Stripping only the newline and indentation the writer added preserves it.

Across the 128 TrueType fonts in `C:\Windows\Fonts`, records lost whitespace in 39 fonts before and 3 after.

Those 3 have a value starting with a space, which a reader cannot recover: the writer indents the first line, so leading whitespace is genuinely ambiguous in the file. Fixing that means escaping it in `xmlWriter.escape`, which every table shares, so I left it out of this change. Happy to follow up if you want it.

One behaviour change beyond the bug: in a hand-written ttx, a value surrounded by blank lines used to have them stripped and now keeps them. Nothing in the suite depends on it.

4558 tests pass. The new test fails on revert.
