### PR TITLE
[otlLib] Fix overflow handling when building contextual lookups

### DIFF
--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -392,7 +392,11 @@ class ChainContextualBuilder(LookupBuilder):
         # We need to make a copy here because compiling
         # modifies the subtable (finalizing formats etc.)
         table = self.buildLookup_(copy.deepcopy(subtables))
-        w = OTTableWriter()
+        w = OTTableWriter(tableTag=self.table)
+        # This standalone lookup has no LookupList parent to set its metadata.
+        # Overflow reporting still needs a lookup name and index.
+        w.name = "Lookup"
+        w.repeatIndex = 0
         table.compile(w, self.font)
         size = len(w.getAllData())
         return size

--- a/Lib/fontTools/otlLib/builder.py
+++ b/Lib/fontTools/otlLib/builder.py
@@ -427,7 +427,9 @@ class ChainContextualBuilder(LookupBuilder):
         if not write_gpos7 and self.subtable_type == "Pos":
             chaining = True
 
-        for ruleset in rulesets:
+        pending_rulesets = list(reversed(rulesets))
+        while pending_rulesets:
+            ruleset = pending_rulesets.pop()
             # Determine format strategy. We try to build formats 1, 2 and 3
             # subtables and then work out which is best. candidates list holds
             # the subtables in each format for this ruleset (including a dummy
@@ -463,7 +465,16 @@ class ChainContextualBuilder(LookupBuilder):
                         candidates_by_size.append((size, candidates[i]))
 
             if not candidates_by_size:
-                raise OpenTypeLibError("All candidates overflowed", self.location)
+                if len(ruleset.rules) <= 1:
+                    raise OpenTypeLibError("All candidates overflowed", self.location)
+                # Retry smaller consecutive groups in the same lookup. Keeping
+                # their order preserves the first-matching-rule semantics.
+                midpoint = len(ruleset.rules) // 2
+                for rules in (ruleset.rules[midpoint:], ruleset.rules[:midpoint]):
+                    part = ChainContextualRuleset()
+                    part.rules = rules
+                    pending_rulesets.append(part)
+                continue
 
             _min_size, winner = min(candidates_by_size, key=lambda x: x[0])
             subtables.extend(winner)

--- a/Tests/otlLib/builder_test.py
+++ b/Tests/otlLib/builder_test.py
@@ -1884,6 +1884,29 @@ def test_buildMathTable_horizAssembly():
 
 
 class ChainContextualRulesetTest(object):
+    @pytest.mark.parametrize(
+        "builder_class",
+        [builder.ChainContextPosBuilder, builder.ChainContextSubstBuilder],
+    )
+    @pytest.mark.parametrize("extension", [False, True])
+    def test_format2_overflow_falls_back_to_format3(self, builder_class, extension):
+        font = ttLib.TTFont()
+        glyphs = [f"g{i}" for i in range(44000)]
+        font.setGlyphOrder(glyphs)
+        lookup_builder = builder_class(font, None)
+        lookup_builder.extension = extension
+        # Alternating glyph IDs make the format-2 ClassDef too large, while
+        # the equivalent format-3 Coverage fits in a single subtable.
+        lookup_builder.rules.append(
+            builder.ChainContextualRule([], [glyphs[::2]], [], [None])
+        )
+        lookup = lookup_builder.build()
+        assert len(lookup.SubTable) == 1
+        subtable = lookup.SubTable[0]
+        if extension:
+            subtable = subtable.ExtSubTable
+        assert subtable.Format == 3
+
     def test_makeRulesets(self):
         font = ttLib.TTFont()
         font.setGlyphOrder(["a", "b", "c", "d", "A", "B", "C", "D", "E"])

--- a/Tests/otlLib/contextual_overflow_test.py
+++ b/Tests/otlLib/contextual_overflow_test.py
@@ -1,0 +1,63 @@
+from fontTools import ttLib
+from fontTools.otlLib import builder
+from fontTools.otlLib.error import OpenTypeLibError
+from fontTools.ttLib.tables import otTables
+from types import SimpleNamespace
+import pytest
+
+
+def make_builder():
+    font = ttLib.TTFont()
+    glyphs = [".notdef"] + [f"g{i}" for i in range(1, 44000)]
+    font.setGlyphOrder(glyphs + ["before", "after"])
+    lookup_builder = builder.ChainContextSubstBuilder(font, None)
+    even = glyphs[2::2]
+    odd = glyphs[1::2]
+    # Overlapping classes rule out format 2; each coverage is about 44KB, so
+    # format 3 overflows the lookup offsets when all four rules are sized
+    # together, but each consecutive pair fits.
+    classes = [even, ["g1"] + even, odd, ["g2"] + odd]
+    return lookup_builder, classes
+
+
+def test_overflow_splits_rules_in_order():
+    lookup_builder, classes = make_builder()
+    for index, glyphs in enumerate(classes):
+        # Only the last rule has context. Splitting must keep the lookup
+        # chaining for the earlier rules, which have neither prefix nor suffix.
+        context = index == 3
+        lookup_builder.rules.append(
+            builder.ChainContextualRule(
+                [["before"]] if context else [],
+                [glyphs],
+                [["after"]] if context else [],
+                [None if index == 0 else SimpleNamespace(lookup_index=index)],
+            )
+        )
+
+    lookup = lookup_builder.build()
+
+    assert len(lookup.SubTable) == 4
+    for index, (subtable, glyphs) in enumerate(zip(lookup.SubTable, classes)):
+        assert isinstance(subtable, otTables.ChainContextSubst)
+        assert subtable.Format == 3
+        assert [set(c.glyphs) for c in subtable.InputCoverage] == [set(glyphs)]
+        assert [c.glyphs for c in subtable.BacktrackCoverage] == (
+            [["before"]] if index == 3 else []
+        )
+        assert [c.glyphs for c in subtable.LookAheadCoverage] == (
+            [["after"]] if index == 3 else []
+        )
+        assert [
+            (r.SequenceIndex, r.LookupListIndex) for r in subtable.SubstLookupRecord
+        ] == ([] if index == 0 else [(0, index)])
+
+
+def test_single_rule_overflow_still_raises():
+    lookup_builder, classes = make_builder()
+    # An offset overflow inside a single format-3 subtable cannot be split.
+    lookup_builder.rules.append(
+        builder.ChainContextualRule([], classes[:3], [], [None, None, None])
+    )
+    with pytest.raises(OpenTypeLibError, match="^All candidates overflowed$"):
+        lookup_builder.build()


### PR DESCRIPTION
Set the standalone lookup writer’s metadata so offset overflows raise OTLOffsetOverflowError instead of AttributeError, allowing another contextual format to be tried. Fixes a regression introduced by #3439.
