### PR TITLE
[varLib.interpolatable] escape glyph name in HTML report

### DIFF
--- a/Lib/fontTools/varLib/interpolatable.py
+++ b/Lib/fontTools/varLib/interpolatable.py
@@ -1177,6 +1177,7 @@ def main(args=None):
                     svg.draw_cupcake()
 
             import base64
+            import html
 
             with open(ensure_parent_dir(args.html), "wb") as f:
                 f.write(b"<!DOCTYPE html>\n")
@@ -1186,7 +1187,11 @@ def main(args=None):
                 f.write(b"<title>fonttools varLib.interpolatable report</title>\n")
                 for i, svg in enumerate(svgs):
                     if i in glyph_starts:
-                        f.write(f"<h1>Glyph {glyph_starts[i]}</h1>\n".encode("utf-8"))
+                        f.write(
+                            f"<h1>Glyph {html.escape(glyph_starts[i])}</h1>\n".encode(
+                                "utf-8"
+                            )
+                        )
                     f.write("<img src='data:image/svg+xml;base64,".encode("utf-8"))
                     f.write(base64.b64encode(svg))
                     f.write(b"' />\n")

--- a/Tests/varLib/interpolatable_test.py
+++ b/Tests/varLib/interpolatable_test.py
@@ -281,6 +281,47 @@ class InterpolatableTest(unittest.TestCase):
         # normal order, with --ignore-missing
         self.assertIsNone(interpolatable_main(["--ignore-missing", glyphsapp_path]))
 
+    def test_html_report_escapes_glyph_name(self):
+        pytest.importorskip("cairo")
+        from fontTools.fontBuilder import FontBuilder
+        from fontTools.pens.ttGlyphPen import TTGlyphPen
+
+        glyph_name = "<img src=x onerror=alert(1)>"
+
+        def build_master(path, num_contours):
+            fb = FontBuilder(1000, isTTF=True)
+            fb.setupGlyphOrder([".notdef", glyph_name])
+            fb.setupCharacterMap({0x41: glyph_name})
+            pen = TTGlyphPen(None)
+            for i in range(num_contours):
+                y = i * 300
+                pen.moveTo((0, y))
+                pen.lineTo((0, y + 200))
+                pen.lineTo((200, y + 200))
+                pen.lineTo((200, y))
+                pen.closePath()
+            fb.setupGlyf({".notdef": TTGlyphPen(None).glyph(), glyph_name: pen.glyph()})
+            fb.setupHorizontalMetrics({".notdef": (500, 0), glyph_name: (500, 0)})
+            fb.setupHorizontalHeader(ascent=800, descent=-200)
+            fb.setupNameTable({"familyName": "Test", "styleName": "Regular"})
+            fb.setupOS2()
+            fb.setupPost()
+            fb.save(path)
+
+        master_a = self.temp_path(".ttf")
+        master_b = self.temp_path(".ttf")
+        # different contour counts so the glyph is reported as a problem
+        build_master(master_a, 1)
+        build_master(master_b, 2)
+        html_path = self.temp_path(".html")
+
+        interpolatable_main(["--quiet", "--html", html_path, master_a, master_b])
+
+        with open(html_path, "rb") as f:
+            html = f.read().decode("utf-8")
+        self.assertIn("<h1>Glyph &lt;img src=x onerror=alert(1)&gt;</h1>", html)
+        self.assertNotIn(glyph_name, html)
+
     def test_interpolatable_varComposite(self):
         input_path = self.get_test_input(
             "..", "..", "ttLib", "data", "varc-ac00-ac01.ttf"


### PR DESCRIPTION
Running `fonttools varLib.interpolatable --html report.html` on two masters whose only glyph is named `<img src=x onerror=alert(1)>`:

    $ grep '<h1>' report.html
    <h1>Glyph <img src=x onerror=alert(1)></h1>

Glyph names are lifted verbatim from the sources under test (post table for TTF/OTF, contents.plist for UFO), so a hostile name in a third-party font project becomes live markup that runs when the report is opened in a browser. The SVG pages are inert (base64 `<img>` data); only the heading was written raw.

Pass the name through `html.escape` at the write site. Ordinary glyph names carry no markup characters, so existing reports are unchanged. A regression test builds the two masters above and checks the heading comes out escaped.
