### PR TITLE
[svgLib.path] Implement implicit moveto after closepath

### DIFF
--- a/Lib/fontTools/svgLib/path/parser.py
+++ b/Lib/fontTools/svgLib/path/parser.py
@@ -120,6 +120,12 @@ def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):
     # Reverse for easy use of .pop()
     elements.reverse()
 
+    # A path data segment (if there is one) must begin with a moveto
+    # command (https://www.w3.org/TR/SVG11/paths.html#PathDataMovetoCommands);
+    # raise before any pen call instead of inventing a start point.
+    if elements and elements[-1] not in ("M", "m"):
+        raise ValueError("Path must start with a moveto command: %r" % pathdef)
+
     # start_pos is the initial point of the current subpath; it is retained
     # after a closepath so that a drawto command following Z can start a new
     # subpath at that same point, while subpath_open tracks whether there is

--- a/Lib/fontTools/svgLib/path/parser.py
+++ b/Lib/fontTools/svgLib/path/parser.py
@@ -120,7 +120,12 @@ def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):
     # Reverse for easy use of .pop()
     elements.reverse()
 
+    # start_pos is the initial point of the current subpath; it is retained
+    # after a closepath so that a drawto command following Z can start a new
+    # subpath at that same point, while subpath_open tracks whether there is
+    # a subpath in progress that still needs closePath/endPath.
     start_pos = None
+    subpath_open = False
     command = None
     last_control = None
 
@@ -143,6 +148,14 @@ def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):
                 )
             last_command = command  # Used by S and T
 
+        if command not in ("M", "Z") and not subpath_open and start_pos is not None:
+            # If a closepath is followed immediately by any other command,
+            # the next subpath starts at the same initial point as the
+            # current subpath:
+            # https://www.w3.org/TR/SVG11/paths.html#PathDataClosePathCommand
+            pen.moveTo((start_pos.real, start_pos.imag))
+            subpath_open = True
+
         if command == "M":
             # Moveto command.
             x = elements.pop()
@@ -154,7 +167,7 @@ def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):
                 current_pos += pos
 
             # M is not preceded by Z; it's an open subpath
-            if start_pos is not None:
+            if subpath_open:
                 pen.endPath()
 
             pen.moveTo((current_pos.real, current_pos.imag))
@@ -163,6 +176,7 @@ def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):
             # This behavior of Z is defined in svg spec:
             # http://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand
             start_pos = current_pos
+            subpath_open = True
 
             # Implicit moveto commands are treated as lineto commands.
             # So we set command to lineto here, in case there are
@@ -172,16 +186,16 @@ def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):
         elif command == "Z":
             # Close path
             # A redundant Z with no open subpath (e.g. "M0,0 Z Z") is valid
-            # per the SVG path grammar and has no effect; ignore it instead of
-            # crashing on start_pos being None.
-            if start_pos is not None:
+            # per the SVG path grammar and has no effect; ignore it instead
+            # of emitting a second closePath.
+            if subpath_open:
                 if not cmath.isclose(
                     current_pos, start_pos, rel_tol=1e-15, abs_tol=1e-15
                 ):
                     pen.lineTo((start_pos.real, start_pos.imag))
                 pen.closePath()
                 current_pos = start_pos
-                start_pos = None
+                subpath_open = False
             command = None  # You can't have implicit commands after closing.
 
         elif command == "L":
@@ -231,7 +245,8 @@ def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):
             # Smooth curve. First control point is the "reflection" of
             # the second control point in the previous path.
 
-            if last_command not in "CS":
+            # last_command is None right after a closepath (Z is not C/S)
+            if last_command not in ("C", "S"):
                 # If there is no previous command or if the previous command
                 # was not an C, c, S or s, assume the first control point is
                 # coincident with the current point.
@@ -273,7 +288,8 @@ def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):
             # Smooth curve. Control point is the "reflection" of
             # the second control point in the previous path.
 
-            if last_command not in "QT":
+            # last_command is None right after a closepath (Z is not Q/T)
+            if last_command not in ("Q", "T"):
                 # If there is no previous command or if the previous command
                 # was not an Q, q, T or t, assume the first control point is
                 # coincident with the current point.
@@ -324,5 +340,5 @@ def parse_path(pathdef, pen, current_pos=(0, 0), arc_class=EllipticalArc):
             current_pos = end
 
     # no final Z command, it's an open path
