### PR TITLE
Raise TTLibError instead of AssertionError on a truncated table entry

### DIFF
--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -519,7 +519,14 @@ class DirectoryEntry(object):
     def loadData(self, file):
         file.seek(self.offset)
         data = file.read(self.length)
-        assert len(data) == self.length
+        if len(data) != self.length:
+            # A corrupt or truncated table directory entry can point past the
+            # end of the file; raise a TTLibError instead of a bare assertion
+            # (which is also silently skipped under `python -O`).
+            raise TTLibError(
+                "unexpected end of table data: expected %d bytes but got %d "
+                "at offset %d" % (self.length, len(data), self.offset)
+            )
         if hasattr(self.__class__, "decodeData"):
             data = self.decodeData(data)
         return data

--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -523,9 +523,16 @@ class DirectoryEntry(object):
             # A corrupt or truncated table directory entry can point past the
             # end of the file; raise a TTLibError instead of a bare assertion
             # (which is also silently skipped under `python -O`).
+            tag = getattr(self, "tag", None)
             raise TTLibError(
-                "unexpected end of table data: expected %d bytes but got %d "
-                "at offset %d" % (self.length, len(data), self.offset)
+                "unexpected end of '%s' table data: expected %d bytes but got "
+                "%d at offset %d"
+                % (
+                    Tag(tag) if tag is not None else "????",
+                    self.length,
+                    len(data),
+                    self.offset,
+                )
             )
         if hasattr(self.__class__, "decodeData"):
             data = self.decodeData(data)

--- a/Tests/ttLib/sfnt_test.py
+++ b/Tests/ttLib/sfnt_test.py
@@ -2,8 +2,13 @@ import io
 import copy
 import pickle
 import tempfile
-from fontTools.ttLib import TTFont
-from fontTools.ttLib.sfnt import calcChecksum, SFNTReader, WOFFFlavorData
+from fontTools.ttLib import TTFont, TTLibError
+from fontTools.ttLib.sfnt import (
+    calcChecksum,
+    SFNTDirectoryEntry,
+    SFNTReader,
+    WOFFFlavorData,
+)
 from pathlib import Path
 import pytest
 
@@ -73,6 +78,18 @@ class SFNTReaderTest:
             if k == "file":
                 continue
             assert getattr(reader2, k) == v
+
+
+def test_loadData_truncated_raises_TTLibError():
+    # A corrupt table directory entry whose length runs past the end of the
+    # file must raise TTLibError, not a bare AssertionError (which is also
+    # silently skipped under `python -O`).
+    entry = SFNTDirectoryEntry()
+    entry.tag = "test"
+    entry.offset = 0
+    entry.length = 1000  # more than the stream holds
+    with pytest.raises(TTLibError):
+        entry.loadData(io.BytesIO(b"short"))
 
 
 def test_ttLib_sfnt_write_privData(tmp_path, ttfont_path):

--- a/Tests/ttLib/sfnt_test.py
+++ b/Tests/ttLib/sfnt_test.py
@@ -92,6 +92,17 @@ def test_loadData_truncated_raises_TTLibError():
         entry.loadData(io.BytesIO(b"short"))
 
 
+def test_load_truncated_font_raises_TTLibError(ttfont_path):
+    # End-to-end: a font file cut short past its last table directory entry
+    # must fail with TTLibError when that table is loaded. Chop 4 bytes so we
+    # land inside the last table regardless of its 4-byte padding.
+    data = ttfont_path.read_bytes()[:-4]
+    font = TTFont(io.BytesIO(data), lazy=True)
+    with pytest.raises(TTLibError, match="unexpected end of table data"):
+        for tag in font.keys():
+            font[tag]
+
+
 def test_ttLib_sfnt_write_privData(tmp_path, ttfont_path):
     output_path = tmp_path / "TestTTF-Regular.woff"
     font = TTFont(ttfont_path)

--- a/Tests/ttLib/sfnt_test.py
+++ b/Tests/ttLib/sfnt_test.py
@@ -88,7 +88,7 @@ def test_loadData_truncated_raises_TTLibError():
     entry.tag = "test"
     entry.offset = 0
     entry.length = 1000  # more than the stream holds
-    with pytest.raises(TTLibError):
+    with pytest.raises(TTLibError, match="unexpected end of 'test' table data"):
         entry.loadData(io.BytesIO(b"short"))
 
 
@@ -98,7 +98,7 @@ def test_load_truncated_font_raises_TTLibError(ttfont_path):
     # land inside the last table regardless of its 4-byte padding.
     data = ttfont_path.read_bytes()[:-4]
     font = TTFont(io.BytesIO(data), lazy=True)
-    with pytest.raises(TTLibError, match="unexpected end of table data"):
+    with pytest.raises(TTLibError, match=r"unexpected end of '\w{4}' table data"):
         for tag in font.keys():
             font[tag]
 


### PR DESCRIPTION
### Problem

`SFNTDirectoryEntry.loadData()` (in `sfnt.py`) validates the read with a bare assertion:

```python
def loadData(self, file):
    file.seek(self.offset)
    data = file.read(self.length)
    assert len(data) == self.length
```

A corrupt or truncated table directory entry whose `offset`/`length` runs past the end of the file makes `file.read()` return fewer bytes than `self.length`, so loading a malformed font raises a bare `AssertionError` (with no message) instead of `TTLibError`:

```python
import io
from fontTools.ttLib import TTFont
data = bytearray(open('some.ttf','rb').read())
data[5] ^= 0xFF                 # corrupt the table count / directory
f = TTFont(io.BytesIO(bytes(data)), lazy=True)
[f[t] for t in f.keys()]        # AssertionError
```

Two problems: the `AssertionError` isn't `TTLibError` (so callers guarding font loading don't catch it), and under `python -O` the assert is stripped entirely, so the short data is returned silently.

### Fix

Raise a `TTLibError` with a descriptive message when the read comes up short.

### Test

Added `test_loadData_truncated_raises_TTLibError` in `Tests/ttLib/sfnt_test.py`. It fails with a bare `AssertionError` before this change and passes after. `Tests/ttLib/sfnt_test.py` and `ttFont_test.py` pass (33 tests).