### PR TITLE
[mort] Preserve legacy state-table round trips

### DIFF
--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1591,6 +1591,14 @@ class STXHeader(BaseConverter):
                 xmlWriter.newline()
             xmlWriter.endtag("LigComponents")
             xmlWriter.newline()
+        if hasattr(value, "_MortLigatureRebase"):
+            xmlWriter.begintag("MortLigatureRebase")
+            xmlWriter.newline()
+            for componentIndex in sorted(value._MortLigatureRebase):
+                xmlWriter.simpletag("Component", index=componentIndex)
+                xmlWriter.newline()
+            xmlWriter.endtag("MortLigatureRebase")
+            xmlWriter.newline()
         self._xmlWriteLigatures(xmlWriter, font, value, name, attrs)
         xmlWriter.endtag(name)
         xmlWriter.newline()
@@ -1623,9 +1631,21 @@ class STXHeader(BaseConverter):
                 table.LigComponents = self._xmlReadLigComponents(
                     eltAttrs, eltContent, font
                 )
+            elif eltName == "MortLigatureRebase":
+                table._MortLigatureRebase = {
+                    safeEval(componentAttrs["index"])
+                    for componentName, componentAttrs, _componentContent in filter(
+                        istuple, eltContent
+                    )
+                    if componentName == "Component"
+                }
             elif eltName == "Ligatures":
                 table.Ligatures = self._xmlReadLigatures(eltAttrs, eltContent, font)
-        table.GlyphClassCount = max(table.GlyphClasses.values()) + 1
+        glyphClasses = list(table.GlyphClasses.values())
+        glyphClasses.extend(
+            glyphClass for state in table.States for glyphClass in state.Transitions
+        )
+        table.GlyphClassCount = max(glyphClasses, default=-1) + 1
         return table
 
     def _xmlReadState(self, attrs, content, font):
@@ -1741,12 +1761,15 @@ class StateHeader(STXHeader):
             )
         elif ligatureOffset is not None:
             ligatureBase = ligatureOffset // 2
+            table._MortLigatureRebase = {
+                componentIndex
+                for componentIndex in table._MortLigatureRebase
+                if table.LigComponents[componentIndex] >= ligatureBase
+            }
             for componentIndex in table._MortLigatureRebase:
                 # Unused entries are commonly zero. Only values which actually
                 # include the ligature-table base need to be normalized.
-                if table.LigComponents[componentIndex] >= ligatureBase:
-                    table.LigComponents[componentIndex] -= ligatureBase
-            del table._MortLigatureRebase
+                table.LigComponents[componentIndex] -= ligatureBase
 
             ligatureCount = self._countLegacyLigatures(table, len(font.getGlyphOrder()))
             ligatureReader = reader.getSubReader(0)
@@ -2083,7 +2106,11 @@ class StateHeader(STXHeader):
 
         actionOffsets = {}
         actionData = b""
-        rebaseComponents = set()
+        rebaseComponents = getattr(table, "_MortLigatureRebase", None)
+        if rebaseComponents is None:
+            rebaseComponents = set()
+        else:
+            rebaseComponents = set(rebaseComponents)
         for sequence in sequences:
             sequenceOffset = actionOffset + len(actionData)
             if sequenceOffset > 0x3FFF:
@@ -2100,7 +2127,7 @@ class StateHeader(STXHeader):
                 value |= 0x80000000 if last else 0
                 actionData += struct.pack(">I", value)
                 addBase = (store or last) and not rebased
-                if addBase:
+                if addBase and not hasattr(table, "_MortLigatureRebase"):
                     start = max(0, delta)
                     limit = min(len(table.LigComponents), delta + glyphCount)
                     rebaseComponents.update(range(start, limit))

--- a/Tests/ttLib/tables/_m_o_r_t_test.py
+++ b/Tests/ttLib/tables/_m_o_r_t_test.py
@@ -266,9 +266,23 @@ class MORTLigatureRoundTripTest(unittest.TestCase):
         font = FakeFont([".notdef", "space", "a", "b", "c", "a_c", "b_c"])
         table = newTable("mort")
         table.decompile(MORT_LIGATURE_REBASE_DATA, font)
+        xml = getXML(table.toXML)
+        first = xml.index("        <MortLigatureRebase>")
+        last = xml.index("        </MortLigatureRebase>", first) + 1
+        self.assertEqual(
+            xml[first:last],
+            [
+                "        <MortLigatureRebase>",
+                '          <Component index="4"/>',
+                '          <Component index="5"/>',
+                '          <Component index="6"/>',
+                '          <Component index="7"/>',
+                "        </MortLigatureRebase>",
+            ],
+        )
 
         compiled = newTable("mort")
