### PR TITLE
escape anon block tag in feaLib scan_anonymous_block

### DIFF
--- a/Lib/fontTools/feaLib/lexer.py
+++ b/Lib/fontTools/feaLib/lexer.py
@@ -179,7 +179,7 @@ class Lexer(object):
         tag = tag.strip()
         self.scan_until_(Lexer.CHAR_NEWLINE_)
         self.scan_over_(Lexer.CHAR_NEWLINE_)
-        regexp = r"}\s*" + tag + r"\s*;"
+        regexp = r"}\s*" + re.escape(tag) + r"\s*;"
         split = re.split(regexp, self.text_[self.pos_ :], maxsplit=1)
         if len(split) != 2:
             raise FeatureLibError(

--- a/Tests/feaLib/parser_test.py
+++ b/Tests/feaLib/parser_test.py
@@ -234,6 +234,25 @@ class ParserTest(unittest.TestCase):
             "anon TEST { \n no end in sight",
         )
 
+    def test_anon_regexMetacharacterTag(self):
+        # the closing tag is matched literally: regex metacharacters in the tag
+        # (all of ``. + * ^ ~ !`` are valid feature-file name characters) must
+        # not move where the block ends, so the inner "} X;" does not terminate it
+        anon = self.parse("anon .+.+ {\n} X;\n} .+.+;\n").statements[0]
+        self.assertIsInstance(anon, ast.AnonymousBlock)
+        self.assertEqual(anon.tag, ".+.+")
+        self.assertEqual(anon.content, "} X;\n")
+
+    def test_anon_invalidRegexTag(self):
+        # a tag that is not a valid regular expression must raise a
+        # FeatureLibError rather than leaking a re.error out of the parser
+        self.assertRaisesRegex(
+            FeatureLibError,
+            r"Expected '} \*;' to terminate anonymous block",
+            self.parse,
+            "anon * {\n no end in sight",
+        )
+
     def test_attach(self):
         doc = self.parse("table GDEF {Attach [a e] 2;} GDEF;")
         s = doc.statements[0].statements[0]


### PR DESCRIPTION
the anon block tag is spliced straight into the terminator regex in `scan_anonymous_block`, so a tag carrying regex metacharacters (all of `. + * ^ ~ !` are valid feature-file name characters) can end the block at the wrong `}...;`, leak an uncaught `re.error` out of the parser, or backtrack catastrophically (a 20 KB anon block tagged `.+.+` ran for ~96s here); escaping it with `re.escape` before the split matches the terminator literally as the spec intends and leaves valid tags untouched.