### PR TITLE
[designspaceLib] Read an empty <lib> element as an empty lib

### DIFF
--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -2561,6 +2561,9 @@ class BaseDocReader(LogMixin):
 
     def readLibElement(self, libElement, instanceObject):
         """Read the lib element for the given instance."""
+        if len(libElement) == 0:
+            # an empty <lib> element is equivalent to no lib at all
+            return
         instanceObject.lib = plistlib.fromtree(libElement[0])
 
     def readInfoElement(self, infoElement, instanceObject):
@@ -2638,6 +2641,9 @@ class BaseDocReader(LogMixin):
     def readLib(self):
         """Read the lib element for the whole document."""
         for libElement in self.root.findall(".lib"):
+            if len(libElement) == 0:
+                # an empty <lib> element is equivalent to no lib at all
+                continue
             self.documentObject.lib = plistlib.fromtree(libElement[0])
 
 

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -919,6 +919,32 @@ def test_documentLib(tmpdir):
     assert new.lib[dummyKey] == dummyData
 
 
+def test_emptyLib(tmpdir):
+    # an empty <lib> element should read as an empty lib, not raise IndexError
+    tmpdir = str(tmpdir)
+    testDocPath = os.path.join(tmpdir, "testEmptyLibTest.designspace")
+    with open(testDocPath, "w", encoding="utf-8") as f:
+        f.write(
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<designspace format="4.1">\n'
+            "  <axes>\n"
+            '    <axis tag="TAGA" name="axisName_a" minimum="0" maximum="1000"'
+            ' default="0"/>\n'
+            "  </axes>\n"
+            "  <instances>\n"
+            '    <instance name="instance.a" filename="instance.a.ufo">\n'
+            "      <lib/>\n"
+            "    </instance>\n"
+            "  </instances>\n"
+            "  <lib/>\n"
+            "</designspace>\n"
+        )
+    doc = DesignSpaceDocument()
+    doc.read(testDocPath)
+    assert doc.lib == {}
+    assert doc.instances[0].lib == {}
+
+
 def test_updatePaths(tmpdir):
     doc = DesignSpaceDocument()
     doc.path = str(tmpdir / "foo" / "bar" / "MyDesignspace.designspace")


### PR DESCRIPTION
Closes #4142

`readLib()` and `readLibElement()` indexed `libElement[0]` unconditionally, so a designspace file with an empty `<lib>` element raised `IndexError` instead of loading. Both now skip an element with no children, leaving `lib` as the default empty dict — the same result as omitting the `<lib>` lines entirely.

`test_emptyLib` covers the document-level and instance-level cases; it fails with `IndexError` without the fix and passes with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