-    if start_pos is not None:
+    if subpath_open:
         pen.endPath()

--- a/Tests/svgLib/path/parser_test.py
+++ b/Tests/svgLib/path/parser_test.py
@@ -356,6 +356,22 @@ def test_closepath_ignores_floating_point_rounding():
     ]
 
 
+def test_implicit_moveto_after_drift_suppressed_closepath():
+    # a closepath returning to its start with floating-point drift emits no
+    # closing lineTo (see test above), but must still reset the current
+    # position to the exact initial point, so that the implicit moveto of a
+    # following drawto lands on it rather than on the drifted position
+    assert 0.1 + 0.2 - 0.2 != 0.1  # the drift this test relies on
+    pen = RecordingPen()
+    parse_path("M 0.1 0 l 0.2 0 l -0.2 0 z l 0.1 0.1", pen)
+
+    assert pen.value[3] == ("closePath", ())
+    assert pen.value[4] == ("moveTo", ((0.1, 0.0),))
+    # the relative lineTo resolves against the exact initial point too
+    assert pen.value[5] == ("lineTo", ((0.1 + 0.1, 0.1),))
+    assert pen.value[6] == ("endPath", ())
+
+
 def test_exponents():
     # It can be e or E, the plus is optional, and a minimum of +/-3.4e38 must be supported.
     pen = RecordingPen()

--- a/Tests/svgLib/path/parser_test.py
+++ b/Tests/svgLib/path/parser_test.py
@@ -401,6 +401,48 @@ def test_invalid_implicit_command():
     assert exc_info.match("Unallowed implicit command")
 
 
+@pytest.mark.parametrize(
+    "pathdef",
+    [
+        "L 5 5",
+        "Z",
+        # bare coordinates aren't a moveto either
+        "5 5",
+        # a later moveto doesn't repair a bad start
+        "L 5 5 M 0 0",
+    ],
+)
+def test_path_must_start_with_moveto(pathdef):
+    # A path data segment must begin with a moveto command (SVG 1.1
+    # sec 8.3.2); raise before any pen call instead of inventing a
+    # start point for the malformed path.
+    # https://github.com/fonttools/fonttools/issues/4154
+    pen = RecordingPen()
+    with pytest.raises(ValueError, match="must start with a moveto"):
+        parse_path(pathdef, pen)
+    assert pen.value == []
+
+
+def test_initial_relative_moveto_with_current_pos():
+    # a caller-supplied current_pos affects an initial relative moveto...
+    pen = RecordingPen()
+    parse_path("m 5 5", pen, current_pos=(10, 20))
+    assert pen.value == [("moveTo", ((15.0, 25.0),)), ("endPath", ())]
+
+    # ...but does not legalize a leading drawto
+    pen = RecordingPen()
+    with pytest.raises(ValueError, match="must start with a moveto"):
+        parse_path("l 5 5", pen, current_pos=(10, 20))
+    assert pen.value == []
+
+
+def test_empty_path_is_noop():
+    pen = RecordingPen()
+    parse_path("", pen)
+    parse_path("   ", pen)
+    assert pen.value == []
+
+
 def test_arc_to_cubic_bezier():
     pen = RecordingPen()
     parse_path("M300,200 h-150 a150,150 0 1,0 150,-150 z", pen)

--- a/Tests/svgLib/path/parser_test.py
+++ b/Tests/svgLib/path/parser_test.py
@@ -217,6 +217,94 @@ import pytest
                 ("closePath", ()),
             ],
         ),
