### PR TITLE
[colorLib] Validate glyphs referenced by PaintGlyph/PaintColrGlyph exist in glyphMap (#2629)

### DIFF
--- a/Lib/fontTools/colorLib/builder.py
+++ b/Lib/fontTools/colorLib/builder.py
@@ -525,7 +525,8 @@ class LayerListBuilder:
     cache: LayerReuseCache
     allowLayerReuse: bool
 
-    def __init__(self, *, allowLayerReuse=True):
+    def __init__(self, *, glyphMap=None, allowLayerReuse=True):
+        self.glyphMap = glyphMap
         self.layers = []
         if allowLayerReuse:
             self.cache = LayerReuseCache()
@@ -541,7 +542,28 @@ class LayerListBuilder:
                 ot.PaintFormat.PaintColrLayers,
             )
         ] = self._beforeBuildPaintColrLayers
+        # When a glyphMap is available, sanity check that glyphs referenced by
+        # PaintGlyph and PaintColrGlyph actually exist, so a missing glyph raises
+        # a legible error here instead of failing obscurely later (e.g. a
+        # struct.error at compile time).
+        # https://github.com/fonttools/fonttools/issues/2629
+        if glyphMap is not None:
+            for paintFormat in (
+                ot.PaintFormat.PaintGlyph,
+                ot.PaintFormat.PaintColrGlyph,
+            ):
+                callbacks[(BuildCallback.AFTER_BUILD, ot.Paint, paintFormat)] = (
+                    self._checkPaintGlyphExists
+                )
         self.tableBuilder = TableBuilder(callbacks)
+
+    def _checkPaintGlyphExists(self, paint: ot.Paint) -> ot.Paint:
+        if paint.Glyph not in self.glyphMap:
+            paintName = ot.PaintFormat(paint.Format).name
+            raise ColorLibError(
+                f"{paintName}: glyph not found in glyphMap: {paint.Glyph!r}"
+            )
+        return paint
 
     # COLR layers is unusual in that it modifies shared state
     # so we need a callback into an object
