### PR TITLE
[feaLib] Fix tracking for redundant script statements

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -128,6 +128,7 @@ class Builder(object):
             self.scalar_builder = VariableScalarBuilder.from_ttf(font)
         self.default_language_systems_ = set()
         self.script_ = None
+        self.language_ = None
         self.lookupflag_ = 0
         self.lookupflag_markFilterSet_ = None
         self.use_extension_ = False
@@ -1083,7 +1084,10 @@ class Builder(object):
                 location,
             )
         self.language_systems = self.get_default_language_systems_()
-        self.script_ = "DFLT"
+        # The current script and language start out as the first declared
+        # language system, sorted by (script, language) tag. Kind of odd,
+        # but matches makeotf (and fea-rs matches us)
+        self.script_, self.language_ = min(self.language_systems)
         self.cur_lookup_ = None
         self.cur_feature_name_ = name
         self.lookupflag_ = 0
@@ -1097,6 +1101,8 @@ class Builder(object):
         assert self.cur_feature_name_ is not None
         self.cur_feature_name_ = None
         self.language_systems = None
+        self.script_ = None
+        self.language_ = None
         self.cur_lookup_ = None
         self.lookupflag_ = 0
         self.lookupflag_markFilterSet_ = None
@@ -1169,6 +1175,7 @@ class Builder(object):
             cur_lookups = self.features_.get(key, [])
             self.features_[key] = [x for x in cur_lookups if x not in lookups]
         self.language_systems = frozenset([(self.script_, language)])
+        self.language_ = language
 
         if required:
             key = (self.script_, language)
@@ -1237,8 +1244,13 @@ class Builder(object):
                 "Script statements are not allowed " "within standalone lookup blocks",
                 location,
             )
-        if self.language_systems == {(script, "dflt")}:
-            # Nothing to do.
+        if script == self.script_ and self.language_ == "dflt":
+            # A script statement naming the already-current script still narrows
+            # the language systems that the rules after it are registered under,
+            # and still terminates the current lookup; it differs from the normal
+            # path only in leaving script_ and the lookupflag alone, see
+            # https://github.com/fonttools/fonttools/issues/1824.
+            self.set_language(location, "dflt", include_default=True, required=False)
             return
         self.cur_lookup_ = None
         self.script_ = script

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -88,6 +88,8 @@ class BuilderTest(unittest.TestCase):
         contextual_inline_format_4
         chain_context_multi_subst_class
         duplicate_language_stmt
+        script_language_tracking script_language_tracking_DFLT
+        script_language_tracking_multi script_language_tracking_redundant
         CursivePosSubtable
         MarkBasePosSubtable
         MarkLigPosSubtable
@@ -568,6 +570,19 @@ class BuilderTest(unittest.TestCase):
         builder.start_feature(location=None, name="test")
         builder.set_script(location=None, script="cyrl")
         self.assertEqual(builder.language_systems, {("cyrl", "dflt")})