-        for name, attrs, content in parseXML(getXML(table.toXML)):
+        for name, attrs, content in parseXML(xml):
             compiled.fromXML(name, attrs, content, font=font)
 
         self.assertEqual(compiled.compile(font), MORT_LIGATURE_REBASE_DATA)

--- a/Tests/ttLib/tables/_m_o_r_t_test.py
+++ b/Tests/ttLib/tables/_m_o_r_t_test.py
@@ -1,3 +1,5 @@
+import copy
+
 from fontTools.misc.testTools import FakeFont, getXML, parseXML
 from fontTools.misc.textTools import deHexStr, hexStr
 from fontTools.ttLib import newTable
@@ -64,6 +66,17 @@ MORT_ALL_TYPES_DATA = deHexStr(
     "000000000100002c0000ffffffff002c00200000ffff000c"
 )
 assert len(MORT_ALL_TYPES_DATA) == 536
+
+
+# Converted from HarfBuzz's TestMORXFourtyone.ttf. The ligature component
+# table contains relative zeroes in the range covered by the final action.
+MORT_LIGATURE_REBASE_DATA = deHexStr(
+    "00010000000000010000000100000078000200010004000000000001ffffffff"
+    "00000001000000000000000000542002000000010007000e001a002200300038"
+    "00480000000701010405060101000000000001010200001a0000001a8000001a"
+    "803000000000001a8000001e00000002000000000048004a0048004800050006"
+)
+assert len(MORT_LIGATURE_REBASE_DATA) == 128
 
 
 MORT_NONCONTEXTUAL_XML = [
@@ -220,6 +233,45 @@ class MORTAllSubtableTypesTest(unittest.TestCase):
         for name, attrs, content in parseXML(getXML(table.toXML)):
             compiled.fromXML(name, attrs, content, font=self.font)
         self.assertSemantics(self.decompile(compiled.compile(self.font)))
+
+    def test_xml_roundtrip_preserves_unused_glyph_class(self):
+        table = self.decompile(MORT_ALL_TYPES_DATA)
+        stateTable = table.table.MorphChain[0].MorphSubtable[0].SubStruct.StateTable
+        stateTable.GlyphClassCount = 7
+        for state in stateTable.States:
+            state.Transitions[6] = copy.deepcopy(state.Transitions[5])
+
+        compiled = newTable("mort")
+        for name, attrs, content in parseXML(getXML(table.toXML)):
+            compiled.fromXML(name, attrs, content, font=self.font)
+
+        stateTable = (
+            self.decompile(compiled.compile(self.font))
+            .table.MorphChain[0]
+            .MorphSubtable[0]
+            .SubStruct.StateTable
+        )
+        self.assertEqual(stateTable.GlyphClassCount, 7)
+        self.assertIn(6, stateTable.States[0].Transitions)
+
+
+class MORTLigatureRoundTripTest(unittest.TestCase):
+    def test_binary_roundtrip_preserves_component_rebasing(self):
+        font = FakeFont([".notdef", "space", "a", "b", "c", "a_c", "b_c"])
+        table = newTable("mort")
+        table.decompile(MORT_LIGATURE_REBASE_DATA, font)
+        self.assertEqual(table.compile(font), MORT_LIGATURE_REBASE_DATA)
+
+    def test_xml_roundtrip_preserves_component_rebasing(self):
+        font = FakeFont([".notdef", "space", "a", "b", "c", "a_c", "b_c"])
+        table = newTable("mort")
+        table.decompile(MORT_LIGATURE_REBASE_DATA, font)
+
+        compiled = newTable("mort")
+        for name, attrs, content in parseXML(getXML(table.toXML)):
+            compiled.fromXML(name, attrs, content, font=font)
+
+        self.assertEqual(compiled.compile(font), MORT_LIGATURE_REBASE_DATA)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
based on #4158 

Fixes two round-trip losses in @behdad's new legacy mort state-table support.

The [legacy ligature subtable format](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6mort.html) includes the ligature-table base in one component offset. FontTools removes that base for its normalized component model, but the compiler previously inferred a broader rebasing range; zero-valued components make that inference ambiguous and can alter shaping. Preserve the exact rebase mask in the model and TTX, then replay it when compiling.

The [AAT state-table format](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6Tables.html) defines the available class columns independently of the class-table assignments. TTX previously derived `GlyphClassCount` only from those assignments, so transitions for otherwise-unused classes were emitted then discarded on import. Derive the count from both serialized transitions and glyph assignments.