### PR TITLE
[feaLib] Report missing STAT fallback names

### DIFF
--- a/Lib/fontTools/feaLib/builder.py
+++ b/Lib/fontTools/feaLib/builder.py
@@ -673,6 +673,11 @@ class Builder(object):
                 )
         elif "ElidedFallbackName" in self.stat_:
             nameID = self.stat_["ElidedFallbackName"]
+        else:
+            raise FeatureLibError(
+                "STAT table requires an ElidedFallbackName or ElidedFallbackNameID",
+                None,
+            )
 
         otl.buildStatTable(
             self.font,

--- a/README.rst
+++ b/README.rst
@@ -269,8 +269,9 @@ Vincent Connare, David Corbett, Simon Cozens, Dave Crossland, Simon Daniels,
 Peter Dekkers, Behdad Esfahbod, Behnam Esfahbod, Hannes Famira, Sam Fishman,
 Matt Fontaine, Takaaki Fuji, Rob Hagemans, Yannis Haralambous, Greg Hitchcock,
 Jeremie Hornus, Khaled Hosny, John Hudson, Denis Moyogo Jacquerye, Jack Jansen,
-Tom Kacvinsky, Jens Kutilek, Antoine Leca, Werner Lemberg, Tal Leming, Liang Hai, Peter
-Lofting, Cosimo Lupo, Olli Meier, Masaya Nakamura, Dave Opstad, Laurence Penney,
+Tom Kacvinsky, Jens Kutilek, Antoine Leca, Werner Lemberg, Tal Leming,
+Jushuanghui Li, Liang Hai, Peter Lofting, Cosimo Lupo, Olli Meier, Masaya Nakamura,
+Dave Opstad, Laurence Penney,
 Roozbeh Pournader, Garret Rieger, Read Roberts, Colin Rofls, Guido van Rossum,
 Just van Rossum, Andreas Seidel, Georg Seifert, Chris Simpkins, Miguel Sousa,
 Adam Twardoch, Adrien Tétar, Vitaly Volkov, Paul Wise.

--- a/Tests/feaLib/builder_test.py
+++ b/Tests/feaLib/builder_test.py
@@ -731,6 +731,20 @@ class BuilderTest(unittest.TestCase):
             "} test;",
         )
 
+    def test_STAT_elidedfallbackname_missing(self):
+        self.assertRaisesRegex(
+            FeatureLibError,
+            "STAT table requires an ElidedFallbackName or ElidedFallbackNameID",
+            self.build,
+            "table STAT {"
+            '    DesignAxis wght 0 { name "Weight"; };'
+            "    AxisValue {"
+            "        location wght 400;"
+            '        name "Regular";'
+            "    };"
+            "} STAT;",
+        )
+
     def test_STAT_elidedfallbackname_already_defined(self):
         self.assertRaisesRegex(
             FeatureLibError,


### PR DESCRIPTION
Compiling a STAT table without `ElidedFallbackName` or `ElidedFallbackNameID` raises `UnboundLocalError`. Report the missing declaration as `FeatureLibError` so the error explains what needs to be added.

Fixes #3834.