+
+    def test_script_matching_current_script(self):
+        # The current script starts out as the first declared language system,
+        # so this script statement is a no-op and, in particular, does not
+        # reset the lookupflag.
+        # https://github.com/fonttools/fonttools/issues/1824
+        builder = Builder(makeTTFont(), (None, None))
+        builder.add_language_system(None, "latn", "dflt")
+        builder.start_feature(location=None, name="test")
+        builder.set_lookup_flag(None, 8, None, None)
+        builder.set_script(location=None, script="latn")
+        self.assertEqual(builder.language_systems, {("latn", "dflt")})
+        self.assertEqual(builder.lookupflag_, 8)
 
     def test_script_in_aalt_feature(self):
         self.assertRaisesRegex(

--- a/Tests/feaLib/data/script_language_tracking.fea
+++ b/Tests/feaLib/data/script_language_tracking.fea
@@ -1,0 +1,27 @@
+languagesystem latn dflt;
+
+# The current script of a feature starts out as the first declared language
+# system, so "script latn" here is redundant and all rules stay under
+# latn/dflt; no DFLT script record must be created.
+feature kern {
+    script latn;
+    language dflt;
+    pos a b -10;
+} kern;
+
+# Same, but with a rule before the redundant script statement: the feature
+# must not be split between DFLT and latn.
+feature dist {
+    pos c d -10;
+    script latn;
+    language dflt;
+    pos e f -20;
+} dist;
+
+# A script statement that names the already-current script preserves the
+# lookupflag, see https://github.com/fonttools/fonttools/issues/1824.
+feature test {
+    lookupflag IgnoreMarks;
+    script latn;
+    pos a -10;
+} test;

--- a/Tests/feaLib/data/script_language_tracking.ttx
+++ b/Tests/feaLib/data/script_language_tracking.ttx
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=3 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+            <FeatureIndex index="2" value="2"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=3 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="dist"/>
+        <Feature>
+          <!-- LookupCount=2 -->
+          <LookupListIndex index="0" value="1"/>
+          <LookupListIndex index="1" value="2"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="3"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=4 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage>
+            <Glyph value="a"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=1 -->
+          <PairSet index="0">
+            <!-- PairValueCount=1 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="b"/>
+              <Value1 XAdvance="-10"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage>
+            <Glyph value="c"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=1 -->
+          <PairSet index="0">
+            <!-- PairValueCount=1 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="d"/>
+              <Value1 XAdvance="-10"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage>
+            <Glyph value="e"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=1 -->
+          <PairSet index="0">
+            <!-- PairValueCount=1 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="f"/>
+              <Value1 XAdvance="-20"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="a"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="-10"/>
+        </SinglePos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/feaLib/data/script_language_tracking_DFLT.fea
+++ b/Tests/feaLib/data/script_language_tracking_DFLT.fea
@@ -1,0 +1,12 @@
+languagesystem DFLT dflt;
+languagesystem latn dflt;
+
+# Here DFLT/dflt is the first declared language system, so it is the current
+# one until the script statement; the first rule is registered under both
+# declared systems and only the second one is latn-only.
+feature kern {
+    pos a b -10;
+    script latn;
+    language dflt;
+    pos c d -20;
+} kern;

--- a/Tests/feaLib/data/script_language_tracking_DFLT.ttx
+++ b/Tests/feaLib/data/script_language_tracking_DFLT.ttx
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=2 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=2 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage>
+            <Glyph value="a"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=1 -->
+          <PairSet index="0">
+            <!-- PairValueCount=1 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="b"/>
+              <Value1 XAdvance="-10"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage>
+            <Glyph value="c"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=1 -->
+          <PairSet index="0">
+            <!-- PairValueCount=1 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="d"/>
+              <Value1 XAdvance="-20"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/Tests/feaLib/data/script_language_tracking_multi.fea
+++ b/Tests/feaLib/data/script_language_tracking_multi.fea
@@ -1,0 +1,36 @@
+languagesystem DFLT dflt;
+languagesystem bng2 dflt;
+languagesystem beng dflt;
+
+# The feature opens with a script statement naming DFLT, the first declared
+# language system, so it is redundant. It still stops the rules that follow
+# from being registered under every declared language system, so each lookup
+# below is registered under its own script only.
+feature akhn {
+    lookup akhn_dflt {
+        script DFLT;
+        sub a b by c;
+    } akhn_dflt;
+
+    lookup akhn_bng2 {
+        script bng2;
+        sub a b by d;
+    } akhn_bng2;
+
+    lookup akhn_beng {
+        script beng;
+        sub a b by e;
+    } akhn_beng;
+} akhn;
+
+# The same without named lookup blocks.
+feature blwf {
+    script DFLT;
+    sub f by g;
+
+    script bng2;
+    sub f by h;
+
+    script beng;
+    sub f by i;
+} blwf;

--- a/Tests/feaLib/data/script_language_tracking_multi.ttx
+++ b/Tests/feaLib/data/script_language_tracking_multi.ttx
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=3 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="3"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="beng"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="1"/>
+            <FeatureIndex index="1" value="4"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="bng2"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="2"/>
+            <FeatureIndex index="1" value="5"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=6 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="akhn"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="akhn"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="2"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="akhn"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="3">
+        <FeatureTag value="blwf"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="3"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="4">
+        <FeatureTag value="blwf"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="5"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="5">
+        <FeatureTag value="blwf"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="4"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=6 -->
+      <Lookup index="0">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0">
+          <LigatureSet glyph="a">
+            <Ligature components="b" glyph="c"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0">
+          <LigatureSet glyph="a">
+            <Ligature components="b" glyph="d"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0">
+          <LigatureSet glyph="a">
+            <Ligature components="b" glyph="e"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="f" out="g"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="4">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="f" out="h"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="5">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="f" out="i"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/Tests/feaLib/data/script_language_tracking_redundant.fea
+++ b/Tests/feaLib/data/script_language_tracking_redundant.fea
@@ -1,0 +1,32 @@
+languagesystem latn dflt;
+languagesystem cyrl dflt;
+
+# The current script starts out as the first declared language system, sorted
+# by tag, so "script cyrl" is redundant here. It must still restrict the rules
+# that follow to cyrl/dflt, while preserving the lookupflag,
+# see https://github.com/fonttools/fonttools/issues/1824.
+feature test {
+    lookupflag IgnoreMarks;
+    script cyrl;
+    sub A by B;
+} test;
+
+# Same, but with a rule before the redundant script statement. The statement
+# narrows the language systems from both declared ones to cyrl/dflt alone, so
+# it has to terminate the current lookup: C -> D must not be added to the
+# lookup that A -> B already registered under latn/dflt as well.
+feature dist {
+    sub A by B;
+    script cyrl;
+    sub C by D;
+} dist;
+
+# A script statement repeated after a real script change narrows nothing, but
+# it terminates the current lookup all the same, so the rules around it end up
+# in separate lookups. This pattern shows up in the wild, e.g. in Braah One.
+feature psts {
+    script latn;
+    sub A by B;
+    script latn;
+    sub C by D;
+} psts;

--- a/Tests/feaLib/data/script_language_tracking_redundant.ttx
+++ b/Tests/feaLib/data/script_language_tracking_redundant.ttx
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=2 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="3"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="1"/>
+            <FeatureIndex index="1" value="2"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=4 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="dist"/>
+        <Feature>
+          <!-- LookupCount=2 -->
+          <LookupListIndex index="0" value="1"/>
+          <LookupListIndex index="1" value="2"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="dist"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="psts"/>
+        <Feature>
+          <!-- LookupCount=2 -->
+          <LookupListIndex index="0" value="3"/>
+          <LookupListIndex index="1" value="4"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="3">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=5 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="A" out="B"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="A" out="B"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="C" out="D"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="A" out="B"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="4">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="C" out="D"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
This bit of behaviour has been a major source of headaches both here as well as in fea-rs; for a bit of history, see:

- https://github.com/fonttools/fonttools/issues/613
- https://github.com/fonttools/fonttools/issues/1824
- https://github.com/fonttools/fonttools/pull/1883
- https://github.com/fonttools/fonttools/issues/2522 (still open)
- https://github.com/fonttools/fonttools/issues/3748
- https://github.com/googlefonts/fontc/pull/959
- https://github.com/googlefonts/fontc/pull/1595

Digging into some remaining funny diffs has uncovered that both implementations were still not quite correct.

Here the issue was that start_feature() hardcoded self.script_ = "DFLT", and set_script() returned early without assigning self.script_ when the script matched the declared language systems.

Given,

```fea
languagesystem latn dflt;
feature derp {
    script latn;
    language dflt;
    sub a by b;
} derp;
```

`script_` stayed "DFLT", 'sub a by b' ended up in DFLT/dflt, and the font got no latn ScriptRecord at all.

The solution is to track the current script and language explicitly instead. start_feature() now seeds them from the _first declared language system_ (rather than DFLT) and set_script() guards its early return on the _current script and language_ rather than on the set of declared language systems.

The early return exists so that a script statement naming the already-current script does not reset the lookupflag (#1824); that is preserved, and now applies to the first declared language system as well.

This fix is directly based on the logic in makeotf. A separate patch in fea-rs will implement the same behaviour.


- fixes #2522 