### PR TITLE
[designspaceLib] Reject conflicting duplicate inputs in designspace axis maps

### DIFF
--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -941,6 +941,31 @@ class AbstractAxisDescriptor(SimpleDescriptor):
         .. versionadded:: 5.0
         """
 
+    def get_validated_map(self) -> list[tuple[float, float]]:
+        """Return a new list with exact duplicate pairs collapsed.
+
+        The stored :attr:`map` is not modified.
+        Multiple distinct input coordinates may map to the same output;
+        duplicate outputs (many-to-one mappings) are valid.
+
+        This validates only ambiguity in the input coordinates: an input
+        coordinate mapping to different outputs raises
+        :class:`DesignSpaceDocumentError`. It does not validate axis endpoint
+        coverage or output monotonicity.
+        """
+        validated = {}
+        for input_value, output_value in self.map:
+            if input_value in validated:
+                previous_output = validated[input_value]
+                if previous_output != output_value:
+                    raise DesignSpaceDocumentError(
+                        f"Axis '{self.name}': mapping input value {input_value} "
+                        f"has conflicting outputs {previous_output} and {output_value}."
+                    )
+                continue
+            validated[input_value] = output_value
+        return list(validated.items())
+
 
 class AxisDescriptor(AbstractAxisDescriptor):
     """Simple container for the axis data.
@@ -1035,21 +1060,23 @@ class AxisDescriptor(AbstractAxisDescriptor):
         """Maps value from axis mapping's input (user) to output (design)."""
         from fontTools.varLib.models import piecewiseLinearMap
 
-        if not self.map:
+        axis_map = self.get_validated_map()
+        if not axis_map:
             return v
-        return piecewiseLinearMap(v, {k: v for k, v in self.map})
+        return piecewiseLinearMap(v, dict(axis_map))
 
     def map_backward(self, v):
         """Maps value from axis mapping's output (design) to input (user)."""
         if isinstance(v, tuple):
             v = v[0]
-        if not self.map:
+        axis_map = self.get_validated_map()
+        if not axis_map:
             return v
         # Build (design, user) pairs sorted by design then user, keeping
         # both endpoints of any many-to-one (flat) segments so we can
         # invert them and interpolation is correct on both sides.
         # https://github.com/googlefonts/ufo2ft/issues/978
-        backward = sorted((design, user) for user, design in self.map)
+        backward = sorted((design, user) for user, design in axis_map)
         design0, user0 = backward[0]
         if v <= design0:
             return v + user0 - design0
@@ -1141,7 +1168,7 @@ class DiscreteAxisDescriptor(AbstractAxisDescriptor):
         Note: for discrete axes, each value must have its mapping entry, if
         you intend that value to be mapped.
         """
-        return next((v for k, v in self.map if k == value), value)
+        return next((v for k, v in self.get_validated_map() if k == value), value)
 
     def map_backward(self, value):
         """Maps value from axis mapping's output to input.
