### PR TITLE
[misc.etree] don't resolve external entities in XMLParser

### DIFF
--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -1994,7 +1994,7 @@ class BaseDocReader(LogMixin):
     def __init__(self, documentPath, documentObject):
         self.path = documentPath
         self.documentObject = documentObject
-        tree = ET.parse(self.path)
+        tree = ET.parse(self.path, parser=ET.XMLParser())
         self.root = tree.getroot()
         self.documentObject.formatVersion = self.root.attrib.get("format", "3.0")
         self._axes = []

--- a/Lib/fontTools/misc/etree.py
+++ b/Lib/fontTools/misc/etree.py
@@ -43,23 +43,25 @@ __all__ = [
 
 try:
     from lxml.etree import *
+    from lxml.etree import LXML_VERSION
 
     _have_lxml = True
 
-    _XMLParser = XMLParser
+    if LXML_VERSION < (5, 0):
+        # Until lxml 5.0, 'resolve_entities' defaulted to True, so an untrusted
+        # document declaring an external entity could pull in local files. 5.0+
+        # defaults to "internal" (external refused, internal still expanded), so
+        # the bare lxml XMLParser is already safe there and we only override on
+        # older lxml. False is the closest older lxml offers; it also stops
+        # internal entities, but that errs on the safe side.
+        _XMLParser = XMLParser
 
-    class XMLParser(_XMLParser):
-        """XMLParser subclass that doesn't resolve external entities.
+        class XMLParser(_XMLParser):
+            """XMLParser subclass that doesn't resolve external entities."""
 
-        Until lxml 5.0 the 'resolve_entities' option defaulted to True, so a
-        document carrying an external entity declaration could pull in local
-        files. The ElementTree backend never resolves them, and fontTools
-        parses untrusted documents, so keep the two backends in agreement.
-        """
-
-        def __init__(self, *args, **kwargs):
-            kwargs.setdefault("resolve_entities", False)
-            super(XMLParser, self).__init__(*args, **kwargs)
+            def __init__(self, *args, **kwargs):
+                kwargs.setdefault("resolve_entities", False)
+                super(XMLParser, self).__init__(*args, **kwargs)
 
 except ImportError:
     try:

--- a/Lib/fontTools/misc/etree.py
+++ b/Lib/fontTools/misc/etree.py
@@ -45,6 +45,22 @@ try:
     from lxml.etree import *
 
     _have_lxml = True
+
+    _XMLParser = XMLParser
+
+    class XMLParser(_XMLParser):
+        """XMLParser subclass that doesn't resolve external entities.
+
+        Until lxml 5.0 the 'resolve_entities' option defaulted to True, so a
+        document carrying an external entity declaration could pull in local
+        files. The ElementTree backend never resolves them, and fontTools
+        parses untrusted documents, so keep the two backends in agreement.
+        """
+
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("resolve_entities", False)
+            super(XMLParser, self).__init__(*args, **kwargs)
+
 except ImportError:
     try:
         from xml.etree.cElementTree import *

--- a/Lib/fontTools/svgLib/path/__init__.py
+++ b/Lib/fontTools/svgLib/path/__init__.py
@@ -39,14 +39,14 @@ class SVGPath(object):
         if filename is None:
             self.root = etree.ElementTree()
         else:
-            tree = etree.parse(filename)
+            tree = etree.parse(filename, parser=etree.XMLParser())
             self.root = tree.getroot()
         self.transform = transform
 
     @classmethod
     def fromstring(cls, data, transform=None):
         self = cls(transform=transform)
-        self.root = etree.fromstring(data)
+        self.root = etree.fromstring(data, parser=etree.XMLParser())
         return self
 
     def draw(self, pen):

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -1318,3 +1318,25 @@ def test_map_backward_single_entry():
     assert ax.map_backward(200) == 100
     assert ax.map_backward(300) == 200
     assert ax.map_backward(100) == 0
+
+
+def test_no_external_entity_expansion(tmp_path):
+    secret = tmp_path / "secret.txt"
+    secret.write_text("s3cr3t")
+    path = tmp_path / "test.designspace"
+    path.write_text(
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE designspace [<!ENTITY xxe SYSTEM "%s">]>'
+        '<designspace format="4.1"><axes>'
+        '<axis tag="wght" name="Weight" minimum="0" maximum="1" default="0">'
+        '<labelname xml:lang="en">x&xxe;</labelname>'
+        "</axis></axes></designspace>" % secret.as_uri()
+    )
+
+    try:
+        doc = DesignSpaceDocument.fromfile(path)
+    except Exception:
+        # the ElementTree backend rejects the undefined entity outright
+        return
+
+    assert "s3cr3t" not in doc.axes[0].labelNames["en"]

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -22,6 +22,7 @@ from fontTools.designspaceLib import (
     processRules,
 )
 from fontTools.designspaceLib.types import Range
+from fontTools.misc import etree as ET
 from fontTools.misc import plistlib
 
 from .fixtures import datadir
@@ -1335,8 +1336,8 @@ def test_no_external_entity_expansion(tmp_path):
 
     try:
         doc = DesignSpaceDocument.fromfile(path)
-    except Exception:
-        # the ElementTree backend rejects the undefined entity outright
+    except ET.ParseError:
+        # the undefined entity is rejected outright
         return
 
     assert "s3cr3t" not in doc.axes[0].labelNames["en"]

--- a/Tests/misc/etree_test.py
+++ b/Tests/misc/etree_test.py
@@ -55,6 +55,9 @@ def test_pretty_print():
 
 
 def test_no_external_entity_expansion(tmp_path):
+    # NOTE: only lxml < 5.0 ever resolved these, so on a newer lxml (and on the
+    # ElementTree backend) this passes either way; it guards the old versions
+    # that setup.py still allows.
     secret = tmp_path / "secret.txt"
     secret.write_text("s3cr3t")
     xml = (
@@ -66,7 +69,7 @@ def test_no_external_entity_expansion(tmp_path):
     try:
         root = etree.fromstring(xml, parser=etree.XMLParser())
     except etree.ParseError:
-        # the ElementTree backend rejects the undefined entity outright
+        # the undefined entity is rejected outright
         return
 
     assert "s3cr3t" not in etree.tostring(root, encoding="unicode")

--- a/Tests/misc/etree_test.py
+++ b/Tests/misc/etree_test.py
@@ -52,3 +52,21 @@ def test_pretty_print():
         "  <empty-element/>\n"
         "</root>\n"
     )
+
+
+def test_no_external_entity_expansion(tmp_path):
+    secret = tmp_path / "secret.txt"
+    secret.write_text("s3cr3t")
+    xml = (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE root [<!ENTITY xxe SYSTEM "%s">]>'
+        "<root>&xxe;</root>" % secret.as_uri()
+    ).encode("utf-8")
+
+    try:
+        root = etree.fromstring(xml, parser=etree.XMLParser())
+    except etree.ParseError:
+        # the ElementTree backend rejects the undefined entity outright
+        return
+
+    assert "s3cr3t" not in etree.tostring(root, encoding="unicode")

--- a/Tests/misc/plistlib_test.py
+++ b/Tests/misc/plistlib_test.py
@@ -529,6 +529,25 @@ def test_custom_mapping():
     assert plistlib.loads(data) == {"a": 1, "b": 2}
 
 
+def test_load_does_not_resolve_external_entities(tmp_path):
+    secret = tmp_path / "secret.txt"
+    secret.write_text("s3cr3t")
+    data = (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE plist [<!ENTITY xxe SYSTEM "%s">]>'
+        '<plist version="1.0"><dict><key>note</key><string>&xxe;</string>'
+        "</dict></plist>" % secret.as_uri()
+    ).encode("utf-8")
+
+    try:
+        pl = plistlib.load(BytesIO(data))
+    except Exception:
+        # the ElementTree backend rejects the undefined entity outright
+        return
+
+    assert "s3cr3t" not in pl["note"]
+
+
 if __name__ == "__main__":
     import sys
 

--- a/Tests/misc/plistlib_test.py
+++ b/Tests/misc/plistlib_test.py
@@ -541,8 +541,8 @@ def test_load_does_not_resolve_external_entities(tmp_path):
 
     try:
         pl = plistlib.load(BytesIO(data))
-    except Exception:
-        # the ElementTree backend rejects the undefined entity outright
+    except etree.ParseError:
+        # the undefined entity is rejected outright
         return
 
     assert "s3cr3t" not in pl["note"]

--- a/Tests/svgLib/path/path_test.py
+++ b/Tests/svgLib/path/path_test.py
@@ -83,3 +83,23 @@ class SVGPathTest(object):
             ("curveTo", ((250.0, 700.0), (400.0, 700.0), (400.0, 800.0))),
             ("endPath", ()),
         ]
+
+
+def test_no_external_entity_expansion(tmp_path):
+    secret = tmp_path / "secret.txt"
+    secret.write_text("s3cr3t")
+    svg = tmp_path / "test.svg"
+    svg.write_text(
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE svg [<!ENTITY xxe SYSTEM "%s">]>'
+        '<svg xmlns="http://www.w3.org/2000/svg"><desc>&xxe;</desc>'
+        '<path d="M 0 0 L 1 1 z"/></svg>' % secret.as_uri()
+    )
+
+    for load in (lambda: SVGPath(svg), lambda: SVGPath.fromstring(svg.read_bytes())):
+        try:
+            root = load().root
+        except Exception:
+            # the ElementTree backend rejects the undefined entity outright
+            continue
+        assert all("s3cr3t" not in (el.text or "") for el in root.iter())

--- a/Tests/svgLib/path/path_test.py
+++ b/Tests/svgLib/path/path_test.py
@@ -1,3 +1,4 @@
+from fontTools.misc import etree
 from fontTools.misc.textTools import tobytes
 from fontTools.pens.recordingPen import RecordingPen
 from fontTools.svgLib import SVGPath
@@ -99,7 +100,7 @@ def test_no_external_entity_expansion(tmp_path):
     for load in (lambda: SVGPath(svg), lambda: SVGPath.fromstring(svg.read_bytes())):
         try:
             root = load().root
-        except Exception:
-            # the ElementTree backend rejects the undefined entity outright
+        except etree.ParseError:
+            # the undefined entity is rejected outright
             continue
         assert all("s3cr3t" not in (el.text or "") for el in root.iter())


### PR DESCRIPTION
lxml 4.9.4, a UFO whose `fontinfo.plist` declares `<!ENTITY xxe SYSTEM "file:///etc/passwd">`:

    >>> info = SimpleNamespace()
    >>> UFOReader("demo.ufo").readInfo(info)
    >>> info.note
    '##\n# User Database\n# \n# Note that this file is consulted directly only when th'

`subset/svg.py` already parses OT-SVG with `resolve_entities=False`, but the other four entry points into the etree shim take lxml's default, which resolved external entities until lxml 5.0, and `setup.py` still allows `lxml >= 4.0`: `plistlib.load` (every UFO plist), both GLIF readers in `glifLib`, `SVGPath`, and `designspaceLib`'s reader. Turning the option off in the shim's `XMLParser` is what makes the lxml backend agree with ElementTree, which never resolved them, and it covers plistlib and glifLib where the parser is already built explicitly. `SVGPath` and the designspace reader passed no parser at all, so they now pass one.

Predefined and numeric character references go through libxml2's core rather than entity resolution, so valid documents keep their existing behaviour. Regression tests fail on lxml 4.9.4 before this and pass after; suite is green with and without the lxml extra.
