### PR TITLE
[subset] Fully prune VARC auxiliary data

### DIFF
--- a/Lib/fontTools/subset/__init__.py
+++ b/Lib/fontTools/subset/__init__.py
@@ -2840,27 +2840,24 @@ def closure_glyphs(self, s):
 def prune_post_subset(self, font, options):
     table = self.table
 
-    store = table.MultiVarStore
-    if store is not None:
-        usedVarIdxes = set()
-        table.collect_varidxes(usedVarIdxes)
-        varidx_map = store.subset_varidxes(usedVarIdxes)
-        table.remap_varidxes(varidx_map)
-
-    axisIndicesList = table.AxisIndicesList.Item
+    axisIndicesList = table.AxisIndicesList
     if axisIndicesList is not None:
+        items = axisIndicesList.Item
         usedIndices = set()
         for glyph in table.VarCompositeGlyphs.VarCompositeGlyph:
             for comp in glyph.components:
                 if comp.axisIndicesIndex is not None:
                     usedIndices.add(comp.axisIndicesIndex)
         usedIndices = sorted(usedIndices)
-        table.AxisIndicesList.Item = _list_subset(axisIndicesList, usedIndices)
-        mapping = {old: new for new, old in enumerate(usedIndices)}
-        for glyph in table.VarCompositeGlyphs.VarCompositeGlyph:
-            for comp in glyph.components:
-                if comp.axisIndicesIndex is not None:
-                    comp.axisIndicesIndex = mapping[comp.axisIndicesIndex]
+        if usedIndices:
+            axisIndicesList.Item = _list_subset(items, usedIndices)
+            mapping = {old: new for new, old in enumerate(usedIndices)}
+            for glyph in table.VarCompositeGlyphs.VarCompositeGlyph:
+                for comp in glyph.components:
+                    if comp.axisIndicesIndex is not None:
+                        comp.axisIndicesIndex = mapping[comp.axisIndicesIndex]
+        else:
+            table.AxisIndicesList = None
 
     conditionList = table.ConditionList
     if conditionList is not None:
@@ -2871,12 +2868,25 @@ def prune_post_subset(self, font, options):
                 if comp.conditionIndex is not None:
                     usedIndices.add(comp.conditionIndex)
         usedIndices = sorted(usedIndices)
-        conditionList.ConditionTable = _list_subset(conditionTables, usedIndices)
-        mapping = {old: new for new, old in enumerate(usedIndices)}
-        for glyph in table.VarCompositeGlyphs.VarCompositeGlyph:
-            for comp in glyph.components:
-                if comp.conditionIndex is not None:
-                    comp.conditionIndex = mapping[comp.conditionIndex]
+        if usedIndices:
+            conditionList.ConditionTable = _list_subset(conditionTables, usedIndices)
+            mapping = {old: new for new, old in enumerate(usedIndices)}
+            for glyph in table.VarCompositeGlyphs.VarCompositeGlyph:
+                for comp in glyph.components:
+                    if comp.conditionIndex is not None:
+                        comp.conditionIndex = mapping[comp.conditionIndex]
+        else:
+            table.ConditionList = None
+
+    # Conditions can reference the variation store, so subset them first.
+    store = table.MultiVarStore
+    if store is not None:
+        usedVarIdxes = set()
+        table.collect_varidxes(usedVarIdxes)
+        varidx_map = store.subset_varidxes(usedVarIdxes)
+        table.remap_varidxes(varidx_map)
+        if not store:
+            table.MultiVarStore = None
 
     return True
 

--- a/Lib/fontTools/varLib/multiVarStore.py
+++ b/Lib/fontTools/varLib/multiVarStore.py
@@ -234,11 +234,38 @@ def MultiVarStore_get_supports(self, major, fvarAxes):
 ot.MultiVarStore.get_supports = MultiVarStore_get_supports
 
 
+def ConditionTable_collect_varidxes(self, varidxes):
+    if self.Format == 2:
+        varidxes.add(self.VarIdx)
+    elif self.Format in (3, 4):
+        for condition in self.ConditionTable:
+            condition.collect_varidxes(varidxes)
+    elif self.Format == 5:
+        self.ConditionTable.collect_varidxes(varidxes)
+
+
+def ConditionTable_remap_varidxes(self, varidxes_map):
+    if self.Format == 2:
+        self.VarIdx = varidxes_map[self.VarIdx]
+    elif self.Format in (3, 4):
+        for condition in self.ConditionTable:
+            condition.remap_varidxes(varidxes_map)
+    elif self.Format == 5:
+        self.ConditionTable.remap_varidxes(varidxes_map)
+
+
+ot.ConditionTable.collect_varidxes = ConditionTable_collect_varidxes
+ot.ConditionTable.remap_varidxes = ConditionTable_remap_varidxes
+
+
 def VARC_collect_varidxes(self, varidxes):
     for glyph in self.VarCompositeGlyphs.VarCompositeGlyph:
         for component in glyph.components:
             varidxes.add(component.axisValuesVarIndex)
             varidxes.add(component.transformVarIndex)
+    if self.ConditionList is not None:
+        for condition in self.ConditionList.ConditionTable:
+            condition.collect_varidxes(varidxes)
 
 
 def VARC_remap_varidxes(self, varidxes_map):
@@ -246,6 +273,9 @@ def VARC_remap_varidxes(self, varidxes_map):
         for component in glyph.components:
             component.axisValuesVarIndex = varidxes_map[component.axisValuesVarIndex]
             component.transformVarIndex = varidxes_map[component.transformVarIndex]
