### PR TITLE
Raise TTLibError for a truncated or out-of-bounds cmap subtable header

### DIFF
--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -1,6 +1,6 @@
 from fontTools.misc.textTools import bytesjoin, safeEval, readHex
 from fontTools.misc.encodingTools import getEncoding
-from fontTools.ttLib import getSearchRange
+from fontTools.ttLib import getSearchRange, TTLibError
 from fontTools.unicode import Unicode
 from . import DefaultTable
 import sys
@@ -153,21 +153,33 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
         return result
 
     def decompile(self, data, ttFont):
+        if len(data) < 4:
+            raise TTLibError("cmap table is too short")
         tableVersion, numSubTables = struct.unpack(">HH", data[:4])
         self.tableVersion = int(tableVersion)
         self.tables = tables = []
         seenOffsets = {}
         for i in range(numSubTables):
-            platformID, platEncID, offset = struct.unpack(
-                ">HHl", data[4 + i * 8 : 4 + (i + 1) * 8]
-            )
+            entry = data[4 + i * 8 : 4 + (i + 1) * 8]
+            if len(entry) < 8:
+                raise TTLibError("cmap subtable directory is truncated")
+            platformID, platEncID, offset = struct.unpack(">HHl", entry)
             platformID, platEncID = int(platformID), int(platEncID)
+            # The offset points somewhere inside the cmap table; a malformed
+            # font can put it past the end of the data, so guard the header
+            # reads below instead of letting struct.unpack raise struct.error.
+            if offset < 0 or offset + 4 > len(data):
+                raise TTLibError("cmap subtable offset is out of bounds")
             format, length = struct.unpack(">HH", data[offset : offset + 4])
             if format in [8, 10, 12, 13]:
+                if offset + 8 > len(data):
+                    raise TTLibError("cmap subtable header is truncated")
                 format, reserved, length = struct.unpack(
                     ">HHL", data[offset : offset + 8]
                 )
             elif format in [14]:
+                if offset + 6 > len(data):
+                    raise TTLibError("cmap subtable header is truncated")
                 format, length = struct.unpack(">HL", data[offset : offset + 6])
 
             if not length:

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -1192,13 +1192,18 @@ class cmap_format_12_or_13(CmapSubtable):
         format, reserved, length, language, nGroups = struct.unpack(
             self.headerFormat, data[:headerSize]
         )
-        assert (
-            len(data) == (16 + nGroups * 12) == (length)
-        ), "corrupt cmap table format %d (data length: %d, header length: %d)" % (
-            self.format,
-            len(data),
-            length,
-        )
+        if len(data) != length:
+            raise TTLibError(
+                "cmap subtable format %d is truncated: length %d, got %d bytes"
+                % (self.format, length, len(data))
+            )
+        expectedLength = headerSize + nGroups * 12
+        if length != expectedLength:
+            raise TTLibError(
+                "cmap subtable format %d has an inconsistent group count: "
+                "length %d, but %d groups need %d bytes"
+                % (self.format, length, nGroups, expectedLength)
+            )
         self.format = format
         self.reserved = reserved
         self.length = length

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -12,21 +12,6 @@ import logging
 log = logging.getLogger(__name__)
 
 
-# Minimum length of a subtable, in bytes, for the fixed header that each
-# format's decompileHeader unpacks. Formats not listed here (8, 10 and any
-# unrecognised format, which fall back to cmap_format_unknown) store the body
-# verbatim without unpacking a fixed header, so they have no minimum.
-_CMAP_SUBTABLE_HEADER_SIZE = {
-    0: 6,  # ">HHH"
-    2: 6,  # ">HHH"
-    4: 6,  # ">HHH"
-    6: 6,  # ">HHH"
-    12: 16,  # ">HHLLL"
-    13: 16,  # ">HHLLL"
-    14: 10,  # ">HLL"
-}
-
-
 def _make_map(font, chars, gids):
     assert len(chars) == len(gids)
     glyphNames = font.getGlyphNameMany(gids)
@@ -222,8 +207,11 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
             # fixed header decompileHeader will unpack. Otherwise the slice is
             # short and we hit either an AssertionError (silenced under python
             # -O, leaving a bogus length) or a struct.error deep inside
