### PR TITLE
[qu2cu] Accept tuple splines when compiled

### DIFF
--- a/Lib/fontTools/qu2cu/qu2cu.py
+++ b/Lib/fontTools/qu2cu/qu2cu.py
@@ -28,6 +28,7 @@ from collections import namedtuple
 import math
 from typing import (
     List,
+    Sequence,
     Tuple,
     Union,
 )
@@ -195,14 +196,14 @@ def _validate_positive_tolerance(max_err):
     is_complex=cython.int,
 )
 def quadratic_to_curves(
-    quads: List[List[Point]],
+    quads: List[Sequence[Point]],
     max_err: float = 0.5,
     all_cubic: bool = False,
 ) -> List[Tuple[Point, ...]]:
     """Converts a connecting list of quadratic splines to a list of quadratic
     and cubic curves.
 
-    A quadratic spline is specified as a list of points.  Either each point is
+    A quadratic spline is specified as a sequence of points.  Either each point is
     a 2-tuple of X,Y coordinates, or each point is a complex number with
     real/imaginary components representing X,Y coordinates.
 

--- a/Tests/qu2cu/qu2cu_test.py
+++ b/Tests/qu2cu/qu2cu_test.py
@@ -28,6 +28,11 @@ class Qu2CuTest:
     def test_empty_input(self):
         assert quadratic_to_curves([]) == []
 
+    def test_tuple_spline(self):
+        assert quadratic_to_curves([((0, 0), (0, 1), (1, 1))]) == [
+            ((0, 0), (0, 1), (1, 1))
+        ]
+
     @pytest.mark.parametrize(
         "quadratics, expected, tolerance, cubic_only",
         [


### PR DESCRIPTION
Cython treats List[List[Point]] as a runtime list check. Qu2CuPen passes tuple splines, so the Cython build fails with TypeError: Expected list, got tuple.

Use Sequence for the inner spline annotation and cover tuple input.