### PR TITLE
[mort] Support all metamorphosis subtable types

### DIFF
--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1591,6 +1591,14 @@ class STXHeader(BaseConverter):
                 xmlWriter.newline()
             xmlWriter.endtag("LigComponents")
             xmlWriter.newline()
+        if hasattr(value, "_MortLigatureRebase"):
+            xmlWriter.begintag("MortLigatureRebase")
+            xmlWriter.newline()
+            for componentIndex in sorted(value._MortLigatureRebase):
+                xmlWriter.simpletag("Component", index=componentIndex)
+                xmlWriter.newline()
+            xmlWriter.endtag("MortLigatureRebase")
+            xmlWriter.newline()
         self._xmlWriteLigatures(xmlWriter, font, value, name, attrs)
         xmlWriter.endtag(name)
         xmlWriter.newline()
@@ -1623,9 +1631,21 @@ class STXHeader(BaseConverter):
                 table.LigComponents = self._xmlReadLigComponents(
                     eltAttrs, eltContent, font
                 )
+            elif eltName == "MortLigatureRebase":
+                table._MortLigatureRebase = {
+                    safeEval(componentAttrs["index"])
+                    for componentName, componentAttrs, _componentContent in filter(
+                        istuple, eltContent
+                    )
+                    if componentName == "Component"
+                }
             elif eltName == "Ligatures":
                 table.Ligatures = self._xmlReadLigatures(eltAttrs, eltContent, font)
-        table.GlyphClassCount = max(table.GlyphClasses.values()) + 1
+        glyphClasses = list(table.GlyphClasses.values())
+        glyphClasses.extend(
+            glyphClass for state in table.States for glyphClass in state.Transitions
+        )
+        table.GlyphClassCount = max(glyphClasses, default=-1) + 1
         return table
 
     def _xmlReadState(self, attrs, content, font):
@@ -1741,12 +1761,15 @@ class StateHeader(STXHeader):
             )
         elif ligatureOffset is not None:
             ligatureBase = ligatureOffset // 2
+            table._MortLigatureRebase = {
+                componentIndex
+                for componentIndex in table._MortLigatureRebase
+                if table.LigComponents[componentIndex] >= ligatureBase
+            }
             for componentIndex in table._MortLigatureRebase:
                 # Unused entries are commonly zero. Only values which actually
                 # include the ligature-table base need to be normalized.
-                if table.LigComponents[componentIndex] >= ligatureBase:
-                    table.LigComponents[componentIndex] -= ligatureBase
-            del table._MortLigatureRebase
+                table.LigComponents[componentIndex] -= ligatureBase
 
             ligatureCount = self._countLegacyLigatures(table, len(font.getGlyphOrder()))
             ligatureReader = reader.getSubReader(0)
@@ -2083,7 +2106,11 @@ class StateHeader(STXHeader):
 
         actionOffsets = {}
         actionData = b""
-        rebaseComponents = set()
+        rebaseComponents = getattr(table, "_MortLigatureRebase", None)
+        if rebaseComponents is None:
+            rebaseComponents = set()
+        else:
+            rebaseComponents = set(rebaseComponents)
         for sequence in sequences:
             sequenceOffset = actionOffset + len(actionData)
             if sequenceOffset > 0x3FFF:
@@ -2100,7 +2127,7 @@ class StateHeader(STXHeader):
                 value |= 0x80000000 if last else 0
                 actionData += struct.pack(">I", value)
                 addBase = (store or last) and not rebased