@@ -1153,7 +1180,7 @@ class DiscreteAxisDescriptor(AbstractAxisDescriptor):
         """
         if isinstance(value, tuple):
             value = value[0]
-        return next((k for k, v in self.map if v == value), value)
+        return next((k for k, v in self.get_validated_map() if v == value), value)
 
 
 class AxisLabelDescriptor(SimpleDescriptor):

--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -181,6 +181,8 @@ def _add_avar(font, axes, mappings, axisTags):
     interesting = False
     vals_triples = {}
     for axis in axes.values():
+        axis_map = axis.get_validated_map()
+
         # Currently, some rasterizers require that the default value maps
         # (-1 to -1, 0 to 0, and 1 to 1) be present for all the segment
         # maps, even when the default normalization mapping for the axis
@@ -193,11 +195,12 @@ def _add_avar(font, axes, mappings, axisTags):
         keys_triple = (axis.minimum, axis.default, axis.maximum)
         vals_triple = tuple(axis.map_forward(v) for v in keys_triple)
         vals_triples[axis.tag] = vals_triple
-
-        if not axis.map:
+        if not axis_map:
             continue
 
-        items = sorted(axis.map)
+        # The validated view removes repeated pairs while preserving legal
+        # duplicate output values.
+        items = sorted(axis_map)
         keys = [item[0] for item in items]
         vals = [item[1] for item in items]
 
@@ -218,12 +221,6 @@ def _add_avar(font, axes, mappings, axisTags):
             raise VarLibValidationError(
                 f"Axis '{axis.name}': there must be a mapping for the axis default "
                 f"value {axis.default}."
-            )
-        # No duplicate input values (output values can be >= their preceeding value).
-        if len(set(keys)) != len(keys):
-            raise VarLibValidationError(
-                f"Axis '{axis.name}': All axis mapping input='...' values must be "
-                "unique, but we found duplicates."
             )
         # Ascending values
         if sorted(vals) != vals:

--- a/Tests/designspaceLib/designspace_test.py
+++ b/Tests/designspaceLib/designspace_test.py
@@ -1234,6 +1234,88 @@ def test_map_backward_many_to_one():
     assert result == pytest.approx(expected)
 
 
+def test_axis_map_conflicting_duplicate_input_is_rejected_when_consumed():
+    raw_map = [(900, 1000), (400, 450), (100, 100), (400, 500)]
+    original_map = list(raw_map)
+    axis = AxisDescriptor(
+        name="Weight",
+        tag="wght",
+        minimum=100,
+        default=400,
+        maximum=900,
+        # Deliberately out of input order: validation must not depend on
+        # adjacent entries in the source list.
+        map=raw_map,
+    )
+
+    with pytest.raises(
+        DesignSpaceDocumentError,
+        match=r"Axis 'Weight': mapping input value 400 .* 450 and 500",
+    ):
+        axis.map_forward(400)
+    with pytest.raises(DesignSpaceDocumentError, match="Axis 'Weight'"):
+        axis.map_backward(450)
+    assert axis.map is raw_map
+    assert axis.map == original_map
+
+
+def test_axis_map_identical_duplicate_input_is_ignored_by_consumers():
+    raw_map = [(900, 1000), (400, 450), (100, 100), (400, 450)]
+    original_map = list(raw_map)
+    axis = AxisDescriptor(
+        name="Weight",
+        tag="wght",
+        minimum=100,
+        default=400,
+        maximum=900,
+        map=raw_map,
+    )
+
+    assert axis.get_validated_map() == [(900, 1000), (400, 450), (100, 100)]
+    assert axis.map_forward(400) == 450
+    assert axis.map_backward(450) == 400
+    assert axis.map is raw_map
+    assert axis.map == original_map
+
+
+def test_discrete_axis_map_rejects_conflicting_duplicate_inputs_when_consumed():
+    axis = DiscreteAxisDescriptor(
+        name="Style",
+        tag="STYL",
+        values=[0, 1],
+        default=0,
+        map=[(0, 10), (1, 20), (0, 11)],
+    )
+
+    with pytest.raises(DesignSpaceDocumentError, match="Axis 'Style'"):
+        axis.map_forward(0)
+    with pytest.raises(DesignSpaceDocumentError, match="Axis 'Style'"):
+        axis.map_backward(10)
+
+
+def test_parsed_axis_map_conflicting_duplicate_input_is_rejected_when_consumed():
+    designspace = """
+    <designspace format="5.0">
+      <axes>
+        <axis name="Weight" tag="wght" minimum="100" default="400" maximum="900">
+          <map input="900" output="1000"/>
+          <map input="400" output="450"/>
+          <map input="100" output="100"/>
+          <map input="400" output="500"/>
+        </axis>
+      </axes>
+    </designspace>
+    """
+
+    doc = DesignSpaceDocument.fromstring(designspace)
+    raw_map = [(900, 1000), (400, 450), (100, 100), (400, 500)]
+    assert doc.axes[0].map == raw_map
+
+    with pytest.raises(DesignSpaceDocumentError, match="Axis 'Weight'"):
+        doc.axes[0].map_forward(400)
+    assert doc.axes[0].map == raw_map
+
+
 def test_map_backward_many_to_one_mid_range():
     """Test map_backward with a flat segment in the middle of the axis range."""
     ax = AxisDescriptor()

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from fontTools.colorLib.builder import buildCOLR
 from fontTools.ttLib import TTFont, newTable
 from fontTools.ttLib.tables import otTables as ot
@@ -6,6 +8,7 @@ from fontTools.varLib import (
     build_many,
     load_designspace,
     _add_COLR,
+    _add_avar,
     addGSUBFeatureVariations,
 )
 from fontTools.varLib.errors import VarLibValidationError
@@ -15,6 +18,7 @@ from fontTools.varLib.mutator import instantiateVariableFont
 from fontTools.varLib import main as varLib_main, load_masters
 from fontTools.varLib import set_default_weight_width_slant
 from fontTools.designspaceLib import (
+    AxisDescriptor,
     DesignSpaceDocumentError,
     DesignSpaceDocument,
     SourceDescriptor,
@@ -40,6 +44,71 @@ def reload_font(font):
     font.close()
     buf.seek(0)
     return TTFont(buf)
+
+
+def test_varlib_avar_accepts_identical_duplicate_axis_map_input():
+    axis = AxisDescriptor(
+        name="Weight",
+        tag="wght",
+        minimum=100,
+        default=400,
+        maximum=900,
+        map=[
+            (100, 80),
+            (400, 450),
+            (400, 450),
+            (600, 700),
+            (900, 1000),
+        ],
+    )
+
+    avar = _add_avar(
+        TTFont(),
+        OrderedDict([(axis.name, axis)]),
+        mappings=[],
+        axisTags=[axis.tag],
+    )
+
+    assert avar.segments[axis.tag] == {
+        -1.0: -1.0,
+        0.0: 0.0,
+        1.0: 1.0,
+        0.4: 5 / 11,
+    }
+
+
+def test_varlib_avar_rejects_conflicting_duplicate_axis_map_input():
+    axis = AxisDescriptor(
+        name="Weight",
+        tag="wght",
+        minimum=100,
+        default=400,
+        maximum=900,
+        map=[(100, 80), (400, 450), (600, 700), (400, 500), (900, 1000)],
+    )
+
+    with pytest.raises(DesignSpaceDocumentError, match="Axis 'Weight'"):
+        _add_avar(
+            TTFont(),
+            OrderedDict([(axis.name, axis)]),
+            mappings=[],
+            axisTags=[axis.tag],
+        )
+
+
+def test_varlib_build_conflicting_default_map_raises_designspace_error():
+    designspace = DesignSpaceDocument.fromfile(
+        os.path.join(os.path.dirname(__file__), "data", "Build.designspace")
+    )
+    axis = next(axis for axis in designspace.axes if axis.name == "weight")
+    # A last-wins temporary dict previously shifted the duplicate default's
+    # normalized value from zero, causing a misleading "Base master not found"
+    # before _add_avar.
+    axis.map = [(0, 0), (368, 368), (368, 369), (1000, 1000)]
+
+    with pytest.raises(DesignSpaceDocumentError, match="input value 368") as exc_info:
+        build(designspace)
+    assert "Base master not found" not in str(exc_info.value)
 
 
 class BuildTest(unittest.TestCase):


### PR DESCRIPTION
`AxisDescriptor.map_forward()` currently converts `axis.map` to a dict, so an input with conflicting outputs silently becomes last-wins. varLib rejects duplicate inputs later in `_add_avar()`, but `load_designspace()` has already consumed the mapping by then. A conflict at the default can therefore surface as the misleading `"Base master not found error"`.

This mirrors googlefonts/fontc#2083, which rejects the same ambiguity when constructing a piecewise-linear coordinate map.

Add `AbstractAxisDescriptor.get_validated_map()` and use it for continuous and discrete forward/backward mapping and `_add_avar()`. Conflicting outputs for one input now raise `DesignSpaceDocumentError` when consumed.

Distinct inputs may share an output just like before. And exact repeated same-input -> same-output pairs are collapsed (there's no ambiguity there) but only in the returned view, the map stored in the reader remains unchanged.