### PR TITLE
[mort] Decode trimmed contextual substitution windows

### DIFF
--- a/Lib/fontTools/ttLib/tables/otConverters.py
+++ b/Lib/fontTools/ttLib/tables/otConverters.py
@@ -1855,20 +1855,29 @@ class StateHeader(STXHeader):
         )
         offsetToIndex = {offset: i for i, offset in enumerate(offsets)}
         glyphOrder = font.getGlyphOrder()
+        # reader.data holds just this subtable, so this is the room between
+        # the state-table header and the end of the subtable.
+        available = len(reader.data) - stateTablePos
         for offset in offsets:
-            byteOffset = offset * 2
-            if byteOffset < substitutionTableOffset:
-                raise ValueError("mort substitution offset precedes substitution table")
-            lookupReader = reader.getSubReader(0)
-            lookupReader.seek(stateTablePos + byteOffset)
-            replacements = lookupReader.readUShortArray(len(glyphOrder))
-            table.PerGlyphLookups.append(
-                {
-                    glyph: font.getGlyphName(replacement)
-                    for glyph, replacement in zip(glyphOrder, replacements)
+            # The entry offset plus a glyph ID gives the word offset of that
+            # glyph's replacement, so an offset (which may be negative) exposes
+            # a per-glyph window rather than a whole lookup table. Fonts trim
+            # the windows: words before the substitution table mean "no
+            # substitution" (like HarfBuzz), and we also stop at the end of
+            # the subtable (stricter than HarfBuzz's blob-wide bound).
+            firstGlyph = max(0, (substitutionTableOffset + 1) // 2 - offset)
+            lastGlyph = min(len(glyphOrder) - 1, (available - 2) // 2 - offset)
+            lookup = {}
+            if firstGlyph <= lastGlyph:
+                lookupReader = reader.getSubReader(0)
+                lookupReader.seek(stateTablePos + 2 * (offset + firstGlyph))
+                replacements = lookupReader.readUShortArray(lastGlyph - firstGlyph + 1)
+                lookup = {
+                    glyphOrder[firstGlyph + i]: font.getGlyphName(replacement)
+                    for i, replacement in enumerate(replacements)
                     if replacement != 0
                 }
-            )
+            table.PerGlyphLookups.append(lookup)
         for transition in transitions:
             transition.MarkIndex = (
                 offsetToIndex[transition._MortMarkOffset]

--- a/Tests/ttLib/tables/_m_o_r_t_test.py
+++ b/Tests/ttLib/tables/_m_o_r_t_test.py
@@ -79,6 +79,32 @@ MORT_LIGATURE_REBASE_DATA = deHexStr(
 assert len(MORT_LIGATURE_REBASE_DATA) == 128
 
 
+# Modeled on the contextual subtables of Apple's CharcoalCY/GenevaCY/
+# HelveticaCY: the entry's mark offset is negative, arranged so that
+# 2 * (offset + glyphID) lands inside the substitution table only for the
+# glyphs the entry can apply to. Words outside the substitution table mean
+# "no substitution", so per-entry windows are trimmed rather than covering
+# the whole glyph repertoire.
+MORT_TRIMMED_CONTEXTUAL_DATA = deHexStr(
+    "0001000000000001000000010000004c0000000100400001000000010005000a"
+    "0010001a0032001e000104000000000001000000000200100000000000000015"
+    "80000000000000100000fffb0000001f00000000"
+)
+assert len(MORT_TRIMMED_CONTEXTUAL_DATA) == 84
+
+
+# Same layout, but the entries carry three distinct offsets: -5 (trimmed by
+# both bounds), 24 (clamped only by the subtable end, overlapping the first
+# window), and 100 (entirely out of bounds, so an empty per-glyph window that
+# must still keep its lookup index).
+MORT_TRIMMED_CONTEXTUAL_WINDOWS_DATA = deHexStr(
+    "0001000000000001000000010000004c0000000100400001000000010005000a"
+    "0010001a0032001e000104000000000001000000000200100000000000000015"
+    "80000064000000100000fffb0018001f00000000"
+)
+assert len(MORT_TRIMMED_CONTEXTUAL_WINDOWS_DATA) == 84
+
+
 MORT_NONCONTEXTUAL_XML = [
     '<Version value="0x00010000"/>',
     "<!-- MorphChainCount=1 -->",
@@ -253,6 +279,70 @@ class MORTAllSubtableTypesTest(unittest.TestCase):
         )
         self.assertEqual(stateTable.GlyphClassCount, 7)
         self.assertIn(6, stateTable.States[0].Transitions)
+
+
+class MORTTrimmedContextualTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.font = FakeFont(
+            [".notdef"]
+            + ["g%d" % i for i in range(1, 30)]
+            + ["hyphen", "emdash"]
+            + ["h%d" % i for i in range(32, 40)]
+        )
+
+    def decompile(self, data):
+        table = newTable("mort")
+        table.decompile(data, self.font)
+        return table
+
+    def assertSemantics(self, table):
+        stateTable = table.table.MorphChain[0].MorphSubtable[0].SubStruct.StateTable
+        self.assertEqual(stateTable.PerGlyphLookups, [{"hyphen": "emdash"}])
+        self.assertEqual(stateTable.GlyphClasses, {"hyphen": 4})
+        transition = stateTable.States[1].Transitions[4]
+        self.assertEqual(transition.MarkIndex, 0)
+        self.assertEqual(transition.CurrentIndex, 0xFFFF)
+
+    def test_decompile_trimmed_window(self):
+        self.assertSemantics(self.decompile(MORT_TRIMMED_CONTEXTUAL_DATA))
+
+    def test_binary_roundtrip(self):
+        table = self.decompile(MORT_TRIMMED_CONTEXTUAL_DATA)
+        self.assertSemantics(self.decompile(table.compile(self.font)))
+
+    def test_xml_roundtrip(self):
+        table = self.decompile(MORT_TRIMMED_CONTEXTUAL_DATA)
+        compiled = newTable("mort")
+        for name, attrs, content in parseXML(getXML(table.toXML)):
+            compiled.fromXML(name, attrs, content, font=self.font)
+        self.assertSemantics(self.decompile(compiled.compile(self.font)))
+
+    def assertWindowSemantics(self, table):
+        stateTable = table.table.MorphChain[0].MorphSubtable[0].SubStruct.StateTable
+        self.assertEqual(
+            stateTable.PerGlyphLookups, [{"hyphen": "emdash"}, {"g1": "emdash"}, {}]
+        )
+        transition = stateTable.States[0].Transitions[4]
+        self.assertEqual(transition.MarkIndex, 2)
+        self.assertEqual(transition.CurrentIndex, 0xFFFF)
+        transition = stateTable.States[1].Transitions[4]
+        self.assertEqual(transition.MarkIndex, 0)
+        self.assertEqual(transition.CurrentIndex, 1)
+
+    def test_decompile_empty_and_tail_clamped_windows(self):
+        self.assertWindowSemantics(self.decompile(MORT_TRIMMED_CONTEXTUAL_WINDOWS_DATA))
+
+    def test_windows_binary_roundtrip(self):
+        table = self.decompile(MORT_TRIMMED_CONTEXTUAL_WINDOWS_DATA)
+        self.assertWindowSemantics(self.decompile(table.compile(self.font)))
+
+    def test_windows_xml_roundtrip(self):
+        table = self.decompile(MORT_TRIMMED_CONTEXTUAL_WINDOWS_DATA)
+        compiled = newTable("mort")
+        for name, attrs, content in parseXML(getXML(table.toXML)):
+            compiled.fromXML(name, attrs, content, font=self.font)
+        self.assertWindowSemantics(self.decompile(compiled.compile(self.font)))
 
 
 class MORTLigatureRoundTripTest(unittest.TestCase):


### PR DESCRIPTION
Stacked on #4159.

The classic contextual format resolves a substitution by adding the entry's word offset (possibly negative) to the glyph ID, so each entry exposes a per-glyph window into the substitution table rather than a whole lookup. Real fonts trim the windows: the mort fonts still shipping in macOS (CharcoalCY, GenevaCY, HelveticaCY under FontServices' ApplicationSupport, cf. harfbuzz/harfbuzz#5887) use negative offsets and windows covering only the glyphs an entry can apply to, so the current decoder, which reads a full numGlyphs array per offset and rejects offsets that precede the substitution table, fails on all of them.

So here we decode only the words that fall inside the substitution table, treating everything else as "no substitution". The lower bound matches HarfBuzz (`wordOffsetToIndex` rejects reads below the substitution table); the upper bound is clamped at the subtable end, which is slightly stricter than HarfBuzz's blob-wide bound (its per-subtable sanitizer narrowing is disabled, cf. harfbuzz/harfbuzz#4873); but a cross-subtable read has no representation in the object model anyway.

With this change, every mort font shipping in macOS decompiles, and hb-shape 14.3.1 (which includes the harfbuzz/harfbuzz#6003 offset-0 fix) shapes original vs recompiled identically, including an exhaustive two-glyph sweep over CharcoalCY's full cmap.

Round trips for these fonts are semantic rather than byte-identical: the compiler writes full per-glyph arrays, so e.g. CharcoalCY's mort grows from 2388 to 4076 bytes.