### PR TITLE
[ttLib.sfnt] raise TTLibError not assert for WOFF decompressed sizes

### DIFF
--- a/Lib/fontTools/ttLib/sfnt.py
+++ b/Lib/fontTools/ttLib/sfnt.py
@@ -585,9 +585,23 @@ class WOFFDirectoryEntry(DirectoryEntry):
         if self.length == self.origLength:
             data = rawData
         else:
-            assert self.length < self.origLength
+            # These lengths come straight from the (untrusted) WOFF table
+            # directory; a bare assertion is also silently skipped under
+            # `python -O`, so a corrupt WOFF would be accepted with wrong-sized
+            # table data instead of failing.
+            tag = Tag(getattr(self, "tag", None) or "????")
+            if self.length >= self.origLength:
+                raise TTLibError(
+                    "corrupt WOFF table '%s': compressed length %d is not "
+                    "smaller than original length %d"
+                    % (tag, self.length, self.origLength)
+                )
             data = zlib.decompress(rawData)
-            assert len(data) == self.origLength
+            if len(data) != self.origLength:
+                raise TTLibError(
+                    "unexpected size for decompressed WOFF table '%s': "
+                    "expected %d but got %d" % (tag, self.origLength, len(data))
+                )
         return data
 
     def encodeData(self, data):
@@ -615,17 +629,32 @@ class WOFFFlavorData:
         if reader:
             self.majorVersion = reader.majorVersion
             self.minorVersion = reader.minorVersion
+            # The metadata/private-data offsets and lengths are read from the
+            # (untrusted) WOFF header; validate them with real checks rather
+            # than bare assertions, which are silently skipped under `python -O`.
             if reader.metaLength:
                 reader.file.seek(reader.metaOffset)
                 rawData = reader.file.read(reader.metaLength)
-                assert len(rawData) == reader.metaLength
+                if len(rawData) != reader.metaLength:
+                    raise TTLibError(
+                        "unexpected end of WOFF metadata: expected %d bytes "
+                        "but got %d" % (reader.metaLength, len(rawData))
+                    )
                 data = self._decompress(rawData)
-                assert len(data) == reader.metaOrigLength
+                if len(data) != reader.metaOrigLength:
+                    raise TTLibError(
+                        "unexpected size for decompressed WOFF metadata: "
+                        "expected %d but got %d" % (reader.metaOrigLength, len(data))
+                    )
                 self.metaData = data
             if reader.privLength:
                 reader.file.seek(reader.privOffset)
                 data = reader.file.read(reader.privLength)
-                assert len(data) == reader.privLength
+                if len(data) != reader.privLength:
+                    raise TTLibError(
+                        "unexpected end of WOFF private data: expected %d "
+                        "bytes but got %d" % (reader.privLength, len(data))
+                    )
                 self.privData = data
 
     def _decompress(self, rawData):

--- a/Tests/ttLib/sfnt_test.py
+++ b/Tests/ttLib/sfnt_test.py
@@ -2,12 +2,15 @@ import io
 import copy
 import pickle
 import tempfile
+import zlib
+from types import SimpleNamespace
 from fontTools.ttLib import TTFont, TTLibError
 from fontTools.ttLib.sfnt import (
     calcChecksum,
     SFNTDirectoryEntry,
     SFNTReader,
     sfntDirectorySize,
+    WOFFDirectoryEntry,
     WOFFFlavorData,
 )
 from pathlib import Path
@@ -120,6 +123,77 @@ def test_bogus_numTables_raises_TTLibError(ttfont_path):
     data[5] ^= 0xFF
     with pytest.raises(TTLibError, match="unexpected end of table directory"):
         TTFont(io.BytesIO(bytes(data)))
+
+
+# The WOFF decode path validated its (untrusted) sizes with bare assertions,
+# which raise the wrong exception and, under `python -O`, are dropped entirely,
+# so a corrupt WOFF was accepted with wrong-sized data. These mirror the
+# truncated-table-directory tests above for the WOFF-specific sites.
+
+
+def test_woff_table_bad_compressed_length_raises_TTLibError():
+    entry = WOFFDirectoryEntry()
+    entry.tag = "test"
+    # A compressed table must be smaller than its original size.
+    entry.length = 20
+    entry.origLength = 10
+    with pytest.raises(TTLibError, match="corrupt WOFF table 'test'"):
+        entry.decodeData(zlib.compress(b"A" * 10))
+
+
+def test_woff_table_decompressed_size_mismatch_raises_TTLibError():
+    payload = b"A" * 100
+    rawData = zlib.compress(payload)
+    entry = WOFFDirectoryEntry()
+    entry.tag = "test"
+    entry.length = len(rawData)
+    entry.origLength = len(payload) + 5  # lie about the original size
+    assert entry.length < entry.origLength
+    with pytest.raises(
+        TTLibError, match="unexpected size for decompressed WOFF table 'test'"
+    ):
+        entry.decodeData(rawData)
+
+
+def _woff_flavor_reader(**kwargs):
+    attrs = dict(
+        majorVersion=1,
+        minorVersion=0,
+        metaOffset=0,
+        metaLength=0,
+        metaOrigLength=0,
+        privOffset=0,
+        privLength=0,
+        file=io.BytesIO(b""),
+    )
+    attrs.update(kwargs)
+    return SimpleNamespace(**attrs)
+
+
+def test_woff_metadata_truncated_raises_TTLibError():
+    reader = _woff_flavor_reader(metaLength=100, file=io.BytesIO(b"short"))
+    with pytest.raises(TTLibError, match="unexpected end of WOFF metadata"):
+        WOFFFlavorData(reader)
+
+
+def test_woff_metadata_size_mismatch_raises_TTLibError():
+    meta = b"<metadata/>"
+    compressed = zlib.compress(meta)
+    reader = _woff_flavor_reader(
+        metaLength=len(compressed),
+        metaOrigLength=len(meta) + 3,  # lie about the uncompressed size
+        file=io.BytesIO(compressed),
+    )
+    with pytest.raises(
+        TTLibError, match="unexpected size for decompressed WOFF metadata"
+    ):
+        WOFFFlavorData(reader)
+
+
+def test_woff_privData_truncated_raises_TTLibError():
+    reader = _woff_flavor_reader(privLength=100, file=io.BytesIO(b"short"))
+    with pytest.raises(TTLibError, match="unexpected end of WOFF private data"):
+        WOFFFlavorData(reader)
 
 
 def test_ttLib_sfnt_write_privData(tmp_path, ttfont_path):


### PR DESCRIPTION
Under `python -O`, asserts are stripped, so the size checks in the WOFF decode path in `sfnt.py` disappear entirely:

    $ python -O -c "from fontTools.ttLib import TTFont; TTFont('crafted.woff')['glyf']"
    # no error: a table whose declared origLength differs from the decompressed
    # length is accepted, and the wrong-sized buffer is handed to the decompiler

`WOFFDirectoryEntry.decodeData` and `WOFFFlavorData.__init__` validate attacker-controlled lengths (compressed vs original table size, decompressed size, metadata/private-data lengths) with bare `assert`. Beyond vanishing under `-O`, they also raise `AssertionError` rather than the library's `TTLibError` on a corrupt file.

#4149 replaced the same assert-based validation in `DirectoryEntry.fromFile`/`loadData` for this exact reason but left the WOFF-specific sites; this converts the remaining five to matching `TTLibError` checks. The added tests exercise each site and fail on the current tree (`AssertionError` normally, silent acceptance under `-O`).