@@ -663,7 +685,7 @@ def buildColrV1(
 
     errors = {}
     baseGlyphs = []
-    layerBuilder = LayerListBuilder(allowLayerReuse=allowLayerReuse)
+    layerBuilder = LayerListBuilder(glyphMap=glyphMap, allowLayerReuse=allowLayerReuse)
     for baseGlyph, paint in colorGlyphItems:
         try:
             baseGlyphs.append(buildBaseGlyphPaintRecord(baseGlyph, layerBuilder, paint))

--- a/Lib/fontTools/colorLib/builder.py
+++ b/Lib/fontTools/colorLib/builder.py
@@ -170,6 +170,10 @@ def populateCOLRv0(
         baseGlyphRecords.append(baseRec)
 
         for layerGlyph, paletteIndex in layers:
+            if glyphMap is not None and layerGlyph not in glyphMap:
+                raise ColorLibError(
+                    f"populateCOLRv0: layer glyph not found in glyphMap: {layerGlyph!r}"
+                )
             layerRec = ot.LayerRecord()
             layerRec.LayerGlyph = layerGlyph
             layerRec.PaletteIndex = paletteIndex

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,5 @@
+- [colorLib] Raise a legible error when a PaintGlyph or PaintColrGlyph references a
+  glyph missing from the glyphMap, instead of failing obscurely later (#2629)
 - [feaLib] Fix name-table parsing for multibyte Mac encodings (#1196) (#4092)
 - [subset] keep East Asian spacing palt by default (#4094)
 - [subset] bug fix for MATH table in which constructions for glyphs that are only added

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,5 +1,6 @@
-- [colorLib] Raise a legible error when a PaintGlyph or PaintColrGlyph references a
-  glyph missing from the glyphMap, instead of failing obscurely later (#2629)
+- [colorLib] Raise a legible error when a COLRv0 layer, or a COLRv1 PaintGlyph or
+  PaintColrGlyph, references a glyph missing from the glyphMap, instead of failing
+  obscurely later (#2629)
 - [feaLib] Fix name-table parsing for multibyte Mac encodings (#1196) (#4092)
 - [subset] keep East Asian spacing palt by default (#4094)
 - [subset] bug fix for MATH table in which constructions for glyphs that are only added

--- a/Tests/colorLib/builder_test.py
+++ b/Tests/colorLib/builder_test.py
@@ -1827,3 +1827,11 @@ def test_buildCOLR_missing_paint_colr_glyph_in_glyphMap_raises_clear_error():
         ColorLibError, match="PaintColrGlyph.*not found in glyphMap.*'B'"
     ):
         buildCOLR(colorGlyphs, version=1, glyphMap=glyphMap)
+
+
+def test_buildCOLRv0_missing_layer_glyph_in_glyphMap_raises_clear_error():
+    glyphMap = {"A": 0}  # font only contains glyph A
+
+    # base glyph A exists, but one of its layers references glyph "B" which does not
+    with pytest.raises(ColorLibError, match="layer glyph not found in glyphMap: 'B'"):
+        buildCOLR({"A": [("A", 0), ("B", 1)]}, version=0, glyphMap=glyphMap)

--- a/Tests/colorLib/builder_test.py
+++ b/Tests/colorLib/builder_test.py
@@ -1790,3 +1790,40 @@ def test_buildCOLR_missing_base_glyph_in_glyphMap_raises_clear_error():
 
     with pytest.raises(ColorLibError, match="base glyph\\(s\\) not found in glyphMap"):
         buildCOLR(colorGlyphs, version=0, glyphMap=glyphMap)
+
+
+def test_buildCOLR_missing_paint_glyph_in_glyphMap_raises_clear_error():
+    glyphMap = {"A": 0}  # font only contains glyph A
+
+    # base glyph A exists, but its PaintGlyph references glyph "B" which does not
+    colorGlyphs = {
+        "A": {
+            "Format": ot.PaintFormat.PaintGlyph,
+            "Glyph": "B",
+            "Paint": {
+                "Format": ot.PaintFormat.PaintSolid,
+                "PaletteIndex": 0,
+                "Alpha": 1.0,
+            },
+        },
+    }
+
+    with pytest.raises(ColorLibError, match="PaintGlyph.*not found in glyphMap.*'B'"):
+        buildCOLR(colorGlyphs, version=1, glyphMap=glyphMap)
+
+
+def test_buildCOLR_missing_paint_colr_glyph_in_glyphMap_raises_clear_error():
+    glyphMap = {"A": 0}  # font only contains glyph A
+
+    # base glyph A exists, but its PaintColrGlyph references glyph "B" which does not
+    colorGlyphs = {
+        "A": {
+            "Format": ot.PaintFormat.PaintColrGlyph,
+            "Glyph": "B",
+        },
+    }
+
+    with pytest.raises(
+        ColorLibError, match="PaintColrGlyph.*not found in glyphMap.*'B'"
+    ):
+        buildCOLR(colorGlyphs, version=1, glyphMap=glyphMap)


### PR DESCRIPTION
Fixes #2629

## Problem

`buildColrV1` already validates that *base* glyphs exist in the `glyphMap` (via `_check_base_glyphs_exist`), but glyphs referenced *inside* paints — `PaintGlyph` (format 10) and `PaintColrGlyph` (format 11) — were not checked. A reference to a glyph that isn't in the `glyphMap` therefore surfaced as an obscure failure later on rather than a clear message. As noted in #2629, this shows up e.g. as a `struct.error: ('required argument is not an integer', 'str', 'Paint', ...)` at compile time, which is hard to act on.

## Change

When a `glyphMap` is provided, `LayerListBuilder` now registers `AFTER_BUILD` callbacks for `PaintGlyph` and `PaintColrGlyph` that raise a legible `ColorLibError` naming the offending paint and glyph, e.g.:

```
PaintGlyph: glyph not found in glyphMap: 'B'
```

This reuses the existing callback mechanism already used elsewhere in the builder, and `buildColrV1`'s per-base-glyph error collection wraps it into the usual "Failed to build BaseGlyphList" report.

The check is a no-op when no `glyphMap` is passed, matching the existing behaviour of the base-glyph check, so this is backward compatible.

## Tests

- `test_buildCOLR_missing_paint_glyph_in_glyphMap_raises_clear_error`
- `test_buildCOLR_missing_paint_colr_glyph_in_glyphMap_raises_clear_error`

Both assert a clear `ColorLibError` is raised. The full `Tests/colorLib/` suite passes and `black --check` is clean. A `NEWS.rst` entry is included.
