### PR TITLE
Raise TTLibError on a truncated table directory

### DIFF
--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -502,7 +502,15 @@ class DirectoryEntry(object):
         self.uncompressed = False  # if True, always embed entry raw
 
     def fromFile(self, file):
-        sstruct.unpack(self.format, file.read(self.formatSize), self)
+        data = file.read(self.formatSize)
+        if len(data) != self.formatSize:
+            # A file truncated inside the table directory, or one whose
+            # numTables is corrupt, would otherwise fail with a struct.error.
+            raise TTLibError(
+                "unexpected end of table directory: expected %d bytes but got %d"
+                % (self.formatSize, len(data))
+            )
+        sstruct.unpack(self.format, data, self)
 
     def fromString(self, str):
         sstruct.unpack(self.format, str, self)

--- a/Tests/ttLib/sfnt_test.py
+++ b/Tests/ttLib/sfnt_test.py
@@ -7,6 +7,7 @@ from fontTools.ttLib.sfnt import (
     calcChecksum,
     SFNTDirectoryEntry,
     SFNTReader,
+    sfntDirectorySize,
     WOFFFlavorData,
 )
 from pathlib import Path
@@ -101,6 +102,24 @@ def test_load_truncated_font_raises_TTLibError(ttfont_path):
     with pytest.raises(TTLibError, match=r"unexpected end of '\w{4}' table data"):
         for tag in font.keys():
             font[tag]
+
+
+def test_truncated_table_directory_raises_TTLibError(ttfont_path):
+    # Keep the complete sfnt header but only half of its first table-directory
+    # entry. The short entry must raise TTLibError rather than struct.error.
+    data = ttfont_path.read_bytes()[
+        : sfntDirectorySize + SFNTDirectoryEntry.formatSize // 2
+    ]
+    with pytest.raises(TTLibError, match="unexpected end of table directory"):
+        TTFont(io.BytesIO(data))
+
+
+def test_bogus_numTables_raises_TTLibError(ttfont_path):
+    # Corrupting numTables makes the directory run past the end of the file.
+    data = bytearray(ttfont_path.read_bytes())
+    data[5] ^= 0xFF
+    with pytest.raises(TTLibError, match="unexpected end of table directory"):
+        TTFont(io.BytesIO(bytes(data)))
 
 
 def test_ttLib_sfnt_write_privData(tmp_path, ttfont_path):


### PR DESCRIPTION
Follow-up to #4147 (/cc @eeshsaxena).

`DirectoryEntry.fromFile` unpacked whatever it read, so a file cut short *inside* the directory (or one with a corrupt `numTables`, as happens when a font is fuzzed) escaped as `struct.error` rather than `TTLibError`.

It now raises `TTLibError("unexpected end of table directory: expected %d bytes but got %d")`.