-            # decompileHeader; surface a TTLibError in both cases.
-            minHeaderSize = _CMAP_SUBTABLE_HEADER_SIZE.get(format, 0)
+            # decompileHeader; surface a TTLibError in both cases. Formats
+            # without a fixed header (8, 10 and any unrecognised format, which
+            # fall back to cmap_format_unknown) have an empty headerFormat and
+            # so no minimum.
+            minHeaderSize = struct.calcsize(table.headerFormat)
             if length < minHeaderSize:
                 raise TTLibError(
                     "cmap subtable header is truncated: length %d < %d"
@@ -317,6 +305,8 @@ class CmapSubtable(object):
     character codepoints to glyph names.
     """
 
+    headerFormat = ">HHH"
+
     @staticmethod
     def getSubtableClass(format):
         """Return the subtable class for a format."""
@@ -359,7 +349,8 @@ class CmapSubtable(object):
         return getattr(self, attr)
 
     def decompileHeader(self, data, ttFont):
-        format, length, language = struct.unpack(">HHH", data[:6])
+        headerSize = struct.calcsize(self.headerFormat)
+        format, length, language = struct.unpack(self.headerFormat, data[:headerSize])
         assert (
             len(data) == length
         ), "corrupt cmap table format %d (data length: %d, header length: %d)" % (
@@ -370,7 +361,7 @@ class CmapSubtable(object):
         self.format = int(format)
         self.length = int(length)
         self.language = int(language)
-        self.data = data[6:]
+        self.data = data[headerSize:]
         self.ttFont = ttFont
 
     def toXML(self, writer, ttFont):
@@ -1188,6 +1179,8 @@ class cmap_format_6(CmapSubtable):
 
 
 class cmap_format_12_or_13(CmapSubtable):
+    headerFormat = ">HHLLL"
+
     def __init__(self, format):
         self.format = format
         self.reserved = 0
@@ -1195,7 +1188,10 @@ class cmap_format_12_or_13(CmapSubtable):
         self.ttFont = None
 
     def decompileHeader(self, data, ttFont):
-        format, reserved, length, language, nGroups = struct.unpack(">HHLLL", data[:16])
+        headerSize = struct.calcsize(self.headerFormat)
+        format, reserved, length, language, nGroups = struct.unpack(
+            self.headerFormat, data[:headerSize]
+        )
         assert (
             len(data) == (16 + nGroups * 12) == (length)
         ), "corrupt cmap table format %d (data length: %d, header length: %d)" % (
@@ -1208,7 +1204,7 @@ class cmap_format_12_or_13(CmapSubtable):
         self.length = length
         self.language = language
         self.nGroups = nGroups
-        self.data = data[16:]
+        self.data = data[headerSize:]
         self.ttFont = ttFont
 
     def decompile(self, data, ttFont):
@@ -1398,9 +1394,14 @@ def cvtFromUVS(val):
 
 
 class cmap_format_14(CmapSubtable):
+    headerFormat = ">HLL"
+
     def decompileHeader(self, data, ttFont):
-        format, length, numVarSelectorRecords = struct.unpack(">HLL", data[:10])
-        self.data = data[10:]
+        headerSize = struct.calcsize(self.headerFormat)
+        format, length, numVarSelectorRecords = struct.unpack(
+            self.headerFormat, data[:headerSize]
+        )
+        self.data = data[headerSize:]
         self.length = length
         self.numVarSelectorRecords = numVarSelectorRecords
         self.ttFont = ttFont
@@ -1595,6 +1596,8 @@ class cmap_format_14(CmapSubtable):
 
 
 class cmap_format_unknown(CmapSubtable):
+    headerFormat = ""  # the body is kept verbatim, nothing is unpacked
+
     def toXML(self, writer, ttFont):
         cmapName = self.__class__.__name__[:12] + str(self.format)
         writer.begintag(

--- a/Lib/fontTools/ttLib/tables/_c_m_a_p.py
+++ b/Lib/fontTools/ttLib/tables/_c_m_a_p.py
@@ -12,6 +12,21 @@ import logging
 log = logging.getLogger(__name__)
 
 
+# Minimum length of a subtable, in bytes, for the fixed header that each
+# format's decompileHeader unpacks. Formats not listed here (8, 10 and any
+# unrecognised format, which fall back to cmap_format_unknown) store the body
+# verbatim without unpacking a fixed header, so they have no minimum.
+_CMAP_SUBTABLE_HEADER_SIZE = {
+    0: 6,  # ">HHH"
+    2: 6,  # ">HHH"
+    4: 6,  # ">HHH"
+    6: 6,  # ">HHH"
+    12: 16,  # ">HHLLL"
+    13: 16,  # ">HHLLL"
+    14: 10,  # ">HLL"
+}
+
+
 def _make_map(font, chars, gids):
     assert len(chars) == len(gids)
     glyphNames = font.getGlyphNameMany(gids)
@@ -163,13 +178,17 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
             entry = data[4 + i * 8 : 4 + (i + 1) * 8]
             if len(entry) < 8:
                 raise TTLibError("cmap subtable directory is truncated")
-            platformID, platEncID, offset = struct.unpack(">HHl", entry)
+            platformID, platEncID, offset = struct.unpack(">HHL", entry)
             platformID, platEncID = int(platformID), int(platEncID)
-            # The offset points somewhere inside the cmap table; a malformed
-            # font can put it past the end of the data, so guard the header
-            # reads below instead of letting struct.unpack raise struct.error.
-            if offset < 0 or offset + 4 > len(data):
-                raise TTLibError("cmap subtable offset is out of bounds")
+            # subtableOffset is an unsigned Offset32 pointing somewhere inside
+            # the cmap table; a malformed font can put it past the end of the
+            # data, so guard the header reads below instead of letting
+            # struct.unpack raise struct.error.
+            if offset + 4 > len(data):
+                raise TTLibError(
+                    "cmap subtable offset %d is out of bounds (data length %d)"
+                    % (offset, len(data))
+                )
             format, length = struct.unpack(">HH", data[offset : offset + 4])
             if format in [8, 10, 12, 13]:
                 if offset + 8 > len(data):
@@ -198,6 +217,23 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
             # Note that by default we decompile only the subtable header info;
             # any other data gets decompiled only when an attribute of the
             # subtable is referenced.
+            #
+            # Make sure the body is actually present and large enough for the
+            # fixed header decompileHeader will unpack. Otherwise the slice is
+            # short and we hit either an AssertionError (silenced under python
+            # -O, leaving a bogus length) or a struct.error deep inside
+            # decompileHeader; surface a TTLibError in both cases.
+            minHeaderSize = _CMAP_SUBTABLE_HEADER_SIZE.get(format, 0)
+            if length < minHeaderSize:
+                raise TTLibError(
+                    "cmap subtable header is truncated: length %d < %d"
+                    % (length, minHeaderSize)
+                )
+            if offset + length > len(data):
+                raise TTLibError(
+                    "cmap subtable is truncated: needs %d bytes, only %d available"
+                    % (length, len(data) - offset)
+                )
             table.decompileHeader(data[offset : offset + int(length)], ttFont)
             if offset in seenOffsets:
                 table.data = None  # Mark as decompiled
@@ -244,7 +280,7 @@ class table__c_m_a_p(DefaultTable.DefaultTable):
                         tableData
                     )
                     tableData = tableData + chunk
-            data = data + struct.pack(">HHl", table.platformID, table.platEncID, offset)
+            data = data + struct.pack(">HHL", table.platformID, table.platEncID, offset)
         return data + tableData
 
     def toXML(self, writer, ttFont):

--- a/Tests/ttLib/tables/_c_m_a_p_test.py
+++ b/Tests/ttLib/tables/_c_m_a_p_test.py
@@ -136,6 +136,27 @@ class CmapSubtableTest(unittest.TestCase):
                 self.assertEqual(subtable.format, format)
                 self.assertEqual(subtable.data, header[:4])
 
+    def test_decompile_format_12_inconsistent_nGroups(self):
+        # nGroups and length disagree: the header check used to be an assert,
+        # which python -O drops, leaving a subtable claiming groups that are
+        # not there.
+        font = ttLib.TTFont()
+        # length says 28 bytes, but nGroups == 0 accounts for the 16-byte
+        # header alone.
+        body = struct.pack(">HHLLL", 12, 0, 28, 0, 0) + b"\0" * 12
+        data = struct.pack(">HH", 0, 1) + struct.pack(">HHL", 3, 10, 12) + body
+        table = table__c_m_a_p("cmap")
+        with self.assertRaisesRegex(ttLib.TTLibError, "inconsistent group count"):
+            table.decompile(data, font)
+
+    def test_decompile_subtable_format_12_truncated(self):
+        # a subtable decompiled on its own does not go through the length
+        # checks table__c_m_a_p.decompile does up front.
+        subtable = CmapSubtable.newSubtable(12)
+        data = struct.pack(">HHLLL", 12, 0, 28, 0, 1)
+        with self.assertRaisesRegex(ttLib.TTLibError, "is truncated"):
+            subtable.decompile(data, ttLib.TTFont())
+
     def test_compile_2(self):
         subtable = self.makeSubtable(2, 1, 2, 0)
         subtable.cmap = {c: "cid%05d" % c for c in range(32, 8192)}

--- a/Tests/ttLib/tables/_c_m_a_p_test.py
+++ b/Tests/ttLib/tables/_c_m_a_p_test.py
@@ -57,21 +57,59 @@ class CmapSubtableTest(unittest.TestCase):
         self.assertEqual(subtable.getEncoding(default="xyz"), "xyz")
 
     def test_decompile_truncated(self):
-        # A truncated cmap table, or one whose subtable offset points past the
-        # end of the data, used to raise a bare struct.error instead of
-        # TTLibError.
+        # A truncated cmap table, an out-of-bounds subtable offset, or a
+        # subtable whose length does not match the data used to raise a bare
+        # struct.error or AssertionError instead of TTLibError.
         import struct
 
         font = ttLib.TTFont()
-        cases = [
-            b"\x00\x00",  # shorter than the 4-byte header
-            struct.pack(">HH", 0, 3) + b"ab",  # 3 subtables promised, dir truncated
-            struct.pack(">HH", 0, 1) + struct.pack(">HHl", 3, 1, 9999),  # bad offset
-        ]
-        for data in cases:
-            table = table__c_m_a_p("cmap")
-            with self.assertRaises(ttLib.TTLibError):
-                table.decompile(data, font)
+
+        def cmap(numTables, *entries, body=b""):
+            data = struct.pack(">HH", 0, numTables)
+            for platformID, platEncID, offset in entries:
+                data += struct.pack(">HHL", platformID, platEncID, offset)
+            return data + body
+
+        # A subtable directory with one entry pointing at `offset`; the subtable
+        # header itself starts right after the 12-byte directory (offset 12).
+        def one_subtable(header):
+            return cmap(1, (3, 1, 12), body=header)
+
+        cases = {
+            "table shorter than the 4-byte header": (
+                b"\x00\x00",
+                "too short",
+            ),
+            "subtable directory truncated": (
+                struct.pack(">HH", 0, 3) + b"ab",
+                "directory is truncated",
+            ),
+            "offset past the end of the data": (
+                cmap(1, (3, 1, 9999)),
+                "out of bounds",
+            ),
+            # 0xFFFFFFFF pins the offset as an unsigned Offset32: read signed it
+            # would be -1 and slip through as an in-range negative index.
+            "offset 0xFFFFFFFF is unsigned and out of bounds": (
+                cmap(1, (3, 1, 0xFFFFFFFF)),
+                "out of bounds",
+            ),
+            # format 4 header is ">HHH" (6 bytes); a length of 4 is too small.
+            "length smaller than the format header": (
+                one_subtable(struct.pack(">HH", 4, 4)),
+                "header is truncated",
+            ),
+            # length claims 20 bytes but only 6 are present after the offset.
+            "length longer than the available data": (
+                one_subtable(struct.pack(">HHH", 4, 20, 0)),
+                "subtable is truncated",
+            ),
+        }
+        for label, (data, pattern) in cases.items():
+            with self.subTest(label):
+                table = table__c_m_a_p("cmap")
+                with self.assertRaisesRegex(ttLib.TTLibError, pattern):
+                    table.decompile(data, font)
 
     def test_compile_2(self):
         subtable = self.makeSubtable(2, 1, 2, 0)

--- a/Tests/ttLib/tables/_c_m_a_p_test.py
+++ b/Tests/ttLib/tables/_c_m_a_p_test.py
@@ -56,6 +56,23 @@ class CmapSubtableTest(unittest.TestCase):
         self.assertEqual(subtable.getEncoding("ascii"), "ascii")
         self.assertEqual(subtable.getEncoding(default="xyz"), "xyz")
 
+    def test_decompile_truncated(self):
+        # A truncated cmap table, or one whose subtable offset points past the
+        # end of the data, used to raise a bare struct.error instead of
+        # TTLibError.
+        import struct
+
+        font = ttLib.TTFont()
+        cases = [
+            b"\x00\x00",  # shorter than the 4-byte header
+            struct.pack(">HH", 0, 3) + b"ab",  # 3 subtables promised, dir truncated
+            struct.pack(">HH", 0, 1) + struct.pack(">HHl", 3, 1, 9999),  # bad offset
+        ]
+        for data in cases:
+            table = table__c_m_a_p("cmap")
+            with self.assertRaises(ttLib.TTLibError):
+                table.decompile(data, font)
+
     def test_compile_2(self):
         subtable = self.makeSubtable(2, 1, 2, 0)
         subtable.cmap = {c: "cid%05d" % c for c in range(32, 8192)}

--- a/Tests/ttLib/tables/_c_m_a_p_test.py
+++ b/Tests/ttLib/tables/_c_m_a_p_test.py
@@ -1,10 +1,15 @@
 import io
 import os
 import re
+import struct
 from fontTools import ttLib
 from fontTools.fontBuilder import FontBuilder
 import unittest
-from fontTools.ttLib.tables._c_m_a_p import CmapSubtable, table__c_m_a_p
+from fontTools.ttLib.tables._c_m_a_p import (
+    CmapSubtable,
+    cmap_format_unknown,
+    table__c_m_a_p,
+)
 
 CURR_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 DATA_DIR = os.path.join(CURR_DIR, "data")
@@ -60,8 +65,6 @@ class CmapSubtableTest(unittest.TestCase):
         # A truncated cmap table, an out-of-bounds subtable offset, or a
         # subtable whose length does not match the data used to raise a bare
         # struct.error or AssertionError instead of TTLibError.
-        import struct
-
         font = ttLib.TTFont()
 
         def cmap(numTables, *entries, body=b""):
@@ -110,6 +113,28 @@ class CmapSubtableTest(unittest.TestCase):
                 table = table__c_m_a_p("cmap")
                 with self.assertRaisesRegex(ttLib.TTLibError, pattern):
                     table.decompile(data, font)
+
+    def test_decompile_unknown_format_no_header_minimum(self):
+        # Formats 8 and 10, and any unrecognised format, are handled by
+        # cmap_format_unknown, which keeps the body verbatim instead of
+        # unpacking a fixed header, so a body too short for one is fine.
+        font = ttLib.TTFont()
+
+        for format, header in [
+            # 8 and 10 read a ">HHL" header off the subtable offset, so the
+            # body must be 8 bytes even though the length field says 4.
+            (8, struct.pack(">HHL", 8, 0, 4)),
+            (10, struct.pack(">HHL", 10, 0, 4)),
+            (99, struct.pack(">HH", 99, 4)),
+        ]:
+            with self.subTest(format=format):
+                data = struct.pack(">HH", 0, 1) + struct.pack(">HHL", 3, 1, 12) + header
+                table = table__c_m_a_p("cmap")
+                table.decompile(data, font)
+                subtable = table.tables[0]
+                self.assertIsInstance(subtable, cmap_format_unknown)
+                self.assertEqual(subtable.format, format)
+                self.assertEqual(subtable.data, header[:4])
 
     def test_compile_2(self):
         subtable = self.makeSubtable(2, 1, 2, 0)


### PR DESCRIPTION
Following up on #4147 (truncated table entries), here's another spot where a malformed font surfaces a raw `struct.error` instead of `TTLibError`, this time in the `cmap` loader.

`table__c_m_a_p.decompile` reads the table header, the subtable directory, and each subtable's format/length via `struct.unpack` on slices of `data`. A malformed font can make the table shorter than 4 bytes, promise more subtables than the directory holds, or give a subtable an offset past the end of the data, and any of those hands `struct.unpack` a short buffer, e.g. `struct.error: unpack requires a buffer of 4 bytes`.

I added length checks around the header reads so they raise `TTLibError` instead. This covers the subtable-header parsing; deeply malformed subtable *bodies* can still raise from the individual format decompilers, which is a separate surface.

Added a test in _c_m_a_p_test.py (too-short table, truncated directory, out-of-bounds offset); it raises struct.error on main and passes with the change, and the existing cmap tests still pass. Found it by fuzzing font loading with mutated system fonts.