### PR TITLE
Make the glyf table more dict-like

### DIFF
--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -320,6 +320,15 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
     def keys(self):
         return self.glyphs.keys()
 
+    def __iter__(self):
+        return self.glyphs.__iter__()
+
+    def values(self):
+        return self.glyphs.values()
+
+    def items(self):
+        return self.glyphs.items()
+
     def has_key(self, glyphName):
         return glyphName in self.glyphs
 

--- a/Lib/fontTools/ttLib/tables/_g_l_y_f.py
+++ b/Lib/fontTools/ttLib/tables/_g_l_y_f.py
@@ -1,6 +1,7 @@
 """_g_l_y_f.py -- Converter classes for the 'glyf' table."""
 
 from collections import namedtuple
+from collections.abc import ItemsView, ValuesView
 from fontTools.misc import sstruct
 from fontTools import ttLib
 from fontTools import version
@@ -324,10 +325,10 @@ class table__g_l_y_f(DefaultTable.DefaultTable):
         return self.glyphs.__iter__()
 
     def values(self):
-        return self.glyphs.values()
+        return ValuesView(self)
 
     def items(self):
-        return self.glyphs.items()
+        return ItemsView(self)
 
     def has_key(self, glyphName):
         return glyphName in self.glyphs

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -23,6 +23,7 @@ from fontTools.ttLib.tables._g_l_y_f import (
 from fontTools.ttLib.tables import ttProgram
 import sys
 import array
+from collections.abc import ValuesView, ItemsView
 from copy import deepcopy
 from io import StringIO, BytesIO
 import itertools
@@ -952,6 +953,39 @@ class GlyphComponentTest:
         assert comp.flags == 0
         assert (comp.firstPt, comp.secondPt) == (1, 2)
         assert not hasattr(comp, "transform")
+
+    def test_items(self):
+        glyf = newTable("glyf")
+        glyf.glyphs = {}
+        glyf.glyphOrder = [".notdef", "a", "b"]
+        for name in glyf.glyphOrder:
+            glyf[name] = Glyph()
+        assert isinstance(glyf.items(), ItemsView)
+        items = list(glyf.items())
+        assert items == [
+            (".notdef", glyf[".notdef"]),
+            ("a", glyf["a"]),
+            ("b", glyf["b"]),
+        ]
+
+    def test_iter(self):
+        glyf = newTable("glyf")
+        glyf.glyphs = {}
+        glyf.glyphOrder = [".notdef", "a", "b"]
+        for name in glyf.glyphOrder:
+            glyf[name] = Glyph()
+        names = [name for name in glyf]
+        assert names == [".notdef", "a", "b"]
+
+    def test_values(self):
+        glyf = newTable("glyf")
+        glyf.glyphs = {}
+        glyf.glyphOrder = [".notdef", "a", "b"]
+        for name in glyf.glyphOrder:
+            glyf[name] = Glyph()
+        assert isinstance(glyf.values(), ValuesView)
+        glyphs = list(glyf.values())
+        assert glyphs == [glyf[".notdef"], glyf["a"], glyf["b"]]
 
 
 class GlyphCubicTest:

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -977,6 +977,7 @@ class GlyphComponentTest:
         glyf = font["glyf"]
         assert isinstance(glyf.items(), ItemsView)
         items = list(glyf.items())
+        assert items[0][1].numberOfContours == 2  # .notdef
         assert items == [
             (".notdef", glyf[".notdef"]),
             (".null", glyf[".null"]),
@@ -985,7 +986,6 @@ class GlyphComponentTest:
             ("period", glyf["period"]),
             ("ellipsis", glyf["ellipsis"]),
         ]
-        assert items[0][1].numberOfContours == 2  # .notdef
 
     def test_iter(self):
         glyf = newTable("glyf")
@@ -1023,6 +1023,7 @@ class GlyphComponentTest:
         glyf = font["glyf"]
         assert isinstance(glyf.values(), ValuesView)
         glyphs = list(glyf.values())
+        assert glyphs[0].numberOfContours == 2  # .notdef
         assert glyphs == [
             glyf[".notdef"],
             glyf[".null"],
@@ -1031,7 +1032,6 @@ class GlyphComponentTest:
             glyf["period"],
             glyf["ellipsis"],
         ]
-        assert glyphs[0].numberOfContours == 2  # .notdef
 
 
 class GlyphCubicTest:

--- a/Tests/ttLib/tables/_g_l_y_f_test.py
+++ b/Tests/ttLib/tables/_g_l_y_f_test.py
@@ -26,6 +26,7 @@ import array
 from collections.abc import ValuesView, ItemsView
 from copy import deepcopy
 from io import StringIO, BytesIO
+from pathlib import Path
 import itertools
 import pytest
 import re
@@ -968,6 +969,24 @@ class GlyphComponentTest:
             ("b", glyf["b"]),
         ]
 