+    if self.ConditionList is not None:
+        for condition in self.ConditionList.ConditionTable:
+            condition.remap_varidxes(varidxes_map)
 
 
 ot.VARC.collect_varidxes = VARC_collect_varidxes

--- a/Tests/subset/subset_test.py
+++ b/Tests/subset/subset_test.py
@@ -472,9 +472,88 @@ class SubsetTest:
         subset.main([fontpath, "--unicodes=ac00", "--output-file=%s" % subsetpath])
         subsetfont = TTFont(subsetpath)
         assert len(subsetfont.getGlyphOrder()) == 6
+        varc = subsetfont["VARC"].table
+        assert len(varc.AxisIndicesList.Item) == 2
+        assert len(varc.MultiVarStore.MultiVarData) == 1
+        assert len(varc.MultiVarStore.MultiVarData[0].Item) == 2
+        assert len(varc.MultiVarStore.SparseVarRegionList.Region) == 3
         subset.main([fontpath, "--unicodes=ac01", "--output-file=%s" % subsetpath])
         subsetfont = TTFont(subsetpath)
         assert len(subsetfont.getGlyphOrder()) == 8
+        varc = subsetfont["VARC"].table
+        assert len(varc.AxisIndicesList.Item) == 2
+        assert len(varc.MultiVarStore.MultiVarData) == 1
+        assert len(varc.MultiVarStore.MultiVarData[0].Item) == 5
+        assert len(varc.MultiVarStore.SparseVarRegionList.Region) == 3
+
+    def test_varComposite_condition_varidx(self):
+        fontpath = self.getpath("..", "..", "ttLib", "data", "varc-ac00-ac01.ttf")
+        font = TTFont(fontpath)
+        varc = font["VARC"].table
+
+        def makeCondition(varIdx):
+            condition = ot.ConditionTable()
+            condition.Format = 2
+            condition.DefaultValue = 0
+            condition.VarIdx = varIdx
+            return condition
+
+        unusedCondition = makeCondition(5)
+        negatedCondition = ot.ConditionTable()
+        negatedCondition.Format = 5
+        negatedCondition.ConditionTable = makeCondition(4)
+        usedCondition = ot.ConditionTable()
+        usedCondition.Format = 3
+        usedCondition.ConditionTable = [makeCondition(6), negatedCondition]
+
+        conditionList = ot.ConditionList()
+        conditionList.ConditionTable = [unusedCondition, usedCondition]
+        varc.ConditionList = conditionList
+        varc.VarCompositeGlyphs.VarCompositeGlyph[0].components[0].conditionIndex = 1
+
+        inputpath = self.temp_path(".ttf")
+        font.save(inputpath)
+        subsetpath = self.temp_path(".ttf")
+        subset.main([inputpath, "--unicodes=ac00", "--output-file=%s" % subsetpath])
+
+        subsetfont = TTFont(subsetpath)
+        varc = subsetfont["VARC"].table
+        assert len(varc.ConditionList.ConditionTable) == 1
+        condition = varc.ConditionList.ConditionTable[0]
+        assert condition.ConditionTable[0].VarIdx == 3
+        assert condition.ConditionTable[1].ConditionTable.VarIdx == 2
+        assert len(varc.MultiVarStore.MultiVarData) == 1
+        assert len(varc.MultiVarStore.MultiVarData[0].Item) == 4
+
+    def test_varComposite_drops_empty_auxiliary_data(self):
+        fontpath = self.getpath("..", "..", "ttLib", "data", "varc-ac00-ac01.ttf")
+        font = TTFont(fontpath)
+        varc = font["VARC"].table
+        for glyph in varc.VarCompositeGlyphs.VarCompositeGlyph:
+            for component in glyph.components:
+                component.axisIndicesIndex = None
+                component.axisValues = ()
+                component.axisValuesVarIndex = ot.NO_VARIATION_INDEX
+                component.transformVarIndex = ot.NO_VARIATION_INDEX
+
+        conditionList = ot.ConditionList()
+        condition = ot.ConditionTable()
+        condition.Format = 1
+        condition.AxisIndex = 0
+        condition.FilterRangeMinValue = 0
+        condition.FilterRangeMaxValue = 1
+        conditionList.ConditionTable = [condition]
+        varc.ConditionList = conditionList
+
+        inputpath = self.temp_path(".ttf")
+        font.save(inputpath)
+        subsetpath = self.temp_path(".ttf")
+        subset.main([inputpath, "--unicodes=ac00", "--output-file=%s" % subsetpath])
+
+        varc = TTFont(subsetpath)["VARC"].table
+        assert varc.MultiVarStore is None
+        assert varc.ConditionList is None
+        assert varc.AxisIndicesList is None
 
     def test_timing_publishes_parts(self):
         fontpath = self.compile_font(self.getpath("TestTTF-Regular.ttx"), ".ttf")


### PR DESCRIPTION
The VARC subsetter already compacted component variation indices, axis-index entries, conditions, MultiVarData, and sparse regions. This completes auxiliary pruning by:

- recursively collecting and remapping Format 2 VarIdx references in condition formats 3 through 5
- pruning conditions before the MultiVarStore, so discarded conditions do not retain variation data
- removing empty MultiVarStore, ConditionList, and AxisIndicesList structures
- adding structural tests for variation records, nested conditions, and empty auxiliary data

VarComponent decoding remains centralized in the existing decoded object model.

Validation:
- 117 relevant tests passed, 6 skipped
- RCJK Hangul and Hanzi subsets reload and draw successfully with HarfBuzz hb-draw-all