### PR TITLE
basename variable-font name when building varLib output path

### DIFF
--- a/Lib/fontTools/varLib/__init__.py
+++ b/Lib/fontTools/varLib/__init__.py
@@ -1543,7 +1543,9 @@ def main(args=None):
                 # Only use basename to prevent path traversal attacks
                 filename = os.path.basename(vf.filename)
             else:
-                filename = vf.name + ".{ext}"
+                # vf.name comes straight from the designspace and is equally
+                # attacker-controlled, so basename it too
+                filename = os.path.basename(vf.name) + ".{ext}"
             vf_name_to_output_path[vf.name] = os.path.join(output_dir, filename)
 
     vf_names_to_build = {vf.name for vf in vfs_to_build}

--- a/Tests/varLib/varLib_test.py
+++ b/Tests/varLib/varLib_test.py
@@ -661,6 +661,54 @@ class BuildTest(unittest.TestCase):
         self.assertTrue(os.path.isdir(outdir))
         self.assertTrue(os.path.exists(os.path.join(outdir, "BuildMain-VF.ttf")))
 
+    def test_varLib_main_output_dir_contains_traversal_name(self):
+        # A designspace can name a variable font with path separators; that name
+        # is used to build the output filename, so an un-basenamed name escapes
+        # --output-dir. The compile step is stubbed out to isolate path handling.
+        from unittest import mock
+        from fontTools.designspaceLib import (
+            RangeAxisSubsetDescriptor,
+            VariableFontDescriptor,
+        )
+
+        self.temp_dir()
+        outdir = os.path.join(self.tempdir, "output_dir_traversal_test")
+        os.makedirs(outdir)
+
+        doc = DesignSpaceDocument()
+        axis = AxisDescriptor()
+        axis.name = "Weight"
+        axis.tag = "wght"
+        axis.minimum, axis.default, axis.maximum = 400, 400, 700
+        doc.addAxis(axis)
+        doc.addVariableFont(
+            VariableFontDescriptor(
+                name="../escaped",
+                axisSubsets=[RangeAxisSubsetDescriptor(name="Weight")],
+            )
+        )
+        doc.formatVersion = "5.0"
+        ds_path = os.path.join(self.tempdir, "traversal.designspace")
+        doc.write(ds_path)
+
+        class FakeVF:
+            sfntVersion = "\x00\x01\x00\x00"
+
+            def save(self, path):
+                with open(path, "wb") as f:
+                    f.write(b"")
+
+        with mock.patch(
+            "fontTools.varLib.build_many",
+            lambda designspace, finder, **kw: {
+                vf.name: FakeVF() for vf in designspace.getVariableFonts()
+            },
+        ):
+            varLib_main([ds_path, "--output-dir", outdir])
+
+        self.assertTrue(os.path.exists(os.path.join(outdir, "escaped.ttf")))
+        self.assertFalse(os.path.exists(os.path.join(self.tempdir, "escaped.ttf")))
+
     def test_varLib_main_drop_implied_oncurves(self):
         self.temp_dir()
         outdir = os.path.join(self.tempdir, "drop_implied_oncurves_test")


### PR DESCRIPTION
varLib's build command derives each output filename from the <variable-font> element in the designspace. The filename attribute is already run through os.path.basename with a note that it guards against path traversal, but when that attribute is absent the code falls back to vf.name + ".{ext}" and joins it onto the output directory unchanged. vf.name is a required attribute read verbatim from the designspace by readVariableFonts, so a document declaring <variable-font name="../../evil"> with no filename steers the join outside whatever --output-dir the caller passed, and the compiled font is written there. I noticed it reading the two branches side by side: one is basenamed, the sibling is not. Basenaming vf.name as well keeps the write inside the output directory, and real font names carry no separators so existing builds are unaffected. Added a regression test that drives main() with a traversal name and asserts the output stays put.