+    def test_items_lazy(self):
+        font = TTFont(
+            Path(__file__).parent.parent.parent / "ttx" / "data" / "TestTTF.ttf",
+            lazy=True,
+        )
+        glyf = font["glyf"]
+        assert isinstance(glyf.items(), ItemsView)
+        items = list(glyf.items())
+        assert items == [
+            (".notdef", glyf[".notdef"]),
+            (".null", glyf[".null"]),
+            ("CR", glyf["CR"]),
+            ("space", glyf["space"]),
+            ("period", glyf["period"]),
+            ("ellipsis", glyf["ellipsis"]),
+        ]
+        assert items[0][1].numberOfContours == 2  # .notdef
+
     def test_iter(self):
         glyf = newTable("glyf")
         glyf.glyphs = {}
@@ -976,6 +995,15 @@ class GlyphComponentTest:
             glyf[name] = Glyph()
         names = [name for name in glyf]
         assert names == [".notdef", "a", "b"]
+
+    def test_iter_lazy(self):
+        font = TTFont(
+            Path(__file__).parent.parent.parent / "ttx" / "data" / "TestTTF.ttf",
+            lazy=True,
+        )
+        glyf = font["glyf"]
+        names = [name for name in glyf]
+        assert names == [".notdef", ".null", "CR", "space", "period", "ellipsis"]
 
     def test_values(self):
         glyf = newTable("glyf")
@@ -986,6 +1014,24 @@ class GlyphComponentTest:
         assert isinstance(glyf.values(), ValuesView)
         glyphs = list(glyf.values())
         assert glyphs == [glyf[".notdef"], glyf["a"], glyf["b"]]
+
+    def test_values_lazy(self):
+        font = TTFont(
+            Path(__file__).parent.parent.parent / "ttx" / "data" / "TestTTF.ttf",
+            lazy=True,
+        )
+        glyf = font["glyf"]
+        assert isinstance(glyf.values(), ValuesView)
+        glyphs = list(glyf.values())
+        assert glyphs == [
+            glyf[".notdef"],
+            glyf[".null"],
+            glyf["CR"],
+            glyf["space"],
+            glyf["period"],
+            glyf["ellipsis"],
+        ]
+        assert glyphs[0].numberOfContours == 2  # .notdef
 
 
 class GlyphCubicTest:


### PR DESCRIPTION
When I do something like this:

```py
for glyph_name in self.font["glyf"].keys():
    print(glyph_name)
```
`ruff` will tell me to _Use `key in dict` instead of `key in dict.keys()`_ ([SIM118](https://docs.astral.sh/ruff/rules/in-dict-keys/)).

Following this advice results in a traceback:

```txt
File "iter_glyphs.py", line 5, in <module>
    for name in f["glyf"]:
                ~^^^^^^^^
  File "Lib/fontTools/ttLib/tables/_g_l_y_f.py", line 344, in __getitem__
    glyph = self.glyphs[glyphName]
            ~~~~~~~~~~~^^^^^^^^^^^
KeyError: 0
```

This PR adds the `__iter__`, `items` and `values` methods to the `glyf` table to make it more dict-like.