+        # a drawto command following a closepath starts a new subpath at the
+        # initial point of the just-closed subpath, i.e. there is an implicit
+        # moveto (SVG 1.1 sec 8.3.3); the new subpath is open, hence endPath
+        # https://github.com/fonttools/fonttools/issues/4154
+        (
+            "M0,0 L10,10 Z L5,5",
+            [
+                ("moveTo", ((0.0, 0.0),)),
+                ("lineTo", ((10.0, 10.0),)),
+                ("lineTo", ((0.0, 0.0),)),
+                ("closePath", ()),
+                ("moveTo", ((0.0, 0.0),)),
+                ("lineTo", ((5.0, 5.0),)),
+                ("endPath", ()),
+            ],
+        ),
+        # a redundant Z before the drawto must not emit a second closePath
+        # nor a spurious moveTo
+        (
+            "M0,0 L10,10 Z Z L5,5",
+            [
+                ("moveTo", ((0.0, 0.0),)),
+                ("lineTo", ((10.0, 10.0),)),
+                ("lineTo", ((0.0, 0.0),)),
+                ("closePath", ()),
+                ("moveTo", ((0.0, 0.0),)),
+                ("lineTo", ((5.0, 5.0),)),
+                ("endPath", ()),
+            ],
+        ),
+        # a relative drawto after closepath is relative to the initial point
+        # of the just-closed subpath
+        (
+            "M10,10 L20,20 Z l5,5",
+            [
+                ("moveTo", ((10.0, 10.0),)),
+                ("lineTo", ((20.0, 20.0),)),
+                ("lineTo", ((10.0, 10.0),)),
+                ("closePath", ()),
+                ("moveTo", ((10.0, 10.0),)),
+                ("lineTo", ((15.0, 15.0),)),
+                ("endPath", ()),
+            ],
+        ),
+        # the implicitly-opened subpath can itself be closed, back to the
+        # same initial point
+        (
+            "M0,0 L10,0 L10,10 Z L5,5 Z",
+            [
+                ("moveTo", ((0.0, 0.0),)),
+                ("lineTo", ((10.0, 0.0),)),
+                ("lineTo", ((10.0, 10.0),)),
+                ("lineTo", ((0.0, 0.0),)),
+                ("closePath", ()),
+                ("moveTo", ((0.0, 0.0),)),
+                ("lineTo", ((5.0, 5.0),)),
+                ("lineTo", ((0.0, 0.0),)),
+                ("closePath", ()),
+            ],
+        ),
+        # S/T immediately after a closepath: the previous command (Z) is
+        # not a C/S or Q/T, so the reflected first control point falls
+        # back to the current point, i.e. the initial point of the
+        # just-closed subpath
+        (
+            "M0,0 C0,5 5,5 5,0 Z S10,5 10,0",
+            [
+                ("moveTo", ((0.0, 0.0),)),
+                ("curveTo", ((0.0, 5.0), (5.0, 5.0), (5.0, 0.0))),
+                ("lineTo", ((0.0, 0.0),)),
+                ("closePath", ()),
+                ("moveTo", ((0.0, 0.0),)),
+                ("curveTo", ((0.0, 0.0), (10.0, 5.0), (10.0, 0.0))),
+                ("endPath", ()),
+            ],
+        ),
+        (
+            "M0,0 Q2.5,5 5,0 Z T10,0",
+            [
+                ("moveTo", ((0.0, 0.0),)),
+                ("qCurveTo", ((2.5, 5.0), (5.0, 0.0))),
+                ("lineTo", ((0.0, 0.0),)),
+                ("closePath", ()),
+                ("moveTo", ((0.0, 0.0),)),
+                ("qCurveTo", ((0.0, 0.0), (10.0, 0.0))),
+                ("endPath", ()),
+            ],
+        ),
     ],
 )
 def test_parse_path(pathdef, expected):


### PR DESCRIPTION
Fixes #4154.

Per [SVG 1.1 sec 8.3.3](https://www.w3.org/TR/SVG11/paths.html#PathDataClosePathCommand), a drawto command following a closepath starts a new subpath at the same initial point as the just-closed subpath. The parser instead kept drawing without opening a subpath: the implicit moveTo was dropped, the terminating endPath was suppressed (TTGlyphPen raised "Didn't close last contour" on the result), and S/T right after Z raised TypeError because Z resets the command state to None.

The problem was `start_pos` doubling as both the subpath origin and the open/closed flag; Z reset it to None, losing the initial point exactly when a following drawto needed it. Now Z leaves `start_pos` in place and a separate `subpath_open` flag tracks whether a closePath/endPath is still needed.

The redundant-Z handling from #4122 and the float-drift close from #4127 are preserved.

While at it, I noticed an inconsistency with the SVG spec which requires that a path data segment must begin with a moveto per the spec (https://www.w3.org/TR/SVG11/paths.html#PathDataMovetoCommands): e.g. `"L 5 5"` is invalid and should not draw. Instead the previous code was silently emitting a `lineTo(5, 5)` out of nowhere even with no subpath open. It now raises ValueError instead.

The old output was invalid segment pen input anyway (contours are expected to start with a moveTo).

