### PR TITLE
[glyf] Don't crash recompiling OTB fonts with single-entry loca

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -139,6 +139,17 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
         dataList = []
         recalcBBoxes = ttFont.recalcBBoxes
         boundsDone = set()
+        if not self.glyphs:
+            # Bitmap-only sfnt fonts (X11 OTB) have an empty 'glyf' table and a
+            # single-entry 'loca': the glyphs are bitmaps in EBLC/EBDT and no
+            # outline glyph records exist. Emit that empty shell instead of
+            # iterating glyphOrder (which would raise KeyError), and leave
+            # maxp.numGlyphs alone since in these fonts it counts the bitmap
+            # glyphs, not the 'loca' entries.
+            # https://github.com/fonttools/fonttools/issues/4120
+            if "loca" in ttFont:
+                ttFont["loca"].set([0])
+            return b"\0"
         for glyphName in self.glyphOrder:
             glyph = self.glyphs[glyphName]
             glyphData = glyph.compile(

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -111,6 +111,14 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
             glyph = Glyph(glyphdata)
             self.glyphs[glyphName] = glyph
             pos = nextPos
+        # OTB bitmap-only sfnt fonts use a single-entry loca ([0]) with an empty
+        # glyf shell; fill placeholder glyphs so compile() doesn't KeyError.
+        # Mirrors the tolerant handling in toXML() and _l_o_c_a.py.
+        # https://github.com/fonttools/fonttools/issues/4120
+        for glyphName in glyphOrder:
+            if glyphName not in self.glyphs:
+                log.warning("glyph '%s' has no entry in glyf table", glyphName)
+                self.glyphs[glyphName] = Glyph()
         if len(data) - nextPos >= 4:
             log.warning(
                 "too much 'glyf' table data: expected %d, received %d bytes",

--- a/Lib/fontTools/ttLib/tables/_m_a_x_p.py
+++ b/Lib/fontTools/ttLib/tables/_m_a_x_p.py
@@ -46,7 +46,16 @@ class table__m_a_x_p(DefaultTable.DefaultTable):
 
     def compile(self, ttFont):
         if "glyf" in ttFont:
-            if ttFont.isLoaded("glyf") and ttFont.recalcBBoxes:
+            if (
+                ttFont.isLoaded("glyf")
+                and ttFont.recalcBBoxes
+                # bitmap-only sfnt fonts (X11 OTB) have an empty glyf table with
+                # no outline glyph records to recalculate from; recalc() also
+                # assumes numGlyphs matches the loca/glyphs, which does not
+                # hold for these fonts as numGlyphs counts the bitmap glyphs
+                # https://github.com/fonttools/fonttools/issues/4120
+                and ttFont["glyf"].glyphs
+            ):
                 self.recalc(ttFont)
         else:
             pass  # CFF

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -381,6 +381,37 @@ class GlyfTableTest(unittest.TestCase):
         self.assertEqual(font["glyf"][".notdef"].numberOfContours, 0)
         self.assertEqual(font["glyf"]["space"].numberOfContours, 0)
 
+    def test_decompile_otb_style_single_entry_loca(self):
+        # https://github.com/fonttools/fonttools/issues/4120
+        font = TTFont()
+        glyphNames = [".notdef", "space"]
+        font.setGlyphOrder(glyphNames)
+        font["loca"] = newTable("loca")
+        font["loca"].locations = [0]
+        font["glyf"] = newTable("glyf")
+        font["glyf"].decompile(b"", font)
+        self.assertEqual(len(font["glyf"]), len(glyphNames))
+        for name in glyphNames:
+            self.assertEqual(font["glyf"][name].numberOfContours, 0)
+
+    def test_compile_after_decompile_otb_style(self):
+        # https://github.com/fonttools/fonttools/issues/4120
+        font = TTFont(sfntVersion="\x00\x01\x00\x00")
+        glyphNames = [".notdef", "space"]
+        font.setGlyphOrder(glyphNames)
+        font["head"] = newTable("head")
+        font["head"].indexToLocFormat = 0
+        font["maxp"] = newTable("maxp")
+        font["maxp"].numGlyphs = len(glyphNames)
+        font["loca"] = newTable("loca")
+        font["loca"].locations = [0]
+        font["glyf"] = newTable("glyf")
+        font["glyf"].decompile(b"", font)
+        glyfData = font["glyf"].compile(font)
+        self.assertEqual(glyfData, b"\x00")
+        self.assertEqual(list(font["loca"]), [0] * (len(glyphNames) + 1))
+        self.assertEqual(font["maxp"].numGlyphs, len(glyphNames))
+
     def test_getPhantomPoints(self):
         # https://github.com/fonttools/fonttools/issues/2295
         font = TTFont()

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -442,6 +442,84 @@ class GlyfTableTest(unittest.TestCase):
         self.assertEqual(font["glyf"][".notdef"].numberOfContours, 0)
         self.assertEqual(font["glyf"]["space"].numberOfContours, 0)
 
+    def test_decompile_otb_style_single_entry_loca(self):
+        # https://github.com/fonttools/fonttools/issues/4120
+        # An OTB bitmap-only sfnt has an empty glyf table and a single-entry
+        # loca; decompiling it must not synthesize outline glyph records.
+        font = TTFont()
+        glyphNames = [".notdef", "space"]
+        font.setGlyphOrder(glyphNames)
+        font["loca"] = newTable("loca")
+        font["loca"].locations = [0]
+        font["glyf"] = newTable("glyf")
+        font["glyf"].decompile(b"", font)
+        self.assertEqual(len(font["glyf"].glyphs), 0)
+        self.assertIsNone(font["glyf"].get(".notdef"))
+
+    def test_compile_after_decompile_otb_style(self):
+        # https://github.com/fonttools/fonttools/issues/4120
+        # Recompiling the OTB empty shell must not raise KeyError, must keep
+        # the single-entry loca, and must leave maxp.numGlyphs (which counts
+        # the bitmap glyphs in these fonts) untouched.
+        font = TTFont(sfntVersion="\x00\x01\x00\x00")
+        glyphNames = [".notdef", "space"]
+        font.setGlyphOrder(glyphNames)
+        font["head"] = newTable("head")
+        font["head"].indexToLocFormat = 0
+        font["maxp"] = newTable("maxp")
+        font["maxp"].numGlyphs = len(glyphNames)
+        font["loca"] = newTable("loca")
+        font["loca"].locations = [0]
+        font["glyf"] = newTable("glyf")
+        font["glyf"].decompile(b"", font)
+        glyfData = font["glyf"].compile(font)
+        self.assertEqual(glyfData, b"\x00")
+        self.assertEqual(list(font["loca"]), [0])
+        self.assertEqual(font["maxp"].numGlyphs, len(glyphNames))
+
+    def test_save_reload_otb_style_single_entry_loca(self):
+        # https://github.com/fonttools/fonttools/issues/4120
+        # The crash was on save after loading an OTB font; the structure must
+        # also survive a save->reload->save round trip.
+        font = TTFont(sfntVersion="\x00\x01\x00\x00")
+        glyphNames = [".notdef", "space"]
+        font.setGlyphOrder(glyphNames)
+        font["head"] = newTable("head")
+        font["head"].decompile(b"\0" * 54, font)  # zeroed but complete 'head'
+        font["head"].indexToLocFormat = 0
+        font["maxp"] = newTable("maxp")
+        font["maxp"].tableVersion = 0x00005000
+        font["maxp"].numGlyphs = len(glyphNames)
+        font["hmtx"] = newTable("hmtx")
+        font["hmtx"].metrics = {name: (600, 0) for name in glyphNames}
+        font["loca"] = newTable("loca")
+        font["loca"].locations = [0]
+        font["glyf"] = newTable("glyf")
+        font["glyf"].decompile(b"", font)
+
+        buf = BytesIO()
+        font.save(buf)
+        buf.seek(0)
+        font2 = TTFont(buf)
+        self.assertEqual(list(font2["loca"]), [0])
+        self.assertEqual(font2["maxp"].numGlyphs, len(glyphNames))
+        self.assertEqual(len(font2["glyf"].glyphs), 0)
+
+        # saving the reloaded font again must not raise (issue #4120 pt. 1)
+        buf2 = BytesIO()
+        font2.save(buf2)
+
+    def test_compile_glyph_missing_from_glyphs_raises(self):
+        # a partially-populated glyf.glyphs (e.g. from a truncated loca in an
+        # ordinary TrueType font) must keep failing loudly instead of being
+        # normalized to empty glyphs
+        font = TTFont()
+        font.setGlyphOrder([".notdef", "space"])
+        font["glyf"] = newTable("glyf")
+        font["glyf"].glyphs = {".notdef": Glyph()}
+        with self.assertRaises(KeyError):
+            font["glyf"].compile(font)
+
     def test_getPhantomPoints(self):
         # https://github.com/fonttools/fonttools/issues/2295
         font = TTFont()


### PR DESCRIPTION
Fixes the `KeyError` from `font.save()` after loading an OTB-style font (single-entry loca, zero-length glyf).

Loading and ttx-dumping these fonts already worked since #1680 / #1681; this finishes the round-trip on the compile side, preserving the empty-shell state: when `self.glyphs` is empty, `compile()` skips the `glyphOrder` traversal and emits the single-entry `loca`, leaving `maxp.numGlyphs` (which counts the bitmap glyphs in these fonts) untouched. Nothing is synthesized at decompile time, so a `glyf` table with no outline records stays distinguishable from one whose records are all empty, and a truncated `loca` in an ordinary TrueType font still fails loudly.

`maxp.recalc()` is likewise skipped for the empty shell, as it assumes `numGlyphs` matches the glyphs and there are no outlines to recalculate bounds from.

The `b"\0"` rule from #1829 is left alone. Part 2 of #4120 (true zero-length glyf) is out of scope here.