-                if addBase:
+                if addBase and not hasattr(table, "_MortLigatureRebase"):
                     start = max(0, delta)
                     limit = min(len(table.LigComponents), delta + glyphCount)
                     rebaseComponents.update(range(start, limit))

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -26,8 +26,10 @@ from .otTables import (
     AATState,
     AATAction,
     ContextualMorphAction,
+    LigAction,
     LigatureMorphAction,
     InsertionMorphAction,
+    MortSubtable,
     MorxSubtable,
     ExtendMode as _ExtendMode,
     CompositeMode as _CompositeMode,
@@ -1150,6 +1152,71 @@ class AATLookupWithDataOffset(BaseConverter):
         lookup.xmlWrite(xmlWriter, font, value, name, attrs)
 
 
+class MortSubtableConverter(BaseConverter):
+    def read(self, reader, font, tableDict):
+        pos = reader.pos
+        m = MortSubtable()
+        m.StructLength = reader.readUShort()
+        m.CoverageFlags = reader.readUInt8()
+        m.MorphType = reader.readUInt8()
+        m.SubFeatureFlags = reader.readULong()
+        tableClass = lookupTypes["mort"].get(m.MorphType)
+        if tableClass is None:
+            assert False, "unsupported 'mort' lookup type %s" % m.MorphType
+
+        # Limit the state-table reader to this subtable. In particular, the
+        # legacy ligature format has no encoded ligature count and uses the end
+        # of the subtable as its only upper bound.
+        headerLength = reader.pos - pos
+        data = reader.data[reader.pos : reader.pos + m.StructLength - headerLength]
+        assert len(data) == m.StructLength - headerLength
+        subReader = OTTableReader(data=data, tableTag=reader.tableTag)
+        m.SubStruct = tableClass()
+        m.SubStruct.decompile(subReader, font)
+        reader.seek(pos + m.StructLength)
+        return m
+
+    def xmlWrite(self, xmlWriter, font, value, name, attrs):
+        xmlWriter.begintag(name, attrs)
+        xmlWriter.newline()
+        xmlWriter.comment("StructLength=%d" % value.StructLength)
+        xmlWriter.newline()
+        xmlWriter.simpletag("CoverageFlags", value=value.CoverageFlags)
+        xmlWriter.newline()
+        xmlWriter.comment("MorphType=%d" % value.MorphType)
+        xmlWriter.newline()
+        xmlWriter.simpletag("SubFeatureFlags", value="0x%08x" % value.SubFeatureFlags)
+        xmlWriter.newline()
+        value.SubStruct.toXML(xmlWriter, font)
+        xmlWriter.endtag(name)
+        xmlWriter.newline()
+
+    def xmlRead(self, attrs, content, font):
+        m = MortSubtable()
+        m.CoverageFlags = 0
+        for eltName, eltAttrs, eltContent in filter(istuple, content):
+            if eltName == "CoverageFlags":
+                m.CoverageFlags = safeEval(eltAttrs["value"])
+            elif eltName == "SubFeatureFlags":
+                m.SubFeatureFlags = safeEval(eltAttrs["value"])
+            elif eltName.endswith("Morph"):
+                m.fromXML(eltName, eltAttrs, eltContent, font)
+            else:
+                assert False, eltName
+        return m
+
+    def write(self, writer, font, tableDict, value, repeatIndex=None):
+        lengthIndex = len(writer.items)
+        before = writer.getDataLength()
+        value.StructLength = 0xDEAD
+        value.compile(writer, font)
+        assert writer.items[lengthIndex] == b"\xde\xad"
+        length = writer.getDataLength() - before
+        if length > 0xFFFF:
+            raise ValueError("mort subtable exceeds 65535 bytes")
+        writer.items[lengthIndex] = struct.pack(">H", length)
+
+
 class MorxSubtableConverter(BaseConverter):
     _PROCESSING_ORDERS = {
         # bits 30 and 28 of morx.CoverageFlags; see morx spec
@@ -1584,6 +1651,556 @@ class STXHeader(BaseConverter):
             if eltName == "Ligature":
                 ligs.append(eltAttrs["glyph"])
         return ligs
+
+
+class StateHeader(STXHeader):
+    """Converter for the obsolete, non-extended AAT state-table format."""
+
+    def read(self, reader, font, tableDict):
+        table = AATStateTable()
+        pos = reader.pos
+        table.GlyphClassCount = reader.readUShort()
+        classTableOffset = reader.readUShort()
+        stateArrayOffset = reader.readUShort()
+        entryTableOffset = reader.readUShort()
+        if table.GlyphClassCount == 0:
+            raise ValueError("mort state table has no glyph classes")
+
+        substitutionTableOffset = None
+        actionOffset = componentOffset = ligatureOffset = None
+        actionReader = None
+        if issubclass(self.tableClass, ContextualMorphAction):
+            substitutionTableOffset = reader.readUShort()
+        elif issubclass(self.tableClass, LigatureMorphAction):
+            actionOffset = reader.readUShort()
+            componentOffset = reader.readUShort()
+            ligatureOffset = reader.readUShort()
+            if (
+                componentOffset > ligatureOffset
+                or (ligatureOffset - componentOffset) % 2
+            ):
+                raise ValueError("invalid mort ligature component table")
+            componentReader = reader.getSubReader(0)
+            componentReader.seek(pos + componentOffset)
+            rawComponents = componentReader.readUShortArray(
+                (ligatureOffset - componentOffset) // 2
+            )
+            if any(component % 2 for component in rawComponents):
+                raise ValueError("invalid mort ligature component value")
+            table.LigComponents = [component // 2 for component in rawComponents]
+            table.Ligatures = []
+            table._MortLigatureRebase = set()
+        elif issubclass(self.tableClass, InsertionMorphAction):
+            actionOffset = reader.readUShort()
+            actionReader = reader.getSubReader(0)
+            actionReader.seek(pos + actionOffset)
+
+        classTableReader = reader.getSubReader(0)
+        classTableReader.seek(pos + classTableOffset)
+        firstGlyph = classTableReader.readUShort()
+        glyphCount = classTableReader.readUShort()
+        glyphClasses = classTableReader.readUInt8Array(glyphCount)
+        table.GlyphClasses = {
+            font.getGlyphName(firstGlyph + i): glyphClass
+            for i, glyphClass in enumerate(glyphClasses)
+        }
+
+        stateArrayReader = reader.getSubReader(0)
+        stateArrayReader.seek(pos + stateArrayOffset)
+        entryTableReader = reader.getSubReader(0)
+        entryTableReader.seek(pos + entryTableOffset)
+        stateDataLength = entryTableOffset - stateArrayOffset
+        if stateDataLength < 0:
+            raise ValueError("mort state-array offset follows its entry table")
+        numStates = stateDataLength // table.GlyphClassCount
+        transitionCache = {}
+        for _stateIndex in range(numStates):
+            state = AATState()
+            table.States.append(state)
+            for glyphClass in range(table.GlyphClassCount):
+                entryIndex = stateArrayReader.readUInt8()
+                transition = transitionCache.get(entryIndex)
+                if transition is None:
+                    transition = self._readTransition(
+                        entryTableReader,
+                        entryIndex,
+                        font,
+                        actionReader,
+                        pos,
+                        stateArrayOffset,
+                        componentOffset,
+                        ligatureOffset,
+                        table,
+                    )
+                    transitionCache[entryIndex] = transition
+                state.Transitions[glyphClass] = transition
+
+        if substitutionTableOffset is not None:
+            self._readContextualLookups(
+                table, reader, font, pos, substitutionTableOffset
+            )
+        elif ligatureOffset is not None:
+            ligatureBase = ligatureOffset // 2
+            for componentIndex in table._MortLigatureRebase:
+                # Unused entries are commonly zero. Only values which actually
+                # include the ligature-table base need to be normalized.
+                if table.LigComponents[componentIndex] >= ligatureBase:
+                    table.LigComponents[componentIndex] -= ligatureBase
+            del table._MortLigatureRebase
+
+            ligatureCount = self._countLegacyLigatures(table, len(font.getGlyphOrder()))
+            ligatureReader = reader.getSubReader(0)
+            ligatureReader.seek(pos + ligatureOffset)
+            table.Ligatures = font.getGlyphNameMany(
+                ligatureReader.readUShortArray(ligatureCount)
+            )
+        return table
+
+    def _readTransition(
+        self,
+        reader,
+        entryIndex,
+        font,
+        actionReader,
+        stateTablePos,
+        stateArrayOffset,
+        componentOffset,
+        ligatureOffset,
+        table,
+    ):
+        transition = self.tableClass()
+        entrySize = (
+            4
+            if issubclass(self.tableClass, LigatureMorphAction)
+            else transition.staticSize
+        )
+        entryReader = reader.getSubReader(reader.pos + entryIndex * entrySize)
+
+        if issubclass(self.tableClass, ContextualMorphAction):
+            transition.NewState = entryReader.readUShort()
+            flags = entryReader.readUShort()
+            transition.SetMark = bool(flags & 0x8000)
+            transition.DontAdvance = bool(flags & 0x4000)
+            transition.ReservedFlags = flags & 0x3FFF
+            transition._MortMarkOffset = entryReader.readShort()
+            transition._MortCurrentOffset = entryReader.readShort()
+        elif issubclass(self.tableClass, LigatureMorphAction):
+            transition.NewState = entryReader.readUShort()
+            flags = entryReader.readUShort()
+            transition.SetComponent = bool(flags & 0x8000)
+            transition.DontAdvance = bool(flags & 0x4000)
+            transition.ReservedFlags = 0
+            transition.Actions = []
+            ligActionOffset = flags & 0x3FFF
+            if ligActionOffset:
+                transition.Actions = self._readLigatureActions(
+                    reader,
+                    font,
+                    stateTablePos,
+                    ligActionOffset,
+                    componentOffset,
+                    ligatureOffset,
+                    table,
+                )
+        else:
+            transition.decompile(entryReader, font, actionReader)
+
+        newStateOffset = transition.NewState - stateArrayOffset
+        if newStateOffset < 0 or newStateOffset % table.GlyphClassCount:
+            raise ValueError("invalid mort new-state offset")
+        transition.NewState = newStateOffset // table.GlyphClassCount
+        return transition
+
+    def _readContextualLookups(
+        self, table, reader, font, stateTablePos, substitutionTableOffset
+    ):
+        transitions = {
+            transition
+            for state in table.States
+            for transition in state.Transitions.values()
+        }
+        offsets = sorted(
+            {
+                offset
+                for transition in transitions
+                for offset in (
+                    transition._MortMarkOffset,
+                    transition._MortCurrentOffset,
+                )
+                if offset
+            }
+        )
+        offsetToIndex = {offset: i for i, offset in enumerate(offsets)}
+        glyphOrder = font.getGlyphOrder()
+        for offset in offsets:
+            byteOffset = offset * 2
+            if byteOffset < substitutionTableOffset:
+                raise ValueError("mort substitution offset precedes substitution table")
+            lookupReader = reader.getSubReader(0)
+            lookupReader.seek(stateTablePos + byteOffset)
+            replacements = lookupReader.readUShortArray(len(glyphOrder))
+            table.PerGlyphLookups.append(
+                {
+                    glyph: font.getGlyphName(replacement)
+                    for glyph, replacement in zip(glyphOrder, replacements)
+                    if replacement != 0
+                }
+            )
+        for transition in transitions:
+            transition.MarkIndex = (
+                offsetToIndex[transition._MortMarkOffset]
+                if transition._MortMarkOffset
+                else 0xFFFF
+            )
+            transition.CurrentIndex = (
+                offsetToIndex[transition._MortCurrentOffset]
+                if transition._MortCurrentOffset
+                else 0xFFFF
+            )
+            del transition._MortMarkOffset
+            del transition._MortCurrentOffset
+
+    def _readLigatureActions(
+        self,
+        reader,
+        font,
+        stateTablePos,
+        ligActionOffset,
+        componentOffset,
+        ligatureOffset,
+        table,
+    ):
+        actionReader = reader.getSubReader(0)
+        actionReader.seek(stateTablePos + ligActionOffset)
+        glyphCount = len(font.getGlyphOrder())
+        result = []
+        rebased = False
+        last = False
+        while not last:
+            value = actionReader.readULong()
+            last = bool(value & 0x80000000)
+            store = bool(value & 0x40000000)
+            componentWordOffset = value & 0x3FFFFFFF
+            if componentWordOffset & 0x20000000:
+                componentWordOffset -= 0x40000000
+            componentIndex = componentWordOffset - componentOffset // 2
+            if (
+                componentIndex >= len(table.LigComponents)
+                or componentIndex + glyphCount <= 0
+            ):
+                raise ValueError("mort ligature component offset is out of bounds")
+            if (store or last) and not rebased:
+                start = max(0, componentIndex)
+                limit = min(len(table.LigComponents), componentIndex + glyphCount)
+                table._MortLigatureRebase.update(range(start, limit))
+                rebased = True
+
+            action = LigAction()
+            action.Store = store
+            action.GlyphIndexDelta = componentIndex
+            result.append(action)
+        return result
+
+    @staticmethod
+    def _countLegacyLigatures(table, glyphCount):
+        count = 0
+        transitions = {
+            transition
+            for state in table.States
+            for transition in state.Transitions.values()
+        }
+        for transition in transitions:
+            cumulativeMax = 0
+            for index, action in enumerate(transition.Actions):
+                start = max(0, action.GlyphIndexDelta)
+                limit = min(
+                    len(table.LigComponents),
+                    action.GlyphIndexDelta + glyphCount,
+                )
+                cumulativeMax += max(table.LigComponents[start:limit], default=0)
+                if action.Store or index == len(transition.Actions) - 1:
+                    count = max(count, cumulativeMax + 1)
+        return count
+
+    def write(self, writer, font, tableDict, value, repeatIndex=None):
+        glyphClassCount = value.GlyphClassCount
+        if not 0 < glyphClassCount <= 256:
+            raise ValueError("mort state tables support 1 to 256 glyph classes")
+
+        glyphClasses = sorted(
+            (font.getGlyphID(glyph), glyphClass)
+            for glyph, glyphClass in value.GlyphClasses.items()
+        )
+        if glyphClasses:
+            firstGlyph = glyphClasses[0][0]
+            lastGlyph = glyphClasses[-1][0]
+            classValues = dict(glyphClasses)
+            classes = bytes(
+                classValues.get(glyphID, 1)
+                for glyphID in range(firstGlyph, lastGlyph + 1)
+            )
+        else:
+            firstGlyph = 0
+            classes = b""
+        classData = struct.pack(">HH", firstGlyph, len(classes)) + classes
+
+        genericActionData, genericActionIndex = self.tableClass.compileActions(
+            font, value.States
+        )
+        entries = []
+        entryIDs = {}
+        stateEntryIDs = []
+        for state in value.States:
+            row = []
+            for glyphClass in range(glyphClassCount):
+                transition = state.Transitions[glyphClass]
+                transitionWriter = OTTableWriter()
+                transition.compile(transitionWriter, font, genericActionIndex)
+                key = transitionWriter.getAllData()
+                entryIndex = entryIDs.get(key)
+                if entryIndex is None:
+                    entryIndex = len(entries)
+                    if entryIndex > 0xFF:
+                        raise ValueError(
+                            "mort state tables support at most 256 entries"
+                        )
+                    entryIDs[key] = entryIndex
+                    entries.append(transition)
+                row.append(entryIndex)
+            stateEntryIDs.append(row)
+
+        extraSize = 0
+        if issubclass(self.tableClass, ContextualMorphAction):
+            extraSize = 2
+        elif issubclass(self.tableClass, LigatureMorphAction):
+            extraSize = 6
+        elif issubclass(self.tableClass, InsertionMorphAction):
+            extraSize = 2
+        classTableOffset = 8 + extraSize
+        stateArrayOffset = self._aligned(classTableOffset + len(classData), 2)
+        stateData = bytes(entry for row in stateEntryIDs for entry in row)
+        entryTableOffset = self._aligned(stateArrayOffset + len(stateData), 2)
+        entrySize = (
+            4
+            if issubclass(self.tableClass, LigatureMorphAction)
+            else self.tableClass.staticSize
+        )
+        tailOffset = entryTableOffset + len(entries) * entrySize
+
+        extra = b""
+        tail = b""
+        contextOffsets = None
+        ligatureActionOffsets = None
+        if issubclass(self.tableClass, ContextualMorphAction):
+            extra, tail, contextOffsets = self._compileContextualLookups(
+                value, font, tailOffset
+            )
+        elif issubclass(self.tableClass, LigatureMorphAction):
+            extra, tail, ligatureActionOffsets = self._compileLigatureData(
+                value, font, entries, tailOffset
+            )
+        elif issubclass(self.tableClass, InsertionMorphAction):
+            if tailOffset > 0xFFFF:
+                raise ValueError("mort insertion-action offset exceeds 16 bits")
+            extra = struct.pack(">H", tailOffset)
+            tail = genericActionData
+
+        entryData = b"".join(
+            self._compileTransition(
+                transition,
+                font,
+                genericActionIndex,
+                stateArrayOffset,
+                glyphClassCount,
+                contextOffsets,
+                ligatureActionOffsets,
+            )
+            for transition in entries
+        )
+        data = struct.pack(
+            ">HHHH",
+            glyphClassCount,
+            classTableOffset,
+            stateArrayOffset,
+            entryTableOffset,
+        )
+        data += extra + classData
+        data = pad(data, 2) + stateData
+        data = pad(data, 2) + entryData + tail
+        data = pad(data, 4)
+        if len(data) > 0xFFFF:
+            raise ValueError("mort state table exceeds 65535 bytes")
+        writer.writeData(data)
+
+    @staticmethod
+    def _aligned(value, alignment):
+        return value + (-value % alignment)
+
+    def _compileContextualLookups(self, table, font, tailOffset):
+        count = self._countPerGlyphLookups(table)
+        if len(table.PerGlyphLookups) != count:
+            raise ValueError(
+                "mort contextual actions refer to %d lookups, but the table has %d"
+                % (count, len(table.PerGlyphLookups))
+            )
+        glyphOrder = font.getGlyphOrder()
+        offsets = []
+        data = b""
+        for lookup in table.PerGlyphLookups:
+            offset = (tailOffset + len(data)) // 2
+            if offset > 0x7FFF:
+                raise ValueError("mort substitution offset exceeds signed 16 bits")
+            offsets.append(offset)
+            replacements = []
+            for glyph in glyphOrder:
+                replacement = lookup.get(glyph)
+                replacements.append(
+                    0 if replacement is None else font.getGlyphID(replacement)
+                )
+            data += struct.pack(">%dH" % len(replacements), *replacements)
+        if tailOffset > 0xFFFF:
+            raise ValueError("mort substitution-table offset exceeds 16 bits")
+        return struct.pack(">H", tailOffset), data, offsets
+
+    def _compileLigatureData(self, table, font, entries, tailOffset):
+        sequences = []
+        sequenceSet = set()
+        for transition in entries:
+            sequence = tuple(
+                (action.GlyphIndexDelta, action.Store) for action in transition.Actions
+            )
+            if sequence and sequence not in sequenceSet:
+                sequenceSet.add(sequence)
+                sequences.append(sequence)
+
+        actionOffset = self._aligned(tailOffset, 4)
+        actionCount = sum(len(sequence) for sequence in sequences)
+        componentOffset = actionOffset + actionCount * 4
+        glyphCount = len(font.getGlyphOrder())
+        ligatureOffset = componentOffset + len(table.LigComponents) * 2
+        if max(actionOffset, componentOffset, ligatureOffset) > 0xFFFF:
+            raise ValueError("mort ligature-table offset exceeds 16 bits")
+
+        actionOffsets = {}
+        actionData = b""
+        rebaseComponents = set()
+        for sequence in sequences:
+            sequenceOffset = actionOffset + len(actionData)
+            if sequenceOffset > 0x3FFF:
+                raise ValueError("mort ligature-action offset exceeds 14 bits")
+            actionOffsets[sequence] = sequenceOffset
+            rebased = False
+            for index, (delta, store) in enumerate(sequence):
+                value = componentOffset // 2 + delta
+                if not -(1 << 29) <= value < (1 << 29):
+                    raise ValueError("mort ligature component offset exceeds 30 bits")
+                value &= 0x3FFFFFFF
+                last = index == len(sequence) - 1
+                value |= 0x40000000 if store else 0
+                value |= 0x80000000 if last else 0
+                actionData += struct.pack(">I", value)
+                addBase = (store or last) and not rebased
+                if addBase:
+                    start = max(0, delta)
+                    limit = min(len(table.LigComponents), delta + glyphCount)
+                    rebaseComponents.update(range(start, limit))
+                rebased |= store or last
+
+        componentData = b""
+        for componentIndex, component in enumerate(table.LigComponents):
+            component *= 2
+            if componentIndex in rebaseComponents:
+                component += ligatureOffset
+            if not 0 <= component <= 0xFFFF:
+                raise ValueError("mort ligature component value exceeds 16 bits")
+            componentData += struct.pack(">H", component)
+
+        ligatureData = b"".join(
+            struct.pack(">H", font.getGlyphID(glyph)) for glyph in table.Ligatures
+        )
+        extra = struct.pack(">HHH", actionOffset, componentOffset, ligatureOffset)
+        tail = (
+            bytes(actionOffset - tailOffset) + actionData + componentData + ligatureData
+        )
+        return extra, tail, actionOffsets
+
+    def _compileTransition(
+        self,
+        transition,
+        font,
+        actionIndex,
+        stateArrayOffset,
+        glyphClassCount,
+        contextOffsets,
+        ligatureActionOffsets,
+    ):
+        newState = stateArrayOffset + transition.NewState * glyphClassCount
+        if not 0 <= newState <= 0xFFFF:
+            raise ValueError("mort new-state offset exceeds 16 bits")
+
+        if issubclass(self.tableClass, ContextualMorphAction):
+            flags = transition.ReservedFlags
+            flags |= 0x8000 if transition.SetMark else 0
+            flags |= 0x4000 if transition.DontAdvance else 0
+            markOffset = (
+                0
+                if transition.MarkIndex == 0xFFFF
+                else contextOffsets[transition.MarkIndex]
+            )
+            currentOffset = (
+                0
+                if transition.CurrentIndex == 0xFFFF
+                else contextOffsets[transition.CurrentIndex]
+            )
+            return struct.pack(">HHhh", newState, flags, markOffset, currentOffset)
+
+        if issubclass(self.tableClass, LigatureMorphAction):
+            if transition.ReservedFlags:
+                raise ValueError("mort ligature entries cannot encode reserved flags")
+            flags = 0x8000 if transition.SetComponent else 0
+            flags |= 0x4000 if transition.DontAdvance else 0
+            sequence = tuple(
+                (action.GlyphIndexDelta, action.Store) for action in transition.Actions
+            )
+            flags |= ligatureActionOffsets.get(sequence, 0)
+            return struct.pack(">HH", newState, flags)
+
+        transitionWriter = OTTableWriter()
+        transition.compile(transitionWriter, font, actionIndex)
+        data = transitionWriter.getAllData()
+        return struct.pack(">H", newState) + data[2:]
+
+
+class MorphStateTable(BaseConverter):
+    """Dispatch to classic or extended AAT state-table encoding by table tag."""
+
+    def __init__(self, name, repeat, aux, tableClass, *, description=""):
+        BaseConverter.__init__(
+            self, name, repeat, aux, tableClass, description=description
+        )
+        self.legacy = StateHeader(
+            name, repeat, aux, tableClass, description=description
+        )
+        self.extended = STXHeader(
+            name, repeat, aux, tableClass, description=description
+        )
+
+    def _converter(self, tableTag):
+        return self.legacy if tableTag == "mort" else self.extended
+
+    def read(self, reader, font, tableDict):
+        return self._converter(reader.tableTag).read(reader, font, tableDict)
+
+    def write(self, writer, font, tableDict, value, repeatIndex=None):
+        return self._converter(writer.tableTag).write(
+            writer, font, tableDict, value, repeatIndex
+        )
+
+    def xmlRead(self, attrs, content, font):
+        return self.extended.xmlRead(attrs, content, font)
+
+    def xmlWrite(self, xmlWriter, font, value, name, attrs):
+        return self.extended.xmlWrite(xmlWriter, font, value, name, attrs)
 
 
 class CIDGlyphMap(BaseConverter):
@@ -2321,12 +2938,13 @@ converterMapping = {
     "CIDGlyphMap": CIDGlyphMap,
     "GlyphCIDMap": GlyphCIDMap,
     "MortChain": StructWithLength,
-    "MortSubtable": StructWithLength,
+    "MortSubtable": MortSubtableConverter,
     "MorxChain": StructWithLength,
     "MorxSubtable": MorxSubtableConverter,
     # "Template" types
     "AATLookup": lambda C: partial(AATLookup, tableClass=C),
     "AATLookupWithDataOffset": lambda C: partial(AATLookupWithDataOffset, tableClass=C),
+    "MorphStateTable": lambda C: partial(MorphStateTable, tableClass=C),
     "STXHeader": lambda C: partial(STXHeader, tableClass=C),
     "OffsetTo": lambda C: partial(Table, tableClass=C),
     "LOffsetTo": lambda C: partial(LTable, tableClass=C),

--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1855,20 +1855,29 @@ class StateHeader(STXHeader):
         )
         offsetToIndex = {offset: i for i, offset in enumerate(offsets)}
         glyphOrder = font.getGlyphOrder()
+        # reader.data holds just this subtable, so this is the room between
+        # the state-table header and the end of the subtable.
+        available = len(reader.data) - stateTablePos
         for offset in offsets:
-            byteOffset = offset * 2
-            if byteOffset < substitutionTableOffset:
-                raise ValueError("mort substitution offset precedes substitution table")
-            lookupReader = reader.getSubReader(0)
-            lookupReader.seek(stateTablePos + byteOffset)
-            replacements = lookupReader.readUShortArray(len(glyphOrder))
-            table.PerGlyphLookups.append(
-                {
-                    glyph: font.getGlyphName(replacement)
-                    for glyph, replacement in zip(glyphOrder, replacements)
+            # The entry offset plus a glyph ID gives the word offset of that
+            # glyph's replacement, so an offset (which may be negative) exposes
+            # a per-glyph window rather than a whole lookup table. Fonts trim
+            # the windows: words before the substitution table mean "no
+            # substitution" (like HarfBuzz), and we also stop at the end of
+            # the subtable (stricter than HarfBuzz's blob-wide bound).
+            firstGlyph = max(0, (substitutionTableOffset + 1) // 2 - offset)
+            lastGlyph = min(len(glyphOrder) - 1, (available - 2) // 2 - offset)
+            lookup = {}
+            if firstGlyph <= lastGlyph:
+                lookupReader = reader.getSubReader(0)
+                lookupReader.seek(stateTablePos + 2 * (offset + firstGlyph))
+                replacements = lookupReader.readUShortArray(lastGlyph - firstGlyph + 1)
+                lookup = {
+                    glyphOrder[firstGlyph + i]: font.getGlyphName(replacement)
+                    for i, replacement in enumerate(replacements)
                     if replacement != 0
                 }
-            )
+            table.PerGlyphLookups.append(lookup)
         for transition in transitions:
             transition.MarkIndex = (
                 offsetToIndex[transition._MortMarkOffset]

--- a/Lib/fontTools/ttLib/tables/otData.py
+++ b/Lib/fontTools/ttLib/tables/otData.py
@@ -4563,7 +4563,7 @@ otData = [
         "RearrangementMorph",
         [
             FieldSpec(
-                "STXHeader(RearrangementMorphAction)",
+                "MorphStateTable(RearrangementMorphAction)",
                 "StateTable",
                 description="Finite-state transducer table for indic rearrangement.",
             ),
@@ -4573,7 +4573,7 @@ otData = [
         "ContextualMorph",
         [
             FieldSpec(
-                "STXHeader(ContextualMorphAction)",
+                "MorphStateTable(ContextualMorphAction)",
                 "StateTable",
                 description="Finite-state transducer for contextual glyph substitution.",
             ),
@@ -4583,7 +4583,7 @@ otData = [
         "LigatureMorph",
         [
             FieldSpec(
-                "STXHeader(LigatureMorphAction)",
+                "MorphStateTable(LigatureMorphAction)",
                 "StateTable",
                 description="Finite-state transducer for ligature substitution.",
             ),
@@ -4603,7 +4603,7 @@ otData = [
         "InsertionMorph",
         [
             FieldSpec(
-                "STXHeader(InsertionMorphAction)",
+                "MorphStateTable(InsertionMorphAction)",
                 "StateTable",
                 description="Finite-state transducer for glyph insertion.",
             ),

--- a/Lib/fontTools/ttLib/tables/otTables.py
+++ b/Lib/fontTools/ttLib/tables/otTables.py
@@ -2723,7 +2723,11 @@ def _buildClasses():
             9: ExtensionPos,
         },
         "mort": {
+            0: RearrangementMorph,
+            1: ContextualMorph,
+            2: LigatureMorph,
             4: NoncontextualMorph,
+            5: InsertionMorph,
         },
         "morx": {
             0: RearrangementMorph,

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,5 @@
+- [mort] Add semantic decompilation, TTX, and compilation support for
+  rearrangement, contextual-substitution, ligature, and insertion subtables.
 - [colorLib] Raise a legible error when a COLRv0 layer, or a COLRv1 PaintGlyph or
   PaintColrGlyph, references a glyph missing from the glyphMap, instead of failing
   obscurely later (#2629)

--- a/Tests/ttLib/tables/_m_o_r_t_test.py
+++ b/Tests/ttLib/tables/_m_o_r_t_test.py
@@ -79,6 +79,32 @@ MORT_LIGATURE_REBASE_DATA = deHexStr(
 assert len(MORT_LIGATURE_REBASE_DATA) == 128
 
 
+# Modeled on the contextual subtables of Apple's CharcoalCY/GenevaCY/
+# HelveticaCY: the entry's mark offset is negative, arranged so that
+# 2 * (offset + glyphID) lands inside the substitution table only for the
+# glyphs the entry can apply to. Words outside the substitution table mean
+# "no substitution", so per-entry windows are trimmed rather than covering
+# the whole glyph repertoire.
+MORT_TRIMMED_CONTEXTUAL_DATA = deHexStr(
+    "0001000000000001000000010000004c0000000100400001000000010005000a"
+    "0010001a0032001e000104000000000001000000000200100000000000000015"
+    "80000000000000100000fffb0000001f00000000"
+)
+assert len(MORT_TRIMMED_CONTEXTUAL_DATA) == 84
+
+
+# Same layout, but the entries carry three distinct offsets: -5 (trimmed by
+# both bounds), 24 (clamped only by the subtable end, overlapping the first
+# window), and 100 (entirely out of bounds, so an empty per-glyph window that
+# must still keep its lookup index).
+MORT_TRIMMED_CONTEXTUAL_WINDOWS_DATA = deHexStr(
+    "0001000000000001000000010000004c0000000100400001000000010005000a"
+    "0010001a0032001e000104000000000001000000000200100000000000000015"
+    "80000064000000100000fffb0018001f00000000"
+)
+assert len(MORT_TRIMMED_CONTEXTUAL_WINDOWS_DATA) == 84
+
+
 MORT_NONCONTEXTUAL_XML = [
     '<Version value="0x00010000"/>',
     "<!-- MorphChainCount=1 -->",
@@ -253,6 +279,70 @@ class MORTAllSubtableTypesTest(unittest.TestCase):
         )
         self.assertEqual(stateTable.GlyphClassCount, 7)
         self.assertIn(6, stateTable.States[0].Transitions)
+
+
+class MORTTrimmedContextualTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.font = FakeFont(
+            [".notdef"]
+            + ["g%d" % i for i in range(1, 30)]
+            + ["hyphen", "emdash"]
+            + ["h%d" % i for i in range(32, 40)]
+        )
+
+    def decompile(self, data):
+        table = newTable("mort")
+        table.decompile(data, self.font)
+        return table
+
+    def assertSemantics(self, table):
+        stateTable = table.table.MorphChain[0].MorphSubtable[0].SubStruct.StateTable
+        self.assertEqual(stateTable.PerGlyphLookups, [{"hyphen": "emdash"}])
+        self.assertEqual(stateTable.GlyphClasses, {"hyphen": 4})
+        transition = stateTable.States[1].Transitions[4]
+        self.assertEqual(transition.MarkIndex, 0)
+        self.assertEqual(transition.CurrentIndex, 0xFFFF)
+
+    def test_decompile_trimmed_window(self):
+        self.assertSemantics(self.decompile(MORT_TRIMMED_CONTEXTUAL_DATA))
+
+    def test_binary_roundtrip(self):
+        table = self.decompile(MORT_TRIMMED_CONTEXTUAL_DATA)
+        self.assertSemantics(self.decompile(table.compile(self.font)))
+
+    def test_xml_roundtrip(self):
+        table = self.decompile(MORT_TRIMMED_CONTEXTUAL_DATA)
+        compiled = newTable("mort")
+        for name, attrs, content in parseXML(getXML(table.toXML)):
+            compiled.fromXML(name, attrs, content, font=self.font)
+        self.assertSemantics(self.decompile(compiled.compile(self.font)))
+
+    def assertWindowSemantics(self, table):
+        stateTable = table.table.MorphChain[0].MorphSubtable[0].SubStruct.StateTable
+        self.assertEqual(
+            stateTable.PerGlyphLookups, [{"hyphen": "emdash"}, {"g1": "emdash"}, {}]
+        )
+        transition = stateTable.States[0].Transitions[4]
+        self.assertEqual(transition.MarkIndex, 2)
+        self.assertEqual(transition.CurrentIndex, 0xFFFF)
+        transition = stateTable.States[1].Transitions[4]
+        self.assertEqual(transition.MarkIndex, 0)
+        self.assertEqual(transition.CurrentIndex, 1)
+
+    def test_decompile_empty_and_tail_clamped_windows(self):
+        self.assertWindowSemantics(self.decompile(MORT_TRIMMED_CONTEXTUAL_WINDOWS_DATA))
+
+    def test_windows_binary_roundtrip(self):
+        table = self.decompile(MORT_TRIMMED_CONTEXTUAL_WINDOWS_DATA)
+        self.assertWindowSemantics(self.decompile(table.compile(self.font)))
+
+    def test_windows_xml_roundtrip(self):
+        table = self.decompile(MORT_TRIMMED_CONTEXTUAL_WINDOWS_DATA)
+        compiled = newTable("mort")
+        for name, attrs, content in parseXML(getXML(table.toXML)):
+            compiled.fromXML(name, attrs, content, font=self.font)
+        self.assertWindowSemantics(self.decompile(compiled.compile(self.font)))
 
 
 class MORTLigatureRoundTripTest(unittest.TestCase):

--- a/Tests/ttLib/tables/_m_o_r_t_test.py
+++ b/Tests/ttLib/tables/_m_o_r_t_test.py
@@ -266,9 +266,23 @@ class MORTLigatureRoundTripTest(unittest.TestCase):
         font = FakeFont([".notdef", "space", "a", "b", "c", "a_c", "b_c"])
         table = newTable("mort")
         table.decompile(MORT_LIGATURE_REBASE_DATA, font)
+        xml = getXML(table.toXML)
+        first = xml.index("        <MortLigatureRebase>")
+        last = xml.index("        </MortLigatureRebase>", first) + 1
+        self.assertEqual(
+            xml[first:last],
+            [
+                "        <MortLigatureRebase>",
+                '          <Component index="4"/>',
+                '          <Component index="5"/>',
+                '          <Component index="6"/>',
+                '          <Component index="7"/>',
+                "        </MortLigatureRebase>",
+            ],
+        )
 
         compiled = newTable("mort")
-        for name, attrs, content in parseXML(getXML(table.toXML)):
+        for name, attrs, content in parseXML(xml):
             compiled.fromXML(name, attrs, content, font=font)
 
         self.assertEqual(compiled.compile(font), MORT_LIGATURE_REBASE_DATA)

--- a/Tests/ttLib/tables/_m_o_r_t_test.py
+++ b/Tests/ttLib/tables/_m_o_r_t_test.py
@@ -1,3 +1,5 @@
+import copy
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import newTable
@@ -64,6 +66,17 @@ MORT_ALL_TYPES_DATA = deHexStr(
     "000000000100002c0000ffffffff002c00200000ffff000c"
 )
 assert len(MORT_ALL_TYPES_DATA) == 536
+
+
+# Converted from HarfBuzz's TestMORXFourtyone.ttf. The ligature component
+# table contains relative zeroes in the range covered by the final action.
+MORT_LIGATURE_REBASE_DATA = deHexStr(
+    "00010000000000010000000100000078000200010004000000000001ffffffff"
+    "00000001000000000000000000542002000000010007000e001a002200300038"
+    "00480000000701010405060101000000000001010200001a0000001a8000001a"
+    "803000000000001a8000001e00000002000000000048004a0048004800050006"
+)
+assert len(MORT_LIGATURE_REBASE_DATA) == 128
 
 
 MORT_NONCONTEXTUAL_XML = [
@@ -220,6 +233,45 @@ class MORTAllSubtableTypesTest(unittest.TestCase):
         for name, attrs, content in parseXML(getXML(table.toXML)):
             compiled.fromXML(name, attrs, content, font=self.font)
         self.assertSemantics(self.decompile(compiled.compile(self.font)))
+
+    def test_xml_roundtrip_preserves_unused_glyph_class(self):
+        table = self.decompile(MORT_ALL_TYPES_DATA)
+        stateTable = table.table.MorphChain[0].MorphSubtable[0].SubStruct.StateTable
+        stateTable.GlyphClassCount = 7
+        for state in stateTable.States:
+            state.Transitions[6] = copy.deepcopy(state.Transitions[5])
+
+        compiled = newTable("mort")
+        for name, attrs, content in parseXML(getXML(table.toXML)):
+            compiled.fromXML(name, attrs, content, font=self.font)
+
+        stateTable = (
+            self.decompile(compiled.compile(self.font))
+            .table.MorphChain[0]
+            .MorphSubtable[0]
+            .SubStruct.StateTable
+        )
+        self.assertEqual(stateTable.GlyphClassCount, 7)
+        self.assertIn(6, stateTable.States[0].Transitions)
+
+
+class MORTLigatureRoundTripTest(unittest.TestCase):
+    def test_binary_roundtrip_preserves_component_rebasing(self):
+        font = FakeFont([".notdef", "space", "a", "b", "c", "a_c", "b_c"])
+        table = newTable("mort")
+        table.decompile(MORT_LIGATURE_REBASE_DATA, font)
+        self.assertEqual(table.compile(font), MORT_LIGATURE_REBASE_DATA)
+
+    def test_xml_roundtrip_preserves_component_rebasing(self):
+        font = FakeFont([".notdef", "space", "a", "b", "c", "a_c", "b_c"])
+        table = newTable("mort")
+        table.decompile(MORT_LIGATURE_REBASE_DATA, font)
+
+        compiled = newTable("mort")
+        for name, attrs, content in parseXML(getXML(table.toXML)):
+            compiled.fromXML(name, attrs, content, font=font)
+
+        self.assertEqual(compiled.compile(font), MORT_LIGATURE_REBASE_DATA)
 
 
 if __name__ == "__main__":

--- a/Tests/ttLib/tables/_m_o_r_t_test.py
+++ b/Tests/ttLib/tables/_m_o_r_t_test.py
@@ -42,6 +42,30 @@ MORT_NONCONTEXTUAL_DATA = deHexStr(
 assert len(MORT_NONCONTEXTUAL_DATA) == 88
 
 
+# Paired with TestAATMorx.ttf in unicode-org/text-rendering-tests. This table
+# exercises all five metamorphosis subtable types.
+MORT_ALL_TYPES_DATA = deHexStr(
+    "00010000000000010000001f0000021000000005004420000000000100060008"
+    "002a00300000001e010104050101010101010101010101010101010101010101"
+    "010101010101000000000102002a0000002a8000002a20010088200100000002"
+    "0005000a002c003200420000001e010101010401010101010101010101010101"
+    "010101010101010101010101000000000100002c000000000000002c00000000"
+    "0021000000000000000000050000000000000000000000000000000000000000"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+    "00d42002000000040006000e0030003c0048005000c80000001e010101010101"
+    "0405010101010101010101010101010101010101010101010000000001000000"
+    "0000000200300000003680000030804800000028800000460000000000000000"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+    "000000000000000000000000000000000000000000c800c800c800c800c800c8"
+    "00c800c800c800c800c800c800c800c800c800c800c800c800c800c800c800c8"
+    "00c800c800c800c800c800c800c800c8000f0000001820040000000800060004"
+    "000100040000000000080009004c2005000000100005000a002c003200420000"
+    "001e010101010101010101010104010101010101010101010101010101010101"
+    "000000000100002c0000ffffffff002c00200000ffff000c"
+)
+assert len(MORT_ALL_TYPES_DATA) == 536
+
+
 MORT_NONCONTEXTUAL_XML = [
     '<Version value="0x00010000"/>',
     "<!-- MorphChainCount=1 -->",
@@ -105,6 +129,97 @@ class MORTNoncontextualGlyphSubstitutionTest(unittest.TestCase):
         self.assertEqual(
             hexStr(table.compile(self.font)), hexStr(MORT_NONCONTEXTUAL_DATA)
         )
+
+
+class MORTAllSubtableTypesTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.maxDiff = None
+        cls.font = FakeFont(
+            [
+                ".notdef",
+                "space",
+                "A",
+                "B",
+                "C",
+                "D",
+                "E",
+                "F",
+                "G",
+                "H",
+                "O",
+                "X",
+                "Y",
+                "Z",
+                "zero",
+                "one",
+                "one_zero",
+                "one_one",
+                "one_two",
+                "one_three",
+                "one_four",
+                "one_five",
+                "two",
+                "three",
+                "four",
+                "five",
+                "six",
+                "seven",
+                "eight",
+                "nine",
+            ]
+        )
+
+    def decompile(self, data):
+        table = newTable("mort")
+        table.decompile(data, self.font)
+        return table
+
+    def assertSemantics(self, table):
+        subtables = table.table.MorphChain[0].MorphSubtable
+        self.assertEqual(
+            [subtable.MorphType for subtable in subtables], [0, 1, 2, 4, 5]
+        )
+
+        rearrangement = subtables[0].SubStruct.StateTable
+        self.assertTrue(rearrangement.States[0].Transitions[4].MarkFirst)
+        transition = rearrangement.States[0].Transitions[5]
+        self.assertTrue(transition.MarkLast)
+        self.assertEqual(transition.Verb, 1)
+
+        contextual = subtables[1].SubStruct.StateTable
+        self.assertEqual(contextual.PerGlyphLookups, [{"C": "D"}])
+        self.assertEqual(contextual.States[0].Transitions[4].CurrentIndex, 0)
+
+        ligature = subtables[2].SubStruct.StateTable
+        transition = ligature.States[1].Transitions[5]
+        self.assertTrue(transition.SetComponent)
+        self.assertEqual(
+            [(action.GlyphIndexDelta, action.Store) for action in transition.Actions],
+            [(0, False), (30, False)],
+        )
+        self.assertEqual(ligature.LigComponents, [0] * 60)
+        self.assertEqual(ligature.Ligatures, ["one"])
+
+        self.assertEqual(subtables[3].SubStruct.Substitution, {"G": "H"})
+
+        insertion = subtables[4].SubStruct.StateTable
+        transition = insertion.States[0].Transitions[4]
+        self.assertEqual(transition.CurrentInsertionAction, ["Y"])
+
+    def test_decompile_all_types(self):
+        self.assertSemantics(self.decompile(MORT_ALL_TYPES_DATA))
+
+    def test_binary_roundtrip(self):
+        table = self.decompile(MORT_ALL_TYPES_DATA)
+        self.assertSemantics(self.decompile(table.compile(self.font)))
+
+    def test_xml_roundtrip(self):
+        table = self.decompile(MORT_ALL_TYPES_DATA)
+        compiled = newTable("mort")
+        for name, attrs, content in parseXML(getXML(table.toXML)):
+            compiled.fromXML(name, attrs, content, font=self.font)
+        self.assertSemantics(self.decompile(compiled.compile(self.font)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add semantic decompilation, TTX, and compilation for mort rearrangement, contextual substitution, ligature, and insertion subtables
- share the existing morx action and XML model through a state-table converter that dispatches to classic or extended binary encodings
- preserve the existing non-contextual mort support and TTX representation
- add all-five-subtable coverage based on unicode-org/text-rendering-tests#108

The classic adapter handles mort-specific byte entry indexes, absolute and word offsets, contextual substitution arrays, and ligature component rebasing. The extended morx encoding remains unchanged.

## Testing

- PYTHONPATH=Lib pytest -q
  - 4,765 passed, 47 skipped, 2 xfailed
- Black check and mypy pass
- 76 HarfBuzz morx fixtures converted to mort and successfully parsed, compiled, and re-parsed
- the MORT-1 font shapes identically in HarfBuzz before and after a FontTools TTX round trip

Related fixtures and converter: https://github.com/unicode-org/text-rendering-tests/pull/108
HarfBuzz shaping-test import: https://github.com/harfbuzz/harfbuzz/pull/6206